### PR TITLE
feat: refactor the stabilizer backend

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -817,6 +817,158 @@ fn bench_factored_dense(c: &mut Criterion) {
     group.finish();
 }
 
+fn clifford_t_circuit(n_qubits: usize, t_count: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut circuit = Circuit::new(n_qubits, 0);
+    let cliffords = [Gate::H, Gate::S, Gate::Sdg, Gate::X, Gate::Y, Gate::Z];
+
+    // Clifford layer first
+    for q in 0..n_qubits {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    for q in 0..n_qubits - 1 {
+        if rng.gen_bool(0.5) {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+
+    // Insert T gates on random qubits
+    for _ in 0..t_count {
+        let q = rng.gen_range(0..n_qubits);
+        circuit.add_gate(Gate::T, &[q]);
+    }
+
+    // More Clifford layers
+    for _ in 0..3 {
+        for q in 0..n_qubits {
+            let gate_idx = rng.gen_range(0..cliffords.len());
+            circuit.add_gate(cliffords[gate_idx].clone(), &[q]);
+        }
+        for q in 0..n_qubits - 1 {
+            if rng.gen_bool(0.5) {
+                circuit.add_gate(Gate::Cx, &[q, q + 1]);
+            }
+        }
+    }
+    circuit
+}
+
+fn bench_quasi_prob(c: &mut Criterion) {
+    let mut group = c.benchmark_group("quasi_prob");
+    configure_group(&mut group);
+
+    // Compare quasi-prob exact vs statevector for varying T-counts at fixed qubit count
+    let n = 10;
+    for &t in &[1, 2, 4, 8, 12] {
+        let circuit = clifford_t_circuit(n, t, SEED);
+
+        group.bench_function(BenchmarkId::new("exact", format!("{n}q_{t}t")), |b| {
+            b.iter(|| {
+                prism_q::run_quasi_prob(&circuit, 42).unwrap();
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("statevector", format!("{n}q_{t}t")), |b| {
+            b.iter(|| {
+                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+            });
+        });
+    }
+
+    // Qubit scaling at fixed T-count (t=4)
+    for &n in &[5, 15, 20] {
+        let circuit = clifford_t_circuit(n, 4, SEED);
+
+        group.bench_function(BenchmarkId::new("exact", format!("{n}q_4t")), |b| {
+            b.iter(|| {
+                prism_q::run_quasi_prob(&circuit, 42).unwrap();
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("statevector", format!("{n}q_4t")), |b| {
+            b.iter(|| {
+                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_stabilizer_rank(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stabilizer_rank");
+    configure_group(&mut group);
+
+    // Compare stabilizer_rank exact vs quasi_prob vs statevector
+    let n = 10;
+    for &t in &[2, 4, 8, 12] {
+        let circuit = clifford_t_circuit(n, t, SEED);
+        let id = format!("{n}q_{t}t");
+
+        group.bench_function(BenchmarkId::new("stab_rank", &id), |b| {
+            b.iter(|| {
+                prism_q::run_stabilizer_rank(&circuit, 42).unwrap();
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("quasi_prob", &id), |b| {
+            b.iter(|| {
+                prism_q::run_quasi_prob(&circuit, 42).unwrap();
+            });
+        });
+    }
+
+    // Approximate mode: higher T-counts with bounded terms
+    for &t in &[16, 20] {
+        let circuit = clifford_t_circuit(n, t, SEED);
+        let id = format!("{n}q_{t}t");
+
+        group.bench_function(BenchmarkId::new("approx_256", &id), |b| {
+            b.iter(|| {
+                prism_q::run_stabilizer_rank_approx(&circuit, 256, 42).unwrap();
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("approx_1024", &id), |b| {
+            b.iter(|| {
+                prism_q::run_stabilizer_rank_approx(&circuit, 1024, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_compiled_sampler(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compiled_sampler");
+    configure_group(&mut group);
+
+    for &n in &[100, 500, 1000] {
+        let mut circuit = circuits::clifford_heavy_circuit(n, 10, SEED);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let id = format!("noiseless_{}q_10k", n);
+        group.bench_function(BenchmarkId::new("noiseless", &id), |b| {
+            b.iter(|| {
+                prism_q::run_shots_compiled(&circuit, 10_000, SEED).unwrap();
+            });
+        });
+
+        let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let id_noisy = format!("noisy_{}q_10k", n);
+        group.bench_function(BenchmarkId::new("noisy", &id_noisy), |b| {
+            b.iter(|| {
+                prism_q::run_shots_noisy(&circuit, &noise, 10_000, SEED).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     // Statevector sweeps
@@ -864,5 +1016,11 @@ criterion_group!(
     bench_factored_sim_only,
     bench_factored_dynamic,
     bench_factored_dense,
+    // Quasi-probability (Clifford+T)
+    bench_quasi_prob,
+    // Stabilizer rank
+    bench_stabilizer_rank,
+    // Compiled sampler (noiseless + noisy shot sampling)
+    bench_compiled_sampler,
 );
 criterion_main!(benches);

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -608,14 +608,22 @@ fn apply_cz_seq(state: &mut [Complex64], num_qubits: usize, q0: usize, q1: usize
 }
 
 #[inline(always)]
-fn apply_swap_seq(state: &mut [Complex64], num_qubits: usize, q0: usize, q1: usize) {
-    let mask0 = 1usize << q0;
-    let mask1 = 1usize << q1;
-    let n = 1usize << num_qubits;
+fn apply_swap_seq(state: &mut [Complex64], _num_qubits: usize, q0: usize, q1: usize) {
+    let (lo, hi) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
+    let lo_half = 1usize << lo;
+    let lo_block = lo_half << 1;
+    let hi_half = 1usize << hi;
+    let block_size = hi_half << 1;
 
-    for i in 0..n {
-        if (i & mask0) == 0 && (i & mask1) != 0 {
-            state.swap(i, i ^ mask0 ^ mask1);
+    for chunk in state.chunks_mut(block_size) {
+        let (lo_group, hi_group) = chunk.split_at_mut(hi_half);
+        for (lo_sub, hi_sub) in lo_group
+            .chunks_mut(lo_block)
+            .zip(hi_group.chunks_mut(lo_block))
+        {
+            let (_, lo_sub_hi) = lo_sub.split_at_mut(lo_half);
+            let (hi_sub_lo, _) = hi_sub.split_at_mut(lo_half);
+            simd::swap_slices(lo_sub_hi, hi_sub_lo);
         }
     }
 }

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -909,7 +909,7 @@ pub(crate) fn negate_slice(slice: &mut [Complex64]) {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", any(feature = "parallel", test)))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn swap_slices_avx2(a: &mut [Complex64], b: &mut [Complex64]) {
     debug_assert_eq!(a.len(), b.len());
@@ -930,7 +930,6 @@ unsafe fn swap_slices_avx2(a: &mut [Complex64], b: &mut [Complex64]) {
     }
 }
 
-#[cfg(any(feature = "parallel", test))]
 pub(crate) fn swap_slices(a: &mut [Complex64], b: &mut [Complex64]) {
     debug_assert_eq!(a.len(), b.len());
     #[cfg(target_arch = "x86_64")]

--- a/src/backend/stabilizer.rs
+++ b/src/backend/stabilizer.rs
@@ -46,17 +46,17 @@ use rand_chacha::ChaCha8Rng;
 unsafe fn xor_words(dst: *mut u64, src: *const u64, len: usize) {
     #[cfg(target_arch = "x86_64")]
     if has_avx2() {
-        // SAFETY: caller guarantees non-overlapping valid regions, has_avx2() ensures ISA.
-        unsafe {
-            xor_words_avx2(dst, src, len);
-        }
+        unsafe { xor_words_avx2(dst, src, len) };
         return;
     }
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { xor_words_neon(dst, src, len) };
+        return;
+    }
+    #[allow(unreachable_code)]
     for i in 0..len {
-        // SAFETY: caller guarantees valid pointers for len elements.
-        unsafe {
-            *dst.add(i) ^= *src.add(i);
-        }
+        unsafe { *dst.add(i) ^= *src.add(i) };
     }
 }
 
@@ -79,14 +79,70 @@ unsafe fn xor_words_avx2(dst: *mut u64, src: *const u64, len: usize) {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn xor_words_neon(dst: *mut u64, src: *const u64, len: usize) {
+    use std::arch::aarch64::*;
+
+    let chunks = len / 2;
+    for i in 0..chunks {
+        let off = i * 2;
+        let d = vld1q_u64(dst.add(off));
+        let s = vld1q_u64(src.add(off));
+        vst1q_u64(dst.add(off), veorq_u64(d, s));
+    }
+    if len & 1 != 0 {
+        *dst.add(len - 1) ^= *src.add(len - 1);
+    }
+}
+
+/// Rowmul word loop: XOR x/z words from src into dst, returning the
+/// accumulated phase sum (caller applies `sum & 3 >= 2`).
+#[inline(always)]
+fn rowmul_words(
+    dst_x: &mut [u64],
+    dst_z: &mut [u64],
+    src_x: &[u64],
+    src_z: &[u64],
+    initial_sum: u64,
+) -> u64 {
+    debug_assert_eq!(dst_x.len(), dst_z.len());
+    debug_assert_eq!(dst_x.len(), src_x.len());
+    debug_assert_eq!(dst_x.len(), src_z.len());
+    let nw = dst_x.len();
+    let mut sum = initial_sum;
+
+    for w in 0..nw {
+        let x1 = src_x[w];
+        let z1 = src_z[w];
+        let x2 = dst_x[w];
+        let z2 = dst_z[w];
+
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        dst_x[w] = new_x;
+        dst_z[w] = new_z;
+
+        if (x1 | z1 | x2 | z2) == 0 {
+            continue;
+        }
+
+        let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+        let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+        sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+        sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+    }
+
+    sum
+}
 #[cfg(target_arch = "x86_64")]
 fn has_avx2() -> bool {
     static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| is_x86_feature_detected!("avx2"))
 }
 
-#[allow(dead_code)]
 #[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
 fn has_avx2() -> bool {
     false
 }
@@ -94,6 +150,44 @@ fn has_avx2() -> bool {
 /// Minimum qubit count for parallel row iteration in gate kernels.
 #[cfg(feature = "parallel")]
 const MIN_QUBITS_FOR_PAR_GATES: usize = 128;
+
+/// Minimum anti-commuting rows to justify Rayon overhead for measurement rowmul.
+#[cfg(feature = "parallel")]
+const MIN_ANTI_ROWS_FOR_PAR: usize = 4;
+
+/// Send/Sync wrapper for `*mut u64` — parallel tasks access disjoint rows.
+#[cfg(feature = "parallel")]
+struct SendU64Ptr(*mut u64);
+#[cfg(feature = "parallel")]
+impl SendU64Ptr {
+    #[inline(always)]
+    fn ptr(&self) -> *mut u64 {
+        self.0
+    }
+}
+#[cfg(feature = "parallel")]
+// SAFETY: Used only when each parallel task accesses non-overlapping row regions.
+unsafe impl Send for SendU64Ptr {}
+#[cfg(feature = "parallel")]
+// SAFETY: The pointer itself is read-only; mutation goes through derived slices at disjoint offsets.
+unsafe impl Sync for SendU64Ptr {}
+
+/// Send/Sync wrapper for `*mut bool` used in parallel measurement pre-scan.
+#[cfg(feature = "parallel")]
+struct SendBoolPtr(*mut bool);
+#[cfg(feature = "parallel")]
+impl SendBoolPtr {
+    #[inline(always)]
+    fn ptr(&self) -> *mut bool {
+        self.0
+    }
+}
+#[cfg(feature = "parallel")]
+// SAFETY: Used only when each parallel task accesses a distinct phase element.
+unsafe impl Send for SendBoolPtr {}
+#[cfg(feature = "parallel")]
+// SAFETY: The pointer itself is read-only; mutation goes through distinct indices.
+unsafe impl Sync for SendBoolPtr {}
 
 /// Minimum number of u64 words for word-group gate batching to be profitable.
 ///
@@ -325,6 +419,7 @@ fn apply_prepared_ops(xw: &mut u64, zw: &mut u64, p: &mut bool, ops: &[PrepOp]) 
 }
 
 /// Clifford-only O(n^2) stabilizer simulation (Aaronson-Gottesman tableau).
+#[derive(Clone)]
 pub struct StabilizerBackend {
     n: usize,
     num_words: usize,
@@ -332,6 +427,12 @@ pub struct StabilizerBackend {
     phase: Vec<bool>,
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
+    qubit_active: Vec<Vec<u32>>,
+    total_weight: usize,
+    sgi_merge_buf: Vec<u32>,
+    sgi_new_a: Vec<u32>,
+    sgi_new_b: Vec<u32>,
+    sgi_max_active: usize,
 }
 
 impl StabilizerBackend {
@@ -344,7 +445,137 @@ impl StabilizerBackend {
             phase: Vec::new(),
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
+            qubit_active: Vec::new(),
+            total_weight: 0,
+            sgi_merge_buf: Vec::new(),
+            sgi_new_a: Vec::new(),
+            sgi_new_b: Vec::new(),
+            sgi_max_active: 0,
         }
+    }
+
+    pub fn raw_tableau(&self) -> (&[u64], &[bool]) {
+        (&self.xz, &self.phase)
+    }
+
+    pub fn into_tableau(self) -> (Vec<u64>, Vec<bool>, usize, usize) {
+        (self.xz, self.phase, self.n, self.num_words)
+    }
+
+    pub fn apply_gates_only(&mut self, instructions: &[Instruction]) -> Result<()> {
+        let nw = self.num_words;
+        if nw < MIN_WORDS_FOR_BATCH {
+            for instruction in instructions {
+                match instruction {
+                    Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
+                    Instruction::Conditional {
+                        condition,
+                        gate,
+                        targets,
+                    } => {
+                        if condition.evaluate(&self.classical_bits) {
+                            self.dispatch_gate(gate, targets)?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return Ok(());
+        }
+
+        if self.sgi_enabled() {
+            return self.apply_gates_only_sgi(instructions);
+        }
+
+        self.apply_gates_only_word_batch(instructions)
+    }
+
+    fn apply_gates_only_sgi(&mut self, instructions: &[Instruction]) -> Result<()> {
+        for (idx, instruction) in instructions.iter().enumerate() {
+            if !self.sgi_enabled() {
+                return self.apply_gates_only_word_batch(&instructions[idx..]);
+            }
+
+            match instruction {
+                Instruction::Gate { gate, targets } => {
+                    self.sgi_dispatch_gate(gate, targets)?;
+                }
+                Instruction::Conditional {
+                    condition,
+                    gate,
+                    targets,
+                } => {
+                    if condition.evaluate(&self.classical_bits) {
+                        self.sgi_dispatch_gate(gate, targets)?;
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_gates_only_word_batch(&mut self, instructions: &[Instruction]) -> Result<()> {
+        let nw = self.num_words;
+        let mut word_groups: Vec<Vec<BatchGate>> = vec![Vec::new(); nw];
+        let mut cross_word: Vec<CrossWordGate> = Vec::new();
+        let mut cross_word_qubits: Vec<u64> = vec![0u64; nw];
+
+        for instruction in instructions {
+            match instruction {
+                Instruction::Gate { gate, targets } => {
+                    if let Some((w, bg)) = Self::classify_gate(gate, targets) {
+                        let mut bits = 1u64 << bg.a_bit;
+                        if bg.kind >= BatchGate::CX {
+                            bits |= 1u64 << bg.b_bit;
+                        }
+                        if cross_word_qubits[w] & bits != 0 {
+                            self.flush_all_with_cross_word(&mut word_groups, &mut cross_word);
+                            cross_word_qubits.fill(0);
+                        }
+                        word_groups[w].push(bg);
+                    } else if let (Gate::Cx | Gate::Cz | Gate::Swap, &[t0, t1]) =
+                        (gate, targets.as_slice())
+                    {
+                        let w0 = t0 / 64;
+                        let w1 = t1 / 64;
+                        let b0 = (t0 % 64) as u8;
+                        let b1 = (t1 % 64) as u8;
+                        let m0 = 1u64 << b0;
+                        let m1 = 1u64 << b1;
+                        if cross_word_qubits[w0] & m0 != 0 || cross_word_qubits[w1] & m1 != 0 {
+                            self.flush_all_with_cross_word(&mut word_groups, &mut cross_word);
+                            cross_word_qubits.fill(0);
+                        }
+                        let kind = match gate {
+                            Gate::Cx => BatchGate::CX,
+                            Gate::Cz => BatchGate::CZ,
+                            _ => BatchGate::SWAP,
+                        };
+                        cross_word.push(CrossWordGate {
+                            kind,
+                            w0: w0 as u16,
+                            w1: w1 as u16,
+                            b0,
+                            b1,
+                        });
+                        cross_word_qubits[w0] |= m0;
+                        cross_word_qubits[w1] |= m1;
+                    } else {
+                        self.flush_all_with_cross_word(&mut word_groups, &mut cross_word);
+                        cross_word_qubits.fill(0);
+                        self.dispatch_gate(gate, targets)?;
+                    }
+                }
+                _ => {
+                    self.flush_all_with_cross_word(&mut word_groups, &mut cross_word);
+                    cross_word_qubits.fill(0);
+                }
+            }
+        }
+
+        self.flush_all_with_cross_word(&mut word_groups, &mut cross_word);
+        Ok(())
     }
 
     #[inline(always)]
@@ -649,40 +880,474 @@ impl StabilizerBackend {
         }
     }
 
+    fn sgi_enabled(&self) -> bool {
+        let n = self.n;
+        if n < 256 {
+            return false;
+        }
+        let total_rows = 2 * n;
+        let avg = self.total_weight / total_rows;
+        avg < n / 8 && self.sgi_max_active < total_rows / 16
+    }
+
+    fn sgi_apply_1q(&mut self, gate: &Gate, q: usize) {
+        let word = q / 64;
+        let bit_mask = 1u64 << (q % 64);
+        let stride = self.stride();
+        let nw = self.num_words;
+
+        for &g in &self.qubit_active[q] {
+            let row = &mut self.xz[g as usize * stride..(g as usize + 1) * stride];
+            let phase = &mut self.phase[g as usize];
+
+            match gate {
+                Gate::H => {
+                    let xw = row[word];
+                    let zw = row[nw + word];
+                    let x = xw & bit_mask;
+                    let z = zw & bit_mask;
+                    *phase ^= (x != 0) && (z != 0);
+                    row[word] = (xw & !bit_mask) | z;
+                    row[nw + word] = (zw & !bit_mask) | x;
+                }
+                Gate::S => {
+                    let x = row[word] & bit_mask;
+                    let z = row[nw + word] & bit_mask;
+                    *phase ^= (x != 0) && (z != 0);
+                    row[nw + word] ^= x;
+                }
+                Gate::Sdg => {
+                    let x = row[word] & bit_mask;
+                    row[nw + word] ^= x;
+                    let z_new = row[nw + word] & bit_mask;
+                    *phase ^= (x != 0) && (z_new != 0);
+                }
+                Gate::X => {
+                    let z = row[nw + word] & bit_mask;
+                    *phase ^= z != 0;
+                }
+                Gate::Y => {
+                    let x = row[word] & bit_mask;
+                    let z = row[nw + word] & bit_mask;
+                    *phase ^= (x ^ z) != 0;
+                }
+                Gate::Z => {
+                    let x = row[word] & bit_mask;
+                    *phase ^= x != 0;
+                }
+                Gate::SX => {
+                    let x = row[word] & bit_mask;
+                    let z = row[nw + word] & bit_mask;
+                    *phase ^= (z != 0) && (x == 0);
+                    row[word] ^= z;
+                }
+                Gate::SXdg => {
+                    let x = row[word] & bit_mask;
+                    let z = row[nw + word] & bit_mask;
+                    *phase ^= (x != 0) && (z != 0);
+                    row[word] ^= z;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn sgi_merge_active(&mut self, q_a: usize, q_b: usize) {
+        self.sgi_merge_buf.clear();
+        let list_a = &self.qubit_active[q_a];
+        let list_b = &self.qubit_active[q_b];
+        let (mut ia, mut ib) = (0, 0);
+        while ia < list_a.len() && ib < list_b.len() {
+            if list_a[ia] < list_b[ib] {
+                self.sgi_merge_buf.push(list_a[ia]);
+                ia += 1;
+            } else if list_a[ia] > list_b[ib] {
+                self.sgi_merge_buf.push(list_b[ib]);
+                ib += 1;
+            } else {
+                self.sgi_merge_buf.push(list_a[ia]);
+                ia += 1;
+                ib += 1;
+            }
+        }
+        if ia < list_a.len() {
+            self.sgi_merge_buf.extend_from_slice(&list_a[ia..]);
+        }
+        if ib < list_b.len() {
+            self.sgi_merge_buf.extend_from_slice(&list_b[ib..]);
+        }
+    }
+
+    fn sgi_apply_cx(&mut self, ctrl: usize, tgt: usize) {
+        let c_word = ctrl / 64;
+        let c_bit = ctrl % 64;
+        let c_mask = 1u64 << c_bit;
+        let t_word = tgt / 64;
+        let t_bit = tgt % 64;
+        let t_mask = 1u64 << t_bit;
+        let stride = self.stride();
+        let nw = self.num_words;
+
+        self.sgi_merge_active(ctrl, tgt);
+        self.sgi_new_a.clear();
+        self.sgi_new_b.clear();
+
+        for i in 0..self.sgi_merge_buf.len() {
+            let g = self.sgi_merge_buf[i];
+            let row = &mut self.xz[g as usize * stride..(g as usize + 1) * stride];
+            let phase = &mut self.phase[g as usize];
+
+            let xa = (row[c_word] >> c_bit) & 1;
+            let za = (row[nw + c_word] >> c_bit) & 1;
+            let xb = (row[t_word] >> t_bit) & 1;
+            let zb = (row[nw + t_word] >> t_bit) & 1;
+
+            *phase ^= (xa & zb & (xb ^ za ^ 1)) == 1;
+
+            if xa == 1 {
+                row[t_word] ^= t_mask;
+            }
+            if zb == 1 {
+                row[nw + c_word] ^= c_mask;
+            }
+
+            let new_xa = (row[c_word] >> c_bit) & 1;
+            let new_za = (row[nw + c_word] >> c_bit) & 1;
+            let new_xb = (row[t_word] >> t_bit) & 1;
+            let new_zb = (row[nw + t_word] >> t_bit) & 1;
+
+            let old_a = xa | za;
+            let new_a = new_xa | new_za;
+            let old_b = xb | zb;
+            let new_b = new_xb | new_zb;
+
+            if new_a != 0 {
+                self.sgi_new_a.push(g);
+            }
+            if old_a != 0 && new_a == 0 {
+                self.total_weight -= 1;
+            } else if old_a == 0 && new_a != 0 {
+                self.total_weight += 1;
+            }
+
+            if new_b != 0 {
+                self.sgi_new_b.push(g);
+            }
+            if old_b != 0 && new_b == 0 {
+                self.total_weight -= 1;
+            } else if old_b == 0 && new_b != 0 {
+                self.total_weight += 1;
+            }
+        }
+
+        std::mem::swap(&mut self.qubit_active[ctrl], &mut self.sgi_new_a);
+        std::mem::swap(&mut self.qubit_active[tgt], &mut self.sgi_new_b);
+        let ma = self.qubit_active[ctrl].len();
+        let mb = self.qubit_active[tgt].len();
+        if ma > self.sgi_max_active {
+            self.sgi_max_active = ma;
+        }
+        if mb > self.sgi_max_active {
+            self.sgi_max_active = mb;
+        }
+    }
+
+    fn sgi_apply_cz(&mut self, a: usize, b: usize) {
+        let a_word = a / 64;
+        let a_bit = a % 64;
+        let a_mask = 1u64 << a_bit;
+        let b_word = b / 64;
+        let b_bit = b % 64;
+        let b_mask = 1u64 << b_bit;
+        let stride = self.stride();
+        let nw = self.num_words;
+
+        self.sgi_merge_active(a, b);
+        self.sgi_new_a.clear();
+        self.sgi_new_b.clear();
+
+        for i in 0..self.sgi_merge_buf.len() {
+            let g = self.sgi_merge_buf[i];
+            let row = &mut self.xz[g as usize * stride..(g as usize + 1) * stride];
+            let phase = &mut self.phase[g as usize];
+
+            let xa = (row[a_word] >> a_bit) & 1;
+            let xb = (row[b_word] >> b_bit) & 1;
+            let za = (row[nw + a_word] >> a_bit) & 1;
+            let zb = (row[nw + b_word] >> b_bit) & 1;
+
+            *phase ^= (xa & xb & (za ^ zb)) == 1;
+
+            if xb == 1 {
+                row[nw + a_word] ^= a_mask;
+            }
+            if xa == 1 {
+                row[nw + b_word] ^= b_mask;
+            }
+
+            let new_xa = (row[a_word] >> a_bit) & 1;
+            let new_za = (row[nw + a_word] >> a_bit) & 1;
+            let new_xb = (row[b_word] >> b_bit) & 1;
+            let new_zb = (row[nw + b_word] >> b_bit) & 1;
+
+            let old_a_active = xa | za;
+            let new_a_active = new_xa | new_za;
+            let old_b_active = xb | zb;
+            let new_b_active = new_xb | new_zb;
+
+            if new_a_active != 0 {
+                self.sgi_new_a.push(g);
+            }
+            if old_a_active != 0 && new_a_active == 0 {
+                self.total_weight -= 1;
+            } else if old_a_active == 0 && new_a_active != 0 {
+                self.total_weight += 1;
+            }
+
+            if new_b_active != 0 {
+                self.sgi_new_b.push(g);
+            }
+            if old_b_active != 0 && new_b_active == 0 {
+                self.total_weight -= 1;
+            } else if old_b_active == 0 && new_b_active != 0 {
+                self.total_weight += 1;
+            }
+        }
+
+        std::mem::swap(&mut self.qubit_active[a], &mut self.sgi_new_a);
+        std::mem::swap(&mut self.qubit_active[b], &mut self.sgi_new_b);
+        let ma = self.qubit_active[a].len();
+        let mb = self.qubit_active[b].len();
+        if ma > self.sgi_max_active {
+            self.sgi_max_active = ma;
+        }
+        if mb > self.sgi_max_active {
+            self.sgi_max_active = mb;
+        }
+    }
+
+    fn sgi_apply_swap(&mut self, a: usize, b: usize) {
+        let a_word = a / 64;
+        let a_bit = a % 64;
+        let a_mask = 1u64 << a_bit;
+        let b_word = b / 64;
+        let b_bit = b % 64;
+        let b_mask = 1u64 << b_bit;
+        let stride = self.stride();
+        let nw = self.num_words;
+
+        self.sgi_merge_active(a, b);
+        self.sgi_new_a.clear();
+        self.sgi_new_b.clear();
+
+        for i in 0..self.sgi_merge_buf.len() {
+            let g = self.sgi_merge_buf[i];
+            let row = &mut self.xz[g as usize * stride..(g as usize + 1) * stride];
+
+            let xa = (row[a_word] >> a_bit) & 1;
+            let xb = (row[b_word] >> b_bit) & 1;
+            if xa != xb {
+                row[a_word] ^= a_mask;
+                row[b_word] ^= b_mask;
+            }
+
+            let za = (row[nw + a_word] >> a_bit) & 1;
+            let zb = (row[nw + b_word] >> b_bit) & 1;
+            if za != zb {
+                row[nw + a_word] ^= a_mask;
+                row[nw + b_word] ^= b_mask;
+            }
+
+            let new_xa = (row[a_word] >> a_bit) & 1;
+            let new_za = (row[nw + a_word] >> a_bit) & 1;
+            let new_xb = (row[b_word] >> b_bit) & 1;
+            let new_zb = (row[nw + b_word] >> b_bit) & 1;
+
+            if (new_xa | new_za) != 0 {
+                self.sgi_new_a.push(g);
+            }
+            if (new_xb | new_zb) != 0 {
+                self.sgi_new_b.push(g);
+            }
+        }
+
+        std::mem::swap(&mut self.qubit_active[a], &mut self.sgi_new_a);
+        std::mem::swap(&mut self.qubit_active[b], &mut self.sgi_new_b);
+        let ma = self.qubit_active[a].len();
+        let mb = self.qubit_active[b].len();
+        if ma > self.sgi_max_active {
+            self.sgi_max_active = ma;
+        }
+        if mb > self.sgi_max_active {
+            self.sgi_max_active = mb;
+        }
+    }
+
+    fn sgi_dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        match gate {
+            Gate::Id => {}
+            Gate::X | Gate::Y | Gate::Z | Gate::H | Gate::S | Gate::Sdg | Gate::SX | Gate::SXdg => {
+                self.sgi_apply_1q(gate, targets[0]);
+            }
+            Gate::Cx => self.sgi_apply_cx(targets[0], targets[1]),
+            Gate::Cz => self.sgi_apply_cz(targets[0], targets[1]),
+            Gate::Swap => self.sgi_apply_swap(targets[0], targets[1]),
+            _ => {
+                return Err(PrismError::BackendUnsupported {
+                    backend: self.name().to_string(),
+                    operation: format!(
+                        "non-Clifford gate `{}` (stabilizer backend supports Clifford gates only)",
+                        gate.name()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn sgi_measure(&mut self, qubit: usize, classical_bit: usize) {
+        let n = self.n;
+        let word = qubit / 64;
+        let bit_mask = 1u64 << (qubit % 64);
+        let stride = self.stride();
+
+        let mut p_row: Option<usize> = None;
+        for &g in &self.qubit_active[qubit] {
+            let g = g as usize;
+            if g >= n && g < 2 * n && self.xz[g * stride + word] & bit_mask != 0 {
+                p_row = Some(g);
+                break;
+            }
+        }
+
+        if let Some(p_row) = p_row {
+            self.sgi_measure_random(p_row, qubit, classical_bit);
+        } else {
+            let scratch = 2 * n;
+            self.zero_row(scratch);
+
+            let destab_active: SmallVec<[usize; 32]> = self.qubit_active[qubit]
+                .iter()
+                .filter_map(|&g| {
+                    let g = g as usize;
+                    if g < n && self.xz[g * stride + word] & bit_mask != 0 {
+                        Some(g)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for g in destab_active {
+                self.rowmul(scratch, g + n);
+            }
+
+            let outcome = self.phase[scratch];
+            self.classical_bits[classical_bit] = outcome;
+        }
+    }
+
+    fn sgi_measure_random(&mut self, p_row: usize, qubit: usize, classical_bit: usize) {
+        let n = self.n;
+        let nw = self.num_words;
+        let stride = self.stride();
+        let word = qubit / 64;
+        let bit_mask = 1u64 << (qubit % 64);
+
+        let p_base = p_row * stride;
+        let p_data: SmallVec<[u64; 32]> = SmallVec::from_slice(&self.xz[p_base..p_base + stride]);
+        let p_phase = self.phase[p_row];
+
+        for i in 0..2 * n {
+            if i == p_row {
+                continue;
+            }
+            if self.xz[i * stride + word] & bit_mask != 0 {
+                let initial_sum =
+                    if p_phase { 2u64 } else { 0 } + if self.phase[i] { 2u64 } else { 0 };
+                let row = &mut self.xz[i * stride..(i + 1) * stride];
+                let (rx, rz) = row.split_at_mut(nw);
+                let sum = rowmul_words(
+                    rx,
+                    &mut rz[..nw],
+                    &p_data[..nw],
+                    &p_data[nw..2 * nw],
+                    initial_sum,
+                );
+                self.phase[i] = (sum & 3) >= 2;
+            }
+        }
+
+        let d_row = p_row - n;
+        let d_base = d_row * stride;
+        self.xz.copy_within(p_base..p_base + stride, d_base);
+        self.phase[d_row] = self.phase[p_row];
+
+        self.zero_row(p_row);
+        let outcome: bool = self.rng.gen();
+        self.phase[p_row] = outcome;
+        self.xz[p_row * stride + nw + word] |= bit_mask;
+
+        self.classical_bits[classical_bit] = outcome;
+
+        self.rebuild_qubit_active();
+    }
+
+    fn rebuild_qubit_active(&mut self) {
+        let n = self.n;
+        let stride = self.stride();
+        let nw = self.num_words;
+
+        for list in &mut self.qubit_active {
+            list.clear();
+        }
+        self.total_weight = 0;
+
+        for g in 0..2 * n {
+            let row = &self.xz[g * stride..(g + 1) * stride];
+            for w in 0..nw {
+                let active = row[w] | row[nw + w];
+                let mut bits = active;
+                while bits != 0 {
+                    let b = bits.trailing_zeros() as usize;
+                    let q = w * 64 + b;
+                    if q < n {
+                        self.qubit_active[q].push(g as u32);
+                        self.total_weight += 1;
+                    }
+                    bits &= bits - 1;
+                }
+            }
+        }
+        self.sgi_max_active = self.qubit_active.iter().map(|a| a.len()).max().unwrap_or(0);
+    }
+
     /// Multiply row `h` by row `i` (replace `h` with the Pauli product).
     ///
-    /// Fused phase+XOR: Aaronson-Gottesman g-function with wordwise popcount,
-    /// with the row XOR update performed in the same loop to eliminate a
-    /// separate memory pass.
+    /// Fused phase+XOR: AG g-function with wordwise popcount, row XOR in the
+    /// same loop to avoid a separate memory pass.
     fn rowmul(&mut self, h: usize, i: usize) {
         let stride = self.stride();
         let nw = self.num_words;
         let base_h = h * stride;
         let base_i = i * stride;
 
-        let mut sum = if self.phase[i] { 2u64 } else { 0 } + if self.phase[h] { 2u64 } else { 0 };
+        let initial_sum =
+            if self.phase[i] { 2u64 } else { 0 } + if self.phase[h] { 2u64 } else { 0 };
 
-        for w in 0..nw {
-            let x1 = self.xz[base_i + w];
-            let z1 = self.xz[base_i + nw + w];
-            let x2 = self.xz[base_h + w];
-            let z2 = self.xz[base_h + nw + w];
+        // SAFETY: h != i in all callers, so row regions [base_h..base_h+stride]
+        // and [base_i..base_i+stride] are non-overlapping.
+        let (dst_x, dst_z, src_x, src_z) = unsafe {
+            let ptr = self.xz.as_mut_ptr();
+            (
+                std::slice::from_raw_parts_mut(ptr.add(base_h), nw),
+                std::slice::from_raw_parts_mut(ptr.add(base_h + nw), nw),
+                std::slice::from_raw_parts(ptr.add(base_i) as *const u64, nw),
+                std::slice::from_raw_parts(ptr.add(base_i + nw) as *const u64, nw),
+            )
+        };
 
-            let new_x = x1 ^ x2;
-            let new_z = z1 ^ z2;
-            self.xz[base_h + w] = new_x;
-            self.xz[base_h + nw + w] = new_z;
-
-            if (x1 | z1 | x2 | z2) == 0 {
-                continue;
-            }
-
-            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
-            let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
-            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
-            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
-        }
-
+        let sum = rowmul_words(dst_x, dst_z, src_x, src_z, initial_sum);
         self.phase[h] = (sum & 3) >= 2;
     }
 
@@ -703,6 +1368,14 @@ impl StabilizerBackend {
     }
 
     fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
+        self.apply_measure_with_info(qubit, classical_bit);
+    }
+
+    pub(crate) fn apply_measure_with_info(
+        &mut self,
+        qubit: usize,
+        classical_bit: usize,
+    ) -> (bool, Vec<usize>) {
         let n = self.n;
         let word = qubit / 64;
         let bit_mask = 1u64 << (qubit % 64);
@@ -717,7 +1390,15 @@ impl StabilizerBackend {
         }
 
         if let Some(p_row) = p {
+            let p_base = p_row * stride;
+            let mut support = Vec::new();
+            for q in 0..n {
+                if self.xz[p_base + q / 64] & (1u64 << (q % 64)) != 0 {
+                    support.push(q);
+                }
+            }
             self.measure_random(p_row, word, bit_mask, classical_bit);
+            (true, support)
         } else {
             let scratch = 2 * n;
             self.zero_row(scratch);
@@ -730,14 +1411,181 @@ impl StabilizerBackend {
 
             let outcome = self.phase[scratch];
             self.classical_bits[classical_bit] = outcome;
+            (false, Vec::new())
         }
     }
 
-    /// Random-outcome measurement: rowmul all anti-commuting rows against the
-    /// pivot, then collapse the pivot to a Z-eigenstate.
-    ///
-    /// All rowmul(i, p_row) calls are independent (same read-only source, disjoint
-    /// destinations), enabling parallel execution at high qubit counts.
+    pub(crate) fn batch_measure_ref_info(
+        &mut self,
+        measurements: &[(usize, usize)],
+    ) -> (Vec<bool>, Vec<Vec<usize>>, Vec<bool>) {
+        let num_meas = measurements.len();
+        let n = self.n;
+        let nw = self.num_words;
+        let stride = self.stride();
+
+        let mut is_random = vec![false; num_meas];
+        let mut random_x_support: Vec<Vec<usize>> = vec![Vec::new(); num_meas];
+        let mut outcomes = vec![false; num_meas];
+
+        let mut qubit_to_meas: Vec<usize> = vec![usize::MAX; n];
+        for (mi, &(qubit, _)) in measurements.iter().enumerate() {
+            qubit_to_meas[qubit] = mi;
+        }
+
+        let mut first_destab = vec![usize::MAX; num_meas];
+        let mut match_count = vec![0u16; num_meas];
+        let mut match_a = vec![0usize; num_meas];
+        let mut match_b = vec![0usize; num_meas];
+
+        let build_index = |first_destab: &mut [usize],
+                           match_count: &mut [u16],
+                           match_a: &mut [usize],
+                           match_b: &mut [usize],
+                           xz: &[u64],
+                           qubit_to_meas: &[usize],
+                           n: usize,
+                           nw: usize,
+                           stride: usize,
+                           num_meas: usize| {
+            first_destab.iter_mut().for_each(|v| *v = usize::MAX);
+            match_count.iter_mut().for_each(|v| *v = 0);
+            for r in 0..2 * n {
+                let r_base = r * stride;
+                for w in 0..nw {
+                    let x_word = xz[r_base + w];
+                    if x_word == 0 {
+                        continue;
+                    }
+                    let mut bits = x_word;
+                    while bits != 0 {
+                        let b = bits.trailing_zeros() as usize;
+                        let q = w * 64 + b;
+                        if q < n {
+                            let mi = qubit_to_meas[q];
+                            if mi < num_meas {
+                                if r >= n {
+                                    if first_destab[mi] == usize::MAX {
+                                        first_destab[mi] = r;
+                                    }
+                                } else {
+                                    let c = match_count[mi];
+                                    if c == 0 {
+                                        match_a[mi] = r;
+                                    } else if c == 1 {
+                                        match_b[mi] = r;
+                                    }
+                                    match_count[mi] = c.saturating_add(1);
+                                }
+                            }
+                        }
+                        bits &= bits - 1;
+                    }
+                }
+            }
+        };
+
+        build_index(
+            &mut first_destab,
+            &mut match_count,
+            &mut match_a,
+            &mut match_b,
+            &self.xz,
+            &qubit_to_meas,
+            n,
+            nw,
+            stride,
+            num_meas,
+        );
+
+        for mi in 0..num_meas {
+            let (qubit, classical_bit) = measurements[mi];
+            if first_destab[mi] != usize::MAX {
+                let (_, support) = self.apply_measure_with_info(qubit, classical_bit);
+                is_random[mi] = true;
+                outcomes[mi] = self.classical_bits[classical_bit];
+                random_x_support[mi] = support;
+                build_index(
+                    &mut first_destab,
+                    &mut match_count,
+                    &mut match_a,
+                    &mut match_b,
+                    &self.xz,
+                    &qubit_to_meas,
+                    n,
+                    nw,
+                    stride,
+                    num_meas,
+                );
+            }
+        }
+
+        let mut all_diagonal = true;
+        'diag_check: for i in 0..n {
+            let base = (i + n) * stride;
+            for w in 0..nw {
+                if self.xz[base + w] != 0 {
+                    all_diagonal = false;
+                    break 'diag_check;
+                }
+            }
+        }
+
+        if all_diagonal {
+            for i in 0..n {
+                let phase_i = self.phase[i + n];
+                if !phase_i {
+                    continue;
+                }
+                let base = i * stride;
+                for w in 0..nw {
+                    let x_word = self.xz[base + w];
+                    if x_word == 0 {
+                        continue;
+                    }
+                    let mut bits = x_word;
+                    while bits != 0 {
+                        let b = bits.trailing_zeros() as usize;
+                        let q = w * 64 + b;
+                        if q < n {
+                            let mi = qubit_to_meas[q];
+                            if mi < num_meas && !is_random[mi] {
+                                outcomes[mi] ^= true;
+                            }
+                        }
+                        bits &= bits - 1;
+                    }
+                }
+            }
+            for mi in 0..num_meas {
+                if !is_random[mi] {
+                    self.classical_bits[measurements[mi].1] = outcomes[mi];
+                }
+            }
+        } else {
+            for mi in 0..num_meas {
+                if is_random[mi] {
+                    continue;
+                }
+                let (qubit, classical_bit) = measurements[mi];
+                let word = qubit / 64;
+                let bit_mask = 1u64 << (qubit % 64);
+                let scratch = 2 * n;
+                self.zero_row(scratch);
+                for i in 0..n {
+                    if self.xz[i * stride + word] & bit_mask != 0 {
+                        self.rowmul(scratch, i + n);
+                    }
+                }
+                outcomes[mi] = self.phase[scratch];
+                self.classical_bits[classical_bit] = outcomes[mi];
+            }
+        }
+        (is_random, random_x_support, outcomes)
+    }
+
+    /// Random-outcome measurement: rowmul anti-commuting rows against the pivot,
+    /// then collapse to a Z-eigenstate. Parallelizable (disjoint destinations).
     fn measure_random(&mut self, p_row: usize, word: usize, bit_mask: u64, classical_bit: usize) {
         let n = self.n;
         let nw = self.num_words;
@@ -747,99 +1595,72 @@ impl StabilizerBackend {
         let p_data: SmallVec<[u64; 32]> = SmallVec::from_slice(&self.xz[p_base..p_base + stride]);
         let p_phase = self.phase[p_row];
 
-        let rowmul_inline = |row: &mut [u64], phase: &mut bool| {
-            let mut sum = if p_phase { 2u64 } else { 0 } + if *phase { 2u64 } else { 0 };
-
-            for w in 0..nw {
-                let x1 = p_data[w];
-                let z1 = p_data[nw + w];
-                let x2 = row[w];
-                let z2 = row[nw + w];
-
-                let new_x = x1 ^ x2;
-                let new_z = z1 ^ z2;
-                row[w] = new_x;
-                row[nw + w] = new_z;
-
-                if (x1 | z1 | x2 | z2) == 0 {
-                    continue;
-                }
-
-                let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
-                let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
-                sum = sum.wrapping_add(2 * pos.count_ones() as u64);
-                sum = sum.wrapping_sub(nonzero.count_ones() as u64);
-            }
-
-            *phase = (sum & 3) >= 2;
-        };
+        let anti_rows: SmallVec<[usize; 16]> = (0..2 * n)
+            .filter(|&r| r != p_row && self.xz[r * stride + word] & bit_mask != 0)
+            .collect();
 
         #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
+        if self.n >= MIN_QUBITS_FOR_PAR_GATES && anti_rows.len() >= MIN_ANTI_ROWS_FOR_PAR {
             use rayon::prelude::*;
 
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .enumerate()
-                .for_each(|(row_idx, (row, phase))| {
-                    if row_idx == p_row || row_idx >= 2 * n {
-                        return;
-                    }
-                    if row[word] & bit_mask == 0 {
-                        return;
-                    }
+            let xz_ptr = SendU64Ptr(self.xz.as_mut_ptr());
+            let phase_ptr = SendBoolPtr(self.phase.as_mut_ptr());
 
-                    let mut sum = if p_phase { 2u64 } else { 0 } + if *phase { 2u64 } else { 0 };
+            // SAFETY: Each row index in anti_rows is unique (collected from a filter
+            // with no duplicates) and none equals p_row. Each row occupies
+            // [row*stride .. (row+1)*stride] in xz — non-overlapping regions.
+            // Phase elements are at distinct indices. p_data is a separate copy.
+            anti_rows.par_iter().for_each(|&r| {
+                let xz_base = xz_ptr.ptr();
+                let ph_base = phase_ptr.ptr();
+                let row =
+                    unsafe { std::slice::from_raw_parts_mut(xz_base.add(r * stride), stride) };
+                let phase = unsafe { &mut *ph_base.add(r) };
 
-                    for w in 0..nw {
-                        let x1 = p_data[w];
-                        let z1 = p_data[nw + w];
-                        let x2 = row[w];
-                        let z2 = row[nw + w];
-
-                        let new_x = x1 ^ x2;
-                        let new_z = z1 ^ z2;
-                        row[w] = new_x;
-                        row[nw + w] = new_z;
-
-                        if (x1 | z1 | x2 | z2) == 0 {
-                            continue;
-                        }
-
-                        let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
-                        let pos =
-                            (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
-                        sum = sum.wrapping_add(2 * pos.count_ones() as u64);
-                        sum = sum.wrapping_sub(nonzero.count_ones() as u64);
-                    }
-
-                    *phase = (sum & 3) >= 2;
-                });
-            // skip sequential fallthrough
+                let initial_sum = if p_phase { 2u64 } else { 0 } + if *phase { 2u64 } else { 0 };
+                let (rx, rz) = row.split_at_mut(nw);
+                let sum = rowmul_words(
+                    rx,
+                    &mut rz[..nw],
+                    &p_data[..nw],
+                    &p_data[nw..2 * nw],
+                    initial_sum,
+                );
+                *phase = (sum & 3) >= 2;
+            });
         } else {
-            let anti_rows: SmallVec<[usize; 16]> = (0..2 * n)
-                .filter(|&r| r != p_row && self.xz[r * stride + word] & bit_mask != 0)
-                .collect();
             for &r in &anti_rows {
                 let base = r * stride;
                 let row = &mut self.xz[base..base + stride];
                 let phase = &mut self.phase[r];
-                rowmul_inline(row, phase);
+                let initial_sum = if p_phase { 2u64 } else { 0 } + if *phase { 2u64 } else { 0 };
+                let (rx, rz) = row.split_at_mut(nw);
+                let sum = rowmul_words(
+                    rx,
+                    &mut rz[..nw],
+                    &p_data[..nw],
+                    &p_data[nw..2 * nw],
+                    initial_sum,
+                );
+                *phase = (sum & 3) >= 2;
             }
         }
 
         #[cfg(not(feature = "parallel"))]
-        {
-            let anti_rows: SmallVec<[usize; 16]> = (0..2 * n)
-                .filter(|&r| r != p_row && self.xz[r * stride + word] & bit_mask != 0)
-                .collect();
-            for &r in &anti_rows {
-                let base = r * stride;
-                let row = &mut self.xz[base..base + stride];
-                let phase = &mut self.phase[r];
-                rowmul_inline(row, phase);
-            }
+        for &r in &anti_rows {
+            let base = r * stride;
+            let row = &mut self.xz[base..base + stride];
+            let phase = &mut self.phase[r];
+            let initial_sum = if p_phase { 2u64 } else { 0 } + if *phase { 2u64 } else { 0 };
+            let (rx, rz) = row.split_at_mut(nw);
+            let sum = rowmul_words(
+                rx,
+                &mut rz[..nw],
+                &p_data[..nw],
+                &p_data[nw..2 * nw],
+                initial_sum,
+            );
+            *phase = (sum & 3) >= 2;
         }
 
         let dest_row = p_row - n;
@@ -1045,28 +1866,21 @@ impl StabilizerBackend {
                     }
                     let row_off = row * nw;
                     if (stab_x[row_off + w] >> b) & 1 == 1 {
-                        let mut sum = if stab_phase[pr] { 2u64 } else { 0 }
+                        let initial_sum = if stab_phase[pr] { 2u64 } else { 0 }
                             + if stab_phase[row] { 2u64 } else { 0 };
-                        for ww in 0..nw {
-                            let x1 = stab_x[pr_off + ww];
-                            let z1 = stab_z[pr_off + ww];
-                            let x2 = stab_x[row_off + ww];
-                            let z2 = stab_z[row_off + ww];
-
-                            let new_x = x1 ^ x2;
-                            let new_z = z1 ^ z2;
-                            stab_x[row_off + ww] = new_x;
-                            stab_z[row_off + ww] = new_z;
-
-                            if (x1 | z1 | x2 | z2) == 0 {
-                                continue;
-                            }
-                            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
-                            let pos =
-                                (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
-                            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
-                            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
-                        }
+                        // SAFETY: row != pr, so [row_off..row_off+nw] and
+                        // [pr_off..pr_off+nw] are non-overlapping regions.
+                        let (dst_x, dst_z, src_x, src_z) = unsafe {
+                            let xp = stab_x.as_mut_ptr();
+                            let zp = stab_z.as_mut_ptr();
+                            (
+                                std::slice::from_raw_parts_mut(xp.add(row_off), nw),
+                                std::slice::from_raw_parts_mut(zp.add(row_off), nw),
+                                std::slice::from_raw_parts(xp.add(pr_off) as *const u64, nw),
+                                std::slice::from_raw_parts(zp.add(pr_off) as *const u64, nw),
+                            )
+                        };
+                        let sum = rowmul_words(dst_x, dst_z, src_x, src_z, initial_sum);
                         stab_phase[row] = (sum & 3) >= 2;
                     }
                 }
@@ -1375,6 +2189,122 @@ impl StabilizerBackend {
         }
     }
 
+    fn pcc_apply_cross_word(&mut self, cross_word: &[CrossWordGate]) {
+        let total_rows = 2 * self.n + 1;
+        let col_words = total_rows.div_ceil(64);
+        let nw = self.num_words;
+        let stride = self.stride();
+
+        let mut qubit_to_idx = vec![u32::MAX; self.n];
+        let mut idx_to_qubit: Vec<usize> = Vec::new();
+        for g in cross_word {
+            let q0 = g.w0 as usize * 64 + g.b0 as usize;
+            let q1 = g.w1 as usize * 64 + g.b1 as usize;
+            if qubit_to_idx[q0] == u32::MAX {
+                qubit_to_idx[q0] = idx_to_qubit.len() as u32;
+                idx_to_qubit.push(q0);
+            }
+            if qubit_to_idx[q1] == u32::MAX {
+                qubit_to_idx[q1] = idx_to_qubit.len() as u32;
+                idx_to_qubit.push(q1);
+            }
+        }
+        let num_cached = idx_to_qubit.len();
+        let mut x_cols = vec![0u64; num_cached * col_words];
+        let mut z_cols = vec![0u64; num_cached * col_words];
+
+        let qubit_info: Vec<(usize, u64)> = idx_to_qubit
+            .iter()
+            .map(|&q| (q / 64, 1u64 << (q % 64)))
+            .collect();
+
+        for (ci, &(word, mask)) in qubit_info.iter().enumerate() {
+            let x_off = ci * col_words;
+            let z_off = ci * col_words;
+            for (row_idx, row) in self.xz.chunks(stride).enumerate() {
+                let cw = row_idx / 64;
+                let cb = row_idx % 64;
+                if row[word] & mask != 0 {
+                    x_cols[x_off + cw] |= 1u64 << cb;
+                }
+                if row[nw + word] & mask != 0 {
+                    z_cols[z_off + cw] |= 1u64 << cb;
+                }
+            }
+        }
+
+        let mut phase_col = vec![0u64; col_words];
+        for (i, p) in self.phase.iter().enumerate() {
+            if *p {
+                phase_col[i / 64] |= 1u64 << (i % 64);
+            }
+        }
+
+        for g in cross_word {
+            let q0 = g.w0 as usize * 64 + g.b0 as usize;
+            let q1 = g.w1 as usize * 64 + g.b1 as usize;
+            let i0 = qubit_to_idx[q0] as usize;
+            let i1 = qubit_to_idx[q1] as usize;
+            let off0 = i0 * col_words;
+            let off1 = i1 * col_words;
+
+            match g.kind {
+                BatchGate::CX => {
+                    for w in 0..col_words {
+                        let xa = x_cols[off0 + w];
+                        let za = z_cols[off0 + w];
+                        let xb = x_cols[off1 + w];
+                        let zb = z_cols[off1 + w];
+                        phase_col[w] ^= xa & zb & !(xb ^ za);
+                        x_cols[off1 + w] = xb ^ xa;
+                        z_cols[off0 + w] = za ^ zb;
+                    }
+                }
+                BatchGate::CZ => {
+                    for w in 0..col_words {
+                        let xa = x_cols[off0 + w];
+                        let xb = x_cols[off1 + w];
+                        let za = z_cols[off0 + w];
+                        let zb = z_cols[off1 + w];
+                        phase_col[w] ^= xa & xb & (za ^ zb);
+                        z_cols[off0 + w] = za ^ xb;
+                        z_cols[off1 + w] = zb ^ xa;
+                    }
+                }
+                _ => {
+                    for w in 0..col_words {
+                        let xa = x_cols[off0 + w];
+                        let xb = x_cols[off1 + w];
+                        x_cols[off0 + w] = xb;
+                        x_cols[off1 + w] = xa;
+                        let za = z_cols[off0 + w];
+                        let zb = z_cols[off1 + w];
+                        z_cols[off0 + w] = zb;
+                        z_cols[off1 + w] = za;
+                    }
+                }
+            }
+        }
+
+        for (ci, &(word, mask)) in qubit_info.iter().enumerate() {
+            let bit = mask.trailing_zeros() as usize;
+            let x_off = ci * col_words;
+            let z_off = ci * col_words;
+            for (row_idx, row) in self.xz.chunks_mut(stride).enumerate() {
+                let cw = row_idx / 64;
+                let cb = row_idx % 64;
+                let xbit = (x_cols[x_off + cw] >> cb) & 1;
+                row[word] = (row[word] & !mask) | (xbit << bit);
+                let zbit = (z_cols[z_off + cw] >> cb) & 1;
+                row[nw + word] = (row[nw + word] & !mask) | (zbit << bit);
+            }
+        }
+
+        for (i, p) in self.phase.iter_mut().enumerate() {
+            *p = (phase_col[i / 64] >> (i % 64)) & 1 == 1;
+        }
+    }
+
     /// Flush all word groups and apply all buffered cross-word 2q gates in a
     /// single row iteration.
     ///
@@ -1395,6 +2325,13 @@ impl StabilizerBackend {
 
         if !has_cw {
             self.flush_all_word_groups(word_groups);
+            return;
+        }
+
+        if self.n >= 256 && cross_word.len() >= 4 {
+            self.flush_all_word_groups(word_groups);
+            self.pcc_apply_cross_word(cross_word);
+            cross_word.clear();
             return;
         }
 
@@ -1591,93 +2528,39 @@ impl StabilizerBackend {
         }
     }
 
-    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
-        match gate {
-            Gate::Id => {}
-            Gate::X => self.apply_x(targets[0]),
-            Gate::Y => self.apply_y(targets[0]),
-            Gate::Z => self.apply_z(targets[0]),
-            Gate::H => self.apply_h(targets[0]),
-            Gate::S => self.apply_s(targets[0]),
-            Gate::Sdg => self.apply_sdg(targets[0]),
-            Gate::SX => self.apply_sx(targets[0]),
-            Gate::SXdg => self.apply_sxdg(targets[0]),
-            Gate::Cx => self.apply_cx(targets[0], targets[1]),
-            Gate::Cz => self.apply_cz(targets[0], targets[1]),
-            Gate::Swap => self.apply_swap(targets[0], targets[1]),
-            _ => {
-                return Err(PrismError::BackendUnsupported {
-                    backend: self.name().to_string(),
-                    operation: format!(
-                        "non-Clifford gate `{}` (stabilizer backend supports Clifford gates only)",
-                        gate.name()
-                    ),
-                });
+    fn apply_instructions_sgi(&mut self, instructions: &[Instruction]) -> Result<()> {
+        for (idx, instruction) in instructions.iter().enumerate() {
+            if !self.sgi_enabled() {
+                return self.apply_instructions_word_batch(&instructions[idx..]);
             }
-        }
-        Ok(())
-    }
-}
 
-impl Backend for StabilizerBackend {
-    fn name(&self) -> &'static str {
-        "stabilizer"
-    }
-
-    fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
-        let n = num_qubits;
-        let nw = n.div_ceil(64);
-        let total_rows = 2 * n + 1;
-        let stride = 2 * nw;
-
-        self.n = n;
-        self.num_words = nw;
-
-        self.xz = vec![0u64; total_rows * stride];
-        self.phase = vec![false; total_rows];
-
-        for i in 0..n {
-            let word = i / 64;
-            let bit = i % 64;
-            self.xz[i * stride + word] |= 1u64 << bit;
-            self.xz[(i + n) * stride + nw + word] |= 1u64 << bit;
-        }
-
-        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
-        Ok(())
-    }
-
-    fn apply(&mut self, instruction: &Instruction) -> Result<()> {
-        match instruction {
-            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
-            Instruction::Measure {
-                qubit,
-                classical_bit,
-            } => {
-                self.apply_measure(*qubit, *classical_bit);
-            }
-            Instruction::Barrier { .. } => {}
-            Instruction::Conditional {
-                condition,
-                gate,
-                targets,
-            } => {
-                if condition.evaluate(&self.classical_bits) {
-                    self.dispatch_gate(gate, targets)?;
+            match instruction {
+                Instruction::Gate { gate, targets } => {
+                    self.sgi_dispatch_gate(gate, targets)?;
+                }
+                Instruction::Measure {
+                    qubit,
+                    classical_bit,
+                } => {
+                    self.sgi_measure(*qubit, *classical_bit);
+                }
+                Instruction::Barrier { .. } => {}
+                Instruction::Conditional {
+                    condition,
+                    gate,
+                    targets,
+                } => {
+                    if condition.evaluate(&self.classical_bits) {
+                        self.sgi_dispatch_gate(gate, targets)?;
+                    }
                 }
             }
         }
         Ok(())
     }
 
-    fn apply_instructions(&mut self, instructions: &[Instruction]) -> Result<()> {
+    fn apply_instructions_word_batch(&mut self, instructions: &[Instruction]) -> Result<()> {
         let nw = self.num_words;
-        if nw < MIN_WORDS_FOR_BATCH {
-            for instruction in instructions {
-                self.apply(instruction)?;
-            }
-            return Ok(());
-        }
         let mut word_groups: Vec<Vec<BatchGate>> = vec![Vec::new(); nw];
         let mut cross_word: Vec<CrossWordGate> = Vec::new();
         let mut cross_word_qubits: Vec<u64> = vec![0u64; nw];
@@ -1740,6 +2623,105 @@ impl Backend for StabilizerBackend {
         Ok(())
     }
 
+    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        match gate {
+            Gate::Id => {}
+            Gate::X => self.apply_x(targets[0]),
+            Gate::Y => self.apply_y(targets[0]),
+            Gate::Z => self.apply_z(targets[0]),
+            Gate::H => self.apply_h(targets[0]),
+            Gate::S => self.apply_s(targets[0]),
+            Gate::Sdg => self.apply_sdg(targets[0]),
+            Gate::SX => self.apply_sx(targets[0]),
+            Gate::SXdg => self.apply_sxdg(targets[0]),
+            Gate::Cx => self.apply_cx(targets[0], targets[1]),
+            Gate::Cz => self.apply_cz(targets[0], targets[1]),
+            Gate::Swap => self.apply_swap(targets[0], targets[1]),
+            _ => {
+                return Err(PrismError::BackendUnsupported {
+                    backend: self.name().to_string(),
+                    operation: format!(
+                        "non-Clifford gate `{}` (stabilizer backend supports Clifford gates only)",
+                        gate.name()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Backend for StabilizerBackend {
+    fn name(&self) -> &'static str {
+        "stabilizer"
+    }
+
+    fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        let n = num_qubits;
+        let nw = n.div_ceil(64);
+        let total_rows = 2 * n + 1;
+        let stride = 2 * nw;
+
+        self.n = n;
+        self.num_words = nw;
+
+        self.xz = vec![0u64; total_rows * stride];
+        self.phase = vec![false; total_rows];
+
+        for i in 0..n {
+            let word = i / 64;
+            let bit = i % 64;
+            self.xz[i * stride + word] |= 1u64 << bit;
+            self.xz[(i + n) * stride + nw + word] |= 1u64 << bit;
+        }
+
+        self.qubit_active = (0..n).map(|q| vec![q as u32, (n + q) as u32]).collect();
+        self.total_weight = 2 * n;
+        self.sgi_max_active = 2;
+
+        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
+        Ok(())
+    }
+
+    fn apply(&mut self, instruction: &Instruction) -> Result<()> {
+        match instruction {
+            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => {
+                self.apply_measure(*qubit, *classical_bit);
+            }
+            Instruction::Barrier { .. } => {}
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => {
+                if condition.evaluate(&self.classical_bits) {
+                    self.dispatch_gate(gate, targets)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_instructions(&mut self, instructions: &[Instruction]) -> Result<()> {
+        let nw = self.num_words;
+        if nw < MIN_WORDS_FOR_BATCH {
+            for instruction in instructions {
+                self.apply(instruction)?;
+            }
+            return Ok(());
+        }
+
+        if self.sgi_enabled() {
+            return self.apply_instructions_sgi(instructions);
+        }
+
+        self.apply_instructions_word_batch(instructions)
+    }
+
     fn classical_results(&self) -> &[bool] {
         &self.classical_bits
     }
@@ -1780,6 +2762,338 @@ impl Backend for StabilizerBackend {
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         self.export_statevector()
+    }
+}
+
+pub struct FilteredStabilizerBackend {
+    num_qubits: usize,
+    num_classical_bits: usize,
+    clusters: Vec<Option<ClusterState>>,
+    qubit_to_cluster: Vec<usize>,
+    classical_bits: Vec<bool>,
+    seed: u64,
+}
+
+struct ClusterState {
+    backend: StabilizerBackend,
+    qubits: Vec<usize>,
+    global_to_local: Vec<usize>,
+    local_classical: Vec<usize>,
+}
+
+impl FilteredStabilizerBackend {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            num_qubits: 0,
+            num_classical_bits: 0,
+            clusters: Vec::new(),
+            qubit_to_cluster: Vec::new(),
+            classical_bits: Vec::new(),
+            seed,
+        }
+    }
+
+    pub fn init_with_blocks(
+        &mut self,
+        num_qubits: usize,
+        num_classical_bits: usize,
+        blocks: &[Vec<usize>],
+    ) -> Result<()> {
+        self.num_qubits = num_qubits;
+        self.num_classical_bits = num_classical_bits;
+        self.qubit_to_cluster = vec![0; num_qubits];
+        self.clusters = Vec::with_capacity(blocks.len());
+
+        for (bi, block) in blocks.iter().enumerate() {
+            for &q in block {
+                self.qubit_to_cluster[q] = bi;
+            }
+
+            let mut backend = StabilizerBackend::new(self.seed.wrapping_add(bi as u64));
+            backend.init(block.len(), 0)?;
+
+            let mut g2l = vec![0usize; num_qubits];
+            for (li, &q) in block.iter().enumerate() {
+                g2l[q] = li;
+            }
+
+            self.clusters.push(Some(ClusterState {
+                backend,
+                qubits: block.clone(),
+                global_to_local: g2l,
+                local_classical: Vec::new(),
+            }));
+        }
+
+        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
+        Ok(())
+    }
+
+    fn merge_clusters(&mut self, ci_a: usize, ci_b: usize) {
+        if ci_a == ci_b {
+            return;
+        }
+
+        let (keep, merge) = if ci_a < ci_b {
+            (ci_a, ci_b)
+        } else {
+            (ci_b, ci_a)
+        };
+        let merge_state = self.clusters[merge].take().unwrap();
+
+        let keep_state = self.clusters[keep].as_mut().unwrap();
+
+        let old_n = keep_state.qubits.len();
+        let merge_n = merge_state.qubits.len();
+        let new_n = old_n + merge_n;
+
+        let mut merged_qubits = keep_state.qubits.clone();
+        merged_qubits.extend_from_slice(&merge_state.qubits);
+
+        let mut new_backend = StabilizerBackend::new(self.seed.wrapping_add(keep as u64 * 1000));
+        new_backend.init(new_n, 0).unwrap();
+
+        copy_tableau_into(&keep_state.backend, &mut new_backend, 0);
+        copy_tableau_into(&merge_state.backend, &mut new_backend, old_n);
+
+        let mut merged_classical = keep_state.local_classical.clone();
+        merged_classical.extend_from_slice(&merge_state.local_classical);
+        new_backend
+            .classical_bits
+            .resize(merged_classical.len(), false);
+
+        let mut g2l = vec![0usize; self.num_qubits];
+        for (li, &q) in merged_qubits.iter().enumerate() {
+            g2l[q] = li;
+            self.qubit_to_cluster[q] = keep;
+        }
+
+        *keep_state = ClusterState {
+            backend: new_backend,
+            qubits: merged_qubits,
+            global_to_local: g2l,
+            local_classical: merged_classical,
+        };
+    }
+
+    fn apply_gate_to_cluster(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        let ci = self.qubit_to_cluster[targets[0]];
+
+        if targets.len() > 1 {
+            for &t in &targets[1..] {
+                let other_ci = self.qubit_to_cluster[t];
+                if other_ci != ci {
+                    self.merge_clusters(ci, other_ci);
+                    return self.apply_gate_to_cluster(gate, targets);
+                }
+            }
+        }
+
+        let cluster = self.clusters[ci].as_mut().unwrap();
+        let local_targets: SmallVec<[usize; 4]> = targets
+            .iter()
+            .map(|&t| cluster.global_to_local[t])
+            .collect();
+
+        let local_inst = Instruction::Gate {
+            gate: gate.clone(),
+            targets: local_targets,
+        };
+        cluster.backend.apply(&local_inst)
+    }
+
+    fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
+        let ci = self.qubit_to_cluster[qubit];
+        let cluster = self.clusters[ci].as_mut().unwrap();
+        let local_q = cluster.global_to_local[qubit];
+
+        let local_cbit = cluster
+            .local_classical
+            .iter()
+            .position(|&cb| cb == classical_bit)
+            .unwrap_or_else(|| {
+                let idx = cluster.local_classical.len();
+                cluster.local_classical.push(classical_bit);
+                if idx >= cluster.backend.classical_bits.len() {
+                    cluster.backend.classical_bits.resize(idx + 1, false);
+                }
+                idx
+            });
+
+        cluster.backend.apply_measure(local_q, local_cbit);
+        self.classical_bits[classical_bit] = cluster.backend.classical_bits[local_cbit];
+    }
+}
+
+fn copy_tableau_into(src: &StabilizerBackend, dst: &mut StabilizerBackend, qubit_offset: usize) {
+    let src_n = src.n;
+    let src_nw = src.num_words;
+    let src_stride = 2 * src_nw;
+    let dst_n = dst.n;
+    let dst_nw = dst.num_words;
+    let dst_stride = 2 * dst_nw;
+
+    for i in 0..src_n {
+        let src_row = i;
+        let dst_row = qubit_offset + i;
+
+        let old_word = (qubit_offset + i) / 64;
+        let old_bit = (qubit_offset + i) % 64;
+        dst.xz[dst_row * dst_stride + old_word] &= !(1u64 << old_bit);
+
+        let q_word_offset = qubit_offset / 64;
+        let q_bit_offset = qubit_offset % 64;
+        if q_bit_offset == 0 {
+            for w in 0..src_nw {
+                dst.xz[dst_row * dst_stride + q_word_offset + w] = src.xz[src_row * src_stride + w];
+            }
+            for w in 0..src_nw {
+                dst.xz[dst_row * dst_stride + dst_nw + q_word_offset + w] =
+                    src.xz[src_row * src_stride + src_nw + w];
+            }
+        } else {
+            for w in 0..src_nw {
+                let val = src.xz[src_row * src_stride + w];
+                dst.xz[dst_row * dst_stride + q_word_offset + w] |= val << q_bit_offset;
+                if q_word_offset + w + 1 < dst_nw {
+                    dst.xz[dst_row * dst_stride + q_word_offset + w + 1] |=
+                        val >> (64 - q_bit_offset);
+                }
+            }
+            for w in 0..src_nw {
+                let val = src.xz[src_row * src_stride + src_nw + w];
+                dst.xz[dst_row * dst_stride + dst_nw + q_word_offset + w] |= val << q_bit_offset;
+                if q_word_offset + w + 1 < dst_nw {
+                    dst.xz[dst_row * dst_stride + dst_nw + q_word_offset + w + 1] |=
+                        val >> (64 - q_bit_offset);
+                }
+            }
+        }
+        dst.phase[dst_row] = src.phase[src_row];
+
+        let src_stab = src_n + i;
+        let dst_stab = dst_n + qubit_offset + i;
+
+        let old_word_s = (qubit_offset + i) / 64;
+        let old_bit_s = (qubit_offset + i) % 64;
+        dst.xz[dst_stab * dst_stride + dst_nw + old_word_s] &= !(1u64 << old_bit_s);
+
+        if q_bit_offset == 0 {
+            for w in 0..src_nw {
+                dst.xz[dst_stab * dst_stride + q_word_offset + w] =
+                    src.xz[src_stab * src_stride + w];
+            }
+            for w in 0..src_nw {
+                dst.xz[dst_stab * dst_stride + dst_nw + q_word_offset + w] =
+                    src.xz[src_stab * src_stride + src_nw + w];
+            }
+        } else {
+            for w in 0..src_nw {
+                let val = src.xz[src_stab * src_stride + w];
+                dst.xz[dst_stab * dst_stride + q_word_offset + w] |= val << q_bit_offset;
+                if q_word_offset + w + 1 < dst_nw {
+                    dst.xz[dst_stab * dst_stride + q_word_offset + w + 1] |=
+                        val >> (64 - q_bit_offset);
+                }
+            }
+            for w in 0..src_nw {
+                let val = src.xz[src_stab * src_stride + src_nw + w];
+                dst.xz[dst_stab * dst_stride + dst_nw + q_word_offset + w] |= val << q_bit_offset;
+                if q_word_offset + w + 1 < dst_nw {
+                    dst.xz[dst_stab * dst_stride + dst_nw + q_word_offset + w + 1] |=
+                        val >> (64 - q_bit_offset);
+                }
+            }
+        }
+        dst.phase[dst_stab] = src.phase[src_stab];
+    }
+}
+
+impl Backend for FilteredStabilizerBackend {
+    fn name(&self) -> &'static str {
+        "FilteredStabilizer"
+    }
+
+    fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        self.num_qubits = num_qubits;
+        self.num_classical_bits = num_classical_bits;
+        self.qubit_to_cluster = vec![0; num_qubits];
+        self.clusters.clear();
+
+        for i in 0..num_qubits {
+            self.qubit_to_cluster[i] = i;
+            let mut backend = StabilizerBackend::new(self.seed.wrapping_add(i as u64));
+            backend.init(1, 0)?;
+            let mut g2l = vec![0usize; num_qubits];
+            g2l[i] = 0;
+            self.clusters.push(Some(ClusterState {
+                backend,
+                qubits: vec![i],
+                global_to_local: g2l,
+                local_classical: Vec::new(),
+            }));
+        }
+
+        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
+        Ok(())
+    }
+
+    fn apply(&mut self, instruction: &Instruction) -> Result<()> {
+        match instruction {
+            Instruction::Gate { gate, targets } => {
+                self.apply_gate_to_cluster(gate, targets)?;
+            }
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => {
+                self.apply_measure(*qubit, *classical_bit);
+            }
+            Instruction::Barrier { .. } => {}
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => {
+                if condition.evaluate(&self.classical_bits) {
+                    self.apply_gate_to_cluster(gate, targets)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn classical_results(&self) -> &[bool] {
+        &self.classical_bits
+    }
+
+    fn probabilities(&self) -> Result<Vec<f64>> {
+        if self.num_qubits >= crate::backend::MAX_PROB_QUBITS {
+            return Err(PrismError::BackendUnsupported {
+                backend: self.name().to_string(),
+                operation: format!("probability extraction for {} qubits", self.num_qubits),
+            });
+        }
+
+        let mut blocks: Vec<(Vec<f64>, Vec<usize>)> = Vec::new();
+        for cluster in self.clusters.iter().flatten() {
+            let probs = cluster.backend.compute_probabilities();
+            blocks.push((probs, cluster.qubits.clone()));
+        }
+
+        if blocks.len() == 1 && blocks[0].1.iter().enumerate().all(|(i, &q)| i == q) {
+            return Ok(blocks.into_iter().next().unwrap().0);
+        }
+
+        Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
+    }
+
+    fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    fn supports_fused_gates(&self) -> bool {
+        false
     }
 }
 
@@ -2303,5 +3617,380 @@ mod tests {
         b.init(2, 0).unwrap();
         let err = b.apply(&c.instructions[0]).unwrap_err();
         assert!(matches!(err, PrismError::BackendUnsupported { .. }));
+    }
+
+    #[test]
+    fn test_xor_words_various_lengths() {
+        for len in 0..=17 {
+            let src: Vec<u64> = (0..len)
+                .map(|i| 0xAAAA_BBBB_CCCC_0000u64 | i as u64)
+                .collect();
+            let original: Vec<u64> = (0..len)
+                .map(|i| 0x1111_2222_3333_0000u64 | (i as u64 * 7))
+                .collect();
+
+            let mut expected = original.clone();
+            for i in 0..len {
+                expected[i] ^= src[i];
+            }
+
+            let mut actual = original.clone();
+            if len > 0 {
+                unsafe { xor_words(actual.as_mut_ptr(), src.as_ptr(), len) };
+            }
+
+            assert_eq!(actual, expected, "xor_words mismatch at len={len}");
+        }
+    }
+
+    #[test]
+    fn test_xor_words_all_ones_and_zeros() {
+        let len = 8;
+        let src = vec![u64::MAX; len];
+        let mut dst = vec![0u64; len];
+        unsafe { xor_words(dst.as_mut_ptr(), src.as_ptr(), len) };
+        assert!(dst.iter().all(|&v| v == u64::MAX));
+
+        unsafe { xor_words(dst.as_mut_ptr(), src.as_ptr(), len) };
+        assert!(dst.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn test_rowmul_words_zero_src() {
+        let nw = 4;
+        let mut dst_x = vec![0xFFu64; nw];
+        let mut dst_z = vec![0xAAu64; nw];
+        let src_x = vec![0u64; nw];
+        let src_z = vec![0u64; nw];
+        let sum = rowmul_words(&mut dst_x, &mut dst_z, &src_x, &src_z, 0);
+        assert_eq!(dst_x, vec![0xFFu64; nw]);
+        assert_eq!(dst_z, vec![0xAAu64; nw]);
+        assert_eq!(sum & 3, 0);
+    }
+
+    #[test]
+    fn test_rowmul_words_matches_manual() {
+        let nw = 3;
+        let src_x = vec![0b1010u64, 0b1100u64, 0b0011u64];
+        let src_z = vec![0b0110u64, 0b1010u64, 0b1001u64];
+        let orig_dst_x = vec![0b1100u64, 0b0110u64, 0b1010u64];
+        let orig_dst_z = vec![0b0011u64, 0b1001u64, 0b0110u64];
+
+        let mut manual_x = orig_dst_x.clone();
+        let mut manual_z = orig_dst_z.clone();
+        let mut manual_sum = 4u64;
+        for w in 0..nw {
+            let x1 = src_x[w];
+            let z1 = src_z[w];
+            let x2 = manual_x[w];
+            let z2 = manual_z[w];
+            let new_x = x1 ^ x2;
+            let new_z = z1 ^ z2;
+            manual_x[w] = new_x;
+            manual_z[w] = new_z;
+            if (x1 | z1 | x2 | z2) != 0 {
+                let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+                let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+                manual_sum = manual_sum.wrapping_add(2 * pos.count_ones() as u64);
+                manual_sum = manual_sum.wrapping_sub(nonzero.count_ones() as u64);
+            }
+        }
+
+        let mut fn_x = orig_dst_x.clone();
+        let mut fn_z = orig_dst_z.clone();
+        let fn_sum = rowmul_words(&mut fn_x, &mut fn_z, &src_x, &src_z, 4);
+
+        assert_eq!(fn_x, manual_x);
+        assert_eq!(fn_z, manual_z);
+        assert_eq!(fn_sum & 3, manual_sum & 3);
+    }
+
+    #[test]
+    fn test_rowmul_words_phase_y_times_x() {
+        let src_x = vec![1u64];
+        let src_z = vec![1u64];
+        let mut dst_x = vec![1u64];
+        let mut dst_z = vec![0u64];
+        let sum = rowmul_words(&mut dst_x, &mut dst_z, &src_x, &src_z, 0);
+        assert_eq!(dst_x[0], 0);
+        assert_eq!(dst_z[0], 1);
+        assert!(
+            (sum & 3) >= 2,
+            "Y*X should give phase -1 (sum&3={})",
+            sum & 3
+        );
+    }
+
+    #[test]
+    fn test_rowmul_refactor_preserves_ghz_correctness() {
+        let n = 10;
+        let mut c = Circuit::new(n, n);
+        c.add_gate(Gate::H, &[0]);
+        for i in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[i, i + 1]);
+        }
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+
+        for seed in 0..20u64 {
+            let mut b = StabilizerBackend::new(seed);
+            sim::run_on(&mut b, &c).unwrap();
+            let results = b.classical_results();
+            let first = results[0];
+            assert!(
+                results.iter().all(|&r| r == first),
+                "GHZ violation at seed {seed}: {results:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rowmul_refactor_preserves_probabilities() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        let mut b = StabilizerBackend::new(42);
+        sim::run_on(&mut b, &c).unwrap();
+        let probs = b.probabilities().unwrap();
+        assert!((probs[0] - 0.5).abs() < 1e-10);
+        assert!(probs[1].abs() < 1e-10);
+        assert!(probs[2].abs() < 1e-10);
+        assert!((probs[3] - 0.5).abs() < 1e-10);
+        assert!(probs[4].abs() < 1e-10);
+        assert!(probs[5].abs() < 1e-10);
+        assert!((probs[6]).abs() < 1e-10);
+        assert!(probs[7].abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_rowmul_multi_word_correctness() {
+        let n = 65;
+        let mut c = Circuit::new(n, n);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 64]);
+        c.add_measure(0, 0);
+        c.add_measure(64, 1);
+
+        for seed in 0..10u64 {
+            let mut b = StabilizerBackend::new(seed);
+            sim::run_on(&mut b, &c).unwrap();
+            let results = b.classical_results();
+            assert_eq!(
+                results[0], results[1],
+                "Bell pair violation at seed {seed}: q0={}, q64={}",
+                results[0], results[1]
+            );
+        }
+    }
+
+    #[test]
+    fn test_sgi_500q_clifford_d10_matches_gate_by_gate() {
+        use crate::circuits;
+        let n = 500;
+        let mut circuit = circuits::clifford_heavy_circuit(n, 10, 42);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let mut b1 = StabilizerBackend::new(42);
+        b1.init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        for instr in &circuit.instructions {
+            b1.apply(instr).unwrap();
+        }
+        let r1 = b1.classical_results().to_vec();
+
+        let mut b2 = StabilizerBackend::new(42);
+        sim::run_on(&mut b2, &circuit).unwrap();
+        let r2 = b2.classical_results().to_vec();
+
+        assert_eq!(
+            r1, r2,
+            "SGI 500q Clifford d10: gate-by-gate vs apply_instructions mismatch"
+        );
+    }
+
+    #[test]
+    fn test_sgi_300q_ghz_all_agree() {
+        let n = 300;
+        let mut c = Circuit::new(n, n);
+        c.add_gate(Gate::H, &[0]);
+        for i in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[i, i + 1]);
+        }
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let mut b = StabilizerBackend::new(42);
+        sim::run_on(&mut b, &c).unwrap();
+        let results = b.classical_results();
+        assert!(
+            results.iter().all(|&x| x == results[0]),
+            "GHZ 300q: not all qubits agree"
+        );
+    }
+
+    #[test]
+    fn test_sgi_index_consistency() {
+        let n = 300;
+        let mut circuit = crate::circuits::clifford_heavy_circuit(n, 5, 42);
+        circuit.num_classical_bits = 0;
+
+        let mut b = StabilizerBackend::new(42);
+        b.init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        b.apply_instructions(&circuit.instructions).unwrap();
+
+        let stride = b.stride();
+        let nw = b.num_words;
+        for q in 0..n {
+            for &g in &b.qubit_active[q] {
+                let g = g as usize;
+                let row = &b.xz[g * stride..(g + 1) * stride];
+                let word = q / 64;
+                let bit_mask = 1u64 << (q % 64);
+                let x = row[word] & bit_mask;
+                let z = row[nw + word] & bit_mask;
+                assert!(
+                    x != 0 || z != 0,
+                    "qubit_active[{q}] contains generator {g} which has I on qubit {q}"
+                );
+            }
+        }
+
+        for g in 0..2 * n {
+            let row = &b.xz[g * stride..(g + 1) * stride];
+            for q in 0..n {
+                let word = q / 64;
+                let bit_mask = 1u64 << (q % 64);
+                let x = row[word] & bit_mask;
+                let z = row[nw + word] & bit_mask;
+                let active = x != 0 || z != 0;
+                let in_index = b.qubit_active[q].contains(&(g as u32));
+                assert_eq!(
+                    active, in_index,
+                    "generator {g} qubit {q}: active={active} but in_index={in_index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_pcc_random_pairs_matches_gate_by_gate() {
+        use crate::circuits;
+        let n = 500;
+        let mut circuit = circuits::clifford_random_pairs(n, 10, 42);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let mut b1 = StabilizerBackend::new(42);
+        b1.init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        for instr in &circuit.instructions {
+            b1.apply(instr).unwrap();
+        }
+        let r1 = b1.classical_results().to_vec();
+
+        let mut b2 = StabilizerBackend::new(42);
+        sim::run_on(&mut b2, &circuit).unwrap();
+        let r2 = b2.classical_results().to_vec();
+
+        assert_eq!(
+            r1, r2,
+            "PCC 500q random-pairs d10: gate-by-gate vs apply_instructions mismatch"
+        );
+    }
+
+    #[test]
+    fn filtered_bell_pairs_correct() {
+        use crate::circuits;
+
+        // Test pre-measurement probabilities (no RNG dependence)
+        let n_pairs = 5;
+        let n = n_pairs * 2;
+        let circuit = circuits::independent_bell_pairs(n_pairs);
+
+        let mut filt = FilteredStabilizerBackend::new(42);
+        filt.init(n, 0).unwrap();
+        for inst in &circuit.instructions {
+            filt.apply(inst).unwrap();
+        }
+
+        let filt_probs = filt.probabilities().unwrap();
+        let mono_probs = {
+            let mut mono = StabilizerBackend::new(42);
+            mono.init(n, 0).unwrap();
+            mono.apply_instructions(&circuit.instructions).unwrap();
+            mono.compute_probabilities()
+        };
+
+        assert_eq!(filt_probs.len(), mono_probs.len());
+        for (i, (&f, &m)) in filt_probs.iter().zip(mono_probs.iter()).enumerate() {
+            assert!(
+                (f - m).abs() < 1e-10,
+                "prob mismatch at index {i}: filtered={f}, monolithic={m}"
+            );
+        }
+    }
+
+    #[test]
+    fn filtered_bell_pairs_measurement() {
+        use crate::circuits;
+        let n_pairs = 10;
+        let n = n_pairs * 2;
+        let mut circuit = circuits::independent_bell_pairs(n_pairs);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let mut filt = FilteredStabilizerBackend::new(42);
+        filt.init(n, n).unwrap();
+        for inst in &circuit.instructions {
+            filt.apply(inst).unwrap();
+        }
+        let bits = filt.classical_results();
+
+        for i in 0..n_pairs {
+            assert_eq!(
+                bits[2 * i],
+                bits[2 * i + 1],
+                "filtered: bell pair {i} qubits disagree"
+            );
+        }
+    }
+
+    #[test]
+    fn filtered_with_blocks_matches_monolithic() {
+        use crate::circuits;
+        let n_pairs = 5;
+        let n = n_pairs * 2;
+        let circuit = circuits::independent_bell_pairs(n_pairs);
+
+        let blocks = circuit.independent_subsystems();
+        assert_eq!(blocks.len(), n_pairs);
+
+        let mut filt = FilteredStabilizerBackend::new(42);
+        filt.init_with_blocks(n, 0, &blocks).unwrap();
+        for inst in &circuit.instructions {
+            filt.apply(inst).unwrap();
+        }
+        let filt_probs = filt.probabilities().unwrap();
+
+        let mut mono = StabilizerBackend::new(42);
+        mono.init(n, 0).unwrap();
+        mono.apply_instructions(&circuit.instructions).unwrap();
+        let mono_probs = mono.compute_probabilities();
+
+        for (i, (&f, &m)) in filt_probs.iter().zip(mono_probs.iter()).enumerate() {
+            assert!(
+                (f - m).abs() < 1e-10,
+                "prob mismatch at index {i}: filtered={f}, monolithic={m}"
+            );
+        }
     }
 }

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -961,14 +961,21 @@ impl StatevectorBackend {
             return;
         }
 
-        let mask0 = 1usize << q0;
-        let mask1 = 1usize << q1;
-        let n = 1usize << self.num_qubits;
+        let (lo, hi) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
+        let lo_half = 1usize << lo;
+        let lo_block = lo_half << 1;
+        let hi_half = 1usize << hi;
+        let block_size = hi_half << 1;
 
-        for i in 0..n {
-            if (i & mask0) == 0 && (i & mask1) != 0 {
-                let j = i ^ mask0 ^ mask1;
-                self.state.swap(i, j);
+        for chunk in self.state.chunks_mut(block_size) {
+            let (lo_group, hi_group) = chunk.split_at_mut(hi_half);
+            for (lo_sub, hi_sub) in lo_group
+                .chunks_mut(lo_block)
+                .zip(hi_group.chunks_mut(lo_block))
+            {
+                let (_, lo_sub_hi) = lo_sub.split_at_mut(lo_half);
+                let (hi_sub_lo, _) = hi_sub.split_at_mut(lo_half);
+                simd::swap_slices(lo_sub_hi, hi_sub_lo);
             }
         }
     }

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -222,8 +222,13 @@ struct PendingFusion {
 fn flush(pending: &mut Option<PendingFusion>, output: &mut Vec<Instruction>) {
     if let Some(p) = pending.take() {
         if !is_identity(&p.matrix) {
+            let gate = match Gate::recognize_matrix(&p.matrix) {
+                Some(Gate::Id) => return,
+                Some(named) => named,
+                None => Gate::Fused(Box::new(p.matrix)),
+            };
             output.push(Instruction::Gate {
-                gate: Gate::Fused(Box::new(p.matrix)),
+                gate,
                 targets: smallvec![p.target],
             });
         }
@@ -1473,7 +1478,8 @@ mod tests {
         c.add_gate(Gate::T, &[0]);
         let fused = fuse_single_qubit_gates(&c);
         assert_eq!(fused.instructions.len(), 2);
-        assert_eq!(count_fused(&fused), 2);
+        // H·T on q0 stays Fused (no named match), X on q1 recognized as Gate::X
+        assert_eq!(count_fused(&fused), 1);
 
         let expected = mat_mul_2x2(&Gate::T.matrix_2x2(), &Gate::H.matrix_2x2());
         let fused_mat = extract_fused_matrix(&fused.instructions[0]);
@@ -1657,9 +1663,12 @@ mod tests {
         c.add_gate(Gate::S, &[0]);
         c.add_gate(Gate::S, &[0]);
         let fused = fuse_single_qubit_gates(&c);
-        assert_eq!(count_fused(&fused), 1);
-        let fused_mat = extract_fused_matrix(&fused.instructions[0]);
-        assert_mat_close(&fused_mat, &Gate::Z.matrix_2x2());
+        assert_eq!(fused.instructions.len(), 1);
+        // S·S recognized as Gate::Z
+        assert!(matches!(
+            &fused.instructions[0],
+            Instruction::Gate { gate: Gate::Z, .. }
+        ));
     }
 
     #[test]
@@ -1688,9 +1697,11 @@ mod tests {
         c.add_gate(Gate::T, &[1]);
         let fused = fuse_single_qubit_gates(&c);
         assert_eq!(fused.instructions.len(), 1);
-        assert_eq!(count_fused(&fused), 1);
-        let mat = extract_fused_matrix(&fused.instructions[0]);
-        assert_mat_close(&mat, &Gate::T.matrix_2x2());
+        // H·H on q0 elided, lone T on q1 recognized as Gate::T
+        assert!(matches!(
+            &fused.instructions[0],
+            Instruction::Gate { gate: Gate::T, .. }
+        ));
     }
 
     #[test]
@@ -2333,5 +2344,30 @@ mod tests {
             .count();
         assert_eq!(batch_rzz_count, 3);
         assert_eq!(multi_fused_count, 3);
+    }
+
+    #[test]
+    fn test_recognition_extends_clifford_prefix() {
+        let mut c = Circuit::new(2, 0);
+        // T, T on q0 then CX then Rx on q1
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Rx(0.7), &[1]);
+
+        // Without fusion: first gate is T (non-Clifford), so no prefix at all
+        assert!(c.clifford_prefix_split().is_none());
+
+        // After fusion: T·T recognized as S (Clifford), so prefix = [S, CX], tail = [Rx]
+        let fused = fuse_single_qubit_gates(&c);
+        assert!(matches!(
+            &fused.instructions[0],
+            Instruction::Gate { gate: Gate::S, .. }
+        ));
+        let split = fused.clifford_prefix_split();
+        assert!(split.is_some());
+        let (pre_f, tail_f) = split.unwrap();
+        assert_eq!(pre_f.instructions.len(), 2); // S + CX
+        assert_eq!(tail_f.instructions.len(), 1); // Rx(0.7)
     }
 }

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -98,6 +98,29 @@ impl Circuit {
             .count()
     }
 
+    /// Count T and Tdg gates in the circuit.
+    pub fn t_count(&self) -> usize {
+        self.instructions
+            .iter()
+            .filter(|inst| match inst {
+                Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
+                    matches!(gate, Gate::T | Gate::Tdg)
+                }
+                _ => false,
+            })
+            .count()
+    }
+
+    /// Returns true if the circuit contains any T or Tdg gates.
+    pub fn has_t_gates(&self) -> bool {
+        self.instructions.iter().any(|inst| match inst {
+            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
+                matches!(gate, Gate::T | Gate::Tdg)
+            }
+            _ => false,
+        })
+    }
+
     /// True if every gate in the circuit is a Clifford gate.
     ///
     /// When true, the stabilizer backend can simulate this circuit exactly
@@ -106,6 +129,16 @@ impl Circuit {
         self.instructions.iter().all(|inst| match inst {
             Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
                 gate.is_clifford()
+            }
+            _ => true,
+        })
+    }
+
+    /// True if every gate is Clifford or T/Tdg.
+    pub fn is_clifford_plus_t(&self) -> bool {
+        self.instructions.iter().all(|inst| match inst {
+            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
+                gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)
             }
             _ => true,
         })
@@ -185,7 +218,10 @@ impl Circuit {
     /// Partition qubits into independent (non-interacting) subsystems.
     ///
     /// Two qubits are in the same subsystem if any multi-qubit gate connects
-    /// them, transitively. Returns a list of qubit groups, each sorted.
+    /// them, transitively. Classical dependencies (measure qubit → conditional
+    /// target) also merge subsystems, since the conditional outcome depends on
+    /// measurement results that must be available in the same simulation context.
+    /// Returns a list of qubit groups, each sorted.
     /// A fully-entangled circuit returns a single group containing all qubits.
     pub fn independent_subsystems(&self) -> Vec<Vec<usize>> {
         let n = self.num_qubits;
@@ -219,9 +255,36 @@ impl Circuit {
             }
         }
 
+        // Build cbit → measurement qubit map for classical dependency tracking
+        let mut cbit_to_qubit: Vec<Option<usize>> = vec![None; self.num_classical_bits.max(1)];
+        for inst in &self.instructions {
+            if let Instruction::Measure {
+                qubit,
+                classical_bit,
+            } = inst
+            {
+                cbit_to_qubit[*classical_bit] = Some(*qubit);
+            }
+        }
+
         for inst in &self.instructions {
             let targets = match inst {
-                Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
+                Instruction::Gate { targets, .. } => targets,
+                Instruction::Conditional {
+                    condition, targets, ..
+                } => {
+                    match condition {
+                        ClassicalCondition::BitIsOne(bit) => {
+                            if let Some(mq) = cbit_to_qubit[*bit] {
+                                union(&mut parent, &mut rank, targets[0], mq);
+                            }
+                        }
+                        ClassicalCondition::RegisterEquals { offset, size, .. } => {
+                            for mq in cbit_to_qubit.iter().skip(*offset).take(*size).flatten() {
+                                union(&mut parent, &mut rank, targets[0], *mq);
+                            }
+                        }
+                    }
                     targets
                 }
                 _ => continue,
@@ -325,8 +388,22 @@ impl Circuit {
                             .iter()
                             .map(|&t| old_to_new_qubit[t].unwrap())
                             .collect();
+                        let new_condition = match condition {
+                            ClassicalCondition::BitIsOne(bit) => ClassicalCondition::BitIsOne(
+                                old_to_new_classical[*bit].unwrap_or(*bit),
+                            ),
+                            ClassicalCondition::RegisterEquals {
+                                offset,
+                                size,
+                                value,
+                            } => ClassicalCondition::RegisterEquals {
+                                offset: old_to_new_classical[*offset].unwrap_or(*offset),
+                                size: *size,
+                                value: *value,
+                            },
+                        };
                         sub.instructions.push(Instruction::Conditional {
-                            condition: condition.clone(),
+                            condition: new_condition,
                             gate: gate.clone(),
                             targets: new_targets,
                         });
@@ -431,8 +508,26 @@ impl Circuit {
                     let (comp_idx, _) = qubit_map[targets[0]];
                     let new_targets: SmallVec<[usize; 4]> =
                         targets.iter().map(|&t| qubit_map[t].1).collect();
+                    let new_condition = match condition {
+                        ClassicalCondition::BitIsOne(bit) => {
+                            let (_, nc) = cbit_map[*bit].unwrap_or((comp_idx, *bit));
+                            ClassicalCondition::BitIsOne(nc)
+                        }
+                        ClassicalCondition::RegisterEquals {
+                            offset,
+                            size,
+                            value,
+                        } => {
+                            let new_offset = cbit_map[*offset].map(|(_, nc)| nc).unwrap_or(*offset);
+                            ClassicalCondition::RegisterEquals {
+                                offset: new_offset,
+                                size: *size,
+                                value: *value,
+                            }
+                        }
+                    };
                     subs[comp_idx].instructions.push(Instruction::Conditional {
-                        condition: condition.clone(),
+                        condition: new_condition,
                         gate: gate.clone(),
                         targets: new_targets,
                     });
@@ -727,6 +822,36 @@ mod tests {
     fn test_subsystems_empty() {
         let c = Circuit::new(0, 0);
         assert!(c.independent_subsystems().is_empty());
+    }
+
+    #[test]
+    fn test_subsystems_classical_dependency_merges() {
+        let mut c = Circuit::new(4, 2);
+        // q0-q1 entangled, q2-q3 entangled, but q0 measured and conditional on q2
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cx, &[2, 3]);
+        c.add_measure(0, 0);
+        c.instructions.push(Instruction::Conditional {
+            condition: ClassicalCondition::BitIsOne(0),
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[2]),
+        });
+        let subs = c.independent_subsystems();
+        // All four qubits should be in one group due to classical dependency
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0], vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_subsystems_no_classical_dependency() {
+        let mut c = Circuit::new(4, 2);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cx, &[2, 3]);
+        c.add_measure(0, 0);
+        c.add_measure(2, 1);
+        // No conditionals — subsystems remain independent
+        let subs = c.independent_subsystems();
+        assert_eq!(subs.len(), 2);
     }
 
     #[test]

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -79,6 +79,30 @@ pub fn clifford_heavy_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
     c
 }
 
+pub fn clifford_random_pairs(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let cliffords = [Gate::H, Gate::S, Gate::X, Gate::Y, Gate::Z];
+    for _ in 0..depth {
+        for q in 0..n {
+            c.add_gate(cliffords[rng.gen_range(0..cliffords.len())].clone(), &[q]);
+        }
+        let num_pairs = n / 2;
+        let mut available: Vec<usize> = (0..n).collect();
+        for _ in 0..num_pairs {
+            if available.len() < 2 {
+                break;
+            }
+            let i = rng.gen_range(0..available.len());
+            let q0 = available.swap_remove(i);
+            let j = rng.gen_range(0..available.len());
+            let q1 = available.swap_remove(j);
+            c.add_gate(Gate::Cx, &[q0, q1]);
+        }
+    }
+    c
+}
+
 /// N independent Bell pairs: qubits (0,1), (2,3), ..., (2N-2, 2N-1).
 ///
 /// Decomposes into `n_pairs` blocks of 2 qubits each. Useful for
@@ -158,6 +182,129 @@ pub fn qaoa_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
         for q in 0..n {
             let beta: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
             c.add_gate(Gate::Rx(beta), &[q]);
+        }
+    }
+    c
+}
+
+/// Build a circuit with only single-qubit rotation gates (no entanglement).
+///
+/// `depth` layers of random Rx/Ry/Rz on every qubit. Useful for benchmarking
+/// product-state and single-qubit gate throughput.
+pub fn single_qubit_rotation_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    for _ in 0..depth {
+        for q in 0..n {
+            let choice: usize = rng.gen_range(0..3);
+            let angle: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            match choice {
+                0 => c.add_gate(Gate::Rx(angle), &[q]),
+                1 => c.add_gate(Gate::Ry(angle), &[q]),
+                _ => c.add_gate(Gate::Rz(angle), &[q]),
+            }
+        }
+    }
+    c
+}
+
+/// Build a Clifford+T circuit with controlled T-count.
+///
+/// Clifford depth-10 base with `t_fraction` of single-qubit gates replaced by T/Tdg.
+/// For benchmarking stabilizer rank and quasi-probability dispatch.
+pub fn clifford_t_circuit(n: usize, depth: usize, t_fraction: f64, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let cliffords = [Gate::H, Gate::S, Gate::X, Gate::Y, Gate::Z];
+    for layer in 0..depth {
+        for q in 0..n {
+            if rng.gen::<f64>() < t_fraction {
+                if rng.gen_bool(0.5) {
+                    c.add_gate(Gate::T, &[q]);
+                } else {
+                    c.add_gate(Gate::Tdg, &[q]);
+                }
+            } else {
+                c.add_gate(cliffords[rng.gen_range(0..cliffords.len())].clone(), &[q]);
+            }
+        }
+        let offset = layer % 2;
+        for q in (offset..n.saturating_sub(1)).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    c
+}
+
+/// Build a W-state preparation circuit.
+///
+/// Produces the n-qubit W state: (|100...0⟩ + |010...0⟩ + ... + |000...1⟩) / √n.
+/// Uses a cascade of controlled rotations and CX gates.
+pub fn w_state_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::X, &[0]);
+    for i in 0..n - 1 {
+        let remaining = (n - i) as f64;
+        let theta = 2.0 * (1.0 / remaining).sqrt().acos();
+        c.add_gate(Gate::Ry(theta), &[i + 1]);
+        c.add_gate(Gate::Cx, &[i + 1, i]);
+        c.add_gate(Gate::Ry(-theta), &[i + 1]);
+        c.add_gate(Gate::Cx, &[i, i + 1]);
+    }
+    c
+}
+
+/// Build a quantum volume-style circuit.
+///
+/// `depth` layers, each applying a random permutation of qubit pairs followed
+/// by random SU(4) gates (decomposed into CX + single-qubit rotations).
+pub fn quantum_volume_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let n_pairs = n / 2;
+    for _ in 0..depth {
+        let mut perm: Vec<usize> = (0..n).collect();
+        for i in (1..n).rev() {
+            let j = rng.gen_range(0..=i);
+            perm.swap(i, j);
+        }
+        for p in 0..n_pairs {
+            let q0 = perm[2 * p];
+            let q1 = perm[2 * p + 1];
+            let a0: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            let a1: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            let a2: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            c.add_gate(Gate::Ry(a0), &[q0]);
+            c.add_gate(Gate::Rz(a1), &[q0]);
+            c.add_gate(Gate::Ry(a2), &[q1]);
+            c.add_gate(Gate::Cx, &[q0, q1]);
+            let b0: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            let b1: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            let b2: f64 = rng.gen::<f64>() * std::f64::consts::TAU;
+            c.add_gate(Gate::Ry(b0), &[q0]);
+            c.add_gate(Gate::Rz(b1), &[q1]);
+            c.add_gate(Gate::Cx, &[q0, q1]);
+            c.add_gate(Gate::Ry(b2), &[q0]);
+        }
+    }
+    c
+}
+
+/// Build a linearly-connected circuit with only CZ + single-qubit gates.
+///
+/// `depth` layers of random {H, S, T, X} + linear CZ chain. CZ-heavy circuits
+/// exercise different fusion/reordering paths than CX-heavy ones.
+pub fn cz_chain_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let singles = [Gate::H, Gate::S, Gate::T, Gate::X];
+    for layer in 0..depth {
+        for q in 0..n {
+            c.add_gate(singles[rng.gen_range(0..singles.len())].clone(), &[q]);
+        }
+        let offset = layer % 2;
+        for q in (offset..n.saturating_sub(1)).step_by(2) {
+            c.add_gate(Gate::Cz, &[q, q + 1]);
         }
     }
     c

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -611,6 +611,49 @@ impl Gate {
         }
     }
 
+    /// Try to recognize a 2x2 unitary matrix as a named gate (up to global phase).
+    ///
+    /// Used by the fusion pass to emit named gate variants instead of opaque
+    /// `Gate::Fused` matrices, enabling downstream passes (e.g. `clifford_prefix_split`)
+    /// to identify Clifford gates that arose from fusion (e.g. T·T → S).
+    pub fn recognize_matrix(mat: &[[Complex64; 2]; 2]) -> Option<Gate> {
+        const EPS: f64 = 1e-10;
+
+        // Check each candidate gate. For each, compute the global phase ratio
+        // mat[i][j] / ref[i][j] using the first non-zero entry, then verify
+        // all other entries match under that same phase.
+        let candidates: &[Gate] = &[
+            Gate::H,
+            Gate::X,
+            Gate::Y,
+            Gate::Z,
+            Gate::S,
+            Gate::Sdg,
+            Gate::T,
+            Gate::Tdg,
+            Gate::SX,
+            Gate::SXdg,
+        ];
+
+        for candidate in candidates {
+            let ref_mat = candidate.matrix_2x2();
+            if matrices_equal_up_to_phase(mat, &ref_mat, EPS) {
+                return Some(candidate.clone());
+            }
+        }
+
+        // Identity check: all off-diagonal zero, diagonal entries equal
+        if mat[0][1].norm_sqr() < EPS
+            && mat[1][0].norm_sqr() < EPS
+            && (mat[0][0] - mat[1][1]).norm_sqr() < EPS
+            && mat[0][0].norm_sqr() > EPS
+        {
+            return Some(Gate::Id);
+        }
+
+        None
+    }
+
     /// True if this gate is a Clifford gate (relevant for stabilizer backend).
     #[inline]
     pub fn is_clifford(&self) -> bool {
@@ -630,6 +673,42 @@ impl Gate {
                 | Gate::Swap
         )
     }
+}
+
+/// Check if two 2x2 unitary matrices are equal up to a global phase factor.
+fn matrices_equal_up_to_phase(a: &[[Complex64; 2]; 2], b: &[[Complex64; 2]; 2], eps: f64) -> bool {
+    // Find the first non-zero entry in b to determine the phase ratio
+    let mut phase = None;
+    for i in 0..2 {
+        for j in 0..2 {
+            if b[i][j].norm_sqr() > eps {
+                if a[i][j].norm_sqr() < eps {
+                    return false;
+                }
+                phase = Some(a[i][j] / b[i][j]);
+                break;
+            }
+        }
+        if phase.is_some() {
+            break;
+        }
+    }
+
+    let phase = match phase {
+        Some(p) => p,
+        None => return true, // Both are zero matrices
+    };
+
+    // Verify all entries match under the same phase
+    for i in 0..2 {
+        for j in 0..2 {
+            let expected = phase * b[i][j];
+            if (a[i][j] - expected).norm_sqr() > eps {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -1025,5 +1104,84 @@ mod tests {
             16,
             "Gate enum must stay at 16 bytes"
         );
+    }
+
+    #[test]
+    fn test_recognize_named_gates() {
+        for gate in &[
+            Gate::H,
+            Gate::X,
+            Gate::Y,
+            Gate::Z,
+            Gate::S,
+            Gate::Sdg,
+            Gate::T,
+            Gate::Tdg,
+            Gate::SX,
+            Gate::SXdg,
+        ] {
+            let mat = gate.matrix_2x2();
+            let recognized = Gate::recognize_matrix(&mat);
+            assert_eq!(
+                recognized.as_ref(),
+                Some(gate),
+                "failed to recognize {:?}",
+                gate.name()
+            );
+        }
+    }
+
+    #[test]
+    fn test_recognize_identity() {
+        let id = Gate::Id.matrix_2x2();
+        assert_eq!(Gate::recognize_matrix(&id), Some(Gate::Id));
+    }
+
+    #[test]
+    fn test_recognize_t_squared_is_s() {
+        let t = Gate::T.matrix_2x2();
+        let tt = mat_mul_2x2(&t, &t);
+        assert_eq!(Gate::recognize_matrix(&tt), Some(Gate::S));
+    }
+
+    #[test]
+    fn test_recognize_s_squared_is_z() {
+        let s = Gate::S.matrix_2x2();
+        let ss = mat_mul_2x2(&s, &s);
+        assert_eq!(Gate::recognize_matrix(&ss), Some(Gate::Z));
+    }
+
+    #[test]
+    fn test_recognize_h_squared_is_identity() {
+        let h = Gate::H.matrix_2x2();
+        let hh = mat_mul_2x2(&h, &h);
+        assert_eq!(Gate::recognize_matrix(&hh), Some(Gate::Id));
+    }
+
+    #[test]
+    fn test_recognize_t_fourth_is_z() {
+        let t = Gate::T.matrix_2x2();
+        let t2 = mat_mul_2x2(&t, &t);
+        let t4 = mat_mul_2x2(&t2, &t2);
+        assert_eq!(Gate::recognize_matrix(&t4), Some(Gate::Z));
+    }
+
+    #[test]
+    fn test_recognize_non_clifford_returns_none() {
+        let rx = Gate::Rx(0.7).matrix_2x2();
+        assert_eq!(Gate::recognize_matrix(&rx), None);
+        let ry = Gate::Ry(1.3).matrix_2x2();
+        assert_eq!(Gate::recognize_matrix(&ry), None);
+    }
+
+    #[test]
+    fn test_recognize_global_phase_invariance() {
+        let phase = Complex64::from_polar(1.0, 0.42);
+        let h = Gate::H.matrix_2x2();
+        let phased = [
+            [h[0][0] * phase, h[0][1] * phase],
+            [h[1][0] * phase, h[1][1] * phase],
+        ];
+        assert_eq!(Gate::recognize_matrix(&phased), Some(Gate::H));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,21 @@ pub use circuit::builder::CircuitBuilder;
 pub use circuit::{Circuit, ClassicalCondition, Instruction};
 pub use error::{PrismError, Result};
 pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
+pub use sim::compiled::{
+    compile_forward, compile_measurements, propagate_backward, run_shots_compiled, CompiledSampler,
+    PauliVec,
+};
+pub use sim::homological::{run_shots_homological, ErrorChainComplex, HomologicalSampler};
+pub use sim::noise::{run_shots_noisy, NoiseModel, NoiseOp};
+pub use sim::quasi_prob::{
+    run_quasi_prob, run_quasi_prob_shots, run_quasi_prob_shots_adaptive,
+    run_quasi_prob_shots_stratified, AdaptiveResult, QuasiProbResult,
+};
+pub use sim::stabilizer_rank::{
+    run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_overlap_sq, StabRankResult,
+};
 pub use sim::{
-    run, run_on, run_on_opts, run_qasm, run_shots, run_shots_random, run_shots_with, run_with,
-    run_with_opts, BackendKind, FactoredBlock, Probabilities, ShotsResult, SimOptions,
-    SimulationResult,
+    run, run_on, run_on_opts, run_qasm, run_shots, run_shots_random, run_shots_with,
+    run_shots_with_noise, run_with, run_with_opts, BackendKind, FactoredBlock, Probabilities,
+    ShotsResult, SimOptions, SimulationResult,
 };

--- a/src/sim/compiled.rs
+++ b/src/sim/compiled.rs
@@ -1,0 +1,3229 @@
+use crate::circuit::{Circuit, Instruction};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::ShotsResult;
+use rand::RngCore;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+#[derive(Debug, Clone)]
+pub struct PauliVec {
+    pub x: Vec<u64>,
+    pub z: Vec<u64>,
+}
+
+impl PauliVec {
+    pub fn new(num_words: usize) -> Self {
+        Self {
+            x: vec![0u64; num_words],
+            z: vec![0u64; num_words],
+        }
+    }
+
+    pub fn z_on_qubit(num_words: usize, qubit: usize) -> Self {
+        let mut pv = Self::new(num_words);
+        pv.z[qubit / 64] |= 1u64 << (qubit % 64);
+        pv
+    }
+}
+
+#[inline(always)]
+fn get_bit(words: &[u64], qubit: usize) -> bool {
+    (words[qubit / 64] >> (qubit % 64)) & 1 != 0
+}
+
+#[inline(always)]
+fn set_bit(words: &mut [u64], qubit: usize, val: bool) {
+    let word = qubit / 64;
+    let bit = qubit % 64;
+    if val {
+        words[word] |= 1u64 << bit;
+    } else {
+        words[word] &= !(1u64 << bit);
+    }
+}
+
+#[inline(always)]
+fn flip_bit(words: &mut [u64], qubit: usize) {
+    words[qubit / 64] ^= 1u64 << (qubit % 64);
+}
+
+/// Heisenberg-picture backward propagation of a Pauli through a Clifford gate.
+///
+/// Given P, computes U†·P·U where U is the gate.
+pub fn propagate_backward(pauli: &mut PauliVec, gate: &Gate, targets: &[usize]) {
+    match gate {
+        Gate::H => {
+            let q = targets[0];
+            let xb = get_bit(&pauli.x, q);
+            let zb = get_bit(&pauli.z, q);
+            set_bit(&mut pauli.x, q, zb);
+            set_bit(&mut pauli.z, q, xb);
+        }
+        Gate::S => {
+            let q = targets[0];
+            if get_bit(&pauli.x, q) {
+                flip_bit(&mut pauli.z, q);
+            }
+        }
+        Gate::Sdg => {
+            let q = targets[0];
+            if get_bit(&pauli.x, q) {
+                flip_bit(&mut pauli.z, q);
+            }
+        }
+        Gate::X => {}
+        Gate::Y => {}
+        Gate::Z => {}
+        Gate::SX => {
+            let q = targets[0];
+            if get_bit(&pauli.z, q) {
+                flip_bit(&mut pauli.x, q);
+            }
+        }
+        Gate::SXdg => {
+            let q = targets[0];
+            if get_bit(&pauli.z, q) {
+                flip_bit(&mut pauli.x, q);
+            }
+        }
+        Gate::Cx => {
+            let ctrl = targets[0];
+            let tgt = targets[1];
+            if get_bit(&pauli.x, ctrl) {
+                flip_bit(&mut pauli.x, tgt);
+            }
+            if get_bit(&pauli.z, tgt) {
+                flip_bit(&mut pauli.z, ctrl);
+            }
+        }
+        Gate::Cz => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            let x0 = get_bit(&pauli.x, q0);
+            let x1 = get_bit(&pauli.x, q1);
+            if x1 {
+                flip_bit(&mut pauli.z, q0);
+            }
+            if x0 {
+                flip_bit(&mut pauli.z, q1);
+            }
+        }
+        Gate::Swap => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            let x0 = get_bit(&pauli.x, q0);
+            let x1 = get_bit(&pauli.x, q1);
+            set_bit(&mut pauli.x, q0, x1);
+            set_bit(&mut pauli.x, q1, x0);
+            let z0 = get_bit(&pauli.z, q0);
+            let z1 = get_bit(&pauli.z, q1);
+            set_bit(&mut pauli.z, q0, z1);
+            set_bit(&mut pauli.z, q1, z0);
+        }
+        Gate::Id => {}
+        _ => {}
+    }
+}
+
+/// Batch backward-propagate Z_q through all gates for every measurement simultaneously.
+///
+/// Transposed representation: each qubit's m measurement x/z bits are packed into
+/// m/64 u64 words, so gate propagation is bulk bitwise ops (64× fewer operations).
+///
+/// Returns (PauliVec, classical_bit, sign) per measurement.
+fn build_measurement_rows(circuit: &Circuit) -> Vec<(PauliVec, usize, bool)> {
+    let n = circuit.num_qubits;
+    let num_qubit_words = n.div_ceil(64);
+
+    let measurements: Vec<(usize, usize)> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => Some((*qubit, *classical_bit)),
+            _ => None,
+        })
+        .collect();
+
+    let m = measurements.len();
+    if m == 0 {
+        return Vec::new();
+    }
+
+    let m_words = m.div_ceil(64);
+
+    let mut x_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+    let mut z_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+    let mut sign_packed: Vec<u64> = vec![0u64; m_words];
+
+    for (meas_idx, &(qubit, _)) in measurements.iter().enumerate() {
+        z_packed[qubit][meas_idx / 64] |= 1u64 << (meas_idx % 64);
+    }
+
+    let gate_instructions: Vec<(&Gate, &[usize])> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Gate { gate, targets } => Some((gate, targets.as_slice())),
+            Instruction::Conditional { gate, targets, .. } => Some((gate, targets.as_slice())),
+            _ => None,
+        })
+        .collect();
+
+    for &(gate, targets) in gate_instructions.iter().rev() {
+        batch_propagate_backward(
+            &mut x_packed,
+            &mut z_packed,
+            &mut sign_packed,
+            gate,
+            targets,
+            m_words,
+        );
+    }
+
+    let mut rows: Vec<(PauliVec, usize, bool)> = Vec::with_capacity(m);
+    for (meas_idx, &(_, classical_bit)) in measurements.iter().enumerate() {
+        let mut pauli = PauliVec::new(num_qubit_words);
+        for q in 0..n {
+            if x_packed[q][meas_idx / 64] >> (meas_idx % 64) & 1 != 0 {
+                pauli.x[q / 64] |= 1u64 << (q % 64);
+            }
+            if z_packed[q][meas_idx / 64] >> (meas_idx % 64) & 1 != 0 {
+                pauli.z[q / 64] |= 1u64 << (q % 64);
+            }
+        }
+        let sign = (sign_packed[meas_idx / 64] >> (meas_idx % 64)) & 1 != 0;
+        rows.push((pauli, classical_bit, sign));
+    }
+
+    rows
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_h_avx2(xq: &mut [u64], zq: &mut [u64], sign: &mut [u64], m_words: usize) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let xp = xq.as_mut_ptr() as *mut __m256i;
+    let zp = zq.as_mut_ptr() as *mut __m256i;
+    let sp = sign.as_mut_ptr() as *mut __m256i;
+    for i in 0..chunks {
+        let xv = _mm256_loadu_si256(xp.add(i));
+        let zv = _mm256_loadu_si256(zp.add(i));
+        let sv = _mm256_loadu_si256(sp.add(i));
+        _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, _mm256_and_si256(xv, zv)));
+        _mm256_storeu_si256(xp.add(i), zv);
+        _mm256_storeu_si256(zp.add(i), xv);
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+    }
+    for w in tail..m_words {
+        let tmp = *xq.get_unchecked(w);
+        *xq.get_unchecked_mut(w) = *zq.get_unchecked(w);
+        *zq.get_unchecked_mut(w) = tmp;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_s_avx2(
+    xq: &mut [u64],
+    zq: &mut [u64],
+    sign: &mut [u64],
+    m_words: usize,
+    negate_z: bool,
+) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let xp = xq.as_ptr() as *const __m256i;
+    let zp = zq.as_mut_ptr() as *mut __m256i;
+    let sp = sign.as_mut_ptr() as *mut __m256i;
+    if negate_z {
+        for i in 0..chunks {
+            let xv = _mm256_loadu_si256(xp.add(i));
+            let zv = _mm256_loadu_si256(zp.add(i));
+            let sv = _mm256_loadu_si256(sp.add(i));
+            _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, _mm256_andnot_si256(zv, xv)));
+            _mm256_storeu_si256(zp.add(i), _mm256_xor_si256(zv, xv));
+        }
+        let tail = chunks * 4;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & !*zq.get_unchecked(w);
+            *zq.get_unchecked_mut(w) ^= *xq.get_unchecked(w);
+        }
+    } else {
+        for i in 0..chunks {
+            let xv = _mm256_loadu_si256(xp.add(i));
+            let zv = _mm256_loadu_si256(zp.add(i));
+            let sv = _mm256_loadu_si256(sp.add(i));
+            _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, _mm256_and_si256(xv, zv)));
+            _mm256_storeu_si256(zp.add(i), _mm256_xor_si256(zv, xv));
+        }
+        let tail = chunks * 4;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *zq.get_unchecked_mut(w) ^= *xq.get_unchecked(w);
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_sign_xor_avx2(dst: &mut [u64], src: &[u64], m_words: usize) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let dp = dst.as_mut_ptr() as *mut __m256i;
+    let sp = src.as_ptr() as *const __m256i;
+    for i in 0..chunks {
+        let dv = _mm256_loadu_si256(dp.add(i));
+        let sv = _mm256_loadu_si256(sp.add(i));
+        _mm256_storeu_si256(dp.add(i), _mm256_xor_si256(dv, sv));
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        *dst.get_unchecked_mut(w) ^= *src.get_unchecked(w);
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_sign_xor2_avx2(dst: &mut [u64], a: &[u64], b: &[u64], m_words: usize) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let dp = dst.as_mut_ptr() as *mut __m256i;
+    let ap = a.as_ptr() as *const __m256i;
+    let bp = b.as_ptr() as *const __m256i;
+    for i in 0..chunks {
+        let dv = _mm256_loadu_si256(dp.add(i));
+        let av = _mm256_loadu_si256(ap.add(i));
+        let bv = _mm256_loadu_si256(bp.add(i));
+        _mm256_storeu_si256(dp.add(i), _mm256_xor_si256(dv, _mm256_xor_si256(av, bv)));
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        *dst.get_unchecked_mut(w) ^= *a.get_unchecked(w) ^ *b.get_unchecked(w);
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_sx_avx2(
+    xq: &mut [u64],
+    zq: &[u64],
+    sign: &mut [u64],
+    m_words: usize,
+    negate_x: bool,
+) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let xp = xq.as_mut_ptr() as *mut __m256i;
+    let zp = zq.as_ptr() as *const __m256i;
+    let sp = sign.as_mut_ptr() as *mut __m256i;
+    if negate_x {
+        for i in 0..chunks {
+            let xv = _mm256_loadu_si256(xp.add(i));
+            let zv = _mm256_loadu_si256(zp.add(i));
+            let sv = _mm256_loadu_si256(sp.add(i));
+            _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, _mm256_andnot_si256(xv, zv)));
+            _mm256_storeu_si256(xp.add(i), _mm256_xor_si256(xv, zv));
+        }
+        let tail = chunks * 4;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= !*xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *xq.get_unchecked_mut(w) ^= *zq.get_unchecked(w);
+        }
+    } else {
+        for i in 0..chunks {
+            let xv = _mm256_loadu_si256(xp.add(i));
+            let zv = _mm256_loadu_si256(zp.add(i));
+            let sv = _mm256_loadu_si256(sp.add(i));
+            _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, _mm256_and_si256(xv, zv)));
+            _mm256_storeu_si256(xp.add(i), _mm256_xor_si256(xv, zv));
+        }
+        let tail = chunks * 4;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *xq.get_unchecked_mut(w) ^= *zq.get_unchecked(w);
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_cx_avx2(
+    x_ctrl: &[u64],
+    z_ctrl: &mut [u64],
+    x_tgt: &mut [u64],
+    z_tgt: &[u64],
+    sign: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let xcp = x_ctrl.as_ptr() as *const __m256i;
+    let zcp = z_ctrl.as_mut_ptr() as *mut __m256i;
+    let xtp = x_tgt.as_mut_ptr() as *mut __m256i;
+    let ztp = z_tgt.as_ptr() as *const __m256i;
+    let sp = sign.as_mut_ptr() as *mut __m256i;
+    for i in 0..chunks {
+        let xc = _mm256_loadu_si256(xcp.add(i));
+        let zc = _mm256_loadu_si256(zcp.add(i));
+        let xt = _mm256_loadu_si256(xtp.add(i));
+        let zt = _mm256_loadu_si256(ztp.add(i));
+        let sv = _mm256_loadu_si256(sp.add(i));
+        let xnor = _mm256_andnot_si256(_mm256_xor_si256(zc, xt), _mm256_set1_epi64x(-1));
+        let flip = _mm256_and_si256(_mm256_and_si256(xc, zt), xnor);
+        _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, flip));
+        _mm256_storeu_si256(xtp.add(i), _mm256_xor_si256(xt, xc));
+        _mm256_storeu_si256(zcp.add(i), _mm256_xor_si256(zc, zt));
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        let xc = *x_ctrl.get_unchecked(w);
+        let zc = *z_ctrl.get_unchecked(w);
+        let xt = *x_tgt.get_unchecked(w);
+        let zt = *z_tgt.get_unchecked(w);
+        *sign.get_unchecked_mut(w) ^= xc & zt & !(zc ^ xt);
+        *x_tgt.get_unchecked_mut(w) = xt ^ xc;
+        *z_ctrl.get_unchecked_mut(w) = zc ^ zt;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_cz_avx2(
+    x0: &[u64],
+    z0: &mut [u64],
+    x1: &[u64],
+    z1: &mut [u64],
+    sign: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let x0p = x0.as_ptr() as *const __m256i;
+    let z0p = z0.as_mut_ptr() as *mut __m256i;
+    let x1p = x1.as_ptr() as *const __m256i;
+    let z1p = z1.as_mut_ptr() as *mut __m256i;
+    let sp = sign.as_mut_ptr() as *mut __m256i;
+    for i in 0..chunks {
+        let xv0 = _mm256_loadu_si256(x0p.add(i));
+        let zv0 = _mm256_loadu_si256(z0p.add(i));
+        let xv1 = _mm256_loadu_si256(x1p.add(i));
+        let zv1 = _mm256_loadu_si256(z1p.add(i));
+        let sv = _mm256_loadu_si256(sp.add(i));
+        let xnor = _mm256_andnot_si256(_mm256_xor_si256(zv0, zv1), _mm256_set1_epi64x(-1));
+        let flip = _mm256_and_si256(_mm256_and_si256(xv0, xv1), xnor);
+        _mm256_storeu_si256(sp.add(i), _mm256_xor_si256(sv, flip));
+        _mm256_storeu_si256(z0p.add(i), _mm256_xor_si256(zv0, xv1));
+        _mm256_storeu_si256(z1p.add(i), _mm256_xor_si256(zv1, xv0));
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        let xv0 = *x0.get_unchecked(w);
+        let zv0 = *z0.get_unchecked(w);
+        let xv1 = *x1.get_unchecked(w);
+        let zv1 = *z1.get_unchecked(w);
+        *sign.get_unchecked_mut(w) ^= xv0 & xv1 & !(zv0 ^ zv1);
+        *z0.get_unchecked_mut(w) = zv0 ^ xv1;
+        *z1.get_unchecked_mut(w) = zv1 ^ xv0;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn batch_propagate_swap_avx2(
+    x0: &mut [u64],
+    z0: &mut [u64],
+    x1: &mut [u64],
+    z1: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::x86_64::*;
+    let chunks = m_words / 4;
+    let x0p = x0.as_mut_ptr() as *mut __m256i;
+    let z0p = z0.as_mut_ptr() as *mut __m256i;
+    let x1p = x1.as_mut_ptr() as *mut __m256i;
+    let z1p = z1.as_mut_ptr() as *mut __m256i;
+    for i in 0..chunks {
+        let xv0 = _mm256_loadu_si256(x0p.add(i));
+        let xv1 = _mm256_loadu_si256(x1p.add(i));
+        _mm256_storeu_si256(x0p.add(i), xv1);
+        _mm256_storeu_si256(x1p.add(i), xv0);
+        let zv0 = _mm256_loadu_si256(z0p.add(i));
+        let zv1 = _mm256_loadu_si256(z1p.add(i));
+        _mm256_storeu_si256(z0p.add(i), zv1);
+        _mm256_storeu_si256(z1p.add(i), zv0);
+    }
+    let tail = chunks * 4;
+    for w in tail..m_words {
+        let tmp = *x0.get_unchecked(w);
+        *x0.get_unchecked_mut(w) = *x1.get_unchecked(w);
+        *x1.get_unchecked_mut(w) = tmp;
+        let tmp = *z0.get_unchecked(w);
+        *z0.get_unchecked_mut(w) = *z1.get_unchecked(w);
+        *z1.get_unchecked_mut(w) = tmp;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_h_neon(xq: &mut [u64], zq: &mut [u64], sign: &mut [u64], m_words: usize) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let xp = xq.as_mut_ptr();
+    let zp = zq.as_mut_ptr();
+    let sp = sign.as_mut_ptr();
+    for i in 0..chunks {
+        let off = i * 2;
+        let xv = vld1q_u64(xp.add(off));
+        let zv = vld1q_u64(zp.add(off));
+        let sv = vld1q_u64(sp.add(off));
+        vst1q_u64(sp.add(off), veorq_u64(sv, vandq_u64(xv, zv)));
+        vst1q_u64(xp.add(off), zv);
+        vst1q_u64(zp.add(off), xv);
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+    }
+    for w in tail..m_words {
+        let tmp = *xq.get_unchecked(w);
+        *xq.get_unchecked_mut(w) = *zq.get_unchecked(w);
+        *zq.get_unchecked_mut(w) = tmp;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_s_neon(
+    xq: &mut [u64],
+    zq: &mut [u64],
+    sign: &mut [u64],
+    m_words: usize,
+    negate_z: bool,
+) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let xp = xq.as_ptr();
+    let zp = zq.as_mut_ptr();
+    let sp = sign.as_mut_ptr();
+    if negate_z {
+        for i in 0..chunks {
+            let off = i * 2;
+            let xv = vld1q_u64(xp.add(off));
+            let zv = vld1q_u64(zp.add(off));
+            let sv = vld1q_u64(sp.add(off));
+            vst1q_u64(sp.add(off), veorq_u64(sv, vbicq_u64(xv, zv)));
+            vst1q_u64(zp.add(off), veorq_u64(zv, xv));
+        }
+        let tail = chunks * 2;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & !*zq.get_unchecked(w);
+            *zq.get_unchecked_mut(w) ^= *xq.get_unchecked(w);
+        }
+    } else {
+        for i in 0..chunks {
+            let off = i * 2;
+            let xv = vld1q_u64(xp.add(off));
+            let zv = vld1q_u64(zp.add(off));
+            let sv = vld1q_u64(sp.add(off));
+            vst1q_u64(sp.add(off), veorq_u64(sv, vandq_u64(xv, zv)));
+            vst1q_u64(zp.add(off), veorq_u64(zv, xv));
+        }
+        let tail = chunks * 2;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *zq.get_unchecked_mut(w) ^= *xq.get_unchecked(w);
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_sign_xor_neon(dst: &mut [u64], src: &[u64], m_words: usize) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let dp = dst.as_mut_ptr();
+    let sp = src.as_ptr();
+    for i in 0..chunks {
+        let off = i * 2;
+        let dv = vld1q_u64(dp.add(off));
+        let sv = vld1q_u64(sp.add(off));
+        vst1q_u64(dp.add(off), veorq_u64(dv, sv));
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        *dst.get_unchecked_mut(w) ^= *src.get_unchecked(w);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_sign_xor2_neon(dst: &mut [u64], a: &[u64], b: &[u64], m_words: usize) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let dp = dst.as_mut_ptr();
+    let ap = a.as_ptr();
+    let bp = b.as_ptr();
+    for i in 0..chunks {
+        let off = i * 2;
+        let dv = vld1q_u64(dp.add(off));
+        let av = vld1q_u64(ap.add(off));
+        let bv = vld1q_u64(bp.add(off));
+        vst1q_u64(dp.add(off), veorq_u64(dv, veorq_u64(av, bv)));
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        *dst.get_unchecked_mut(w) ^= *a.get_unchecked(w) ^ *b.get_unchecked(w);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_sx_neon(
+    xq: &mut [u64],
+    zq: &[u64],
+    sign: &mut [u64],
+    m_words: usize,
+    negate_x: bool,
+) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let xp = xq.as_mut_ptr();
+    let zp = zq.as_ptr();
+    let sp = sign.as_mut_ptr();
+    if negate_x {
+        for i in 0..chunks {
+            let off = i * 2;
+            let xv = vld1q_u64(xp.add(off));
+            let zv = vld1q_u64(zp.add(off));
+            let sv = vld1q_u64(sp.add(off));
+            vst1q_u64(sp.add(off), veorq_u64(sv, vbicq_u64(zv, xv)));
+            vst1q_u64(xp.add(off), veorq_u64(xv, zv));
+        }
+        let tail = chunks * 2;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= !*xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *xq.get_unchecked_mut(w) ^= *zq.get_unchecked(w);
+        }
+    } else {
+        for i in 0..chunks {
+            let off = i * 2;
+            let xv = vld1q_u64(xp.add(off));
+            let zv = vld1q_u64(zp.add(off));
+            let sv = vld1q_u64(sp.add(off));
+            vst1q_u64(sp.add(off), veorq_u64(sv, vandq_u64(xv, zv)));
+            vst1q_u64(xp.add(off), veorq_u64(xv, zv));
+        }
+        let tail = chunks * 2;
+        for w in tail..m_words {
+            *sign.get_unchecked_mut(w) ^= *xq.get_unchecked(w) & *zq.get_unchecked(w);
+            *xq.get_unchecked_mut(w) ^= *zq.get_unchecked(w);
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_cx_neon(
+    x_ctrl: &[u64],
+    z_ctrl: &mut [u64],
+    x_tgt: &mut [u64],
+    z_tgt: &[u64],
+    sign: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let xcp = x_ctrl.as_ptr();
+    let zcp = z_ctrl.as_mut_ptr();
+    let xtp = x_tgt.as_mut_ptr();
+    let ztp = z_tgt.as_ptr();
+    let sp = sign.as_mut_ptr();
+    let ones = vdupq_n_u64(!0u64);
+    for i in 0..chunks {
+        let off = i * 2;
+        let xc = vld1q_u64(xcp.add(off));
+        let zc = vld1q_u64(zcp.add(off));
+        let xt = vld1q_u64(xtp.add(off));
+        let zt = vld1q_u64(ztp.add(off));
+        let sv = vld1q_u64(sp.add(off));
+        let xnor = veorq_u64(veorq_u64(zc, xt), ones);
+        let flip = vandq_u64(vandq_u64(xc, zt), xnor);
+        vst1q_u64(sp.add(off), veorq_u64(sv, flip));
+        vst1q_u64(xtp.add(off), veorq_u64(xt, xc));
+        vst1q_u64(zcp.add(off), veorq_u64(zc, zt));
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        let xc = *x_ctrl.get_unchecked(w);
+        let zc = *z_ctrl.get_unchecked(w);
+        let xt = *x_tgt.get_unchecked(w);
+        let zt = *z_tgt.get_unchecked(w);
+        *sign.get_unchecked_mut(w) ^= xc & zt & !(zc ^ xt);
+        *x_tgt.get_unchecked_mut(w) = xt ^ xc;
+        *z_ctrl.get_unchecked_mut(w) = zc ^ zt;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_cz_neon(
+    x0: &[u64],
+    z0: &mut [u64],
+    x1: &[u64],
+    z1: &mut [u64],
+    sign: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let x0p = x0.as_ptr();
+    let z0p = z0.as_mut_ptr();
+    let x1p = x1.as_ptr();
+    let z1p = z1.as_mut_ptr();
+    let sp = sign.as_mut_ptr();
+    let ones = vdupq_n_u64(!0u64);
+    for i in 0..chunks {
+        let off = i * 2;
+        let xv0 = vld1q_u64(x0p.add(off));
+        let zv0 = vld1q_u64(z0p.add(off));
+        let xv1 = vld1q_u64(x1p.add(off));
+        let zv1 = vld1q_u64(z1p.add(off));
+        let sv = vld1q_u64(sp.add(off));
+        let xnor = veorq_u64(veorq_u64(zv0, zv1), ones);
+        let flip = vandq_u64(vandq_u64(xv0, xv1), xnor);
+        vst1q_u64(sp.add(off), veorq_u64(sv, flip));
+        vst1q_u64(z0p.add(off), veorq_u64(zv0, xv1));
+        vst1q_u64(z1p.add(off), veorq_u64(zv1, xv0));
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        let xv0 = *x0.get_unchecked(w);
+        let zv0 = *z0.get_unchecked(w);
+        let xv1 = *x1.get_unchecked(w);
+        let zv1 = *z1.get_unchecked(w);
+        *sign.get_unchecked_mut(w) ^= xv0 & xv1 & !(zv0 ^ zv1);
+        *z0.get_unchecked_mut(w) = zv0 ^ xv1;
+        *z1.get_unchecked_mut(w) = zv1 ^ xv0;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn batch_propagate_swap_neon(
+    x0: &mut [u64],
+    z0: &mut [u64],
+    x1: &mut [u64],
+    z1: &mut [u64],
+    m_words: usize,
+) {
+    use std::arch::aarch64::*;
+    let chunks = m_words / 2;
+    let x0p = x0.as_mut_ptr();
+    let z0p = z0.as_mut_ptr();
+    let x1p = x1.as_mut_ptr();
+    let z1p = z1.as_mut_ptr();
+    for i in 0..chunks {
+        let off = i * 2;
+        let xv0 = vld1q_u64(x0p.add(off));
+        let xv1 = vld1q_u64(x1p.add(off));
+        vst1q_u64(x0p.add(off), xv1);
+        vst1q_u64(x1p.add(off), xv0);
+        let zv0 = vld1q_u64(z0p.add(off));
+        let zv1 = vld1q_u64(z1p.add(off));
+        vst1q_u64(z0p.add(off), zv1);
+        vst1q_u64(z1p.add(off), zv0);
+    }
+    let tail = chunks * 2;
+    for w in tail..m_words {
+        let tmp = *x0.get_unchecked(w);
+        *x0.get_unchecked_mut(w) = *x1.get_unchecked(w);
+        *x1.get_unchecked_mut(w) = tmp;
+        let tmp = *z0.get_unchecked(w);
+        *z0.get_unchecked_mut(w) = *z1.get_unchecked(w);
+        *z1.get_unchecked_mut(w) = tmp;
+    }
+}
+
+#[inline(always)]
+pub(crate) fn batch_propagate_backward(
+    x: &mut [Vec<u64>],
+    z: &mut [Vec<u64>],
+    sign: &mut [u64],
+    gate: &Gate,
+    targets: &[usize],
+    m_words: usize,
+) {
+    #[cfg(target_arch = "x86_64")]
+    let use_avx2 = m_words >= 4 && is_x86_feature_detected!("avx2");
+    #[cfg(target_arch = "aarch64")]
+    let use_neon = m_words >= 2;
+
+    match gate {
+        Gate::H => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_h_avx2(&mut x[q], &mut z[q], sign, m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_h_neon(&mut x[q], &mut z[q], sign, m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w] & z[q][w];
+            }
+            std::mem::swap(&mut x[q], &mut z[q]);
+        }
+        Gate::S => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_s_avx2(&mut x[q], &mut z[q], sign, m_words, true) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_s_neon(&mut x[q], &mut z[q], sign, m_words, true) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w] & !z[q][w];
+                z[q][w] ^= x[q][w];
+            }
+        }
+        Gate::Sdg => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_s_avx2(&mut x[q], &mut z[q], sign, m_words, false) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_s_neon(&mut x[q], &mut z[q], sign, m_words, false) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w] & z[q][w];
+                z[q][w] ^= x[q][w];
+            }
+        }
+        Gate::X => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor_avx2(sign, &z[q], m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor_neon(sign, &z[q], m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= z[q][w];
+            }
+        }
+        Gate::Y => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor2_avx2(sign, &x[q], &z[q], m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor2_neon(sign, &x[q], &z[q], m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w] ^ z[q][w];
+            }
+        }
+        Gate::Z => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor_avx2(sign, &x[q], m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_sign_xor_neon(sign, &x[q], m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w];
+            }
+        }
+        Gate::Id => {}
+        Gate::SX => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_sx_avx2(&mut x[q], &z[q], sign, m_words, true) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_sx_neon(&mut x[q], &z[q], sign, m_words, true) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= !x[q][w] & z[q][w];
+                x[q][w] ^= z[q][w];
+            }
+        }
+        Gate::SXdg => {
+            let q = targets[0];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                // SAFETY: AVX2 detected, slices are valid with m_words elements
+                unsafe { batch_propagate_sx_avx2(&mut x[q], &z[q], sign, m_words, false) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                // SAFETY: NEON is baseline on aarch64, slices are valid with m_words elements
+                unsafe { batch_propagate_sx_neon(&mut x[q], &z[q], sign, m_words, false) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q][w] & z[q][w];
+                x[q][w] ^= z[q][w];
+            }
+        }
+        Gate::Cx => {
+            let ctrl = targets[0];
+            let tgt = targets[1];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                let (x_ctrl_sl, x_tgt_sl) = if ctrl < tgt {
+                    let (lo, hi) = x.split_at_mut(tgt);
+                    (&lo[ctrl][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(ctrl);
+                    (&hi[0][..], &mut lo[tgt][..])
+                };
+                let (z_ctrl_sl, z_tgt_sl) = if ctrl < tgt {
+                    let (lo, hi) = z.split_at_mut(tgt);
+                    (&mut lo[ctrl][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(ctrl);
+                    (&mut hi[0][..], &lo[tgt][..])
+                };
+                // SAFETY: AVX2 detected, slices are valid, ctrl != tgt
+                unsafe {
+                    batch_propagate_cx_avx2(x_ctrl_sl, z_ctrl_sl, x_tgt_sl, z_tgt_sl, sign, m_words)
+                };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                let (x_ctrl_sl, x_tgt_sl) = if ctrl < tgt {
+                    let (lo, hi) = x.split_at_mut(tgt);
+                    (&lo[ctrl][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(ctrl);
+                    (&hi[0][..], &mut lo[tgt][..])
+                };
+                let (z_ctrl_sl, z_tgt_sl) = if ctrl < tgt {
+                    let (lo, hi) = z.split_at_mut(tgt);
+                    (&mut lo[ctrl][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(ctrl);
+                    (&mut hi[0][..], &lo[tgt][..])
+                };
+                // SAFETY: NEON is baseline on aarch64, slices are valid, ctrl != tgt
+                unsafe {
+                    batch_propagate_cx_neon(x_ctrl_sl, z_ctrl_sl, x_tgt_sl, z_tgt_sl, sign, m_words)
+                };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[ctrl][w] & z[tgt][w] & !(z[ctrl][w] ^ x[tgt][w]);
+                x[tgt][w] ^= x[ctrl][w];
+                z[ctrl][w] ^= z[tgt][w];
+            }
+        }
+        Gate::Cz => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x.split_at_mut(q1);
+                    (&lo[q0][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(q0);
+                    (&hi[0][..], &lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                // SAFETY: AVX2 detected, slices are valid, q0 != q1
+                unsafe { batch_propagate_cz_avx2(x0_sl, z0_sl, x1_sl, z1_sl, sign, m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x.split_at_mut(q1);
+                    (&lo[q0][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(q0);
+                    (&hi[0][..], &lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                // SAFETY: NEON is baseline on aarch64, slices are valid, q0 != q1
+                unsafe { batch_propagate_cz_neon(x0_sl, z0_sl, x1_sl, z1_sl, sign, m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                sign[w] ^= x[q0][w] & x[q1][w] & !(z[q0][w] ^ z[q1][w]);
+                z[q0][w] ^= x[q1][w];
+                z[q1][w] ^= x[q0][w];
+            }
+        }
+        Gate::Swap => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            #[cfg(target_arch = "x86_64")]
+            if use_avx2 {
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                // SAFETY: AVX2 detected, slices are valid, q0 != q1
+                unsafe { batch_propagate_swap_avx2(x0_sl, z0_sl, x1_sl, z1_sl, m_words) };
+                return;
+            }
+            #[cfg(target_arch = "aarch64")]
+            if use_neon {
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                // SAFETY: NEON is baseline on aarch64, slices are valid, q0 != q1
+                unsafe { batch_propagate_swap_neon(x0_sl, z0_sl, x1_sl, z1_sl, m_words) };
+                return;
+            }
+            for w in 0..m_words {
+                let tmp_x = x[q0][w];
+                x[q0][w] = x[q1][w];
+                x[q1][w] = tmp_x;
+                let tmp_z = z[q0][w];
+                z[q0][w] = z[q1][w];
+                z[q1][w] = tmp_z;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn gaussian_eliminate(rows: &mut [Vec<u64>], num_cols: usize) -> (usize, Vec<usize>) {
+    let num_rows = rows.len();
+    let mut pivot_cols: Vec<usize> = Vec::new();
+    let mut current_row = 0;
+
+    for col in 0..num_cols {
+        let word = col / 64;
+        let bit = col % 64;
+        let mask = 1u64 << bit;
+
+        let pivot = rows[current_row..num_rows]
+            .iter()
+            .position(|row| row[word] & mask != 0)
+            .map(|i| i + current_row);
+
+        let pivot_row = match pivot {
+            Some(r) => r,
+            None => continue,
+        };
+
+        if pivot_row != current_row {
+            rows.swap(pivot_row, current_row);
+        }
+
+        let (top, rest) = rows.split_at_mut(current_row + 1);
+        let pivot_data = &top[current_row];
+        for row in rest.iter_mut() {
+            if row[word] & mask != 0 {
+                for w in 0..row.len() {
+                    row[w] ^= pivot_data[w];
+                }
+            }
+        }
+
+        pivot_cols.push(col);
+        current_row += 1;
+    }
+
+    (current_row, pivot_cols)
+}
+
+const LUT_GROUP_SIZE: usize = 8;
+const LUT_MIN_RANK: usize = 8;
+
+struct FlipLut {
+    data: Vec<u64>,
+    m_words: usize,
+    num_full_groups: usize,
+    remainder_size: usize,
+}
+
+impl FlipLut {
+    fn build(flip_rows: &[Vec<u64>], m_words: usize) -> Self {
+        let rank = flip_rows.len();
+        let num_full_groups = rank / LUT_GROUP_SIZE;
+        let remainder_size = rank % LUT_GROUP_SIZE;
+        let total_groups = num_full_groups + usize::from(remainder_size > 0);
+        let entries_per_group = 1 << LUT_GROUP_SIZE;
+
+        let mut data = vec![0u64; total_groups * entries_per_group * m_words];
+
+        for g in 0..total_groups {
+            let group_start = g * LUT_GROUP_SIZE;
+            let k = if g < num_full_groups {
+                LUT_GROUP_SIZE
+            } else {
+                remainder_size
+            };
+            let lut_offset = g * entries_per_group * m_words;
+
+            for byte in 1..(1usize << k) {
+                let lowest = byte & byte.wrapping_neg();
+                let row_idx = group_start + lowest.trailing_zeros() as usize;
+                let prev = byte ^ lowest;
+
+                let dst_start = lut_offset + byte * m_words;
+                let src_start = lut_offset + prev * m_words;
+
+                for w in 0..m_words {
+                    data[dst_start + w] = data[src_start + w] ^ flip_rows[row_idx][w];
+                }
+            }
+        }
+
+        Self {
+            data,
+            m_words,
+            num_full_groups,
+            remainder_size,
+        }
+    }
+
+    #[inline(always)]
+    fn lookup(&self, group: usize, byte: usize) -> &[u64] {
+        let offset = (group * (1 << LUT_GROUP_SIZE) + byte) * self.m_words;
+        &self.data[offset..offset + self.m_words]
+    }
+}
+
+pub struct CompiledSampler {
+    /// r rows, each packed as m_words u64s. Row j stores which measurements
+    /// flip when random bit j is 1.
+    flip_rows: Vec<Vec<u64>>,
+    ref_bits_packed: Vec<u64>,
+    rank: usize,
+    num_measurements: usize,
+    rng: ChaCha8Rng,
+    lut: Option<FlipLut>,
+}
+
+fn pack_bools(bools: &[bool]) -> Vec<u64> {
+    let n_words = bools.len().div_ceil(64);
+    let mut packed = vec![0u64; n_words];
+    for (i, &b) in bools.iter().enumerate() {
+        if b {
+            packed[i / 64] |= 1u64 << (i % 64);
+        }
+    }
+    packed
+}
+
+impl CompiledSampler {
+    pub fn rank(&self) -> usize {
+        self.rank
+    }
+
+    pub fn num_measurements(&self) -> usize {
+        self.num_measurements
+    }
+
+    pub fn sample(&mut self) -> Vec<bool> {
+        let num_meas_words = self.num_measurements.div_ceil(64);
+        let mut accum = vec![0u64; num_meas_words];
+        self.sample_into(&mut accum);
+        self.unpack_result(&accum)
+    }
+
+    pub(crate) fn sample_bulk_words(&mut self, num_shots: usize) -> (Vec<u64>, usize) {
+        let m_words = self.num_measurements.div_ceil(64);
+        if num_shots == 0 || self.num_measurements == 0 || self.rank == 0 {
+            return (vec![0u64; num_shots * m_words], m_words);
+        }
+
+        if let Some(lut) = &self.lut {
+            let total_groups = lut.num_full_groups + usize::from(lut.remainder_size > 0);
+            let bytes_per_shot = total_groups;
+            let total_bytes = num_shots * bytes_per_shot;
+            let mut rand_bytes: Vec<u8> = vec![0u8; total_bytes];
+            {
+                let full_chunks = total_bytes / 8;
+                let tail = full_chunks * 8;
+                for i in 0..full_chunks {
+                    let r = self.rng.next_u64();
+                    rand_bytes[i * 8..(i + 1) * 8].copy_from_slice(&r.to_le_bytes());
+                }
+                if tail < total_bytes {
+                    let r = self.rng.next_u64();
+                    let bytes = r.to_le_bytes();
+                    rand_bytes[tail..total_bytes].copy_from_slice(&bytes[..total_bytes - tail]);
+                }
+                if lut.remainder_size > 0 {
+                    let remainder_mask = (1u8 << lut.remainder_size) - 1;
+                    let last_group = lut.num_full_groups;
+                    for s in 0..num_shots {
+                        rand_bytes[s * bytes_per_shot + last_group] &= remainder_mask;
+                    }
+                }
+            }
+
+            let mut accum: Vec<u64> = vec![0u64; num_shots * m_words];
+
+            let max_batch = if m_words > 0 {
+                (256 * 1024 / (m_words * 8)).max(64)
+            } else {
+                num_shots
+            };
+
+            #[cfg(feature = "parallel")]
+            const PAR_SHOT_THRESHOLD: usize = 256;
+
+            #[cfg(feature = "parallel")]
+            if num_shots >= PAR_SHOT_THRESHOLD {
+                use rayon::prelude::*;
+                let shots_per_chunk =
+                    (num_shots.div_ceil(rayon::current_num_threads())).max(max_batch);
+                let chunk_m = shots_per_chunk * m_words;
+                accum
+                    .par_chunks_mut(chunk_m)
+                    .enumerate()
+                    .for_each(|(ci, chunk)| {
+                        let chunk_shots = chunk.len() / m_words;
+                        let chunk_start = ci * shots_per_chunk;
+                        for tile_start in (0..chunk_shots).step_by(max_batch) {
+                            let tile_end = (tile_start + max_batch).min(chunk_shots);
+                            for g in 0..total_groups {
+                                for s in tile_start..tile_end {
+                                    let gs = chunk_start + s;
+                                    let byte = rand_bytes[gs * bytes_per_shot + g] as usize;
+                                    let entry = lut.lookup(g, byte);
+                                    let base = s * m_words;
+                                    xor_words(&mut chunk[base..base + m_words], entry);
+                                }
+                            }
+                        }
+                    });
+            } else {
+                for tile_start in (0..num_shots).step_by(max_batch) {
+                    let tile_end = (tile_start + max_batch).min(num_shots);
+                    for g in 0..total_groups {
+                        for s in tile_start..tile_end {
+                            let byte = rand_bytes[s * bytes_per_shot + g] as usize;
+                            let entry = lut.lookup(g, byte);
+                            let shot_base = s * m_words;
+                            xor_words(&mut accum[shot_base..shot_base + m_words], entry);
+                        }
+                    }
+                }
+            }
+
+            #[cfg(not(feature = "parallel"))]
+            {
+                for tile_start in (0..num_shots).step_by(max_batch) {
+                    let tile_end = (tile_start + max_batch).min(num_shots);
+                    for g in 0..total_groups {
+                        for s in tile_start..tile_end {
+                            let byte = rand_bytes[s * bytes_per_shot + g] as usize;
+                            let entry = lut.lookup(g, byte);
+                            let shot_base = s * m_words;
+                            xor_words(&mut accum[shot_base..shot_base + m_words], entry);
+                        }
+                    }
+                }
+            }
+
+            (accum, m_words)
+        } else {
+            let mut accum = vec![0u64; num_shots * m_words];
+            for s in 0..num_shots {
+                let shot_base = s * m_words;
+                let shot_accum = &mut accum[shot_base..shot_base + m_words];
+                for j in 0..self.rank {
+                    let bit = self.rng.next_u32() & 1;
+                    if bit != 0 {
+                        let row = &self.flip_rows[j];
+                        xor_words(shot_accum, row);
+                    }
+                }
+            }
+            (accum, m_words)
+        }
+    }
+
+    pub(crate) fn ref_bits_packed(&self) -> &[u64] {
+        &self.ref_bits_packed
+    }
+
+    pub fn sample_bulk(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
+        if num_shots == 0 || self.num_measurements == 0 {
+            return vec![Vec::new(); num_shots];
+        }
+
+        let m_words = self.num_measurements.div_ceil(64);
+
+        if self.rank == 0 {
+            let result = self.unpack_result_static();
+            return vec![result; num_shots];
+        }
+
+        if self.lut.is_some() {
+            self.sample_bulk_grouped(num_shots, m_words)
+        } else {
+            self.sample_bulk_sequential(num_shots, m_words)
+        }
+    }
+
+    fn sample_bulk_grouped(&mut self, num_shots: usize, m_words: usize) -> Vec<Vec<bool>> {
+        let lut = self.lut.as_ref().unwrap();
+        let total_groups = lut.num_full_groups + usize::from(lut.remainder_size > 0);
+
+        let bytes_per_shot = total_groups;
+        let total_bytes = num_shots * bytes_per_shot;
+        let mut rand_bytes: Vec<u8> = vec![0u8; total_bytes];
+        {
+            let full_chunks = total_bytes / 8;
+            let tail = full_chunks * 8;
+            for i in 0..full_chunks {
+                let r = self.rng.next_u64();
+                rand_bytes[i * 8..(i + 1) * 8].copy_from_slice(&r.to_le_bytes());
+            }
+            if tail < total_bytes {
+                let r = self.rng.next_u64();
+                let bytes = r.to_le_bytes();
+                rand_bytes[tail..total_bytes].copy_from_slice(&bytes[..total_bytes - tail]);
+            }
+            if lut.remainder_size > 0 {
+                let remainder_mask = (1u8 << lut.remainder_size) - 1;
+                let last_group = lut.num_full_groups;
+                for s in 0..num_shots {
+                    rand_bytes[s * bytes_per_shot + last_group] &= remainder_mask;
+                }
+            }
+        }
+
+        let mut accum: Vec<u64> = vec![0u64; num_shots * m_words];
+
+        // Tile shots so accumulators fit in L2 (~256KB). Each shot uses m_words × 8 bytes.
+        let max_batch = if m_words > 0 {
+            (256 * 1024 / (m_words * 8)).max(64)
+        } else {
+            num_shots
+        };
+
+        // Group-major loop with tiling: LUT group stays L1-hot within each tile
+        for tile_start in (0..num_shots).step_by(max_batch) {
+            let tile_end = (tile_start + max_batch).min(num_shots);
+            for g in 0..total_groups {
+                for s in tile_start..tile_end {
+                    let byte = rand_bytes[s * bytes_per_shot + g] as usize;
+                    let entry = lut.lookup(g, byte);
+                    let shot_base = s * m_words;
+                    xor_words(&mut accum[shot_base..shot_base + m_words], entry);
+                }
+            }
+        }
+
+        let mut shots = Vec::with_capacity(num_shots);
+        for s in 0..num_shots {
+            let shot_base = s * m_words;
+            shots.push(self.unpack_result(&accum[shot_base..shot_base + m_words]));
+        }
+        shots
+    }
+
+    fn sample_bulk_sequential(&mut self, num_shots: usize, m_words: usize) -> Vec<Vec<bool>> {
+        let mut accum = vec![0u64; m_words];
+        let mut shots = Vec::with_capacity(num_shots);
+
+        for _ in 0..num_shots {
+            accum.fill(0);
+            self.sample_into(&mut accum);
+            shots.push(self.unpack_result(&accum));
+        }
+
+        shots
+    }
+
+    #[inline(always)]
+    #[allow(dead_code)]
+    pub(crate) fn sample_into_raw(&mut self, accum: &mut [u64]) {
+        self.sample_into(accum);
+    }
+
+    #[inline(always)]
+    fn sample_into(&mut self, accum: &mut [u64]) {
+        if self.rank == 0 {
+            return;
+        }
+
+        if let Some(lut) = &self.lut {
+            let mut rand_buf = 0u64;
+            let mut rand_pos = 8usize;
+
+            for g in 0..lut.num_full_groups {
+                if rand_pos >= 8 {
+                    rand_buf = self.rng.next_u64();
+                    rand_pos = 0;
+                }
+                let byte = ((rand_buf >> (rand_pos * 8)) & 0xFF) as usize;
+                rand_pos += 1;
+                let entry = lut.lookup(g, byte);
+                xor_words(accum, entry);
+            }
+            if lut.remainder_size > 0 {
+                if rand_pos >= 8 {
+                    rand_buf = self.rng.next_u64();
+                }
+                let mask = (1u64 << lut.remainder_size) - 1;
+                let byte = (rand_buf & mask) as usize;
+                let entry = lut.lookup(lut.num_full_groups, byte);
+                xor_words(accum, entry);
+            }
+        } else {
+            for j in 0..self.rank {
+                let bit = self.rng.next_u32() & 1;
+                if bit != 0 {
+                    let row = &self.flip_rows[j];
+                    xor_words(accum, row);
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn unpack_result(&self, accum: &[u64]) -> Vec<bool> {
+        let mut result = Vec::with_capacity(self.num_measurements);
+        for m in 0..self.num_measurements {
+            let w = m / 64;
+            let ref_word = if w < self.ref_bits_packed.len() {
+                self.ref_bits_packed[w]
+            } else {
+                0
+            };
+            let bit = ((accum[w] ^ ref_word) >> (m % 64)) & 1 != 0;
+            result.push(bit);
+        }
+        result
+    }
+
+    pub(crate) fn apply_ref_bits(&self, accum: &mut [u64]) {
+        xor_words(accum, &self.ref_bits_packed);
+    }
+
+    fn unpack_result_static(&self) -> Vec<bool> {
+        let mut result = Vec::with_capacity(self.num_measurements);
+        for m in 0..self.num_measurements {
+            let w = m / 64;
+            let bit = if w < self.ref_bits_packed.len() {
+                (self.ref_bits_packed[w] >> (m % 64)) & 1 != 0
+            } else {
+                false
+            };
+            result.push(bit);
+        }
+        result
+    }
+}
+
+/// AVX2 rowmul: src (read-only) multiplied into dst (modified in-place).
+/// Both buffers are laid out as [x_words(nw) | z_words(nw)].
+/// Returns the accumulated Pauli phase sum.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn rowmul_avx2(src_ptr: *const u64, dst_ptr: *mut u64, nw: usize, initial_sum: u64) -> u64 {
+    use std::arch::x86_64::*;
+    let chunks = nw / 4;
+    let mut sum = initial_sum;
+    let src_x = src_ptr;
+    let src_z = src_ptr.add(nw);
+    let dst_x = dst_ptr;
+    let dst_z = dst_ptr.add(nw);
+
+    for i in 0..chunks {
+        let off = i * 4;
+        let x1 = _mm256_loadu_si256(src_x.add(off) as *const __m256i);
+        let z1 = _mm256_loadu_si256(src_z.add(off) as *const __m256i);
+        let x2 = _mm256_loadu_si256(dst_x.add(off) as *const __m256i);
+        let z2 = _mm256_loadu_si256(dst_z.add(off) as *const __m256i);
+
+        let new_x = _mm256_xor_si256(x1, x2);
+        let new_z = _mm256_xor_si256(z1, z2);
+        _mm256_storeu_si256(dst_x.add(off) as *mut __m256i, new_x);
+        _mm256_storeu_si256(dst_z.add(off) as *mut __m256i, new_z);
+
+        let any = _mm256_or_si256(_mm256_or_si256(x1, z1), _mm256_or_si256(x2, z2));
+        if _mm256_testz_si256(any, any) == 0 {
+            let x1z1 = _mm256_and_si256(x1, z1);
+            let x2z2 = _mm256_and_si256(x2, z2);
+
+            let nonzero = _mm256_and_si256(
+                _mm256_and_si256(_mm256_or_si256(new_x, new_z), _mm256_or_si256(x1, z1)),
+                _mm256_or_si256(x2, z2),
+            );
+            // pos = (x1&z1&!x2&z2) | (x1&!z1&x2&z2) | (!x1&z1&x2&!z2)
+            let pos = _mm256_or_si256(
+                _mm256_or_si256(
+                    _mm256_and_si256(x1z1, _mm256_andnot_si256(x2, z2)),
+                    _mm256_and_si256(_mm256_andnot_si256(z1, x1), x2z2),
+                ),
+                _mm256_and_si256(_mm256_andnot_si256(x1, z1), _mm256_andnot_si256(z2, x2)),
+            );
+
+            let nz_arr: [u64; 4] = std::mem::transmute(nonzero);
+            let pos_arr: [u64; 4] = std::mem::transmute(pos);
+            let mut nz_count = 0u64;
+            let mut pos_count = 0u64;
+            for j in 0..4 {
+                nz_count += nz_arr[j].count_ones() as u64;
+                pos_count += pos_arr[j].count_ones() as u64;
+            }
+            sum = sum.wrapping_add(2 * pos_count);
+            sum = sum.wrapping_sub(nz_count);
+        }
+    }
+
+    let tail = chunks * 4;
+    for w in tail..nw {
+        let x1 = *src_x.add(w);
+        let z1 = *src_z.add(w);
+        let x2 = *dst_x.add(w);
+        let z2 = *dst_z.add(w);
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        *dst_x.add(w) = new_x;
+        *dst_z.add(w) = new_z;
+        if (x1 | z1 | x2 | z2) != 0 {
+            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+            let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+        }
+    }
+    sum
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn rowmul_neon(src_ptr: *const u64, dst_ptr: *mut u64, nw: usize, initial_sum: u64) -> u64 {
+    use std::arch::aarch64::*;
+    let chunks = nw / 2;
+    let mut sum = initial_sum;
+    let src_x = src_ptr;
+    let src_z = src_ptr.add(nw);
+    let dst_x = dst_ptr;
+    let dst_z = dst_ptr.add(nw);
+
+    for i in 0..chunks {
+        let off = i * 2;
+        let x1 = vld1q_u64(src_x.add(off));
+        let z1 = vld1q_u64(src_z.add(off));
+        let x2 = vld1q_u64(dst_x.add(off));
+        let z2 = vld1q_u64(dst_z.add(off));
+
+        let new_x = veorq_u64(x1, x2);
+        let new_z = veorq_u64(z1, z2);
+        vst1q_u64(dst_x.add(off), new_x);
+        vst1q_u64(dst_z.add(off), new_z);
+
+        let any = vorrq_u64(vorrq_u64(x1, z1), vorrq_u64(x2, z2));
+        let any_arr: [u64; 2] = std::mem::transmute(any);
+        if (any_arr[0] | any_arr[1]) != 0 {
+            let x1z1 = vandq_u64(x1, z1);
+            let x2z2 = vandq_u64(x2, z2);
+
+            let nonzero = vandq_u64(
+                vandq_u64(vorrq_u64(new_x, new_z), vorrq_u64(x1, z1)),
+                vorrq_u64(x2, z2),
+            );
+            // pos = (x1&z1&!x2&z2) | (x1&!z1&x2&z2) | (!x1&z1&x2&!z2)
+            let pos = vorrq_u64(
+                vorrq_u64(
+                    vandq_u64(x1z1, vbicq_u64(z2, x2)),
+                    vandq_u64(vbicq_u64(x1, z1), x2z2),
+                ),
+                vandq_u64(vbicq_u64(z1, x1), vbicq_u64(x2, z2)),
+            );
+
+            let nz_arr: [u64; 2] = std::mem::transmute(nonzero);
+            let pos_arr: [u64; 2] = std::mem::transmute(pos);
+            let mut nz_count = 0u64;
+            let mut pos_count = 0u64;
+            for j in 0..2 {
+                nz_count += nz_arr[j].count_ones() as u64;
+                pos_count += pos_arr[j].count_ones() as u64;
+            }
+            sum = sum.wrapping_add(2 * pos_count);
+            sum = sum.wrapping_sub(nz_count);
+        }
+    }
+
+    let tail = chunks * 2;
+    for w in tail..nw {
+        let x1 = *src_x.add(w);
+        let z1 = *src_z.add(w);
+        let x2 = *dst_x.add(w);
+        let z2 = *dst_z.add(w);
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        *dst_x.add(w) = new_x;
+        *dst_z.add(w) = new_z;
+        if (x1 | z1 | x2 | z2) != 0 {
+            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+            let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+        }
+    }
+    sum
+}
+
+/// Rowmul: multiply src into xz[r_base..], returning the resulting phase.
+#[inline(always)]
+fn rowmul_phase(
+    src: &[u64],
+    xz: &mut [u64],
+    r_base: usize,
+    nw: usize,
+    src_phase: bool,
+    dst_phase: bool,
+) -> bool {
+    let initial_sum = if src_phase { 2u64 } else { 0 } + if dst_phase { 2u64 } else { 0 };
+
+    #[cfg(target_arch = "x86_64")]
+    if nw >= 4 && is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 detected, src has 2*nw elements, xz[r_base..] has 2*nw elements
+        let sum =
+            unsafe { rowmul_avx2(src.as_ptr(), xz.as_mut_ptr().add(r_base), nw, initial_sum) };
+        return (sum & 3) >= 2;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if nw >= 2 {
+        // SAFETY: NEON is baseline on aarch64, src has 2*nw elements, xz[r_base..] has 2*nw elements
+        let sum =
+            unsafe { rowmul_neon(src.as_ptr(), xz.as_mut_ptr().add(r_base), nw, initial_sum) };
+        return (sum & 3) >= 2;
+    }
+
+    let mut sum = initial_sum;
+    for w in 0..nw {
+        let x1 = src[w];
+        let z1 = src[nw + w];
+        let x2 = xz[r_base + w];
+        let z2 = xz[r_base + nw + w];
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        xz[r_base + w] = new_x;
+        xz[r_base + nw + w] = new_z;
+        if (x1 | z1 | x2 | z2) != 0 {
+            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+            let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+        }
+    }
+    (sum & 3) >= 2
+}
+
+/// Rowmul variant for scratch buffer: multiply src (from xz) into scratch.
+#[inline(always)]
+fn rowmul_phase_into(
+    xz: &[u64],
+    s_base: usize,
+    scratch: &mut [u64],
+    nw: usize,
+    src_phase: bool,
+    dst_phase: bool,
+) -> bool {
+    let initial_sum = if src_phase { 2u64 } else { 0 } + if dst_phase { 2u64 } else { 0 };
+
+    #[cfg(target_arch = "x86_64")]
+    if nw >= 4 && is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 detected, xz[s_base..] is src, scratch is dst
+        let sum = unsafe {
+            rowmul_avx2(
+                xz.as_ptr().add(s_base),
+                scratch.as_mut_ptr(),
+                nw,
+                initial_sum,
+            )
+        };
+        return (sum & 3) >= 2;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if nw >= 2 {
+        // SAFETY: NEON is baseline on aarch64, xz[s_base..] is src, scratch is dst
+        let sum = unsafe {
+            rowmul_neon(
+                xz.as_ptr().add(s_base),
+                scratch.as_mut_ptr(),
+                nw,
+                initial_sum,
+            )
+        };
+        return (sum & 3) >= 2;
+    }
+
+    let mut sum = initial_sum;
+    for w in 0..nw {
+        let x1 = xz[s_base + w];
+        let z1 = xz[s_base + nw + w];
+        let x2 = scratch[w];
+        let z2 = scratch[nw + w];
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        scratch[w] = new_x;
+        scratch[nw + w] = new_z;
+        if (x1 | z1 | x2 | z2) != 0 {
+            let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+            let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+            sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+            sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+        }
+    }
+    (sum & 3) >= 2
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn xor_words_avx2(dst: &mut [u64], src: &[u64]) {
+    use std::arch::x86_64::*;
+    let len = dst.len().min(src.len());
+    let chunks = len / 4;
+    let dp = dst.as_mut_ptr() as *mut __m256i;
+    let sp = src.as_ptr() as *const __m256i;
+    for i in 0..chunks {
+        let d = _mm256_loadu_si256(dp.add(i));
+        let s = _mm256_loadu_si256(sp.add(i));
+        _mm256_storeu_si256(dp.add(i), _mm256_xor_si256(d, s));
+    }
+    let tail = chunks * 4;
+    for i in tail..len {
+        *dst.get_unchecked_mut(i) ^= *src.get_unchecked(i);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)]
+unsafe fn xor_words_neon(dst: &mut [u64], src: &[u64]) {
+    use std::arch::aarch64::*;
+    let len = dst.len().min(src.len());
+    let chunks = len / 2;
+    let dp = dst.as_mut_ptr();
+    let sp = src.as_ptr();
+    for i in 0..chunks {
+        let off = i * 2;
+        let d = vld1q_u64(dp.add(off));
+        let s = vld1q_u64(sp.add(off));
+        vst1q_u64(dp.add(off), veorq_u64(d, s));
+    }
+    let tail = chunks * 2;
+    for i in tail..len {
+        *dst.get_unchecked_mut(i) ^= *src.get_unchecked(i);
+    }
+}
+
+#[inline(always)]
+pub(crate) fn xor_words(dst: &mut [u64], src: &[u64]) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx2") && dst.len() >= 4 {
+            // SAFETY: AVX2 detected, pointers are valid u64 slices
+            unsafe {
+                xor_words_avx2(dst, src);
+            }
+            return;
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if dst.len() >= 2 {
+            // SAFETY: NEON is baseline on aarch64, pointers are valid u64 slices
+            unsafe {
+                xor_words_neon(dst, src);
+            }
+            return;
+        }
+    }
+    for (d, &s) in dst.iter_mut().zip(src) {
+        *d ^= s;
+    }
+}
+
+/// Compute reference measurement outcomes by simulating measurements of the
+/// propagated Paulis on |0⟩^n using the Aaronson-Gottesman measurement protocol.
+/// O(m × n²/64) — avoids re-simulating all T circuit gates through the stabilizer.
+#[allow(clippy::needless_range_loop)]
+fn compute_reference_bits(measurement_rows: &[(PauliVec, usize, bool)], n: usize) -> Vec<bool> {
+    let m = measurement_rows.len();
+    let nw = n.div_ceil(64);
+    let stride = 2 * nw;
+
+    let mut xz = vec![0u64; 2 * n * stride];
+    let mut phase = vec![false; 2 * n];
+
+    for i in 0..n {
+        xz[i * stride + i / 64] |= 1u64 << (i % 64);
+        xz[(n + i) * stride + nw + i / 64] |= 1u64 << (i % 64);
+    }
+
+    let mut ref_bits = vec![false; m];
+
+    for (meas_idx, (pauli, _, _)) in measurement_rows.iter().enumerate() {
+        let mut anti_idx = None;
+        for g in n..2 * n {
+            let base = g * stride;
+            let mut inner = 0u64;
+            for w in 0..nw {
+                inner ^= (pauli.x[w] & xz[base + nw + w]) ^ (pauli.z[w] & xz[base + w]);
+            }
+            if inner.count_ones() % 2 == 1 {
+                anti_idx = Some(g);
+                break;
+            }
+        }
+
+        match anti_idx {
+            Some(p) => {
+                // Random measurement. Pick outcome = 0.
+                // For all rows (0..2n) that anti-commute with P (except p): rowmul(row, p)
+                let p_data: Vec<u64> = xz[p * stride..(p + 1) * stride].to_vec();
+                let p_phase = phase[p];
+
+                for r in 0..2 * n {
+                    if r == p {
+                        continue;
+                    }
+                    let r_base = r * stride;
+                    let mut inner = 0u64;
+                    for w in 0..nw {
+                        inner ^= (pauli.x[w] & xz[r_base + nw + w]) ^ (pauli.z[w] & xz[r_base + w]);
+                    }
+                    if inner.count_ones() % 2 == 1 {
+                        phase[r] = rowmul_phase(&p_data, &mut xz, r_base, nw, p_phase, phase[r]);
+                    }
+                }
+
+                let dest_idx = p - n;
+                let dest_base = dest_idx * stride;
+                xz.copy_within(p * stride..(p + 1) * stride, dest_base);
+                phase[dest_idx] = p_phase;
+
+                let p_base = p * stride;
+                for w in 0..nw {
+                    xz[p_base + w] = pauli.x[w];
+                    xz[p_base + nw + w] = pauli.z[w];
+                }
+                phase[p] = false;
+
+                ref_bits[meas_idx] = false;
+            }
+            None => {
+                // Deterministic: P commutes with all stabilizers.
+                // Accumulate rowmul of stabilizer[g] for each destabilizer[g]
+                // that anti-commutes with P.
+                let mut scratch = vec![0u64; stride];
+                let mut scratch_phase = false;
+
+                for g in 0..n {
+                    let d_base = g * stride;
+                    let mut inner = 0u64;
+                    for w in 0..nw {
+                        inner ^= (pauli.x[w] & xz[d_base + nw + w]) ^ (pauli.z[w] & xz[d_base + w]);
+                    }
+                    if inner.count_ones() % 2 == 1 {
+                        let s_base = (g + n) * stride;
+                        let s_phase = phase[g + n];
+                        scratch_phase = rowmul_phase_into(
+                            &xz,
+                            s_base,
+                            &mut scratch,
+                            nw,
+                            s_phase,
+                            scratch_phase,
+                        );
+                    }
+                }
+
+                ref_bits[meas_idx] = scratch_phase;
+            }
+        }
+    }
+
+    ref_bits
+}
+
+/// Forward-compile a Clifford circuit's measurements into a fast sampler.
+///
+/// SGI-optimized stabilizer processes gates forward; dependency tracking during
+/// measurement extracts reference bits and the flip matrix in one pass.
+///
+/// Compilation: O(T × active_avg × nw) gates + O(m × n × (nw + r_words)) measurements.
+/// Per-shot: O(r·m/64) where r = rank.
+/// Column-major forward stabilizer simulation.
+///
+/// Stores x_cols[qubit][row_word] and z_cols[qubit][row_word] so gate
+/// application is O(row_words) vector XOR instead of O(2n) per-row bit ops.
+///
+/// Returns (xz_rowmajor, phase, nw) transposed back to row-major.
+fn colmajor_forward_sim(
+    n: usize,
+    instructions: &[Instruction],
+) -> Result<(Vec<u64>, Vec<bool>, usize)> {
+    let total_rows = 2 * n;
+    let nw = n.div_ceil(64);
+    let row_words = total_rows.div_ceil(64);
+
+    let mut x_cols: Vec<Vec<u64>> = vec![vec![0u64; row_words]; n];
+    let mut z_cols: Vec<Vec<u64>> = vec![vec![0u64; row_words]; n];
+    let mut phase: Vec<u64> = vec![0u64; row_words];
+
+    for q in 0..n {
+        x_cols[q][q / 64] |= 1u64 << (q % 64);
+        let stab_row = n + q;
+        z_cols[q][stab_row / 64] |= 1u64 << (stab_row % 64);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    let use_avx2 = row_words >= 4 && is_x86_feature_detected!("avx2");
+    #[cfg(not(target_arch = "x86_64"))]
+    let use_avx2 = false;
+    #[cfg(target_arch = "aarch64")]
+    let use_neon = row_words >= 2;
+
+    for inst in instructions {
+        let (gate, targets) = match inst {
+            Instruction::Gate { gate, targets } => (gate, targets.as_slice()),
+            Instruction::Conditional { gate, targets, .. } => (gate, targets.as_slice()),
+            _ => continue,
+        };
+
+        match gate {
+            Gate::H => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected, slices have row_words elements
+                    unsafe {
+                        batch_propagate_h_avx2(
+                            &mut x_cols[q],
+                            &mut z_cols[q],
+                            &mut phase,
+                            row_words,
+                        )
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe {
+                            batch_propagate_h_neon(
+                                &mut x_cols[q],
+                                &mut z_cols[q],
+                                &mut phase,
+                                row_words,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x_cols[q][w] & z_cols[q][w];
+                    }
+                    std::mem::swap(&mut x_cols[q], &mut z_cols[q]);
+                }
+            }
+            Gate::S => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_s_avx2(
+                            &mut x_cols[q],
+                            &mut z_cols[q],
+                            &mut phase,
+                            row_words,
+                            false,
+                        )
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe {
+                            batch_propagate_s_neon(
+                                &mut x_cols[q],
+                                &mut z_cols[q],
+                                &mut phase,
+                                row_words,
+                                false,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x_cols[q][w] & z_cols[q][w];
+                        z_cols[q][w] ^= x_cols[q][w];
+                    }
+                }
+            }
+            Gate::Sdg => {
+                let q = targets[0];
+                // Forward Sdg: z ^= x (first), then p ^= x & z_new
+                // Different order from backward — no reusable SIMD function
+                for w in 0..row_words {
+                    z_cols[q][w] ^= x_cols[q][w];
+                    phase[w] ^= x_cols[q][w] & z_cols[q][w];
+                }
+            }
+            Gate::X => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_sign_xor_avx2(&mut phase, &z_cols[q], row_words)
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe { batch_propagate_sign_xor_neon(&mut phase, &z_cols[q], row_words) };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= z_cols[q][w];
+                    }
+                }
+            }
+            Gate::Y => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_sign_xor2_avx2(
+                            &mut phase, &x_cols[q], &z_cols[q], row_words,
+                        )
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe {
+                            batch_propagate_sign_xor2_neon(
+                                &mut phase, &x_cols[q], &z_cols[q], row_words,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x_cols[q][w] ^ z_cols[q][w];
+                    }
+                }
+            }
+            Gate::Z => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_sign_xor_avx2(&mut phase, &x_cols[q], row_words)
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe { batch_propagate_sign_xor_neon(&mut phase, &x_cols[q], row_words) };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x_cols[q][w];
+                    }
+                }
+            }
+            Gate::Id => {}
+            Gate::SX => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_sx_avx2(
+                            &mut x_cols[q],
+                            &z_cols[q],
+                            &mut phase,
+                            row_words,
+                            true,
+                        )
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe {
+                            batch_propagate_sx_neon(
+                                &mut x_cols[q],
+                                &z_cols[q],
+                                &mut phase,
+                                row_words,
+                                true,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= !x_cols[q][w] & z_cols[q][w];
+                        x_cols[q][w] ^= z_cols[q][w];
+                    }
+                }
+            }
+            Gate::SXdg => {
+                let q = targets[0];
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected
+                    unsafe {
+                        batch_propagate_sx_avx2(
+                            &mut x_cols[q],
+                            &z_cols[q],
+                            &mut phase,
+                            row_words,
+                            false,
+                        )
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64
+                        unsafe {
+                            batch_propagate_sx_neon(
+                                &mut x_cols[q],
+                                &z_cols[q],
+                                &mut phase,
+                                row_words,
+                                false,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x_cols[q][w] & z_cols[q][w];
+                        x_cols[q][w] ^= z_cols[q][w];
+                    }
+                }
+            }
+            Gate::Cx => {
+                let ctrl = targets[0];
+                let tgt = targets[1];
+                let (xc_sl, xt_sl) = if ctrl < tgt {
+                    let (lo, hi) = x_cols.split_at_mut(tgt);
+                    (&lo[ctrl][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x_cols.split_at_mut(ctrl);
+                    (&hi[0][..], &mut lo[tgt][..])
+                };
+                let (zc_sl, zt_sl) = if ctrl < tgt {
+                    let (lo, hi) = z_cols.split_at_mut(tgt);
+                    (&mut lo[ctrl][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = z_cols.split_at_mut(ctrl);
+                    (&mut hi[0][..], &lo[tgt][..])
+                };
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected, ctrl != tgt
+                    unsafe {
+                        batch_propagate_cx_avx2(xc_sl, zc_sl, xt_sl, zt_sl, &mut phase, row_words)
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64, ctrl != tgt
+                        unsafe {
+                            batch_propagate_cx_neon(
+                                xc_sl, zc_sl, xt_sl, zt_sl, &mut phase, row_words,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= xc_sl[w] & zt_sl[w] & !(zc_sl[w] ^ xt_sl[w]);
+                        xt_sl[w] ^= xc_sl[w];
+                        zc_sl[w] ^= zt_sl[w];
+                    }
+                }
+            }
+            Gate::Cz => {
+                let q0 = targets[0];
+                let q1 = targets[1];
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x_cols.split_at_mut(q1);
+                    (&lo[q0][..], &hi[0][..])
+                } else {
+                    let (lo, hi) = x_cols.split_at_mut(q0);
+                    (&hi[0][..], &lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z_cols.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z_cols.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected, q0 != q1
+                    unsafe {
+                        batch_propagate_cz_avx2(x0_sl, z0_sl, x1_sl, z1_sl, &mut phase, row_words)
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64, q0 != q1
+                        unsafe {
+                            batch_propagate_cz_neon(
+                                x0_sl, z0_sl, x1_sl, z1_sl, &mut phase, row_words,
+                            )
+                        };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        phase[w] ^= x0_sl[w] & x1_sl[w] & !(z0_sl[w] ^ z1_sl[w]);
+                        z0_sl[w] ^= x1_sl[w];
+                        z1_sl[w] ^= x0_sl[w];
+                    }
+                }
+            }
+            Gate::Swap => {
+                let q0 = targets[0];
+                let q1 = targets[1];
+                let (x0_sl, x1_sl) = if q0 < q1 {
+                    let (lo, hi) = x_cols.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = x_cols.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                let (z0_sl, z1_sl) = if q0 < q1 {
+                    let (lo, hi) = z_cols.split_at_mut(q1);
+                    (&mut lo[q0][..], &mut hi[0][..])
+                } else {
+                    let (lo, hi) = z_cols.split_at_mut(q0);
+                    (&mut hi[0][..], &mut lo[q1][..])
+                };
+                if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: AVX2 detected, q0 != q1
+                    unsafe {
+                        batch_propagate_swap_avx2(x0_sl, z0_sl, x1_sl, z1_sl, row_words)
+                    };
+                } else {
+                    #[cfg(target_arch = "aarch64")]
+                    if use_neon {
+                        // SAFETY: NEON is baseline on aarch64, q0 != q1
+                        unsafe { batch_propagate_swap_neon(x0_sl, z0_sl, x1_sl, z1_sl, row_words) };
+                        continue;
+                    }
+                    for w in 0..row_words {
+                        std::mem::swap(&mut x0_sl[w], &mut x1_sl[w]);
+                        std::mem::swap(&mut z0_sl[w], &mut z1_sl[w]);
+                    }
+                }
+            }
+            _ => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "CompiledSampler".to_string(),
+                    reason: format!("unsupported gate {:?} in column-major forward sim", gate),
+                });
+            }
+        }
+    }
+
+    let stride = 2 * nw;
+    let mut xz = vec![0u64; total_rows * stride];
+    let mut phase_vec = vec![false; total_rows];
+
+    for q in 0..n {
+        let qw = q / 64;
+        let qb = q % 64;
+        let qm = 1u64 << qb;
+        for rw in 0..row_words {
+            let mut xbits = x_cols[q][rw];
+            while xbits != 0 {
+                let bit = xbits.trailing_zeros() as usize;
+                let row = rw * 64 + bit;
+                if row < total_rows {
+                    xz[row * stride + qw] |= qm;
+                }
+                xbits &= xbits - 1;
+            }
+            let mut zbits = z_cols[q][rw];
+            while zbits != 0 {
+                let bit = zbits.trailing_zeros() as usize;
+                let row = rw * 64 + bit;
+                if row < total_rows {
+                    xz[row * stride + nw + qw] |= qm;
+                }
+                zbits &= zbits - 1;
+            }
+        }
+    }
+
+    for (rw, &pw) in phase.iter().enumerate().take(row_words) {
+        let mut pbits = pw;
+        while pbits != 0 {
+            let bit = pbits.trailing_zeros() as usize;
+            let row = rw * 64 + bit;
+            if row < total_rows {
+                phase_vec[row] = true;
+            }
+            pbits &= pbits - 1;
+        }
+    }
+
+    Ok((xz, phase_vec, nw))
+}
+
+pub fn compile_forward(circuit: &Circuit, seed: u64) -> Result<CompiledSampler> {
+    if !circuit.is_clifford_only() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "CompiledSampler".to_string(),
+            reason: "circuit contains non-Clifford gates".to_string(),
+        });
+    }
+
+    let measurements: Vec<(usize, usize)> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => Some((*qubit, *classical_bit)),
+            _ => None,
+        })
+        .collect();
+
+    let num_measurements = measurements.len();
+    if num_measurements == 0 {
+        return Ok(CompiledSampler {
+            flip_rows: Vec::new(),
+            ref_bits_packed: Vec::new(),
+            rank: 0,
+            num_measurements: 0,
+            rng: ChaCha8Rng::seed_from_u64(seed),
+            lut: None,
+        });
+    }
+
+    let n = circuit.num_qubits;
+
+    let (mut xz, mut phase, nw) = colmajor_forward_sim(n, &circuit.instructions)?;
+    let stride = 2 * nw;
+    let m = num_measurements;
+    let m_words = m.div_ceil(64);
+
+    let rank_words = m_words;
+    let total_rows = 2 * n;
+    let mut gen_dep: Vec<Vec<u64>> = vec![vec![0u64; rank_words]; total_rows + 1];
+    let mut ref_bits: Vec<bool> = vec![false; m];
+    let mut rank = 0usize;
+
+    let mut flip_rows: Vec<Vec<u64>> = Vec::with_capacity(m);
+    let mut p_data: Vec<u64> = vec![0u64; stride];
+    let mut p_dep: Vec<u64> = vec![0u64; rank_words];
+    let mut scratch: Vec<u64> = vec![0u64; stride];
+    let scratch_idx = total_rows;
+
+    for (meas_idx, &(qubit, _)) in measurements.iter().enumerate() {
+        let word = qubit / 64;
+        let bit_mask = 1u64 << (qubit % 64);
+
+        let mut p: Option<usize> = None;
+        for i in n..2 * n {
+            if xz[i * stride + word] & bit_mask != 0 {
+                p = Some(i);
+                break;
+            }
+        }
+
+        if let Some(p_row) = p {
+            // Random measurement — this is the k-th random degree of freedom
+            let k = rank;
+            rank += 1;
+            flip_rows.push(vec![0u64; m_words]);
+
+            flip_rows[k][meas_idx / 64] |= 1u64 << (meas_idx % 64);
+
+            let p_base = p_row * stride;
+            p_data.copy_from_slice(&xz[p_base..p_base + stride]);
+            let p_phase = phase[p_row];
+            p_dep.copy_from_slice(&gen_dep[p_row][..rank_words]);
+
+            for r in 0..total_rows {
+                if r == p_row {
+                    continue;
+                }
+                if xz[r * stride + word] & bit_mask == 0 {
+                    continue;
+                }
+
+                let r_base = r * stride;
+                phase[r] = rowmul_phase(&p_data, &mut xz, r_base, nw, p_phase, phase[r]);
+                xor_words(&mut gen_dep[r][..rank_words], &p_dep[..rank_words]);
+            }
+
+            let dest_idx = p_row - n;
+            let dest_base = dest_idx * stride;
+            xz.copy_within(p_row * stride..p_row * stride + stride, dest_base);
+            phase[dest_idx] = p_phase;
+            gen_dep[dest_idx][..rank_words].copy_from_slice(&p_dep);
+
+            let p_base = p_row * stride;
+            xz[p_base..p_base + stride].fill(0);
+            xz[p_base + nw + word] |= bit_mask;
+            phase[p_row] = false;
+
+            gen_dep[p_row][..rank_words].fill(0);
+            gen_dep[p_row][k / 64] |= 1u64 << (k % 64);
+
+            ref_bits[meas_idx] = false;
+        } else {
+            scratch[..stride].fill(0);
+            let mut scratch_phase = false;
+            gen_dep[scratch_idx][..rank_words].fill(0);
+
+            for g in 0..n {
+                let d_base = g * stride;
+                if xz[d_base + word] & bit_mask == 0 {
+                    continue;
+                }
+
+                let s_base = (g + n) * stride;
+                let s_phase = phase[g + n];
+                scratch_phase =
+                    rowmul_phase_into(&xz, s_base, &mut scratch, nw, s_phase, scratch_phase);
+
+                let (lo, hi) = gen_dep.split_at_mut(scratch_idx);
+                for (dst, &src) in hi[0][..rank_words].iter_mut().zip(&lo[g + n][..rank_words]) {
+                    *dst ^= src;
+                }
+            }
+
+            ref_bits[meas_idx] = scratch_phase;
+
+            for (w, &dep_word) in gen_dep[scratch_idx][..rank_words].iter().enumerate() {
+                let mut bits = dep_word;
+                while bits != 0 {
+                    let bit_pos = bits.trailing_zeros() as usize;
+                    let k = w * 64 + bit_pos;
+                    if k < rank {
+                        flip_rows[k][meas_idx / 64] |= 1u64 << (meas_idx % 64);
+                    }
+                    bits &= bits - 1;
+                }
+            }
+        }
+    }
+
+    let num_meas_words = m_words;
+    let lut = if rank >= LUT_MIN_RANK {
+        Some(FlipLut::build(&flip_rows, num_meas_words))
+    } else {
+        None
+    };
+
+    Ok(CompiledSampler {
+        flip_rows,
+        ref_bits_packed: pack_bools(&ref_bits),
+        rank,
+        num_measurements,
+        rng: ChaCha8Rng::seed_from_u64(seed),
+        lut,
+    })
+}
+
+fn compile_measurements_filtered(
+    circuit: &Circuit,
+    blocks: &[Vec<usize>],
+    seed: u64,
+) -> Result<CompiledSampler> {
+    let num_global_measurements: usize = circuit
+        .instructions
+        .iter()
+        .filter(|i| matches!(i, Instruction::Measure { .. }))
+        .count();
+
+    if num_global_measurements == 0 {
+        return Ok(CompiledSampler {
+            flip_rows: Vec::new(),
+            ref_bits_packed: Vec::new(),
+            rank: 0,
+            num_measurements: 0,
+            rng: ChaCha8Rng::seed_from_u64(seed),
+            lut: None,
+        });
+    }
+
+    let mut qubit_to_block: Vec<usize> = vec![0; circuit.num_qubits];
+    for (bi, block) in blocks.iter().enumerate() {
+        for &q in block {
+            qubit_to_block[q] = bi;
+        }
+    }
+
+    let mut block_samplers: Vec<CompiledSampler> = Vec::with_capacity(blocks.len());
+    for (bi, block) in blocks.iter().enumerate() {
+        let (sub_circuit, _qubit_map, _classical_map) = circuit.extract_subcircuit(block);
+        let block_seed = seed.wrapping_add(bi as u64 * 0x1234_5678);
+        block_samplers.push(compile_measurements(&sub_circuit, block_seed)?);
+    }
+
+    let mut meas_map: Vec<(usize, usize)> = Vec::with_capacity(num_global_measurements);
+    let mut block_meas_count: Vec<usize> = vec![0; blocks.len()];
+    for inst in &circuit.instructions {
+        if let Instruction::Measure { qubit, .. } = inst {
+            let bi = qubit_to_block[*qubit];
+            let local_idx = block_meas_count[bi];
+            block_meas_count[bi] += 1;
+            meas_map.push((bi, local_idx));
+        }
+    }
+
+    let m_words = num_global_measurements.div_ceil(64);
+    let total_rank: usize = block_samplers.iter().map(|s| s.rank).sum();
+
+    let mut flip_rows: Vec<Vec<u64>> = Vec::with_capacity(total_rank);
+    let mut ref_bits_packed: Vec<u64> = vec![0u64; num_global_measurements.div_ceil(64)];
+
+    for (gi, &(bi, li)) in meas_map.iter().enumerate() {
+        let src = &block_samplers[bi].ref_bits_packed;
+        let bit = (src[li / 64] >> (li % 64)) & 1;
+        if bit != 0 {
+            ref_bits_packed[gi / 64] |= 1u64 << (gi % 64);
+        }
+    }
+
+    let mut local_to_global: Vec<Vec<usize>> = vec![Vec::new(); blocks.len()];
+    for (gi, &(bi, _li)) in meas_map.iter().enumerate() {
+        local_to_global[bi].push(gi);
+    }
+
+    for (bi, sampler) in block_samplers.iter().enumerate() {
+        let mapping = &local_to_global[bi];
+        for local_row in &sampler.flip_rows {
+            let mut global_row = vec![0u64; m_words];
+            for (lm, &gi) in mapping.iter().enumerate() {
+                if (local_row[lm / 64] >> (lm % 64)) & 1 != 0 {
+                    global_row[gi / 64] |= 1u64 << (gi % 64);
+                }
+            }
+            flip_rows.push(global_row);
+        }
+    }
+
+    let lut = if total_rank >= LUT_MIN_RANK {
+        Some(FlipLut::build(&flip_rows, m_words))
+    } else {
+        None
+    };
+
+    Ok(CompiledSampler {
+        flip_rows,
+        ref_bits_packed,
+        rank: total_rank,
+        num_measurements: num_global_measurements,
+        rng: ChaCha8Rng::seed_from_u64(seed),
+        lut,
+    })
+}
+
+/// Compile a Clifford circuit's measurements into a fast sampler.
+///
+/// Selects forward (SGI stabilizer + dependency tracking) or backward (Pauli
+/// propagation + Gaussian elimination) based on circuit depth. Forward wins
+/// for deep circuits (gate_count >= 5×measurements).
+pub fn compile_measurements(circuit: &Circuit, seed: u64) -> Result<CompiledSampler> {
+    if !circuit.is_clifford_only() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "CompiledSampler".to_string(),
+            reason: "circuit contains non-Clifford gates".to_string(),
+        });
+    }
+
+    if circuit.num_qubits >= 4 {
+        let blocks = circuit.independent_subsystems();
+        if blocks.len() > 1 {
+            let max_block = blocks.iter().map(|b| b.len()).max().unwrap_or(0);
+            if max_block < circuit.num_qubits {
+                return compile_measurements_filtered(circuit, &blocks, seed);
+            }
+        }
+    }
+
+    if circuit.num_qubits >= 64 {
+        return compile_forward(circuit, seed);
+    }
+
+    let measurement_rows = build_measurement_rows(circuit);
+    let num_measurements = measurement_rows.len();
+
+    if num_measurements == 0 {
+        return Ok(CompiledSampler {
+            flip_rows: Vec::new(),
+            ref_bits_packed: Vec::new(),
+            rank: 0,
+            num_measurements: 0,
+            rng: ChaCha8Rng::seed_from_u64(seed),
+            lut: None,
+        });
+    }
+
+    let n = circuit.num_qubits;
+
+    let x_rows: Vec<Vec<u64>> = measurement_rows
+        .iter()
+        .map(|(p, _, _)| p.x.clone())
+        .collect();
+    let signs: Vec<bool> = measurement_rows.iter().map(|(_, _, s)| *s).collect();
+
+    let mut x_copy = x_rows.clone();
+    let (rank, pivot_cols) = gaussian_eliminate(&mut x_copy, n);
+
+    let gate_count = circuit
+        .instructions
+        .iter()
+        .filter(|i| {
+            matches!(
+                i,
+                Instruction::Gate { .. } | Instruction::Conditional { .. }
+            )
+        })
+        .count();
+
+    let ref_bits: Vec<bool> = if gate_count > 2 * num_measurements {
+        let mini_outcomes = compute_reference_bits(&measurement_rows, n);
+        mini_outcomes
+            .iter()
+            .zip(signs.iter())
+            .map(|(&outcome, &sign)| outcome ^ sign)
+            .collect()
+    } else {
+        use crate::backend::stabilizer::StabilizerBackend;
+        use crate::backend::Backend;
+        let mut stab = StabilizerBackend::new(seed);
+        stab.init(circuit.num_qubits, circuit.num_classical_bits)?;
+        stab.apply_instructions(&circuit.instructions)?;
+        let ref_classical = stab.classical_results().to_vec();
+        let classical_bit_order: Vec<usize> = measurement_rows.iter().map(|(_, c, _)| *c).collect();
+        classical_bit_order
+            .iter()
+            .map(|&cbit| {
+                if cbit < ref_classical.len() {
+                    ref_classical[cbit]
+                } else {
+                    false
+                }
+            })
+            .collect()
+    };
+
+    let num_meas_words = num_measurements.div_ceil(64);
+    let mut flip_rows: Vec<Vec<u64>> = vec![vec![0u64; num_meas_words]; rank];
+
+    for (j, &pcol) in pivot_cols.iter().enumerate() {
+        for (i, x_row) in x_rows.iter().enumerate() {
+            if get_bit(x_row, pcol) {
+                flip_rows[j][i / 64] |= 1u64 << (i % 64);
+            }
+        }
+    }
+
+    let lut = if rank >= LUT_MIN_RANK {
+        Some(FlipLut::build(&flip_rows, num_meas_words))
+    } else {
+        None
+    };
+
+    Ok(CompiledSampler {
+        flip_rows,
+        ref_bits_packed: pack_bools(&ref_bits),
+        rank,
+        num_measurements,
+        rng: ChaCha8Rng::seed_from_u64(seed),
+        lut,
+    })
+}
+
+pub fn run_shots_compiled(circuit: &Circuit, num_shots: usize, seed: u64) -> Result<ShotsResult> {
+    let mut sampler = compile_measurements(circuit, seed)?;
+    let shots = sampler.sample_bulk(num_shots);
+    Ok(ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuits;
+    use crate::sim::BackendKind;
+
+    #[test]
+    fn ghz_rank_is_one() {
+        let mut c = circuits::ghz_circuit(10);
+        c.num_classical_bits = 10;
+        for i in 0..10 {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 1, "GHZ-10 should have rank 1");
+    }
+
+    #[test]
+    fn bell_pairs_rank() {
+        let n_pairs = 5;
+        let mut c = circuits::independent_bell_pairs(n_pairs);
+        let n = c.num_qubits;
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), n_pairs, "5 Bell pairs should have rank 5");
+    }
+
+    #[test]
+    fn random_clifford_rank_is_n() {
+        let n = 10;
+        let mut c = circuits::clifford_heavy_circuit(n, 50, 42);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(
+            sampler.rank(),
+            n,
+            "Random Clifford 10q d50 should have rank {n}"
+        );
+    }
+
+    #[test]
+    fn non_clifford_rejected() {
+        let mut c = Circuit::new(2, 2);
+        c.add_gate(Gate::Rx(0.5), &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+        let result = compile_measurements(&c, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn no_measurements_rank_zero() {
+        let c = circuits::ghz_circuit(5);
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 0);
+        assert_eq!(sampler.num_measurements(), 0);
+    }
+
+    #[test]
+    fn identity_circuit_all_zeros() {
+        let mut c = Circuit::new(4, 4);
+        for i in 0..4 {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 0, "Identity circuit should have rank 0");
+
+        let mut sampler = sampler;
+        for _ in 0..100 {
+            let outcome = sampler.sample();
+            assert!(outcome.iter().all(|&b| !b), "All outcomes should be 0");
+        }
+    }
+
+    #[test]
+    fn single_h_measure() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 1, "H+measure should have rank 1");
+    }
+
+    #[test]
+    fn ghz_distribution() {
+        let n = 10;
+        let mut c = circuits::ghz_circuit(n);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let result = run_shots_compiled(&c, 10_000, 42).unwrap();
+        let counts = result.counts();
+
+        let all_zero: Vec<bool> = vec![false; n];
+        let all_one: Vec<bool> = vec![true; n];
+
+        let n_zero = counts.get(&all_zero).copied().unwrap_or(0);
+        let n_one = counts.get(&all_one).copied().unwrap_or(0);
+
+        assert_eq!(
+            counts.len(),
+            2,
+            "GHZ should produce exactly 2 outcomes, got {}",
+            counts.len()
+        );
+        assert!(
+            n_zero + n_one == 10_000,
+            "All shots should be all-0 or all-1"
+        );
+        let ratio = n_zero as f64 / 10_000.0;
+        assert!(
+            (0.45..=0.55).contains(&ratio),
+            "Expected ~50/50, got {ratio:.3}"
+        );
+    }
+
+    #[test]
+    fn bell_pairs_always_agree() {
+        let n_pairs = 5;
+        let mut c = circuits::independent_bell_pairs(n_pairs);
+        let n = c.num_qubits;
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let result = run_shots_compiled(&c, 10_000, 42).unwrap();
+
+        for shot in &result.shots {
+            for p in 0..n_pairs {
+                assert_eq!(
+                    shot[2 * p],
+                    shot[2 * p + 1],
+                    "Bell pair {p} qubits disagree"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn random_clifford_marginals() {
+        let n = 10;
+        let mut c = circuits::clifford_heavy_circuit(n, 10, 42);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let compiled = run_shots_compiled(&c, 50_000, 42).unwrap();
+        let reference =
+            crate::sim::run_shots_with(BackendKind::Stabilizer, &c, 50_000, 42).unwrap();
+
+        for q in 0..n {
+            let compiled_ones: usize = compiled.shots.iter().filter(|s| s[q]).count();
+            let ref_ones: usize = reference.shots.iter().filter(|s| s[q]).count();
+            let compiled_frac = compiled_ones as f64 / 50_000.0;
+            let ref_frac = ref_ones as f64 / 50_000.0;
+            assert!(
+                (compiled_frac - ref_frac).abs() < 0.03,
+                "Qubit {q} marginal mismatch: compiled={compiled_frac:.4} ref={ref_frac:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn lut_grouped_sampling_50q() {
+        let n = 50;
+        let mut c = circuits::clifford_heavy_circuit(n, 10, 42);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_measurements(&c, 42).unwrap();
+        assert!(sampler.rank() >= 40, "50q should have high rank for LUT");
+        assert!(sampler.lut.is_some(), "rank >= 8 should build LUT");
+
+        let compiled = run_shots_compiled(&c, 5_000, 42).unwrap();
+        let reference = crate::sim::run_shots_with(BackendKind::Stabilizer, &c, 5_000, 42).unwrap();
+
+        for q in 0..n {
+            let compiled_ones: usize = compiled.shots.iter().filter(|s| s[q]).count();
+            let ref_ones: usize = reference.shots.iter().filter(|s| s[q]).count();
+            let compiled_frac = compiled_ones as f64 / 5_000.0;
+            let ref_frac = ref_ones as f64 / 5_000.0;
+            assert!(
+                (compiled_frac - ref_frac).abs() < 0.05,
+                "q{q} marginal mismatch: compiled={compiled_frac:.4} ref={ref_frac:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn forward_ghz_rank_and_distribution() {
+        let n = 10;
+        let mut c = circuits::ghz_circuit(n);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_forward(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 1, "Forward GHZ-10 should have rank 1");
+
+        let mut sampler = compile_forward(&c, 42).unwrap();
+        let shots = sampler.sample_bulk(10_000);
+        let all_zero: Vec<bool> = vec![false; n];
+        let all_one: Vec<bool> = vec![true; n];
+        let n_zero = shots.iter().filter(|s| *s == &all_zero).count();
+        let n_one = shots.iter().filter(|s| *s == &all_one).count();
+        assert_eq!(
+            n_zero + n_one,
+            10_000,
+            "GHZ should produce only all-0 or all-1"
+        );
+        let ratio = n_zero as f64 / 10_000.0;
+        assert!(
+            (0.45..=0.55).contains(&ratio),
+            "Expected ~50/50, got {ratio:.3}"
+        );
+    }
+
+    #[test]
+    fn forward_bell_pairs_agree() {
+        let n_pairs = 5;
+        let mut c = circuits::independent_bell_pairs(n_pairs);
+        let n = c.num_qubits;
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_forward(&c, 42).unwrap();
+        assert_eq!(
+            sampler.rank(),
+            n_pairs,
+            "Forward 5 Bell pairs should have rank 5"
+        );
+
+        let mut sampler = compile_forward(&c, 42).unwrap();
+        let shots = sampler.sample_bulk(10_000);
+        for shot in &shots {
+            for p in 0..n_pairs {
+                assert_eq!(
+                    shot[2 * p],
+                    shot[2 * p + 1],
+                    "Bell pair {p} qubits disagree"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn forward_identity_all_zeros() {
+        let mut c = Circuit::new(4, 4);
+        for i in 0..4 {
+            c.add_measure(i, i);
+        }
+        let sampler = compile_forward(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 0, "Forward identity should have rank 0");
+
+        let mut sampler = sampler;
+        for _ in 0..100 {
+            let outcome = sampler.sample();
+            assert!(outcome.iter().all(|&b| !b), "All outcomes should be 0");
+        }
+    }
+
+    #[test]
+    fn forward_single_h_measure() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+        let sampler = compile_forward(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), 1, "Forward H+measure should have rank 1");
+    }
+
+    #[test]
+    fn forward_x_measure_always_one() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::X, &[0]);
+        c.add_measure(0, 0);
+        let mut sampler = compile_forward(&c, 42).unwrap();
+        assert_eq!(
+            sampler.rank(),
+            0,
+            "X+measure should have rank 0 (deterministic)"
+        );
+        for _ in 0..100 {
+            let outcome = sampler.sample();
+            assert!(outcome[0], "X(q0) + measure should always give 1");
+        }
+    }
+
+    #[test]
+    fn forward_random_clifford_marginals() {
+        let n = 10;
+        let mut c = circuits::clifford_heavy_circuit(n, 10, 42);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+
+        let mut forward = compile_forward(&c, 42).unwrap();
+        let mut backward = compile_measurements(&c, 42).unwrap();
+
+        assert_eq!(forward.rank(), backward.rank(), "Ranks must match");
+
+        let fwd_shots = forward.sample_bulk(50_000);
+        let bwd_shots = backward.sample_bulk(50_000);
+
+        for q in 0..n {
+            let fwd_ones: usize = fwd_shots.iter().filter(|s| s[q]).count();
+            let bwd_ones: usize = bwd_shots.iter().filter(|s| s[q]).count();
+            let fwd_frac = fwd_ones as f64 / 50_000.0;
+            let bwd_frac = bwd_ones as f64 / 50_000.0;
+            assert!(
+                (fwd_frac - bwd_frac).abs() < 0.03,
+                "Qubit {q} marginal mismatch: forward={fwd_frac:.4} backward={bwd_frac:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn forward_clifford_50q_marginals() {
+        let n = 50;
+        let mut c = circuits::clifford_heavy_circuit(n, 10, 42);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+
+        let mut forward = compile_forward(&c, 42).unwrap();
+        let reference = crate::sim::run_shots_with(BackendKind::Stabilizer, &c, 5_000, 42).unwrap();
+
+        let fwd_shots = forward.sample_bulk(5_000);
+
+        for q in 0..n {
+            let fwd_ones: usize = fwd_shots.iter().filter(|s| s[q]).count();
+            let ref_ones: usize = reference.shots.iter().filter(|s| s[q]).count();
+            let fwd_frac = fwd_ones as f64 / 5_000.0;
+            let ref_frac = ref_ones as f64 / 5_000.0;
+            assert!(
+                (fwd_frac - ref_frac).abs() < 0.05,
+                "q{q} marginal mismatch: forward={fwd_frac:.4} ref={ref_frac:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn rank_analysis_across_circuit_types() {
+        let sizes = [10, 50, 100, 200];
+
+        for &n in &sizes {
+            let mut c = circuits::ghz_circuit(n);
+            c.num_classical_bits = n;
+            for i in 0..n {
+                c.add_measure(i, i);
+            }
+            let sampler = compile_measurements(&c, 42).unwrap();
+            assert_eq!(sampler.rank(), 1, "GHZ-{n} should have rank 1");
+        }
+
+        for &n in &sizes {
+            let pairs = n / 2;
+            let mut c = circuits::independent_bell_pairs(pairs);
+            let nq = c.num_qubits;
+            c.num_classical_bits = nq;
+            for i in 0..nq {
+                c.add_measure(i, i);
+            }
+            let sampler = compile_measurements(&c, 42).unwrap();
+            assert_eq!(
+                sampler.rank(),
+                pairs,
+                "Bell-{pairs} should have rank {pairs}"
+            );
+        }
+
+        for &n in &sizes {
+            let mut c = circuits::clifford_heavy_circuit(n, 50, 42);
+            c.num_classical_bits = n;
+            for i in 0..n {
+                c.add_measure(i, i);
+            }
+            let sampler = compile_measurements(&c, 42).unwrap();
+            assert!(
+                sampler.rank() >= n - 1,
+                "Random Clifford {n}q d50 should have rank ~{n}, got {}",
+                sampler.rank()
+            );
+        }
+
+        for &n in &sizes {
+            let mut c = Circuit::new(n, n);
+            for i in 0..n {
+                c.add_gate(Gate::H, &[i]);
+                c.add_measure(i, i);
+            }
+            let sampler = compile_measurements(&c, 42).unwrap();
+            assert_eq!(
+                sampler.rank(),
+                n,
+                "Product H-measure {n}q should have rank {n} (independent random bits)"
+            );
+        }
+    }
+
+    #[test]
+    fn filtered_bell_pairs_matches_monolithic() {
+        let n_pairs = 50;
+        let n = 2 * n_pairs;
+        let mut c = circuits::independent_bell_pairs(n_pairs);
+        c.num_classical_bits = n;
+        for i in 0..n {
+            c.add_measure(i, i);
+        }
+
+        let blocks = c.independent_subsystems();
+        assert_eq!(
+            blocks.len(),
+            n_pairs,
+            "Bell pairs should decompose into {n_pairs} blocks"
+        );
+
+        let mut sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(
+            sampler.rank(),
+            n_pairs,
+            "Bell pairs rank should be {n_pairs}"
+        );
+
+        let shots = sampler.sample_bulk(10_000);
+        for shot in &shots {
+            for p in 0..n_pairs {
+                assert_eq!(
+                    shot[2 * p],
+                    shot[2 * p + 1],
+                    "Bell pair {p}: qubits must agree"
+                );
+            }
+        }
+
+        let ones: usize = shots.iter().filter(|s| s[0]).count();
+        let frac = ones as f64 / shots.len() as f64;
+        assert!(
+            (frac - 0.5).abs() < 0.05,
+            "Bell pair first qubit should be ~50/50, got {frac:.3}"
+        );
+    }
+
+    #[test]
+    fn filtered_product_h_matches_monolithic() {
+        let n = 100;
+        let mut c = Circuit::new(n, n);
+        for i in 0..n {
+            c.add_gate(Gate::H, &[i]);
+            c.add_measure(i, i);
+        }
+
+        let blocks = c.independent_subsystems();
+        assert_eq!(
+            blocks.len(),
+            n,
+            "Product H should decompose into {n} blocks"
+        );
+
+        let mut sampler = compile_measurements(&c, 42).unwrap();
+        assert_eq!(sampler.rank(), n);
+
+        let shots = sampler.sample_bulk(5_000);
+        for q in 0..n {
+            let ones: usize = shots.iter().filter(|s| s[q]).count();
+            let frac = ones as f64 / shots.len() as f64;
+            assert!(
+                (frac - 0.5).abs() < 0.06,
+                "Qubit {q} should be ~50/50, got {frac:.3}"
+            );
+        }
+    }
+}

--- a/src/sim/homological.rs
+++ b/src/sim/homological.rs
@@ -1,0 +1,946 @@
+use crate::circuit::{Circuit, Instruction};
+use crate::error::Result;
+use crate::sim::compiled::batch_propagate_backward;
+use crate::sim::noise::NoiseModel;
+use crate::sim::ShotsResult;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+/// Dense binary matrix over GF(2) stored as packed u64 words per row.
+/// Row-major: row i is stored in words[i * row_words .. (i+1) * row_words].
+struct F2DenseMatrix {
+    #[cfg(test)]
+    num_rows: usize,
+    #[cfg(test)]
+    num_cols: usize,
+    row_words: usize,
+    data: Vec<u64>,
+}
+
+impl F2DenseMatrix {
+    fn new(num_rows: usize, num_cols: usize) -> Self {
+        let row_words = num_cols.div_ceil(64);
+        Self {
+            #[cfg(test)]
+            num_rows,
+            #[cfg(test)]
+            num_cols,
+            row_words,
+            data: vec![0u64; num_rows * row_words],
+        }
+    }
+
+    #[inline(always)]
+    fn set(&mut self, row: usize, col: usize) {
+        self.data[row * self.row_words + col / 64] |= 1u64 << (col % 64);
+    }
+
+    #[inline(always)]
+    fn get(&self, row: usize, col: usize) -> bool {
+        (self.data[row * self.row_words + col / 64] >> (col % 64)) & 1 != 0
+    }
+
+    #[cfg(test)]
+    fn row(&self, row: usize) -> &[u64] {
+        let start = row * self.row_words;
+        &self.data[start..start + self.row_words]
+    }
+
+    #[cfg(test)]
+    fn xor_row(&mut self, dst_row: usize, src_row: usize) {
+        let rw = self.row_words;
+        let (dst_start, src_start) = (dst_row * rw, src_row * rw);
+        if dst_start < src_start {
+            let (left, right) = self.data.split_at_mut(src_start);
+            for w in 0..rw {
+                left[dst_start + w] ^= right[w];
+            }
+        } else {
+            let (left, right) = self.data.split_at_mut(dst_start);
+            for w in 0..rw {
+                right[w] ^= left[src_start + w];
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn swap_rows(&mut self, a: usize, b: usize) {
+        if a == b {
+            return;
+        }
+        let rw = self.row_words;
+        let (a_start, b_start) = (a * rw, b * rw);
+        for w in 0..rw {
+            self.data.swap(a_start + w, b_start + w);
+        }
+    }
+}
+
+/// Compute the kernel (null space) of a binary matrix over GF(2).
+///
+/// Given M ∈ F₂^{m×n}, returns a basis for ker(M) = {x ∈ F₂^n : Mx = 0}.
+/// Uses row reduction on the augmented matrix [M | I_n]^T approach:
+/// transpose M, row-reduce M^T, read off kernel vectors.
+///
+/// Returns: Vec of kernel basis vectors, each as a Vec<u64> packed bitvector of length n.
+#[cfg(test)]
+fn gf2_kernel(matrix: &F2DenseMatrix) -> Vec<Vec<u64>> {
+    let m = matrix.num_rows;
+    let n = matrix.num_cols;
+    let n_words = n.div_ceil(64);
+
+    let aug_cols = m + n;
+    let mut aug = F2DenseMatrix::new(n, aug_cols);
+
+    for r in 0..m {
+        for c in 0..n {
+            if matrix.get(r, c) {
+                aug.set(c, r);
+            }
+        }
+    }
+    for i in 0..n {
+        aug.set(i, m + i);
+    }
+
+    let mut pivot_row = 0;
+    for col in 0..m {
+        let mut found = None;
+        for r in pivot_row..n {
+            if aug.get(r, col) {
+                found = Some(r);
+                break;
+            }
+        }
+        let Some(pr) = found else { continue };
+
+        aug.swap_rows(pivot_row, pr);
+
+        for r in 0..n {
+            if r != pivot_row && aug.get(r, col) {
+                aug.xor_row(r, pivot_row);
+            }
+        }
+        pivot_row += 1;
+    }
+
+    let mut kernel = Vec::new();
+    let m_words = m.div_ceil(64);
+    for r in 0..n {
+        let row = aug.row(r);
+        let mt_zero = row[..m_words].iter().enumerate().all(|(w, &val)| {
+            if w == m_words - 1 && m % 64 != 0 {
+                val & ((1u64 << (m % 64)) - 1) == 0
+            } else {
+                val == 0
+            }
+        });
+        if mt_zero {
+            let mut kv = vec![0u64; n_words];
+            for c in 0..n {
+                if aug.get(r, m + c) {
+                    kv[c / 64] |= 1u64 << (c % 64);
+                }
+            }
+            kernel.push(kv);
+        }
+    }
+
+    kernel
+}
+
+/// Error chain complex for a Clifford circuit with noise.
+///
+/// Represents the chain complex C₂ →∂₂→ C₁ →∂₁→ C₀ where:
+/// - C₀ = F₂^m (measurement/detector space)
+/// - C₁ = F₂^p (error location space)
+/// - C₂ = F₂^s (stabilizer space)
+/// - ∂₁ = E^T (error propagation matrix, transposed)
+pub struct ErrorChainComplex {
+    /// E-matrix: m × p binary matrix. E[d][e] = 1 if error e flips measurement d.
+    e_matrix: F2DenseMatrix,
+    /// Error probabilities: p_total[e] = px + py + pz for error location e.
+    error_probs: Vec<f64>,
+    /// Number of measurements (detectors)
+    num_measurements: usize,
+    /// Number of error locations
+    num_errors: usize,
+    /// dim(im(∂₂) ∩ ker(∂₁)): stabilizer generators undetectable by measurements
+    boundary_dim: usize,
+    /// dim(H₁) = dim(ker(∂₁)/im(∂₂)): independent logical error classes
+    homology_dim: usize,
+}
+
+/// Precomputed sampler for O(r + 1) per-shot noisy measurement sampling.
+///
+/// Combines a compiled sampler (quantum randomness, O(r) per shot) with
+/// precomputed syndrome class probabilities (noise randomness, O(1) per shot).
+/// The syndrome classes are elements of im(E) ⊆ F₂^m where E is the
+/// error-to-measurement propagation matrix.
+pub struct HomologicalSampler {
+    /// Compiled sampler for quantum randomness (noiseless measurement distribution)
+    compiled: crate::sim::compiled::CompiledSampler,
+    /// Syndrome rank = dim(im(E))
+    syndrome_rank: usize,
+    /// 2^r class probabilities (for diagnostics)
+    #[allow(dead_code)]
+    class_probs: Vec<f64>,
+    /// 2^r cumulative probabilities for sampling
+    class_cdf: Vec<f64>,
+    /// 2^r detection signatures: for class c, which measurements are flipped.
+    /// Stored as packed u64 vectors, each of length ceil(m/64).
+    class_detections: Vec<Vec<u64>>,
+    /// Number of measurements
+    #[allow(dead_code)]
+    num_measurements: usize,
+    /// dim(im(∂₂) ∩ ker(∂₁)): undetectable stabilizer generators
+    boundary_dim: usize,
+    /// dim(H₁ = ker(∂₁)/im(∂₂)): independent logical error classes
+    homology_dim: usize,
+    /// RNG for noise sampling
+    rng: ChaCha8Rng,
+}
+
+impl ErrorChainComplex {
+    /// Build the error chain complex from a Clifford circuit and noise model.
+    ///
+    /// Uses backward Pauli propagation (same as the compiled noisy sampler)
+    /// to determine which measurements are sensitive to each error location.
+    pub fn build(circuit: &Circuit, noise: &NoiseModel, _seed: u64) -> Result<Self> {
+        let m = circuit
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, Instruction::Measure { .. }))
+            .count();
+        if m == 0 {
+            return Ok(Self {
+                e_matrix: F2DenseMatrix::new(0, 0),
+                error_probs: Vec::new(),
+                num_measurements: 0,
+                num_errors: 0,
+                boundary_dim: circuit.num_qubits,
+                homology_dim: 0,
+            });
+        }
+
+        let m_words = m.div_ceil(64);
+        let n = circuit.num_qubits;
+
+        let mut x_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+        let mut z_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+        let mut sign_packed = vec![0u64; m_words];
+
+        let mut meas_idx = m;
+        for instr in circuit.instructions.iter().rev() {
+            if let Instruction::Measure { qubit, .. } = instr {
+                meas_idx -= 1;
+                let word = meas_idx / 64;
+                let bit = meas_idx % 64;
+                z_packed[*qubit][word] |= 1u64 << bit;
+            }
+        }
+
+        let mut error_probs = Vec::new();
+        let mut e_cols: Vec<Vec<u64>> = Vec::new();
+
+        for (instr_idx, instr) in circuit.instructions.iter().enumerate().rev() {
+            match instr {
+                Instruction::Gate { gate, targets } => {
+                    let noise_ops = &noise.after_gate[instr_idx];
+                    for op in noise_ops {
+                        let q = op.qubit;
+                        let p_total = op.px + op.py + op.pz;
+                        if p_total < 1e-15 {
+                            continue;
+                        }
+
+                        let x_sens = &z_packed[q];
+                        let z_sens = &x_packed[q];
+
+                        if op.px > 1e-15 && x_sens.iter().any(|&w| w != 0) {
+                            error_probs.push(op.px);
+                            e_cols.push(x_sens.clone());
+                        }
+
+                        if op.pz > 1e-15 && z_sens.iter().any(|&w| w != 0) {
+                            error_probs.push(op.pz);
+                            e_cols.push(z_sens.clone());
+                        }
+
+                        if op.py > 1e-15 {
+                            let mut y_sens = vec![0u64; m_words];
+                            for w in 0..m_words {
+                                y_sens[w] = x_sens[w] ^ z_sens[w];
+                            }
+                            if y_sens.iter().any(|&w| w != 0) {
+                                error_probs.push(op.py);
+                                e_cols.push(y_sens);
+                            }
+                        }
+                    }
+
+                    batch_propagate_backward(
+                        &mut x_packed,
+                        &mut z_packed,
+                        &mut sign_packed,
+                        gate,
+                        targets.as_slice(),
+                        m_words,
+                    );
+                }
+                Instruction::Measure { .. } | Instruction::Barrier { .. } => {}
+                Instruction::Conditional { gate, targets, .. } => {
+                    batch_propagate_backward(
+                        &mut x_packed,
+                        &mut z_packed,
+                        &mut sign_packed,
+                        gate,
+                        targets.as_slice(),
+                        m_words,
+                    );
+                }
+            }
+        }
+
+        let p = error_probs.len();
+        let mut e_matrix = F2DenseMatrix::new(m, p);
+
+        for (col, col_data) in e_cols.iter().enumerate() {
+            for (w, &word) in col_data.iter().enumerate() {
+                if word == 0 {
+                    continue;
+                }
+                let base = w * 64;
+                let mut bits = word;
+                while bits != 0 {
+                    let bit = bits.trailing_zeros() as usize;
+                    let row = base + bit;
+                    if row < m {
+                        e_matrix.set(row, col);
+                    }
+                    bits &= bits - 1;
+                }
+            }
+        }
+
+        let (boundary_dim, homology_dim) = Self::compute_boundary_space(circuit, n);
+
+        Ok(Self {
+            e_matrix,
+            error_probs,
+            num_measurements: m,
+            num_errors: p,
+            boundary_dim,
+            homology_dim,
+        })
+    }
+
+    /// Forward-propagate stabilizer generators and compute ∂₂ boundary space.
+    ///
+    /// Returns (boundary_dim, homology_dim) where:
+    /// - boundary_dim = dim(im(∂₂) ∩ ker(∂₁)) = stabilizers undetectable by measurements
+    /// - homology_dim = dim(H₁) = independent logical error classes
+    ///
+    /// Algorithm: forward-propagate Z_0,...,Z_{n-1} through the circuit to get
+    /// output stabilizer generators. Build X-projection onto measured qubits.
+    /// rank(X_proj) counts stabilizers with detectable X components;
+    /// H₁ = ker(σ) / (S ∩ ker(σ)) has dim = n - num_measured + rank(X_proj).
+    fn compute_boundary_space(circuit: &Circuit, n: usize) -> (usize, usize) {
+        if n == 0 {
+            return (0, 0);
+        }
+
+        let n_words = n.div_ceil(64);
+        let mut stab_x: Vec<Vec<u64>> = vec![vec![0u64; n_words]; n];
+        let mut stab_z: Vec<Vec<u64>> = vec![vec![0u64; n_words]; n];
+        let mut stab_sign = vec![0u64; n_words];
+
+        for i in 0..n {
+            stab_z[i][i / 64] |= 1u64 << (i % 64);
+        }
+
+        for instr in circuit.instructions.iter() {
+            match instr {
+                Instruction::Gate { gate, targets } => {
+                    batch_propagate_backward(
+                        &mut stab_x,
+                        &mut stab_z,
+                        &mut stab_sign,
+                        gate,
+                        targets.as_slice(),
+                        n_words,
+                    );
+                }
+                Instruction::Conditional { gate, targets, .. } => {
+                    batch_propagate_backward(
+                        &mut stab_x,
+                        &mut stab_z,
+                        &mut stab_sign,
+                        gate,
+                        targets.as_slice(),
+                        n_words,
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        let mut measured = vec![false; n];
+        for instr in &circuit.instructions {
+            if let Instruction::Measure { qubit, .. } = instr {
+                measured[*qubit] = true;
+            }
+        }
+        let num_measured = measured.iter().filter(|&&b| b).count();
+        let measured_indices: Vec<usize> = (0..n).filter(|&q| measured[q]).collect();
+
+        if num_measured == 0 {
+            return (n, 0);
+        }
+
+        let proj_words = num_measured.div_ceil(64);
+        let mut proj = vec![0u64; n * proj_words];
+
+        for stab_idx in 0..n {
+            for (proj_col, &q) in measured_indices.iter().enumerate() {
+                let x_bit = (stab_x[q][stab_idx / 64] >> (stab_idx % 64)) & 1;
+                if x_bit != 0 {
+                    proj[stab_idx * proj_words + proj_col / 64] |= 1u64 << (proj_col % 64);
+                }
+            }
+        }
+
+        let mut rank = 0;
+        let mut pivot_row = 0;
+        for col in 0..num_measured {
+            let mut found = None;
+            for r in pivot_row..n {
+                if (proj[r * proj_words + col / 64] >> (col % 64)) & 1 != 0 {
+                    found = Some(r);
+                    break;
+                }
+            }
+            let Some(pr) = found else { continue };
+
+            if pr != pivot_row {
+                for w in 0..proj_words {
+                    proj.swap(pivot_row * proj_words + w, pr * proj_words + w);
+                }
+            }
+
+            for r in 0..n {
+                if r != pivot_row && (proj[r * proj_words + col / 64] >> (col % 64)) & 1 != 0 {
+                    for w in 0..proj_words {
+                        proj[r * proj_words + w] ^= proj[pivot_row * proj_words + w];
+                    }
+                }
+            }
+
+            pivot_row += 1;
+            rank += 1;
+        }
+
+        let boundary_dim = n - rank;
+        let homology_dim = n - num_measured + rank;
+        (boundary_dim, homology_dim)
+    }
+
+    pub fn boundary_dim(&self) -> usize {
+        self.boundary_dim
+    }
+
+    pub fn homology_dim(&self) -> usize {
+        self.homology_dim
+    }
+}
+
+impl HomologicalSampler {
+    /// Build a sampler from a circuit and noise model.
+    ///
+    /// Computes the E-matrix (error-to-measurement propagation), finds a basis
+    /// for im(E), and precomputes 2^r syndrome class probabilities where
+    /// r = rank(E). Also builds a compiled sampler for quantum randomness.
+    ///
+    /// Total per-shot cost: O(r_quantum + 1) where r_quantum is the stabilizer
+    /// rank (number of random measurements) — versus O(p) for brute-force
+    /// where p is the number of error locations.
+    pub fn compile(circuit: &Circuit, noise: &NoiseModel, seed: u64) -> Result<Self> {
+        let ecc = ErrorChainComplex::build(circuit, noise, seed)?;
+        let m = ecc.num_measurements;
+        let p = ecc.num_errors;
+        let compiled = crate::sim::compiled::compile_measurements(circuit, seed)?;
+
+        if m == 0 || p == 0 {
+            return Ok(Self {
+                compiled,
+                syndrome_rank: 0,
+                class_probs: vec![1.0],
+                class_cdf: vec![1.0],
+                class_detections: vec![vec![0u64; m.div_ceil(64)]],
+                num_measurements: m,
+                boundary_dim: ecc.boundary_dim,
+                homology_dim: ecc.homology_dim,
+                rng: ChaCha8Rng::seed_from_u64(seed),
+            });
+        }
+
+        let m_words = m.div_ceil(64);
+
+        let mut work = ecc.e_matrix.data.clone();
+        let rw = ecc.e_matrix.row_words;
+        let mut pivot_cols = Vec::new();
+        let mut pivot_row = 0;
+
+        for col in 0..p {
+            let mut found = None;
+            for r in pivot_row..m {
+                if (work[r * rw + col / 64] >> (col % 64)) & 1 != 0 {
+                    found = Some(r);
+                    break;
+                }
+            }
+            let Some(pr) = found else { continue };
+
+            if pr != pivot_row {
+                for w in 0..rw {
+                    work.swap(pivot_row * rw + w, pr * rw + w);
+                }
+            }
+
+            for r in 0..m {
+                if r != pivot_row && (work[r * rw + col / 64] >> (col % 64)) & 1 != 0 {
+                    for w in 0..rw {
+                        work[r * rw + w] ^= work[pivot_row * rw + w];
+                    }
+                }
+            }
+
+            pivot_cols.push(col);
+            pivot_row += 1;
+        }
+
+        let r = pivot_cols.len();
+        if r > 20 {
+            return Err(crate::error::PrismError::IncompatibleBackend {
+                backend: "HomologicalSampler".to_string(),
+                reason: format!("syndrome rank {} too large (max 20)", r),
+            });
+        }
+
+        // Extract r-bit coordinates from RREF: col j's coordinate at basis i
+        // is work[i][j] in the reduced matrix.
+        let mut col_coords = vec![0usize; p];
+        for (basis_idx, &_pivot_col) in pivot_cols.iter().enumerate() {
+            for j in 0..p {
+                if (work[basis_idx * rw + j / 64] >> (j % 64)) & 1 != 0 {
+                    col_coords[j] |= 1 << basis_idx;
+                }
+            }
+        }
+
+        let num_classes = 1usize << r;
+        let mut class_detections = Vec::with_capacity(num_classes);
+        for c in 0..num_classes {
+            let mut det = vec![0u64; m_words];
+            for (basis_idx, &pivot_col) in pivot_cols.iter().enumerate() {
+                if (c >> basis_idx) & 1 != 0 {
+                    for row in 0..m {
+                        if ecc.e_matrix.get(row, pivot_col) {
+                            det[row / 64] ^= 1u64 << (row % 64);
+                        }
+                    }
+                }
+            }
+            class_detections.push(det);
+        }
+
+        // F₂^r probability convolution: P[c] = (1-p_j) P[c] + p_j P[c ⊕ coord_j]
+        let mut class_probs = vec![0.0_f64; num_classes];
+        class_probs[0] = 1.0;
+
+        for (j, &coord) in col_coords.iter().enumerate() {
+            let pj = ecc.error_probs[j];
+            if pj < 1e-15 {
+                continue;
+            }
+            if coord == 0 {
+                continue;
+            }
+            let mut new_probs = vec![0.0_f64; num_classes];
+            for c in 0..num_classes {
+                new_probs[c] = (1.0 - pj) * class_probs[c] + pj * class_probs[c ^ coord];
+            }
+            class_probs = new_probs;
+        }
+
+        let mut class_cdf = vec![0.0_f64; num_classes];
+        class_cdf[0] = class_probs[0];
+        for c in 1..num_classes {
+            class_cdf[c] = class_cdf[c - 1] + class_probs[c];
+        }
+        let total = class_cdf[num_classes - 1];
+        if total > 0.0 {
+            for v in &mut class_cdf {
+                *v /= total;
+            }
+        }
+
+        Ok(Self {
+            compiled,
+            syndrome_rank: r,
+            class_probs,
+            class_cdf,
+            class_detections,
+            num_measurements: m,
+            boundary_dim: ecc.boundary_dim,
+            homology_dim: ecc.homology_dim,
+            rng: ChaCha8Rng::seed_from_u64(seed),
+        })
+    }
+
+    pub fn syndrome_rank(&self) -> usize {
+        self.syndrome_rank
+    }
+
+    pub fn boundary_dim(&self) -> usize {
+        self.boundary_dim
+    }
+
+    pub fn homology_dim(&self) -> usize {
+        self.homology_dim
+    }
+
+    /// Sample a single shot: returns measurement outcomes.
+    ///
+    /// Cost: O(r_quantum) for compiled sampler + O(1) for noise class lookup.
+    pub fn sample(&mut self) -> Vec<bool> {
+        let mut outcome = self.compiled.sample();
+
+        let u: f64 = rand::Rng::gen(&mut self.rng);
+        let class = match self
+            .class_cdf
+            .binary_search_by(|p| p.partial_cmp(&u).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            Ok(i) => i,
+            Err(i) => i.min(self.class_cdf.len() - 1),
+        };
+
+        let det = &self.class_detections[class];
+        for (mi, bit) in outcome.iter_mut().enumerate() {
+            let det_bit = (det[mi / 64] >> (mi % 64)) & 1 != 0;
+            *bit ^= det_bit;
+        }
+        outcome
+    }
+
+    /// Sample multiple shots.
+    pub fn sample_bulk(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
+        (0..num_shots).map(|_| self.sample()).collect()
+    }
+}
+
+/// Run noisy shot sampling using the homological sampler.
+///
+/// For Clifford circuits where the homology dimension h is small (≤ 20),
+/// precomputes class probabilities and samples in O(1) per shot.
+pub fn run_shots_homological(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    let sampler = HomologicalSampler::compile(circuit, noise, seed)?;
+    run_shots_homological_inner(sampler, circuit, num_shots)
+}
+
+pub(crate) fn run_shots_homological_inner(
+    mut sampler: HomologicalSampler,
+    circuit: &Circuit,
+    num_shots: usize,
+) -> Result<ShotsResult> {
+    let classical_bit_order: Vec<usize> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure { classical_bit, .. } => Some(*classical_bit),
+            _ => None,
+        })
+        .collect();
+    let num_classical = circuit.num_classical_bits;
+
+    let raw_shots = sampler.sample_bulk(num_shots);
+
+    let mut shots = Vec::with_capacity(num_shots);
+    for raw in &raw_shots {
+        let mut out = vec![false; num_classical];
+        for (mi, &cbit) in classical_bit_order.iter().enumerate() {
+            if cbit < num_classical {
+                out[cbit] = raw[mi];
+            }
+        }
+        shots.push(out);
+    }
+
+    Ok(ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuits;
+
+    #[test]
+    fn gf2_kernel_identity() {
+        // Identity matrix: kernel is trivial (empty)
+        let mut m = F2DenseMatrix::new(3, 3);
+        m.set(0, 0);
+        m.set(1, 1);
+        m.set(2, 2);
+        let k = gf2_kernel(&m);
+        assert!(k.is_empty(), "Identity matrix should have trivial kernel");
+    }
+
+    #[test]
+    fn gf2_kernel_zero_matrix() {
+        // Zero matrix: kernel is the full space
+        let m = F2DenseMatrix::new(3, 4);
+        let k = gf2_kernel(&m);
+        assert_eq!(k.len(), 4, "Zero 3×4 matrix should have 4-dim kernel");
+    }
+
+    #[test]
+    fn gf2_kernel_rank_deficient() {
+        // [1 1 0]
+        // [0 1 1]
+        // Row 0 + Row 1 = [1 0 1], so rank = 2, kernel dim = 3 - 2 = 1
+        let mut m = F2DenseMatrix::new(2, 3);
+        m.set(0, 0);
+        m.set(0, 1);
+        m.set(1, 1);
+        m.set(1, 2);
+        let k = gf2_kernel(&m);
+        assert_eq!(k.len(), 1, "rank-2 2×3 matrix should have 1-dim kernel");
+        // Kernel vector should be [1, 1, 1] (x₀ = x₁ = x₂)
+        // Row 0: x₀ + x₁ = 0 → x₀ = x₁
+        // Row 1: x₁ + x₂ = 0 → x₁ = x₂
+        let kv = &k[0];
+        assert_eq!(kv[0] & 0b111, 0b111, "kernel vector should be [1,1,1]");
+    }
+
+    #[test]
+    fn gf2_kernel_verifies() {
+        // Verify Mx = 0 for all kernel vectors
+        let mut m = F2DenseMatrix::new(3, 5);
+        // Some arbitrary matrix
+        m.set(0, 0);
+        m.set(0, 2);
+        m.set(0, 4);
+        m.set(1, 1);
+        m.set(1, 3);
+        m.set(2, 0);
+        m.set(2, 1);
+        m.set(2, 2);
+
+        let k = gf2_kernel(&m);
+        for kv in &k {
+            // Check M · kv = 0
+            for r in 0..3 {
+                let mut dot = 0u32;
+                for c in 0..5 {
+                    if m.get(r, c) && (kv[c / 64] >> (c % 64)) & 1 != 0 {
+                        dot ^= 1;
+                    }
+                }
+                assert_eq!(dot, 0, "kernel vector should satisfy Mx = 0");
+            }
+        }
+    }
+
+    #[test]
+    fn homological_ghz_compiles() {
+        let n = 6;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let sampler = HomologicalSampler::compile(&circuit, &noise, 42).unwrap();
+        assert!(sampler.syndrome_rank() <= n, "syndrome rank should be ≤ n");
+    }
+
+    #[test]
+    fn homological_ghz_samples() {
+        let n = 6;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let mut sampler = HomologicalSampler::compile(&circuit, &noise, 42).unwrap();
+        let shots = sampler.sample_bulk(1000);
+        assert_eq!(shots.len(), 1000);
+        assert_eq!(shots[0].len(), n);
+    }
+
+    #[test]
+    fn homological_bell_pairs() {
+        let n = 4;
+        let mut circuit = circuits::independent_bell_pairs(n / 2);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let sampler = HomologicalSampler::compile(&circuit, &noise, 42).unwrap();
+        // Bell pairs with noise should have non-trivial syndrome rank
+        assert!(sampler.syndrome_rank() > 0);
+    }
+
+    #[test]
+    fn homological_class_probs_sum_to_one() {
+        let n = 6;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let sampler = HomologicalSampler::compile(&circuit, &noise, 42).unwrap();
+        let sum: f64 = sampler.class_probs.iter().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-10,
+            "class probabilities should sum to 1, got {sum}"
+        );
+    }
+
+    #[test]
+    fn homological_matches_brute_force_statistics() {
+        let n = 4;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.05);
+        let num_shots = 10000;
+
+        // Homological sampler
+        let homo_result = run_shots_homological(&circuit, &noise, num_shots, 42).unwrap();
+
+        // Brute-force sampler
+        let brute_result =
+            crate::sim::noise::run_shots_noisy(&circuit, &noise, num_shots, 42).unwrap();
+
+        // Compare per-bit marginal probabilities
+        let m = n;
+        for bit in 0..m {
+            let homo_ones: usize = homo_result.shots.iter().filter(|s| s[bit]).count();
+            let brute_ones: usize = brute_result.shots.iter().filter(|s| s[bit]).count();
+            let homo_p = homo_ones as f64 / num_shots as f64;
+            let brute_p = brute_ones as f64 / num_shots as f64;
+            let diff = (homo_p - brute_p).abs();
+            assert!(
+                diff < 0.05,
+                "bit {bit}: homological p={homo_p:.4}, brute p={brute_p:.4}, diff={diff:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn boundary_trivial_circuit_has_zero_homology() {
+        let n = 4;
+        let mut circuit = crate::circuit::Circuit::new(n, n);
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let ecc = ErrorChainComplex::build(&circuit, &noise, 42).unwrap();
+        assert_eq!(ecc.boundary_dim(), n);
+        assert_eq!(ecc.homology_dim(), 0);
+    }
+
+    #[test]
+    fn boundary_ghz_has_one_logical_qubit() {
+        for n in [3, 5, 8] {
+            let mut circuit = circuits::ghz_circuit(n);
+            circuit.num_classical_bits = n;
+            for i in 0..n {
+                circuit.add_measure(i, i);
+            }
+            let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+            let ecc = ErrorChainComplex::build(&circuit, &noise, 42).unwrap();
+            assert_eq!(
+                ecc.homology_dim(),
+                1,
+                "GHZ-{n} should have 1 logical error class"
+            );
+            assert_eq!(ecc.boundary_dim(), n - 1);
+        }
+    }
+
+    #[test]
+    fn boundary_bell_pair_has_one_logical() {
+        let mut circuit = crate::circuit::Circuit::new(2, 2);
+        circuit.add_gate(crate::gates::Gate::H, &[0]);
+        circuit.add_gate(crate::gates::Gate::Cx, &[0, 1]);
+        circuit.add_measure(0, 0);
+        circuit.add_measure(1, 1);
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let ecc = ErrorChainComplex::build(&circuit, &noise, 42).unwrap();
+        assert_eq!(ecc.homology_dim(), 1);
+        assert_eq!(ecc.boundary_dim(), 1);
+    }
+
+    #[test]
+    fn boundary_independent_bell_pairs() {
+        let n_pairs = 3;
+        let n = n_pairs * 2;
+        let mut circuit = circuits::independent_bell_pairs(n_pairs);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let ecc = ErrorChainComplex::build(&circuit, &noise, 42).unwrap();
+        assert_eq!(
+            ecc.homology_dim(),
+            n_pairs,
+            "{n_pairs} bell pairs should have {n_pairs} logical error classes"
+        );
+    }
+
+    #[test]
+    fn boundary_exposed_via_sampler() {
+        let n = 4;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let sampler = HomologicalSampler::compile(&circuit, &noise, 42).unwrap();
+        assert_eq!(sampler.homology_dim(), 1);
+        assert_eq!(sampler.boundary_dim(), n - 1);
+    }
+
+    #[test]
+    fn boundary_partial_measurement() {
+        let mut circuit = crate::circuit::Circuit::new(3, 1);
+        circuit.add_gate(crate::gates::Gate::H, &[0]);
+        circuit.add_gate(crate::gates::Gate::Cx, &[0, 1]);
+        circuit.add_measure(0, 0);
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let ecc = ErrorChainComplex::build(&circuit, &noise, 42).unwrap();
+        // 3 qubits, 1 measured: ker(σ) has dim 2*3-1=5
+        // Stabilizers: X₀X₁, Z₀Z₁, Z₂ (3 generators)
+        // X-projection on qubit 0: X₀X₁ has X on q0 → rank(A) = 1
+        // boundary_dim = 3-1 = 2, homology_dim = 3-1+1 = 3
+        assert_eq!(ecc.boundary_dim(), 2);
+        assert_eq!(ecc.homology_dim(), 3);
+    }
+}

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -3,6 +3,12 @@
 //! Connects the circuit IR to a backend. This module is deliberately thin —
 //! the complexity lives in the backends and the parser.
 
+pub mod compiled;
+pub mod homological;
+pub mod noise;
+pub mod quasi_prob;
+pub mod stabilizer_rank;
+
 use std::collections::HashMap;
 
 use crate::backend::mps::MpsBackend;
@@ -93,6 +99,13 @@ fn detect_max_sv_qubits() -> Option<usize> {
 
 /// Default bond dimension for MPS when auto-selected.
 const AUTO_MPS_BOND_DIM: usize = 256;
+
+/// Maximum T-gate count for automatic Clifford+T dispatch.
+/// At t=12, stabilizer rank creates 2^12 = 4096 branches.
+const MAX_AUTO_T_COUNT: usize = 12;
+
+/// Maximum qubit count for stabilizer rank exact probability computation.
+const MAX_STABILIZER_RANK_QUBITS: usize = 25;
 
 /// Minimum qubit count for subsystem decomposition.
 ///
@@ -335,12 +348,13 @@ pub enum BackendKind {
     /// Automatically select the optimal backend based on circuit analysis.
     ///
     /// Decision tree:
-    /// 1. No entangling gates   → ProductState (O(n))
-    /// 2. All Clifford gates    → Stabilizer (O(n²))
-    /// 3. Above memory limit:
-    ///    a. Sparse-friendly    → Sparse (O(k) where k = non-zero amplitudes)
-    ///    b. Otherwise          → MPS (bounded bond dimension)
-    /// 4. Otherwise             → Statevector (exact, general-purpose)
+    /// 1. No entangling gates        → ProductState (O(n))
+    /// 2. All Clifford gates         → Stabilizer (O(n²))
+    /// 3. Clifford+T, t ≤ 12        → StabilizerRank/QuasiProb (O(2^t · n²))
+    /// 4. Above memory limit:
+    ///    a. Sparse-friendly         → Sparse (O(k) where k = non-zero amplitudes)
+    ///    b. Otherwise               → MPS (bounded bond dimension)
+    /// 5. Otherwise                  → Statevector (exact, general-purpose)
     Auto,
     /// Full state-vector simulation (exact, exponential memory).
     Statevector,
@@ -359,6 +373,24 @@ pub enum BackendKind {
     TensorNetwork,
     /// Dynamic split-state with on-demand merging.
     Factored,
+    /// Quasi-probability decomposition for Clifford+T circuits.
+    ///
+    /// Decomposes each T gate as T = α·I + β·Z, enumerates all 2^t Clifford
+    /// branches, and accumulates weighted amplitudes for exact probabilities.
+    /// Limits: t ≤ 20, n ≤ 25.
+    QuasiProbability,
+    /// Stabilizer rank decomposition for Clifford+T circuits.
+    ///
+    /// Maintains a weighted sum of stabilizer states. Clifford gates are O(n²)
+    /// per term. Each T gate doubles the term count via T = α·I + β·Z.
+    /// Accumulates weighted amplitudes for exact probabilities. Limits: t ≤ 20, n ≤ 25.
+    StabilizerRank,
+    /// Filtered stabilizer: per-cluster tableaux with dynamic merging.
+    ///
+    /// Starts with one qubit per cluster. Gates within a cluster operate on
+    /// a small tableau. Cross-cluster 2q gates merge tableaux. Independent
+    /// subsystems never merge, giving O(block_size²) per gate vs O(n²).
+    FilteredStabilizer,
 }
 
 /// Validate that an explicitly-chosen backend is compatible with the circuit.
@@ -368,7 +400,7 @@ pub enum BackendKind {
 /// early with clear error messages instead of cryptic backend errors later.
 fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
     match kind {
-        BackendKind::Stabilizer => {
+        BackendKind::Stabilizer | BackendKind::FilteredStabilizer => {
             if !circuit.is_clifford_only() {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "stabilizer".into(),
@@ -384,6 +416,14 @@ fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()
                 });
             }
         }
+        BackendKind::QuasiProbability | BackendKind::StabilizerRank => {
+            if !circuit.has_t_gates() {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "stabilizer_rank".into(),
+                    reason: "circuit has no T gates; use Stabilizer instead".into(),
+                });
+            }
+        }
         _ => {}
     }
     Ok(())
@@ -391,7 +431,10 @@ fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()
 
 fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> bool {
     match kind {
-        BackendKind::Stabilizer => false,
+        BackendKind::Stabilizer
+        | BackendKind::FilteredStabilizer
+        | BackendKind::QuasiProbability
+        | BackendKind::StabilizerRank => false,
         BackendKind::Auto => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
         _ => true,
     }
@@ -423,11 +466,20 @@ fn select_backend(
         }
         BackendKind::Statevector => Box::new(StatevectorBackend::new(seed)),
         BackendKind::Stabilizer => Box::new(StabilizerBackend::new(seed)),
+        BackendKind::FilteredStabilizer => Box::new(
+            crate::backend::stabilizer::FilteredStabilizerBackend::new(seed),
+        ),
         BackendKind::Sparse => Box::new(SparseBackend::new(seed)),
         BackendKind::Mps { max_bond_dim } => Box::new(MpsBackend::new(seed, *max_bond_dim)),
         BackendKind::ProductState => Box::new(ProductStateBackend::new(seed)),
         BackendKind::TensorNetwork => Box::new(TensorNetworkBackend::new(seed)),
         BackendKind::Factored => Box::new(crate::backend::factored::FactoredBackend::new(seed)),
+        BackendKind::QuasiProbability => {
+            unreachable!("QuasiProbability is handled before select_backend")
+        }
+        BackendKind::StabilizerRank => {
+            unreachable!("StabilizerRank is handled before select_backend")
+        }
     }
 }
 
@@ -466,6 +518,9 @@ fn run_blocks_maybe_par(
 }
 
 /// Execute a pre-extracted sub-circuit on an appropriate backend.
+///
+/// Delegates to `run_with_opts` so subcircuits benefit from the full Auto
+/// dispatch tree (Clifford+T → StabilizerRank, temporal Clifford, etc.).
 fn run_subcircuit(
     kind: &BackendKind,
     sub_circuit: &Circuit,
@@ -477,12 +532,7 @@ fn run_subcircuit(
     } else {
         kind.clone()
     };
-
-    if !matches!(block_kind, BackendKind::Auto) {
-        validate_explicit_backend(&block_kind, sub_circuit)?;
-    }
-    let mut backend = select_backend(&block_kind, sub_circuit, block_seed, false);
-    execute(&mut *backend, sub_circuit, opts)
+    run_with_opts(block_kind, sub_circuit, block_seed, opts.clone())
 }
 
 #[cfg(feature = "parallel")]
@@ -534,7 +584,7 @@ fn merge_decomposed_results(
             merged_classical[global_idx] = result.classical_bits[local_idx];
         }
 
-        if opts.probabilities {
+        if opts.probabilities && num_qubits <= 64 {
             if let Some(probs) = result.probabilities {
                 let dense = probs.to_vec();
                 let mut mask = 0u64;
@@ -847,6 +897,35 @@ pub fn run_with_opts(
             has_partial_independence = true;
         }
     }
+    if matches!(kind, BackendKind::QuasiProbability) {
+        let qp = quasi_prob::run_quasi_prob(circuit, seed)?;
+        return Ok(SimulationResult {
+            probabilities: Some(Probabilities::Dense(qp.probabilities)),
+            classical_bits: vec![],
+        });
+    }
+    if matches!(kind, BackendKind::StabilizerRank) {
+        let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
+        return Ok(SimulationResult {
+            probabilities: Some(Probabilities::Dense(sr.probabilities)),
+            classical_bits: vec![],
+        });
+    }
+    // Auto: Clifford+T with small T-count → stabilizer rank decomposition.
+    // Each branch is O(n²) stabilizer instead of O(2^n) statevector, but we
+    // need 2^t branches for exact probabilities, so limit t ≤ 12 (4096 branches).
+    if matches!(kind, BackendKind::Auto)
+        && circuit.is_clifford_plus_t()
+        && circuit.has_t_gates()
+        && circuit.t_count() <= MAX_AUTO_T_COUNT
+        && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
+    {
+        let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
+        return Ok(SimulationResult {
+            probabilities: Some(Probabilities::Dense(sr.probabilities)),
+            classical_bits: vec![],
+        });
+    }
     // Temporal Clifford decomposition: if the circuit has a substantial Clifford
     // prefix followed by non-Clifford gates, run the prefix on Stabilizer and
     // the tail on Statevector with the exported state.
@@ -1019,6 +1098,21 @@ pub fn run_shots_with(
     num_shots: usize,
     seed: u64,
 ) -> Result<ShotsResult> {
+    // Compiled sampler: O(n²·m) compile + O(r·m/64) per shot with LUT.
+    // Always polynomial — avoids the O(2^k) probability computation path.
+    if (matches!(
+        kind,
+        BackendKind::Auto | BackendKind::Stabilizer | BackendKind::FilteredStabilizer
+    )) && circuit.is_clifford_only()
+        && circuit
+            .instructions
+            .iter()
+            .any(|i| matches!(i, Instruction::Measure { .. }))
+        && num_shots >= 2
+    {
+        return compiled::run_shots_compiled(circuit, num_shots, seed);
+    }
+
     if circuit.has_terminal_measurements_only() {
         let stripped = circuit.without_measurements();
         let result = run_with_opts(kind.clone(), &stripped, seed, SimOptions::default())?;
@@ -1060,6 +1154,23 @@ pub fn run_shots_with(
     } else {
         None
     };
+
+    if matches!(kind, BackendKind::QuasiProbability) {
+        return quasi_prob::run_quasi_prob_shots(circuit, num_shots, seed);
+    }
+    if matches!(kind, BackendKind::StabilizerRank) {
+        return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+    }
+    // Auto: Clifford+T with small T-count → quasi-probability shot sampling.
+    // Each shot samples a random Clifford branch (O(n²) stabilizer), avoiding
+    // exponential statevector/MPS cost. No qubit limit for shots.
+    if matches!(kind, BackendKind::Auto)
+        && circuit.is_clifford_plus_t()
+        && circuit.has_t_gates()
+        && circuit.t_count() <= MAX_AUTO_T_COUNT
+    {
+        return quasi_prob::run_quasi_prob_shots(circuit, num_shots, seed);
+    }
 
     if has_temporal_clifford_opportunity(&kind, circuit) {
         return run_shots_fallback(&kind, circuit, num_shots, seed);
@@ -1122,6 +1233,36 @@ pub fn run_shots_with(
         shots,
         probabilities,
     })
+}
+
+/// Execute a noisy circuit for multiple shots with explicit backend selection.
+///
+/// For Clifford circuits with Auto/Stabilizer/FilteredStabilizer backends,
+/// uses the compiled noisy sampler (fast O(n²·m) compile + O(events·m/64) per shot).
+/// For all other cases, falls back to per-shot simulation with noise injection.
+pub fn run_shots_with_noise(
+    kind: BackendKind,
+    circuit: &Circuit,
+    noise_model: &noise::NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    let use_compiled = matches!(
+        kind,
+        BackendKind::Auto | BackendKind::Stabilizer | BackendKind::FilteredStabilizer
+    ) && circuit.is_clifford_only();
+
+    if use_compiled {
+        return noise::run_shots_noisy(circuit, noise_model, num_shots, seed);
+    }
+
+    noise::run_shots_noisy_brute_with(
+        |s| select_backend(&kind, circuit, s, false),
+        circuit,
+        noise_model,
+        num_shots,
+        seed,
+    )
 }
 
 fn run_shots_fallback(
@@ -1753,7 +1894,11 @@ mod tests {
 
     #[test]
     fn test_shots_has_probabilities() {
-        let circuit = make_bell_with_measure();
+        let mut circuit = Circuit::new(2, 2);
+        circuit.add_gate(Gate::Rx(std::f64::consts::FRAC_PI_4), &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_measure(0, 0);
+        circuit.add_measure(1, 1);
         let result = run_shots(&circuit, 5, 42).unwrap();
         assert!(result.probabilities.is_some());
     }
@@ -2074,5 +2219,162 @@ mod tests {
         for shot in &result.shots {
             assert_eq!(shot.len(), 4);
         }
+    }
+
+    #[test]
+    fn test_quasi_prob_dispatch() {
+        let circuit = make_general_circuit(); // H, T, CX on 3 qubits
+        let result = run_with(BackendKind::QuasiProbability, &circuit, 42).unwrap();
+        let probs = result.probabilities.unwrap().to_vec();
+        assert_eq!(probs.len(), 8);
+        let total: f64 = probs.iter().sum();
+        assert!((total - 1.0).abs() < 1e-10);
+
+        // Compare against statevector for correctness
+        let sv_result = run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+        let sv_probs = sv_result.probabilities.unwrap().to_vec();
+        for (i, (qp, sv)) in probs.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (qp - sv).abs() < 1e-10,
+                "prob[{i}]: quasi_prob={qp}, statevector={sv}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quasi_prob_rejects_no_t() {
+        let circuit = make_clifford_circuit();
+        let result = run_with(BackendKind::QuasiProbability, &circuit, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_stabilizer_rank_dispatch() {
+        let circuit = make_general_circuit();
+        let result = run_with(BackendKind::StabilizerRank, &circuit, 42).unwrap();
+        let probs = result.probabilities.unwrap().to_vec();
+        assert_eq!(probs.len(), 8);
+        let total: f64 = probs.iter().sum();
+        assert!((total - 1.0).abs() < 1e-10);
+
+        let sv_result = run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+        let sv_probs = sv_result.probabilities.unwrap().to_vec();
+        for (i, (sr, sv)) in probs.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (sr - sv).abs() < 1e-10,
+                "prob[{i}]: stab_rank={sr}, statevector={sv}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_stabilizer_rank_rejects_no_t() {
+        let circuit = make_clifford_circuit();
+        let result = run_with(BackendKind::StabilizerRank, &circuit, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_auto_clifford_plus_t_probabilities() {
+        let circuit = make_general_circuit();
+        assert!(circuit.is_clifford_plus_t());
+        assert!(circuit.has_t_gates());
+
+        let auto_result = run_with(BackendKind::Auto, &circuit, 42).unwrap();
+        let sv_result = run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+
+        let auto_probs = auto_result.probabilities.unwrap().to_vec();
+        let sv_probs = sv_result.probabilities.unwrap().to_vec();
+        for (i, (a, s)) in auto_probs.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (a - s).abs() < 1e-10,
+                "prob[{i}]: auto={a}, statevector={s}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_auto_clifford_plus_t_shots() {
+        let mut c = Circuit::new(2, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+
+        let result = run_shots_with(BackendKind::Auto, &c, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
+        for shot in &result.shots {
+            assert_eq!(shot.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_decomposed_mixed_clifford_and_t() {
+        // Two independent subsystems: q0-q1 (Clifford+T), q2-q3 (Clifford-only)
+        // Under decomposition, q2-q3 should route to Stabilizer, q0-q1 to StabilizerRank
+        let mut c = Circuit::new(4, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::H, &[2]);
+        c.add_gate(Gate::Cx, &[2, 3]);
+
+        let subs = c.independent_subsystems();
+        assert_eq!(subs.len(), 2);
+
+        let auto_result = run_with(BackendKind::Auto, &c, 42).unwrap();
+        let sv_result = run_with(BackendKind::Statevector, &c, 42).unwrap();
+
+        let auto_probs = auto_result.probabilities.unwrap().to_vec();
+        let sv_probs = sv_result.probabilities.unwrap().to_vec();
+        for (i, (a, s)) in auto_probs.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (a - s).abs() < 1e-10,
+                "prob[{i}]: auto={a}, statevector={s}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_run_shots_with_noise_clifford_uses_compiled() {
+        let n = 10;
+        let mut circuit = crate::circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+        let noise = noise::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result = run_shots_with_noise(BackendKind::Auto, &circuit, &noise, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
+        assert!(result.shots[0].len() == n);
+    }
+
+    #[test]
+    fn test_run_shots_with_noise_statevector_brute() {
+        let mut circuit = Circuit::new(3, 3);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::T, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_measure(0, 0);
+        circuit.add_measure(1, 1);
+        let noise = noise::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result =
+            run_shots_with_noise(BackendKind::Statevector, &circuit, &noise, 50, 42).unwrap();
+        assert_eq!(result.shots.len(), 50);
+        assert_eq!(result.shots[0].len(), 3);
+    }
+
+    #[test]
+    fn test_run_shots_with_noise_auto_non_clifford() {
+        let mut circuit = Circuit::new(3, 3);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::T, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_measure(0, 0);
+        circuit.add_measure(1, 1);
+        let noise = noise::NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        let result = run_shots_with_noise(BackendKind::Auto, &circuit, &noise, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
     }
 }

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -1,0 +1,1427 @@
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::backend::stabilizer::StabilizerBackend;
+use crate::backend::Backend;
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::Result;
+use crate::gates::Gate;
+use crate::sim::compiled::{batch_propagate_backward, compile_measurements, xor_words};
+use crate::sim::ShotsResult;
+
+pub struct NoiseModel {
+    pub after_gate: Vec<Vec<NoiseOp>>,
+}
+
+pub struct NoiseOp {
+    pub qubit: usize,
+    pub px: f64,
+    pub py: f64,
+    pub pz: f64,
+}
+
+impl NoiseModel {
+    pub fn uniform_depolarizing(circuit: &Circuit, p: f64) -> Self {
+        let px = p / 3.0;
+        let py = p / 3.0;
+        let pz = p / 3.0;
+
+        let mut after_gate = Vec::with_capacity(circuit.instructions.len());
+        for instr in &circuit.instructions {
+            match instr {
+                Instruction::Gate { targets, .. } => {
+                    let ops: Vec<NoiseOp> = targets
+                        .iter()
+                        .map(|&q| NoiseOp {
+                            qubit: q,
+                            px,
+                            py,
+                            pz,
+                        })
+                        .collect();
+                    after_gate.push(ops);
+                }
+                _ => {
+                    after_gate.push(Vec::new());
+                }
+            }
+        }
+
+        Self { after_gate }
+    }
+}
+
+struct FlatNoiseSensitivity {
+    x_data: Vec<u64>,
+    z_data: Vec<u64>,
+    probs: Vec<[f64; 3]>,
+    m_words: usize,
+}
+
+impl FlatNoiseSensitivity {
+    fn new(m_words: usize, capacity: usize) -> Self {
+        Self {
+            x_data: Vec::with_capacity(capacity * m_words),
+            z_data: Vec::with_capacity(capacity * m_words),
+            probs: Vec::with_capacity(capacity),
+            m_words,
+        }
+    }
+
+    fn push(&mut self, x_flip: &[u64], z_flip: &[u64], px: f64, py: f64, pz: f64) {
+        self.x_data.extend_from_slice(x_flip);
+        self.z_data.extend_from_slice(z_flip);
+        self.probs.push([px, py, pz]);
+    }
+
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.probs.len()
+    }
+
+    #[inline(always)]
+    fn x_flip(&self, idx: usize) -> &[u64] {
+        let off = idx * self.m_words;
+        &self.x_data[off..off + self.m_words]
+    }
+
+    #[inline(always)]
+    fn z_flip(&self, idx: usize) -> &[u64] {
+        let off = idx * self.m_words;
+        &self.z_data[off..off + self.m_words]
+    }
+}
+
+#[inline(always)]
+fn geometric_sample(rng: &mut ChaCha8Rng, ln_1mp: f64) -> usize {
+    let u: f64 = 1.0 - rand::Rng::gen::<f64>(rng);
+    (u.ln() / ln_1mp) as usize
+}
+
+const NOISE_LUT_K: usize = 8;
+const NOISE_LUT_MIN_EVENTS: usize = 16;
+const NOISE_LUT_TILE: usize = 4096;
+
+fn unpack_and_remap(
+    accum: &[u64],
+    m_words: usize,
+    num_shots: usize,
+    classical_bit_order: &[usize],
+    num_classical: usize,
+) -> Vec<Vec<bool>> {
+    fn unpack_one(src: &[u64], classical_bit_order: &[usize], num_classical: usize) -> Vec<bool> {
+        let mut out = vec![false; num_classical];
+        for (mi, &cbit) in classical_bit_order.iter().enumerate() {
+            if cbit < num_classical {
+                out[cbit] = (src[mi / 64] >> (mi % 64)) & 1 != 0;
+            }
+        }
+        out
+    }
+
+    #[cfg(feature = "parallel")]
+    if num_shots >= 256 {
+        use rayon::prelude::*;
+        return accum
+            .par_chunks(m_words)
+            .map(|src| unpack_one(src, classical_bit_order, num_classical))
+            .collect();
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    let _ = num_shots;
+
+    accum
+        .chunks(m_words)
+        .map(|src| unpack_one(src, classical_bit_order, num_classical))
+        .collect()
+}
+
+struct NoiseFlipLut {
+    data: Vec<u64>,
+    m_words: usize,
+    num_full_groups: usize,
+    remainder_size: usize,
+}
+
+impl NoiseFlipLut {
+    fn build_from_flat(flat_data: &[u64], num_rows: usize, m_words: usize) -> Self {
+        let num_full_groups = num_rows / NOISE_LUT_K;
+        let remainder_size = num_rows % NOISE_LUT_K;
+        let total_groups = num_full_groups + usize::from(remainder_size > 0);
+        let entries = 1 << NOISE_LUT_K;
+
+        let mut data = vec![0u64; total_groups * entries * m_words];
+
+        for g in 0..total_groups {
+            let group_start = g * NOISE_LUT_K;
+            let k = if g < num_full_groups {
+                NOISE_LUT_K
+            } else {
+                remainder_size
+            };
+            let lut_off = g * entries * m_words;
+
+            for byte in 1..(1usize << k) {
+                let lowest = byte & byte.wrapping_neg();
+                let row_idx = group_start + lowest.trailing_zeros() as usize;
+                let prev = byte ^ lowest;
+
+                let dst = lut_off + byte * m_words;
+                let src = lut_off + prev * m_words;
+                let row_off = row_idx * m_words;
+
+                for w in 0..m_words {
+                    data[dst + w] = data[src + w] ^ flat_data[row_off + w];
+                }
+            }
+        }
+
+        Self {
+            data,
+            m_words,
+            num_full_groups,
+            remainder_size,
+        }
+    }
+
+    #[inline(always)]
+    fn total_groups(&self) -> usize {
+        self.num_full_groups + usize::from(self.remainder_size > 0)
+    }
+
+    #[inline(always)]
+    fn apply_masked(&self, accum: &mut [u64], mask: &[u64]) {
+        for g in 0..self.total_groups() {
+            let byte = ((mask[g / 8] >> ((g % 8) * 8)) & 0xFF) as usize;
+            if byte != 0 {
+                let offset = (g * (1 << NOISE_LUT_K) + byte) * self.m_words;
+                xor_words(accum, &self.data[offset..offset + self.m_words]);
+            }
+        }
+    }
+}
+
+fn build_noise_luts(events: &FlatNoiseSensitivity) -> (Option<NoiseFlipLut>, Option<NoiseFlipLut>) {
+    let ne = events.len();
+    if ne < NOISE_LUT_MIN_EVENTS {
+        return (None, None);
+    }
+
+    let avg_p: f64 = events
+        .probs
+        .iter()
+        .map(|[px, py, pz]| px + py + pz)
+        .sum::<f64>()
+        / ne as f64;
+    if avg_p < 0.05 {
+        return (None, None);
+    }
+
+    let mw = events.m_words;
+    let z_lut = NoiseFlipLut::build_from_flat(&events.z_data, ne, mw);
+    let x_lut = NoiseFlipLut::build_from_flat(&events.x_data, ne, mw);
+    (Some(z_lut), Some(x_lut))
+}
+
+struct NoisyCompiledSampler {
+    noiseless: crate::sim::compiled::CompiledSampler,
+    events: FlatNoiseSensitivity,
+    num_measurements: usize,
+    rng: ChaCha8Rng,
+    z_lut: Option<NoiseFlipLut>,
+    x_lut: Option<NoiseFlipLut>,
+}
+
+impl NoisyCompiledSampler {
+    #[allow(dead_code)]
+    fn sample(&mut self) -> Vec<bool> {
+        let num_meas_words = self.num_measurements.div_ceil(64);
+        let mut accum = vec![0u64; num_meas_words];
+
+        self.noiseless.sample_into_raw(&mut accum);
+        self.apply_noise_single(&mut accum);
+
+        self.noiseless.apply_ref_bits(&mut accum);
+        let mut result = Vec::with_capacity(self.num_measurements);
+        for m in 0..self.num_measurements {
+            let bit = (accum[m / 64] >> (m % 64)) & 1 != 0;
+            result.push(bit);
+        }
+        result
+    }
+
+    fn sample_bulk_packed(&mut self, num_shots: usize) -> (Vec<u64>, usize) {
+        let m_words = self.num_measurements.div_ceil(64);
+        if num_shots == 0 || self.num_measurements == 0 {
+            return (vec![0u64; num_shots * m_words], m_words);
+        }
+
+        let (mut accum, m_words) = self.noiseless.sample_bulk_words(num_shots);
+
+        self.apply_noise_bulk(&mut accum, num_shots, m_words);
+
+        let ref_bits_packed = self.noiseless.ref_bits_packed();
+
+        #[cfg(feature = "parallel")]
+        if num_shots >= 256 {
+            use rayon::prelude::*;
+            accum
+                .par_chunks_mut(m_words)
+                .for_each(|shot| xor_words(shot, ref_bits_packed));
+        } else {
+            for s in 0..num_shots {
+                let shot_base = s * m_words;
+                xor_words(&mut accum[shot_base..shot_base + m_words], ref_bits_packed);
+            }
+        }
+
+        #[cfg(not(feature = "parallel"))]
+        for s in 0..num_shots {
+            let shot_base = s * m_words;
+            xor_words(&mut accum[shot_base..shot_base + m_words], ref_bits_packed);
+        }
+
+        (accum, m_words)
+    }
+
+    #[allow(dead_code)]
+    fn sample_bulk(&mut self, num_shots: usize) -> Vec<Vec<bool>> {
+        let (accum, m_words) = self.sample_bulk_packed(num_shots);
+        let mut shots = Vec::with_capacity(num_shots);
+        for s in 0..num_shots {
+            let src = &accum[s * m_words..s * m_words + m_words];
+            let mut result = Vec::with_capacity(self.num_measurements);
+            for m in 0..self.num_measurements {
+                result.push((src[m / 64] >> (m % 64)) & 1 != 0);
+            }
+            shots.push(result);
+        }
+        shots
+    }
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn apply_noise_single(&mut self, accum: &mut [u64]) {
+        for i in 0..self.events.len() {
+            let [px, py, pz] = self.events.probs[i];
+            let r: f64 = rand::Rng::gen(&mut self.rng);
+            if r < px {
+                xor_words(accum, self.events.z_flip(i));
+            } else if r < px + py {
+                xor_words(accum, self.events.x_flip(i));
+                xor_words(accum, self.events.z_flip(i));
+            } else if r < px + py + pz {
+                xor_words(accum, self.events.x_flip(i));
+            }
+        }
+    }
+
+    fn apply_noise_bulk(&mut self, accum: &mut [u64], num_shots: usize, m_words: usize) {
+        if self.events.len() == 0 {
+            return;
+        }
+
+        if self.z_lut.is_some() {
+            self.apply_noise_bulk_grouped(accum, num_shots, m_words);
+        } else {
+            self.apply_noise_bulk_scalar(accum, num_shots, m_words);
+        }
+    }
+
+    fn apply_noise_bulk_scalar(&mut self, accum: &mut [u64], num_shots: usize, m_words: usize) {
+        for i in 0..self.events.len() {
+            let [px, py, pz] = self.events.probs[i];
+            let p_event = px + py + pz;
+            if p_event == 0.0 {
+                continue;
+            }
+
+            if p_event >= 0.5 || num_shots < 32 {
+                for s in 0..num_shots {
+                    let r: f64 = rand::Rng::gen(&mut self.rng);
+                    if r < px {
+                        let b = s * m_words;
+                        xor_words(&mut accum[b..b + m_words], self.events.z_flip(i));
+                    } else if r < px + py {
+                        let b = s * m_words;
+                        xor_words(&mut accum[b..b + m_words], self.events.x_flip(i));
+                        xor_words(&mut accum[b..b + m_words], self.events.z_flip(i));
+                    } else if r < p_event {
+                        let b = s * m_words;
+                        xor_words(&mut accum[b..b + m_words], self.events.x_flip(i));
+                    }
+                }
+            } else {
+                let ln_1mp = (1.0 - p_event).ln();
+                let px_frac = px / p_event;
+                let pxy_frac = (px + py) / p_event;
+
+                let mut pos = geometric_sample(&mut self.rng, ln_1mp);
+                while pos < num_shots {
+                    let r: f64 = rand::Rng::gen(&mut self.rng);
+                    let b = pos * m_words;
+                    if r < px_frac {
+                        xor_words(&mut accum[b..b + m_words], self.events.z_flip(i));
+                    } else if r < pxy_frac {
+                        xor_words(&mut accum[b..b + m_words], self.events.x_flip(i));
+                        xor_words(&mut accum[b..b + m_words], self.events.z_flip(i));
+                    } else {
+                        xor_words(&mut accum[b..b + m_words], self.events.x_flip(i));
+                    }
+                    pos += 1 + geometric_sample(&mut self.rng, ln_1mp);
+                }
+            }
+        }
+    }
+
+    fn apply_noise_bulk_grouped(&mut self, accum: &mut [u64], num_shots: usize, m_words: usize) {
+        let num_events = self.events.len();
+        let e_words = num_events.div_ceil(64);
+
+        for tile_start in (0..num_shots).step_by(NOISE_LUT_TILE) {
+            let tile_end = (tile_start + NOISE_LUT_TILE).min(num_shots);
+            let tile_n = tile_end - tile_start;
+
+            let mut z_mask = vec![0u64; tile_n * e_words];
+            let mut x_mask = vec![0u64; tile_n * e_words];
+
+            for i in 0..num_events {
+                let [px, py, pz] = self.events.probs[i];
+                let p_event = px + py + pz;
+                if p_event == 0.0 {
+                    continue;
+                }
+
+                let ew = i / 64;
+                let eb = 1u64 << (i % 64);
+
+                if p_event >= 0.5 || tile_n < 32 {
+                    for s in 0..tile_n {
+                        let r: f64 = rand::Rng::gen(&mut self.rng);
+                        if r < px {
+                            z_mask[s * e_words + ew] |= eb;
+                        } else if r < px + py {
+                            z_mask[s * e_words + ew] |= eb;
+                            x_mask[s * e_words + ew] |= eb;
+                        } else if r < p_event {
+                            x_mask[s * e_words + ew] |= eb;
+                        }
+                    }
+                } else {
+                    let ln_1mp = (1.0 - p_event).ln();
+                    let px_frac = px / p_event;
+                    let pxy_frac = (px + py) / p_event;
+
+                    let mut pos = geometric_sample(&mut self.rng, ln_1mp);
+                    while pos < tile_n {
+                        let r: f64 = rand::Rng::gen(&mut self.rng);
+                        if r < px_frac {
+                            z_mask[pos * e_words + ew] |= eb;
+                        } else if r < pxy_frac {
+                            z_mask[pos * e_words + ew] |= eb;
+                            x_mask[pos * e_words + ew] |= eb;
+                        } else {
+                            x_mask[pos * e_words + ew] |= eb;
+                        }
+                        pos += 1 + geometric_sample(&mut self.rng, ln_1mp);
+                    }
+                }
+            }
+
+            let z_lut = self.z_lut.as_ref().unwrap();
+            let x_lut = self.x_lut.as_ref().unwrap();
+
+            for s in 0..tile_n {
+                let shot_base = (tile_start + s) * m_words;
+                let mask_base = s * e_words;
+                let shot_accum = &mut accum[shot_base..shot_base + m_words];
+
+                z_lut.apply_masked(shot_accum, &z_mask[mask_base..mask_base + e_words]);
+                x_lut.apply_masked(shot_accum, &x_mask[mask_base..mask_base + e_words]);
+            }
+        }
+    }
+}
+
+fn compile_noisy(circuit: &Circuit, noise: &NoiseModel, seed: u64) -> Result<NoisyCompiledSampler> {
+    if circuit.num_qubits >= 4 {
+        let blocks = circuit.independent_subsystems();
+        if blocks.len() > 1 {
+            let max_block = blocks.iter().map(|b| b.len()).max().unwrap_or(0);
+            if max_block < circuit.num_qubits {
+                return compile_noisy_filtered(circuit, noise, &blocks, seed);
+            }
+        }
+    }
+
+    compile_noisy_monolithic(circuit, noise, seed)
+}
+
+fn compile_noisy_filtered(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    blocks: &[Vec<usize>],
+    seed: u64,
+) -> Result<NoisyCompiledSampler> {
+    let noiseless = compile_measurements(circuit, seed)?;
+
+    let measurement_qubits: Vec<usize> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure { qubit, .. } => Some(*qubit),
+            _ => None,
+        })
+        .collect();
+    let num_measurements = measurement_qubits.len();
+    let m_words = num_measurements.div_ceil(64);
+
+    if num_measurements == 0 {
+        return Ok(NoisyCompiledSampler {
+            noiseless,
+            events: FlatNoiseSensitivity::new(1, 0),
+            num_measurements: 0,
+            rng: ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xA01CE)),
+            z_lut: None,
+            x_lut: None,
+        });
+    }
+
+    let mut qubit_to_block = vec![0usize; circuit.num_qubits];
+    let mut qubit_to_local = vec![0usize; circuit.num_qubits];
+    for (bi, block) in blocks.iter().enumerate() {
+        for (li, &q) in block.iter().enumerate() {
+            qubit_to_block[q] = bi;
+            qubit_to_local[q] = li;
+        }
+    }
+
+    let mut block_meas: Vec<Vec<usize>> = vec![Vec::new(); blocks.len()];
+    for (mi, &q) in measurement_qubits.iter().enumerate() {
+        block_meas[qubit_to_block[q]].push(mi);
+    }
+
+    let total_noise_events: usize = noise.after_gate.iter().map(|ops| ops.len()).sum();
+    let mut events = FlatNoiseSensitivity::new(m_words, total_noise_events);
+    let mut global_x_buf = vec![0u64; m_words];
+    let mut global_z_buf = vec![0u64; m_words];
+
+    for (bi, block) in blocks.iter().enumerate() {
+        let bm_list = &block_meas[bi];
+        if bm_list.is_empty() {
+            continue;
+        }
+
+        let bn = block.len();
+        let bm = bm_list.len();
+        let bm_words = bm.div_ceil(64);
+
+        let mut x_packed: Vec<Vec<u64>> = vec![vec![0u64; bm_words]; bn];
+        let mut z_packed: Vec<Vec<u64>> = vec![vec![0u64; bm_words]; bn];
+        let mut sign_packed: Vec<u64> = vec![0u64; bm_words];
+
+        for (local_mi, &global_mi) in bm_list.iter().enumerate() {
+            let q = measurement_qubits[global_mi];
+            let local_q = qubit_to_local[q];
+            z_packed[local_q][local_mi / 64] |= 1u64 << (local_mi % 64);
+        }
+
+        let block_gates: Vec<(usize, &Gate, SmallVec<[usize; 4]>)> = circuit
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, inst)| match inst {
+                Instruction::Gate { gate, targets } => {
+                    if targets.iter().all(|&t| qubit_to_block[t] == bi) {
+                        let local_targets: SmallVec<[usize; 4]> =
+                            targets.iter().map(|&t| qubit_to_local[t]).collect();
+                        Some((idx, gate, local_targets))
+                    } else {
+                        None
+                    }
+                }
+                Instruction::Conditional { gate, targets, .. } => {
+                    if targets.iter().all(|&t| qubit_to_block[t] == bi) {
+                        let local_targets: SmallVec<[usize; 4]> =
+                            targets.iter().map(|&t| qubit_to_local[t]).collect();
+                        Some((idx, gate, local_targets))
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+        for (instr_idx, gate, local_targets) in block_gates.iter().rev() {
+            let noise_ops = &noise.after_gate[*instr_idx];
+            if !noise_ops.is_empty() {
+                for noise_op in noise_ops {
+                    let local_q = qubit_to_local[noise_op.qubit];
+
+                    let has_any = x_packed[local_q].iter().any(|&w| w != 0)
+                        || z_packed[local_q].iter().any(|&w| w != 0);
+                    if has_any {
+                        global_x_buf.fill(0);
+                        global_z_buf.fill(0);
+                        for (local_mi, &global_mi) in bm_list.iter().enumerate() {
+                            if (x_packed[local_q][local_mi / 64] >> (local_mi % 64)) & 1 != 0 {
+                                global_x_buf[global_mi / 64] |= 1u64 << (global_mi % 64);
+                            }
+                            if (z_packed[local_q][local_mi / 64] >> (local_mi % 64)) & 1 != 0 {
+                                global_z_buf[global_mi / 64] |= 1u64 << (global_mi % 64);
+                            }
+                        }
+                        events.push(
+                            &global_x_buf,
+                            &global_z_buf,
+                            noise_op.px,
+                            noise_op.py,
+                            noise_op.pz,
+                        );
+                    }
+                }
+            }
+
+            batch_propagate_backward(
+                &mut x_packed,
+                &mut z_packed,
+                &mut sign_packed,
+                gate,
+                local_targets.as_slice(),
+                bm_words,
+            );
+        }
+    }
+
+    let (z_lut, x_lut) = build_noise_luts(&events);
+
+    Ok(NoisyCompiledSampler {
+        noiseless,
+        events,
+        num_measurements,
+        rng: ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xCAFE_BABE)),
+        z_lut,
+        x_lut,
+    })
+}
+
+fn compile_noisy_monolithic(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    seed: u64,
+) -> Result<NoisyCompiledSampler> {
+    let noiseless = compile_measurements(circuit, seed)?;
+
+    let n = circuit.num_qubits;
+
+    let gate_indices: Vec<(usize, &Gate, &[usize])> = circuit
+        .instructions
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, inst)| match inst {
+            Instruction::Gate { gate, targets } => Some((idx, gate, targets.as_slice())),
+            Instruction::Conditional { gate, targets, .. } => Some((idx, gate, targets.as_slice())),
+            _ => None,
+        })
+        .collect();
+
+    let measurement_qubits: Vec<usize> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure { qubit, .. } => Some(*qubit),
+            _ => None,
+        })
+        .collect();
+    let num_measurements = measurement_qubits.len();
+    let m_words = num_measurements.div_ceil(64);
+
+    if num_measurements == 0 {
+        return Ok(NoisyCompiledSampler {
+            noiseless,
+            events: FlatNoiseSensitivity::new(m_words, 0),
+            num_measurements: 0,
+            rng: ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xA01CE)),
+            z_lut: None,
+            x_lut: None,
+        });
+    }
+
+    let mut x_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+    let mut z_packed: Vec<Vec<u64>> = vec![vec![0u64; m_words]; n];
+    let mut sign_packed: Vec<u64> = vec![0u64; m_words];
+
+    for (mi, &q) in measurement_qubits.iter().enumerate() {
+        z_packed[q][mi / 64] |= 1u64 << (mi % 64);
+    }
+
+    let total_noise_events: usize = noise.after_gate.iter().map(|ops| ops.len()).sum();
+    let mut events = FlatNoiseSensitivity::new(m_words, total_noise_events);
+
+    for &(instr_idx, gate, targets) in gate_indices.iter().rev() {
+        let noise_ops = &noise.after_gate[instr_idx];
+        if !noise_ops.is_empty() {
+            for noise_op in noise_ops {
+                let q = noise_op.qubit;
+
+                let has_any =
+                    x_packed[q].iter().any(|&w| w != 0) || z_packed[q].iter().any(|&w| w != 0);
+                if has_any {
+                    events.push(
+                        &x_packed[q],
+                        &z_packed[q],
+                        noise_op.px,
+                        noise_op.py,
+                        noise_op.pz,
+                    );
+                }
+            }
+        }
+
+        batch_propagate_backward(
+            &mut x_packed,
+            &mut z_packed,
+            &mut sign_packed,
+            gate,
+            targets,
+            m_words,
+        );
+    }
+
+    let (z_lut, x_lut) = build_noise_luts(&events);
+
+    Ok(NoisyCompiledSampler {
+        noiseless,
+        events,
+        num_measurements,
+        rng: ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xCAFE_BABE)),
+        z_lut,
+        x_lut,
+    })
+}
+
+const FRAME_BATCH_SIZE: usize = 256;
+
+struct ReferenceInfo {
+    outcomes: Vec<bool>,
+    is_random: Vec<bool>,
+    random_x_support: Vec<Vec<usize>>,
+}
+
+fn reference_simulation(circuit: &Circuit, seed: u64) -> Result<ReferenceInfo> {
+    let mut stab = StabilizerBackend::new(seed);
+    stab.init(circuit.num_qubits, circuit.num_classical_bits)?;
+
+    let meas_info: Vec<(usize, usize, usize)> = circuit
+        .instructions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, inst)| match inst {
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => Some((i, *qubit, *classical_bit)),
+            _ => None,
+        })
+        .collect();
+
+    let num_meas = meas_info.len();
+    if num_meas == 0 {
+        return Ok(ReferenceInfo {
+            outcomes: Vec::new(),
+            is_random: Vec::new(),
+            random_x_support: Vec::new(),
+        });
+    }
+
+    let first_meas_idx = meas_info[0].0;
+    let all_at_end = meas_info
+        .iter()
+        .enumerate()
+        .all(|(i, &(inst_idx, _, _))| inst_idx == first_meas_idx + i);
+
+    if all_at_end {
+        stab.apply_gates_only(&circuit.instructions[..first_meas_idx])?;
+
+        let measurements: Vec<(usize, usize)> = meas_info
+            .iter()
+            .map(|&(_, qubit, classical_bit)| (qubit, classical_bit))
+            .collect();
+        let (is_random, random_x_support, outcomes) = stab.batch_measure_ref_info(&measurements);
+
+        return Ok(ReferenceInfo {
+            outcomes,
+            is_random,
+            random_x_support,
+        });
+    }
+
+    let mut is_random = Vec::with_capacity(num_meas);
+    let mut random_x_support: Vec<Vec<usize>> = Vec::with_capacity(num_meas);
+
+    let mut seg_start = 0usize;
+    for &(meas_inst_idx, qubit, classical_bit) in &meas_info {
+        if seg_start < meas_inst_idx {
+            stab.apply_gates_only(&circuit.instructions[seg_start..meas_inst_idx])?;
+        }
+
+        let (meas_random, support) = stab.apply_measure_with_info(qubit, classical_bit);
+        is_random.push(meas_random);
+        random_x_support.push(support);
+        seg_start = meas_inst_idx + 1;
+    }
+
+    if seg_start < circuit.instructions.len() {
+        stab.apply_gates_only(&circuit.instructions[seg_start..])?;
+    }
+
+    let outcomes: Vec<bool> = meas_info
+        .iter()
+        .map(|&(_, _, cbit)| stab.classical_results()[cbit])
+        .collect();
+
+    Ok(ReferenceInfo {
+        outcomes,
+        is_random,
+        random_x_support,
+    })
+}
+
+#[inline(always)]
+fn apply_gate_to_frame(
+    gate: &Gate,
+    targets: &[usize],
+    x_frame: &mut [Vec<u64>],
+    z_frame: &mut [Vec<u64>],
+    bw: usize,
+) {
+    match gate {
+        Gate::H => {
+            let q = targets[0];
+            std::mem::swap(&mut x_frame[q], &mut z_frame[q]);
+        }
+        Gate::S | Gate::Sdg => {
+            let q = targets[0];
+            for w in 0..bw {
+                z_frame[q][w] ^= x_frame[q][w];
+            }
+        }
+        Gate::SX | Gate::SXdg => {
+            let q = targets[0];
+            for w in 0..bw {
+                x_frame[q][w] ^= z_frame[q][w];
+            }
+        }
+        Gate::X | Gate::Y | Gate::Z | Gate::Id => {}
+        Gate::Cx => {
+            let ctrl = targets[0];
+            let tgt = targets[1];
+            for w in 0..bw {
+                x_frame[tgt][w] ^= x_frame[ctrl][w];
+                z_frame[ctrl][w] ^= z_frame[tgt][w];
+            }
+        }
+        Gate::Cz => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            for w in 0..bw {
+                z_frame[q0][w] ^= x_frame[q1][w];
+                z_frame[q1][w] ^= x_frame[q0][w];
+            }
+        }
+        Gate::Swap => {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            x_frame.swap(q0, q1);
+            z_frame.swap(q0, q1);
+        }
+        _ => {
+            debug_assert!(
+                false,
+                "apply_gate_to_frame: unhandled Clifford gate {:?}",
+                gate
+            );
+        }
+    }
+}
+
+fn run_shots_noisy_frame(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    let n = circuit.num_qubits;
+    let num_classical = circuit.num_classical_bits;
+
+    let ref_info = reference_simulation(circuit, seed)?;
+
+    let classical_bit_order: Vec<usize> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure { classical_bit, .. } => Some(*classical_bit),
+            _ => None,
+        })
+        .collect();
+    let num_measurements = classical_bit_order.len();
+    let m_words = num_measurements.div_ceil(64);
+
+    let mut all_packed = vec![0u64; num_shots * m_words];
+    let mut rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xFAAB_E001));
+
+    for batch_start in (0..num_shots).step_by(FRAME_BATCH_SIZE) {
+        let batch_end = (batch_start + FRAME_BATCH_SIZE).min(num_shots);
+        let batch_n = batch_end - batch_start;
+        let bw = batch_n.div_ceil(64);
+
+        let mut x_frame: Vec<Vec<u64>> = vec![vec![0u64; bw]; n];
+        let mut z_frame: Vec<Vec<u64>> = vec![vec![0u64; bw]; n];
+
+        let mut meas_idx = 0usize;
+
+        for (idx, inst) in circuit.instructions.iter().enumerate() {
+            match inst {
+                Instruction::Gate { gate, targets }
+                | Instruction::Conditional { gate, targets, .. } => {
+                    apply_gate_to_frame(gate, targets.as_slice(), &mut x_frame, &mut z_frame, bw);
+
+                    for noise_op in &noise.after_gate[idx] {
+                        let q = noise_op.qubit;
+                        let p_event = noise_op.px + noise_op.py + noise_op.pz;
+                        if p_event == 0.0 {
+                            continue;
+                        }
+
+                        let px_frac = noise_op.px / p_event;
+                        let pxy_frac = (noise_op.px + noise_op.py) / p_event;
+
+                        if p_event < 0.5 && batch_n >= 32 {
+                            let ln_1mp = (1.0 - p_event).ln();
+                            let mut pos = geometric_sample(&mut rng, ln_1mp);
+                            while pos < batch_n {
+                                let r: f64 = rand::Rng::gen(&mut rng);
+                                let bit = 1u64 << (pos % 64);
+                                let w = pos / 64;
+                                if r < px_frac {
+                                    x_frame[q][w] ^= bit;
+                                } else if r < pxy_frac {
+                                    x_frame[q][w] ^= bit;
+                                    z_frame[q][w] ^= bit;
+                                } else {
+                                    z_frame[q][w] ^= bit;
+                                }
+                                pos += 1 + geometric_sample(&mut rng, ln_1mp);
+                            }
+                        } else {
+                            for s in 0..batch_n {
+                                let r: f64 = rand::Rng::gen(&mut rng);
+                                if r < noise_op.px {
+                                    x_frame[q][s / 64] ^= 1u64 << (s % 64);
+                                } else if r < noise_op.px + noise_op.py {
+                                    x_frame[q][s / 64] ^= 1u64 << (s % 64);
+                                    z_frame[q][s / 64] ^= 1u64 << (s % 64);
+                                } else if r < p_event {
+                                    z_frame[q][s / 64] ^= 1u64 << (s % 64);
+                                }
+                            }
+                        }
+                    }
+                }
+                Instruction::Measure {
+                    qubit,
+                    classical_bit: _,
+                } => {
+                    if ref_info.is_random[meas_idx] {
+                        let support = &ref_info.random_x_support[meas_idx];
+                        #[allow(clippy::needless_range_loop)]
+                        for w in 0..bw {
+                            let random_word: u64 = rand::Rng::gen(&mut rng);
+                            let mask = if w == bw - 1 && batch_n % 64 != 0 {
+                                random_word & ((1u64 << (batch_n % 64)) - 1)
+                            } else {
+                                random_word
+                            };
+                            if mask != 0 {
+                                for &q in support {
+                                    x_frame[q][w] ^= mask;
+                                }
+                            }
+                        }
+                    }
+
+                    let ref_bit = ref_info.outcomes[meas_idx];
+                    let mi_word = meas_idx / 64;
+                    let mi_bit = meas_idx % 64;
+                    #[allow(clippy::needless_range_loop)]
+                    for w in 0..bw {
+                        let frame_word = x_frame[*qubit][w];
+                        let effective = if ref_bit { !frame_word } else { frame_word };
+                        let num_bits = if w == bw - 1 && batch_n % 64 != 0 {
+                            batch_n % 64
+                        } else {
+                            64
+                        };
+                        let mask = if num_bits == 64 {
+                            effective
+                        } else {
+                            effective & ((1u64 << num_bits) - 1)
+                        };
+                        let mut bits = mask;
+                        while bits != 0 {
+                            let s = bits.trailing_zeros() as usize;
+                            let gs = batch_start + w * 64 + s;
+                            all_packed[gs * m_words + mi_word] |= 1u64 << mi_bit;
+                            bits &= bits - 1;
+                        }
+                    }
+
+                    meas_idx += 1;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let shots = unpack_and_remap(
+        &all_packed,
+        m_words,
+        num_shots,
+        &classical_bit_order,
+        num_classical,
+    );
+
+    Ok(ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+pub fn run_shots_noisy(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    if !circuit.is_clifford_only() {
+        return run_shots_noisy_brute_with(
+            |s| Box::new(StabilizerBackend::new(s)),
+            circuit,
+            noise,
+            num_shots,
+            seed,
+        );
+    }
+
+    // Try homological sampler for high shot counts — O(r_quantum + 1) per shot
+    // when syndrome rank ≤ 20. Falls back to compiled/frame if rank too high.
+    if num_shots >= 1000 {
+        if let Ok(sampler) = super::homological::HomologicalSampler::compile(circuit, noise, seed) {
+            return super::homological::run_shots_homological_inner(sampler, circuit, num_shots);
+        }
+    }
+
+    let n = circuit.num_qubits;
+    let gate_count = circuit
+        .instructions
+        .iter()
+        .filter(|i| {
+            matches!(
+                i,
+                Instruction::Gate { .. } | Instruction::Conditional { .. }
+            )
+        })
+        .count();
+
+    let depth_ratio = gate_count as f64 / n.max(1) as f64;
+    let use_frame = depth_ratio < 3.0 || (n >= 200 && depth_ratio < 5.0);
+
+    if use_frame {
+        run_shots_noisy_frame(circuit, noise, num_shots, seed)
+    } else {
+        run_shots_noisy_compiled(circuit, noise, num_shots, seed)
+    }
+}
+
+fn run_shots_noisy_compiled(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    let mut sampler = compile_noisy(circuit, noise, seed)?;
+
+    let classical_bit_order: Vec<usize> = circuit
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Measure { classical_bit, .. } => Some(*classical_bit),
+            _ => None,
+        })
+        .collect();
+    let num_classical = circuit.num_classical_bits;
+
+    let (accum, m_words) = sampler.sample_bulk_packed(num_shots);
+
+    let shots = unpack_and_remap(
+        &accum,
+        m_words,
+        num_shots,
+        &classical_bit_order,
+        num_classical,
+    );
+
+    Ok(ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+pub(crate) fn run_shots_noisy_brute_with(
+    backend_factory: impl Fn(u64) -> Box<dyn Backend>,
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    let mut shots = Vec::with_capacity(num_shots);
+
+    for i in 0..num_shots {
+        let shot_seed = seed.wrapping_add(i as u64);
+        let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
+        let mut backend = backend_factory(shot_seed);
+        backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
+
+        for (idx, instr) in circuit.instructions.iter().enumerate() {
+            backend.apply(instr)?;
+
+            let noise_ops = &noise.after_gate[idx];
+            for op in noise_ops {
+                let r: f64 = rand::Rng::gen(&mut rng);
+                if r < op.px {
+                    backend.apply(&Instruction::Gate {
+                        gate: Gate::X,
+                        targets: SmallVec::from_elem(op.qubit, 1),
+                    })?;
+                } else if r < op.px + op.py {
+                    backend.apply(&Instruction::Gate {
+                        gate: Gate::Y,
+                        targets: SmallVec::from_elem(op.qubit, 1),
+                    })?;
+                } else if r < op.px + op.py + op.pz {
+                    backend.apply(&Instruction::Gate {
+                        gate: Gate::Z,
+                        targets: SmallVec::from_elem(op.qubit, 1),
+                    })?;
+                }
+            }
+        }
+
+        shots.push(backend.classical_results().to_vec());
+    }
+
+    Ok(ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuits;
+
+    #[test]
+    fn noisy_ghz_produces_varied_outcomes() {
+        let n = 10;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result = run_shots_noisy(&circuit, &noise, 1000, 42).unwrap();
+
+        assert_eq!(result.shots.len(), 1000);
+        assert_eq!(result.shots[0].len(), n);
+
+        let all_zero: Vec<bool> = vec![false; n];
+        let all_one: Vec<bool> = vec![true; n];
+        let num_00 = result.shots.iter().filter(|s| **s == all_zero).count();
+        let num_11 = result.shots.iter().filter(|s| **s == all_one).count();
+        let num_other = 1000 - num_00 - num_11;
+
+        assert!(num_other > 0, "noise should produce non-GHZ outcomes");
+        assert!(num_00 > 100, "should still have many |00...0> outcomes");
+        assert!(num_11 > 100, "should still have many |11...1> outcomes");
+    }
+
+    #[test]
+    fn zero_noise_matches_noiseless() {
+        let n = 5;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+        let result = run_shots_noisy(&circuit, &noise, 100, 42).unwrap();
+
+        for shot in &result.shots {
+            let all_same = shot.iter().all(|&b| b == shot[0]);
+            assert!(all_same, "GHZ with zero noise must be all-0 or all-1");
+        }
+    }
+
+    #[test]
+    fn noise_model_length_matches_circuit() {
+        let n = 10;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        assert_eq!(noise.after_gate.len(), circuit.instructions.len());
+    }
+
+    #[test]
+    fn compiled_noisy_stats_match_brute_force() {
+        let n = 10;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let num_shots = 10000;
+
+        let brute = run_shots_noisy_brute_with(
+            |s| Box::new(StabilizerBackend::new(s)),
+            &circuit,
+            &noise,
+            num_shots,
+            42,
+        )
+        .unwrap();
+        let compiled = run_shots_noisy_compiled(&circuit, &noise, num_shots, 42).unwrap();
+
+        let count_all_same = |shots: &[Vec<bool>]| -> usize {
+            shots
+                .iter()
+                .filter(|s| s.iter().all(|&b| b == s[0]))
+                .count()
+        };
+
+        let brute_coherent = count_all_same(&brute.shots);
+        let compiled_coherent = count_all_same(&compiled.shots);
+
+        let brute_frac = brute_coherent as f64 / num_shots as f64;
+        let compiled_frac = compiled_coherent as f64 / num_shots as f64;
+
+        assert!(
+            (brute_frac - compiled_frac).abs() < 0.05,
+            "coherent fraction should be similar: brute={brute_frac:.3}, compiled={compiled_frac:.3}"
+        );
+
+        let count_errors = |shots: &[Vec<bool>]| -> usize {
+            shots
+                .iter()
+                .filter(|s| !s.iter().all(|&b| b == s[0]))
+                .count()
+        };
+
+        let brute_errors = count_errors(&brute.shots);
+        let compiled_errors = count_errors(&compiled.shots);
+
+        assert!(
+            brute_errors > 0 && compiled_errors > 0,
+            "both should produce errors"
+        );
+    }
+
+    #[test]
+    fn compiled_noisy_clifford_produces_noise() {
+        let n = 20;
+        let circuit_base = circuits::clifford_heavy_circuit(n, 10, 42);
+        let mut circuit = circuit_base;
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result = run_shots_noisy(&circuit, &noise, 100, 42).unwrap();
+
+        assert_eq!(result.shots.len(), 100);
+        assert_eq!(result.shots[0].len(), n);
+
+        let unique: std::collections::HashSet<Vec<bool>> = result.shots.iter().cloned().collect();
+        assert!(unique.len() > 1, "noise should produce varied outcomes");
+    }
+
+    #[test]
+    fn frame_ghz_100q_produces_varied_outcomes() {
+        let n = 100;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result = run_shots_noisy_frame(&circuit, &noise, 1000, 42).unwrap();
+
+        assert_eq!(result.shots.len(), 1000);
+        assert_eq!(result.shots[0].len(), n);
+
+        let all_zero: Vec<bool> = vec![false; n];
+        let all_one: Vec<bool> = vec![true; n];
+        let num_00 = result.shots.iter().filter(|s| **s == all_zero).count();
+        let num_11 = result.shots.iter().filter(|s| **s == all_one).count();
+        let num_other = 1000 - num_00 - num_11;
+
+        assert!(num_other > 0, "noise should produce non-GHZ outcomes");
+        assert!(num_00 > 50, "should still have many |00...0> outcomes");
+        assert!(num_11 > 50, "should still have many |11...1> outcomes");
+    }
+
+    #[test]
+    fn frame_zero_noise_matches_noiseless_100q() {
+        let n = 100;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+        let result = run_shots_noisy_frame(&circuit, &noise, 100, 42).unwrap();
+
+        for shot in &result.shots {
+            let all_same = shot.iter().all(|&b| b == shot[0]);
+            assert!(all_same, "GHZ with zero noise must be all-0 or all-1");
+        }
+    }
+
+    #[test]
+    fn frame_stats_match_compiled_ghz() {
+        let n = 100;
+        let mut circuit = circuits::ghz_circuit(n);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let num_shots = 5000;
+
+        let frame = run_shots_noisy_frame(&circuit, &noise, num_shots, 42).unwrap();
+        let compiled = run_shots_noisy_compiled(&circuit, &noise, num_shots, 42).unwrap();
+
+        let count_coherent = |shots: &[Vec<bool>]| -> usize {
+            shots
+                .iter()
+                .filter(|s| s.iter().all(|&b| b == s[0]))
+                .count()
+        };
+
+        let frame_coh = count_coherent(&frame.shots) as f64 / num_shots as f64;
+        let compiled_coh = count_coherent(&compiled.shots) as f64 / num_shots as f64;
+
+        assert!(
+            (frame_coh - compiled_coh).abs() < 0.05,
+            "coherent fraction should be similar: frame={frame_coh:.3}, compiled={compiled_coh:.3}"
+        );
+    }
+
+    #[test]
+    fn frame_clifford_100q_produces_noise() {
+        let n = 100;
+        let circuit_base = circuits::clifford_heavy_circuit(n, 10, 42);
+        let mut circuit = circuit_base;
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let result = run_shots_noisy_frame(&circuit, &noise, 100, 42).unwrap();
+
+        assert_eq!(result.shots.len(), 100);
+        assert_eq!(result.shots[0].len(), n);
+
+        let unique: std::collections::HashSet<Vec<bool>> = result.shots.iter().cloned().collect();
+        assert!(unique.len() > 1, "noise should produce varied outcomes");
+    }
+
+    #[test]
+    fn filtered_noisy_bell_pairs_matches_monolithic() {
+        let n_pairs = 50;
+        let n = n_pairs * 2;
+        let mut circuit = circuits::independent_bell_pairs(n_pairs);
+        circuit.num_classical_bits = n;
+        for i in 0..n {
+            circuit.add_measure(i, i);
+        }
+
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let seed = 42u64;
+
+        let filtered =
+            compile_noisy_filtered(&circuit, &noise, &circuit.independent_subsystems(), seed)
+                .unwrap();
+        let monolithic = compile_noisy_monolithic(&circuit, &noise, seed).unwrap();
+
+        assert_eq!(filtered.num_measurements, monolithic.num_measurements);
+        assert_eq!(filtered.events.len(), monolithic.events.len());
+
+        let mut filtered = filtered;
+        let mut monolithic = monolithic;
+        let num_shots = 10_000;
+        let shots_f = filtered.sample_bulk(num_shots);
+        let shots_m = monolithic.sample_bulk(num_shots);
+
+        assert_eq!(shots_f.len(), num_shots);
+        assert_eq!(shots_m.len(), num_shots);
+
+        let mut agree_f = 0usize;
+        let mut agree_m = 0usize;
+        for shot in &shots_f {
+            for pair in shot.chunks(2) {
+                if pair[0] == pair[1] {
+                    agree_f += 1;
+                }
+            }
+        }
+        for shot in &shots_m {
+            for pair in shot.chunks(2) {
+                if pair[0] == pair[1] {
+                    agree_m += 1;
+                }
+            }
+        }
+
+        let total_pairs = num_shots * n_pairs;
+        let agree_rate_f = agree_f as f64 / total_pairs as f64;
+        let agree_rate_m = agree_m as f64 / total_pairs as f64;
+        assert!(
+            agree_rate_f > 0.95,
+            "filtered agreement rate {agree_rate_f:.4} should be >0.95 with low noise"
+        );
+        assert!(
+            agree_rate_m > 0.95,
+            "monolithic agreement rate {agree_rate_m:.4} should be >0.95 with low noise"
+        );
+        assert!(
+            (agree_rate_f - agree_rate_m).abs() < 0.02,
+            "filtered ({agree_rate_f:.4}) and monolithic ({agree_rate_m:.4}) should have similar agreement rates"
+        );
+    }
+}

--- a/src/sim/quasi_prob.rs
+++ b/src/sim/quasi_prob.rs
@@ -1,0 +1,804 @@
+//! Quasi-probability simulation for Clifford+T circuits.
+//!
+//! Decomposes each T gate as T = α·I + β·Z where:
+//!   α = (1 + e^{iπ/4})/2, β = (1 - e^{iπ/4})/2
+//!
+//! Two modes:
+//! - **Exact enumeration** (t ≤ `MAX_EXACT_T`): enumerate all 2^t Clifford branches,
+//!   accumulate weighted amplitudes via `export_statevector()`, compute exact probabilities.
+//!   Cost: O(2^t · (n² + 2^n)).
+//! - **Shot sampling**: sample random Clifford branches, run with measurements.
+//!   Each shot randomly replaces T→I or T→Z weighted by |α|,|β|.
+
+use num_complex::Complex64;
+use rand::Rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use std::f64::consts::FRAC_PI_4;
+
+use crate::backend::stabilizer::StabilizerBackend;
+use crate::backend::Backend;
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::Result;
+use crate::gates::Gate;
+
+const MAX_EXACT_T: usize = 20;
+const MAX_EXACT_QUBITS: usize = 25;
+
+/// Decomposition coefficients for T = α·I + β·Z.
+fn t_decomposition() -> (Complex64, Complex64) {
+    let exp_i_pi_4 = Complex64::new(FRAC_PI_4.cos(), FRAC_PI_4.sin());
+    let alpha = (Complex64::new(1.0, 0.0) + exp_i_pi_4) / 2.0;
+    let beta = (Complex64::new(1.0, 0.0) - exp_i_pi_4) / 2.0;
+    (alpha, beta)
+}
+
+/// Decomposition coefficients for Tdg = α†·I + β†·Z.
+fn tdg_decomposition() -> (Complex64, Complex64) {
+    let (alpha, beta) = t_decomposition();
+    (alpha.conj(), beta.conj())
+}
+
+/// Per-T-gate negativity: |α| + |β| = cos(π/8) + sin(π/8).
+fn negativity_per_t() -> f64 {
+    let (alpha, beta) = t_decomposition();
+    alpha.norm() + beta.norm()
+}
+
+/// Information about a T/Tdg gate location in the circuit.
+struct TGateLocation {
+    instruction_index: usize,
+    qubit: usize,
+    is_dagger: bool,
+}
+
+/// Find all T/Tdg gate locations in a circuit.
+fn find_t_gates(circuit: &Circuit) -> Vec<TGateLocation> {
+    circuit
+        .instructions
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, inst)| match inst {
+            Instruction::Gate { gate, targets } if targets.len() == 1 => match gate {
+                Gate::T => Some(TGateLocation {
+                    instruction_index: idx,
+                    qubit: targets[0],
+                    is_dagger: false,
+                }),
+                Gate::Tdg => Some(TGateLocation {
+                    instruction_index: idx,
+                    qubit: targets[0],
+                    is_dagger: true,
+                }),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+/// Build a Clifford circuit by replacing T/Tdg gates with I or Z choices.
+///
+/// `branch_bits`: bit i = 0 → replace T_i with I, bit i = 1 → replace with Z.
+///
+/// Returns (circuit, weight) where weight is the product of coefficients.
+fn build_clifford_branch(
+    circuit: &Circuit,
+    t_locations: &[TGateLocation],
+    branch_bits: u64,
+) -> (Circuit, Complex64) {
+    let mut out = Circuit::new(circuit.num_qubits, circuit.num_classical_bits);
+    out.instructions.reserve(circuit.instructions.len());
+
+    let mut weight = Complex64::new(1.0, 0.0);
+    let mut t_idx = 0;
+
+    for (instr_idx, inst) in circuit.instructions.iter().enumerate() {
+        if t_idx < t_locations.len() && t_locations[t_idx].instruction_index == instr_idx {
+            let loc = &t_locations[t_idx];
+            let (alpha, beta) = if loc.is_dagger {
+                tdg_decomposition()
+            } else {
+                t_decomposition()
+            };
+
+            if (branch_bits >> t_idx) & 1 == 1 {
+                weight *= beta;
+                out.instructions.push(Instruction::Gate {
+                    gate: Gate::Z,
+                    targets: SmallVec::from_slice(&[loc.qubit]),
+                });
+            } else {
+                weight *= alpha;
+            }
+            t_idx += 1;
+        } else {
+            out.instructions.push(inst.clone());
+        }
+    }
+
+    (out, weight)
+}
+
+/// Result of quasi-probability estimation.
+#[derive(Debug, Clone)]
+pub struct QuasiProbResult {
+    /// Estimated probability distribution.
+    pub probabilities: Vec<f64>,
+    /// Number of Clifford branches evaluated.
+    pub num_branches: usize,
+    /// Total negativity ξ = (|α|+|β|)^t.
+    pub negativity: f64,
+    /// T-gate count.
+    pub t_count: usize,
+}
+
+/// Compute exact probabilities for a Clifford+T circuit via branch enumeration.
+///
+/// Enumerates all 2^t Clifford branches, runs each on stabilizer, accumulates
+/// weighted amplitudes, then computes |amplitude|² for each basis state.
+///
+/// Requirements: t ≤ 20, n ≤ 25 (due to exponential cost in both dimensions).
+pub fn run_quasi_prob(circuit: &Circuit, seed: u64) -> Result<QuasiProbResult> {
+    let t_locations = find_t_gates(circuit);
+    let t_count = t_locations.len();
+
+    if t_count == 0 {
+        let mut backend = StabilizerBackend::new(seed);
+        backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
+        for inst in &circuit.instructions {
+            backend.apply(inst)?;
+        }
+        let probs = backend.probabilities()?;
+        return Ok(QuasiProbResult {
+            probabilities: probs,
+            num_branches: 1,
+            negativity: 1.0,
+            t_count: 0,
+        });
+    }
+
+    if t_count > MAX_EXACT_T {
+        return Err(crate::error::PrismError::BackendUnsupported {
+            backend: "quasi_probability".into(),
+            operation: format!(
+                "exact enumeration for {} T-gates (max {})",
+                t_count, MAX_EXACT_T
+            ),
+        });
+    }
+    if circuit.num_qubits > MAX_EXACT_QUBITS {
+        return Err(crate::error::PrismError::BackendUnsupported {
+            backend: "quasi_probability".into(),
+            operation: format!(
+                "statevector export for {} qubits (max {})",
+                circuit.num_qubits, MAX_EXACT_QUBITS
+            ),
+        });
+    }
+
+    let n_states = 1usize << circuit.num_qubits;
+    let num_branches = 1u64 << t_count;
+    let zero = Complex64::new(0.0, 0.0);
+    let mut total_amps = vec![zero; n_states];
+
+    for branch in 0..num_branches {
+        let (branch_circuit, weight) = build_clifford_branch(circuit, &t_locations, branch);
+
+        let mut backend = StabilizerBackend::new(seed);
+        backend.init(branch_circuit.num_qubits, branch_circuit.num_classical_bits)?;
+        for inst in &branch_circuit.instructions {
+            backend.apply(inst)?;
+        }
+
+        let amps = backend.export_statevector()?;
+        for (i, amp) in amps.iter().enumerate() {
+            total_amps[i] += weight * amp;
+        }
+    }
+
+    let probabilities: Vec<f64> = total_amps.iter().map(|a| a.norm_sqr()).collect();
+    let negativity = negativity_per_t().powi(t_count as i32);
+
+    Ok(QuasiProbResult {
+        probabilities,
+        num_branches: num_branches as usize,
+        negativity,
+        t_count,
+    })
+}
+
+/// Run quasi-probability shot sampling on a Clifford+T circuit.
+///
+/// For each shot, randomly samples a Clifford branch (replacing each T gate
+/// with I or Z weighted by |α| and |β|), runs it on the stabilizer backend
+/// with measurements, and returns the measurement outcomes.
+///
+/// Uses antithetic sampling: each pair of shots uses branch `b` and its
+/// complement `~b`, creating negatively correlated pairs that improve
+/// coverage of the branch space.
+pub fn run_quasi_prob_shots(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<super::ShotsResult> {
+    let t_locations = find_t_gates(circuit);
+    let t_count = t_locations.len();
+
+    if t_count == 0 {
+        return super::run_shots_with(super::BackendKind::Stabilizer, circuit, num_shots, seed);
+    }
+    if t_count > 64 {
+        return Err(crate::error::PrismError::BackendUnsupported {
+            backend: "quasi_probability".into(),
+            operation: format!("shot sampling for {} T-gates (max 64)", t_count),
+        });
+    }
+
+    let (alpha, beta) = t_decomposition();
+    let p_alpha = alpha.norm() / (alpha.norm() + beta.norm());
+    let t_mask = if t_count >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << t_count) - 1
+    };
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut shots = Vec::with_capacity(num_shots);
+
+    while shots.len() < num_shots {
+        let mut branch_bits = 0u64;
+        for i in 0..t_count {
+            if rng.gen::<f64>() >= p_alpha {
+                branch_bits |= 1u64 << i;
+            }
+        }
+
+        // Primary branch
+        let branch_seed = rng.gen::<u64>();
+        shots.push(run_branch(circuit, &t_locations, branch_bits, branch_seed)?);
+
+        // Antithetic branch (complement): every I↔Z swapped
+        if shots.len() < num_shots {
+            let anti_bits = !branch_bits & t_mask;
+            let anti_seed = rng.gen::<u64>();
+            shots.push(run_branch(circuit, &t_locations, anti_bits, anti_seed)?);
+        }
+    }
+
+    shots.truncate(num_shots);
+
+    Ok(super::ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+fn run_branch(
+    circuit: &Circuit,
+    t_locations: &[TGateLocation],
+    branch_bits: u64,
+    seed: u64,
+) -> Result<Vec<bool>> {
+    let (branch_circuit, _weight) = build_clifford_branch(circuit, t_locations, branch_bits);
+    let mut backend = StabilizerBackend::new(seed);
+    backend.init(branch_circuit.num_qubits, branch_circuit.num_classical_bits)?;
+    for inst in &branch_circuit.instructions {
+        backend.apply(inst)?;
+    }
+    Ok(backend.classical_results().to_vec())
+}
+
+/// Run quasi-probability shot sampling with stratified branch selection.
+///
+/// Partitions the 2^t branch space by Hamming weight (number of Z
+/// replacements). Allocates shots proportionally to each stratum's
+/// total weight, ensuring coverage across low-Z and high-Z branches.
+///
+/// Each stratum uses antithetic pairing internally.
+pub fn run_quasi_prob_shots_stratified(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<super::ShotsResult> {
+    let t_locations = find_t_gates(circuit);
+    let t_count = t_locations.len();
+
+    if t_count == 0 {
+        return super::run_shots_with(super::BackendKind::Stabilizer, circuit, num_shots, seed);
+    }
+    if t_count > 64 {
+        return Err(crate::error::PrismError::BackendUnsupported {
+            backend: "quasi_probability".into(),
+            operation: format!("shot sampling for {} T-gates (max 64)", t_count),
+        });
+    }
+
+    let (alpha, beta) = t_decomposition();
+    let p_alpha = alpha.norm() / (alpha.norm() + beta.norm());
+    let p_beta = 1.0 - p_alpha;
+
+    // Compute weight of each Hamming weight stratum: C(t,k) * p_alpha^(t-k) * p_beta^k
+    let mut stratum_weights = Vec::with_capacity(t_count + 1);
+    let mut total_weight = 0.0;
+    for k in 0..=t_count {
+        let binom = binomial(t_count, k) as f64;
+        let w = binom * p_alpha.powi((t_count - k) as i32) * p_beta.powi(k as i32);
+        stratum_weights.push(w);
+        total_weight += w;
+    }
+
+    // Allocate shots per stratum (proportional, at least 1 if weight > 0)
+    let mut shots_per_stratum: Vec<usize> = stratum_weights
+        .iter()
+        .map(|w| ((w / total_weight) * num_shots as f64).round() as usize)
+        .collect();
+    let allocated: usize = shots_per_stratum.iter().sum();
+    if allocated < num_shots {
+        // Add remainder to the heaviest stratum
+        let max_idx = stratum_weights
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        shots_per_stratum[max_idx] += num_shots - allocated;
+    } else if allocated > num_shots {
+        // Remove from the heaviest stratum
+        let max_idx = shots_per_stratum
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, &s)| s)
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        shots_per_stratum[max_idx] -= allocated - num_shots;
+    }
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut shots = Vec::with_capacity(num_shots);
+
+    for (k, &n_shots) in shots_per_stratum.iter().enumerate() {
+        for _ in 0..n_shots {
+            // Sample a random branch with exactly k bits set
+            let branch_bits = random_bits_with_weight(&mut rng, t_count, k);
+            let branch_seed = rng.gen::<u64>();
+            shots.push(run_branch(circuit, &t_locations, branch_bits, branch_seed)?);
+        }
+    }
+
+    Ok(super::ShotsResult {
+        shots,
+        probabilities: None,
+    })
+}
+
+fn binomial(n: usize, k: usize) -> u64 {
+    if k > n {
+        return 0;
+    }
+    let k = k.min(n - k);
+    let mut result = 1u64;
+    for i in 0..k {
+        result = result.saturating_mul((n - i) as u64) / (i as u64 + 1);
+    }
+    result
+}
+
+fn random_bits_with_weight(rng: &mut ChaCha8Rng, n: usize, k: usize) -> u64 {
+    if k == 0 {
+        return 0;
+    }
+    if k >= n {
+        return (1u64 << n) - 1;
+    }
+    // Fisher-Yates partial shuffle to pick k positions from n
+    let mut positions: Vec<usize> = (0..n).collect();
+    for i in 0..k {
+        let j = i + rng.gen_range(0..n - i);
+        positions.swap(i, j);
+    }
+    let mut bits = 0u64;
+    for &pos in &positions[..k] {
+        bits |= 1u64 << pos;
+    }
+    bits
+}
+
+/// Adaptive shot sampling with convergence detection.
+///
+/// Samples shots in batches, monitoring the total-variation distance between
+/// successive normalized histograms. Stops early when the distribution
+/// stabilizes (TV distance < `tolerance`) or `max_shots` is reached.
+///
+/// Returns the shots collected so far plus convergence metadata.
+pub fn run_quasi_prob_shots_adaptive(
+    circuit: &Circuit,
+    max_shots: usize,
+    seed: u64,
+    tolerance: f64,
+) -> Result<AdaptiveResult> {
+    let t_locations = find_t_gates(circuit);
+    let t_count = t_locations.len();
+
+    if t_count > 64 {
+        return Err(crate::error::PrismError::BackendUnsupported {
+            backend: "quasi_probability".into(),
+            operation: format!("shot sampling for {} T-gates (max 64)", t_count),
+        });
+    }
+
+    if t_count == 0 {
+        let result =
+            super::run_shots_with(super::BackendKind::Stabilizer, circuit, max_shots, seed)?;
+        return Ok(AdaptiveResult {
+            shots_result: result,
+            converged: true,
+            tv_distance: 0.0,
+            total_shots: max_shots,
+        });
+    }
+
+    let (alpha, beta) = t_decomposition();
+    let p_alpha = alpha.norm() / (alpha.norm() + beta.norm());
+    let t_mask = if t_count >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << t_count) - 1
+    };
+
+    let n_cbits = circuit.num_classical_bits;
+    let batch_size = (max_shots / 10).max(50).min(max_shots);
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut shots = Vec::with_capacity(max_shots);
+    let mut histogram = std::collections::HashMap::<Vec<bool>, usize>::new();
+    let mut prev_histogram = std::collections::HashMap::<Vec<bool>, usize>::new();
+    let mut converged = false;
+    let mut tv_distance = f64::INFINITY;
+
+    while shots.len() < max_shots {
+        let batch_end = (shots.len() + batch_size).min(max_shots);
+        let this_batch = batch_end - shots.len();
+
+        for _ in 0..this_batch {
+            let mut branch_bits = 0u64;
+            for i in 0..t_count {
+                if rng.gen::<f64>() >= p_alpha {
+                    branch_bits |= 1u64 << i;
+                }
+            }
+
+            let branch_seed = rng.gen::<u64>();
+            let shot = run_branch(circuit, &t_locations, branch_bits, branch_seed)?;
+            *histogram.entry(shot.clone()).or_insert(0) += 1;
+            shots.push(shot);
+
+            // Antithetic
+            if shots.len() < max_shots {
+                let anti_bits = !branch_bits & t_mask;
+                let anti_seed = rng.gen::<u64>();
+                let anti_shot = run_branch(circuit, &t_locations, anti_bits, anti_seed)?;
+                *histogram.entry(anti_shot.clone()).or_insert(0) += 1;
+                shots.push(anti_shot);
+            }
+        }
+
+        // Compute TV distance between current and previous histogram
+        if !prev_histogram.is_empty() {
+            let total_prev: usize = prev_histogram.values().sum();
+            let total_curr: usize = histogram.values().sum();
+
+            if total_prev > 0 && total_curr > 0 {
+                let all_keys: std::collections::HashSet<&Vec<bool>> =
+                    histogram.keys().chain(prev_histogram.keys()).collect();
+
+                let mut tv = 0.0;
+                for key in &all_keys {
+                    let p = *prev_histogram.get(*key).unwrap_or(&0) as f64 / total_prev as f64;
+                    let q = *histogram.get(*key).unwrap_or(&0) as f64 / total_curr as f64;
+                    tv += (p - q).abs();
+                }
+                tv_distance = tv / 2.0;
+
+                if tv_distance < tolerance {
+                    converged = true;
+                    break;
+                }
+            }
+        }
+
+        prev_histogram = histogram.clone();
+    }
+
+    // Ensure we don't have zero-length classical results
+    if n_cbits == 0 && shots.is_empty() {
+        shots.push(vec![]);
+    }
+
+    let total_shots = shots.len();
+    Ok(AdaptiveResult {
+        shots_result: super::ShotsResult {
+            shots,
+            probabilities: None,
+        },
+        converged,
+        tv_distance,
+        total_shots,
+    })
+}
+
+/// Result of adaptive quasi-probability shot sampling.
+#[derive(Debug, Clone)]
+pub struct AdaptiveResult {
+    /// The shot results.
+    pub shots_result: super::ShotsResult,
+    /// Whether the distribution converged within tolerance.
+    pub converged: bool,
+    /// Final total-variation distance between successive histograms.
+    pub tv_distance: f64,
+    /// Number of shots actually taken.
+    pub total_shots: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_t_decomposition_coefficients() {
+        let (alpha, beta) = t_decomposition();
+
+        // T|0⟩ = |0⟩, so (α·I + β·Z)|0⟩ = (α+β)|0⟩ = |0⟩ → α+β = 1
+        let sum = alpha + beta;
+        assert!((sum.re - 1.0).abs() < 1e-12);
+        assert!(sum.im.abs() < 1e-12);
+
+        // T|1⟩ = e^{iπ/4}|1⟩, so (α·I + β·Z)|1⟩ = (α-β)|1⟩ = e^{iπ/4}|1⟩
+        let diff = alpha - beta;
+        let expected = Complex64::new(FRAC_PI_4.cos(), FRAC_PI_4.sin());
+        assert!((diff - expected).norm() < 1e-12);
+    }
+
+    #[test]
+    fn test_negativity_per_t() {
+        // |α| + |β| = cos(π/8) + sin(π/8)
+        let xi = negativity_per_t();
+        let expected = (std::f64::consts::FRAC_PI_8).cos() + (std::f64::consts::FRAC_PI_8).sin();
+        assert!(
+            (xi - expected).abs() < 1e-12,
+            "Per-T negativity should be cos(π/8)+sin(π/8) ≈ {}, got {}",
+            expected,
+            xi
+        );
+        // ≈ 1.3066
+        assert!(xi > 1.3 && xi < 1.31);
+    }
+
+    #[test]
+    fn test_pure_clifford_passthrough() {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+
+        let result = run_quasi_prob(&c, 42).unwrap();
+        assert_eq!(result.t_count, 0);
+        assert_eq!(result.num_branches, 1);
+
+        // Bell state: |00⟩ and |11⟩ each ~50%
+        assert!((result.probabilities[0] - 0.5).abs() < 1e-10);
+        assert!(result.probabilities[1].abs() < 1e-10);
+        assert!(result.probabilities[2].abs() < 1e-10);
+        assert!((result.probabilities[3] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_single_t_exact() {
+        // H·T·H on qubit 0
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_quasi_prob(&c, 42).unwrap();
+        assert_eq!(result.t_count, 1);
+        assert_eq!(result.num_branches, 2); // exact: 2^1 = 2 branches
+
+        // P(0) = cos²(π/8), P(1) = sin²(π/8)
+        let p0_expected = (std::f64::consts::FRAC_PI_8).cos().powi(2);
+        let p1_expected = (std::f64::consts::FRAC_PI_8).sin().powi(2);
+
+        assert!(
+            (result.probabilities[0] - p0_expected).abs() < 1e-10,
+            "P(0) = {}, expected {}",
+            result.probabilities[0],
+            p0_expected
+        );
+        assert!(
+            (result.probabilities[1] - p1_expected).abs() < 1e-10,
+            "P(1) = {}, expected {}",
+            result.probabilities[1],
+            p1_expected
+        );
+    }
+
+    #[test]
+    fn test_two_t_gates_exact() {
+        // T·T = S on qubit 0
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_quasi_prob(&c, 42).unwrap();
+        assert_eq!(result.t_count, 2);
+        assert_eq!(result.num_branches, 4); // 2^2
+
+        // H·S·H|0⟩ = H·S|+⟩ = H·(|0⟩+i|1⟩)/√2 = (1+i)/2|0⟩ + (1-i)/2|1⟩
+        // P(0) = |(1+i)/2|² = 1/2, P(1) = |(1-i)/2|² = 1/2
+        assert!(
+            (result.probabilities[0] - 0.5).abs() < 1e-10,
+            "P(0) = {}, expected 0.5",
+            result.probabilities[0]
+        );
+        assert!(
+            (result.probabilities[1] - 0.5).abs() < 1e-10,
+            "P(1) = {}, expected 0.5",
+            result.probabilities[1]
+        );
+    }
+
+    #[test]
+    fn test_tdg_exact() {
+        // H·Tdg·H on qubit 0
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Tdg, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_quasi_prob(&c, 42).unwrap();
+        assert_eq!(result.t_count, 1);
+
+        // Same probabilities as T (Tdg just conjugates the phase, |amp|² is symmetric)
+        let p0_expected = (std::f64::consts::FRAC_PI_8).cos().powi(2);
+        assert!(
+            (result.probabilities[0] - p0_expected).abs() < 1e-10,
+            "P(0) = {}, expected {}",
+            result.probabilities[0],
+            p0_expected
+        );
+    }
+
+    #[test]
+    fn test_quasi_prob_shots() {
+        let mut c = Circuit::new(2, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+
+        let result = run_quasi_prob_shots(&c, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
+        for shot in &result.shots {
+            assert_eq!(shot.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_tdg_decomposition() {
+        let (alpha_t, beta_t) = t_decomposition();
+        let (alpha_tdg, beta_tdg) = tdg_decomposition();
+        assert!((alpha_tdg - alpha_t.conj()).norm() < 1e-12);
+        assert!((beta_tdg - beta_t.conj()).norm() < 1e-12);
+    }
+
+    #[test]
+    fn test_antithetic_shots() {
+        let mut c = Circuit::new(2, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+
+        let result = run_quasi_prob_shots(&c, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
+        for shot in &result.shots {
+            assert_eq!(shot.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_antithetic_odd_shots() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_measure(0, 0);
+
+        // Odd number of shots — should truncate cleanly
+        let result = run_quasi_prob_shots(&c, 7, 42).unwrap();
+        assert_eq!(result.shots.len(), 7);
+    }
+
+    #[test]
+    fn test_stratified_shots() {
+        let mut c = Circuit::new(2, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::T, &[1]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+
+        let result = run_quasi_prob_shots_stratified(&c, 100, 42).unwrap();
+        assert_eq!(result.shots.len(), 100);
+    }
+
+    #[test]
+    fn test_adaptive_converges() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_measure(0, 0);
+
+        let result = run_quasi_prob_shots_adaptive(&c, 1000, 42, 0.1).unwrap();
+        assert!(result.total_shots <= 1000);
+        assert!(result.total_shots >= 50); // at least one batch
+    }
+
+    #[test]
+    fn test_adaptive_pure_clifford() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+
+        let result = run_quasi_prob_shots_adaptive(&c, 100, 42, 0.01).unwrap();
+        assert!(result.converged);
+        assert_eq!(result.total_shots, 100);
+    }
+
+    #[test]
+    fn test_binomial() {
+        assert_eq!(binomial(5, 0), 1);
+        assert_eq!(binomial(5, 1), 5);
+        assert_eq!(binomial(5, 2), 10);
+        assert_eq!(binomial(5, 3), 10);
+        assert_eq!(binomial(5, 5), 1);
+        assert_eq!(binomial(10, 5), 252);
+        assert_eq!(binomial(0, 0), 1);
+    }
+
+    #[test]
+    fn test_random_bits_with_weight() {
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        for _ in 0..20 {
+            let bits = random_bits_with_weight(&mut rng, 8, 3);
+            assert_eq!(bits.count_ones(), 3);
+            assert!(bits < 256); // only bottom 8 bits
+        }
+        assert_eq!(random_bits_with_weight(&mut rng, 5, 0), 0);
+        assert_eq!(random_bits_with_weight(&mut rng, 5, 5), 0b11111);
+    }
+
+    #[test]
+    fn test_probabilities_sum_to_one() {
+        // Multi-T circuit: H-T-H on each qubit + CX
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::T, &[1]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+
+        let result = run_quasi_prob(&c, 42).unwrap();
+        assert_eq!(result.t_count, 2);
+
+        let total: f64 = result.probabilities.iter().sum();
+        assert!(
+            (total - 1.0).abs() < 1e-8,
+            "Probabilities sum to {}, expected 1.0",
+            total
+        );
+    }
+}

--- a/src/sim/stabilizer_rank.rs
+++ b/src/sim/stabilizer_rank.rs
@@ -1,0 +1,716 @@
+//! Stabilizer rank simulation for Clifford+T circuits.
+//!
+//! Maintains a weighted sum of stabilizer states: |ψ⟩ = Σ_k c_k |φ_k⟩.
+//! Clifford gates are applied to all terms (O(n²) per term). Each T gate
+//! expands every term into two via T = α·I + β·Z, doubling the term count.
+//!
+//! Two modes:
+//! - **Exact probabilities** (n ≤ 25): export statevectors per term, accumulate
+//!   weighted amplitudes, compute |amplitude|² for each basis state.
+//! - **Measurement sampling** (any n): compute Born probabilities via pairwise
+//!   stabilizer inner products O(χ² · n³), sample outcomes.
+
+use num_complex::Complex64;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use std::f64::consts::FRAC_PI_4;
+
+use crate::backend::stabilizer::StabilizerBackend;
+use crate::backend::Backend;
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+
+const MAX_STATEVECTOR_QUBITS: usize = 25;
+const MAX_TERMS: usize = 1 << 20; // 1M terms safety limit
+
+fn t_coefficients() -> (Complex64, Complex64) {
+    let exp_i_pi_4 = Complex64::new(FRAC_PI_4.cos(), FRAC_PI_4.sin());
+    let alpha = (Complex64::new(1.0, 0.0) + exp_i_pi_4) / 2.0;
+    let beta = (Complex64::new(1.0, 0.0) - exp_i_pi_4) / 2.0;
+    (alpha, beta)
+}
+
+fn tdg_coefficients() -> (Complex64, Complex64) {
+    let (alpha, beta) = t_coefficients();
+    (alpha.conj(), beta.conj())
+}
+
+/// A weighted stabilizer state: coefficient × stabilizer tableau.
+struct WeightedStabilizer {
+    weight: Complex64,
+    backend: StabilizerBackend,
+}
+
+/// Result of stabilizer rank probability computation.
+#[derive(Debug, Clone)]
+pub struct StabRankResult {
+    /// Probability distribution over computational basis states.
+    pub probabilities: Vec<f64>,
+    /// Number of stabilizer terms in the decomposition.
+    pub num_terms: usize,
+    /// T-gate count in the circuit.
+    pub t_count: usize,
+    /// Number of terms pruned during approximate simulation (0 for exact).
+    pub pruned_count: usize,
+}
+
+/// Minimum term count for parallel Clifford gate application.
+#[cfg(feature = "parallel")]
+const MIN_TERMS_FOR_PAR: usize = 16;
+
+/// Run stabilizer rank simulation for exact probabilities.
+///
+/// Clifford gates update all terms in O(n²). T gates double the term count
+/// via T = α·I + β·Z decomposition. n ≤ 25, total terms ≤ 2²⁰.
+pub fn run_stabilizer_rank(circuit: &Circuit, seed: u64) -> Result<StabRankResult> {
+    let n = circuit.num_qubits;
+    let nc = circuit.num_classical_bits;
+
+    if n > MAX_STATEVECTOR_QUBITS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!(
+                "exact probabilities for {} qubits (max {})",
+                n, MAX_STATEVECTOR_QUBITS
+            ),
+        });
+    }
+
+    let mut terms: Vec<WeightedStabilizer> = vec![WeightedStabilizer {
+        weight: Complex64::new(1.0, 0.0),
+        backend: StabilizerBackend::new(seed),
+    }];
+    terms[0].backend.init(n, nc)?;
+
+    let mut t_count = 0usize;
+
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate { gate, targets } => match gate {
+                Gate::T => {
+                    t_count += 1;
+                    expand_t(&mut terms, targets[0], false)?;
+                }
+                Gate::Tdg => {
+                    t_count += 1;
+                    expand_t(&mut terms, targets[0], true)?;
+                }
+                _ => apply_to_all_terms(&mut terms, inst)?,
+            },
+            _ => apply_to_all_terms(&mut terms, inst)?,
+        }
+    }
+
+    accumulate_probabilities(&terms, n).map(|probabilities| StabRankResult {
+        probabilities,
+        num_terms: terms.len(),
+        t_count,
+        pruned_count: 0,
+    })
+}
+
+/// Apply an instruction to all terms, parallelized when term count is large.
+fn apply_to_all_terms(terms: &mut [WeightedStabilizer], inst: &Instruction) -> Result<()> {
+    #[cfg(feature = "parallel")]
+    if terms.len() >= MIN_TERMS_FOR_PAR {
+        use rayon::prelude::*;
+        terms
+            .par_iter_mut()
+            .try_for_each(|term| term.backend.apply(inst))?;
+        return Ok(());
+    }
+
+    for term in terms.iter_mut() {
+        term.backend.apply(inst)?;
+    }
+    Ok(())
+}
+
+/// Accumulate weighted amplitudes across all terms and compute probabilities.
+fn accumulate_probabilities(terms: &[WeightedStabilizer], n: usize) -> Result<Vec<f64>> {
+    let dim = 1usize << n;
+    let zero = Complex64::new(0.0, 0.0);
+
+    #[cfg(feature = "parallel")]
+    if terms.len() >= MIN_TERMS_FOR_PAR {
+        use rayon::prelude::*;
+        let total_amps = terms
+            .par_iter()
+            .map(|term| {
+                let amps = term.backend.export_statevector().unwrap();
+                let mut partial = vec![zero; dim];
+                for (i, amp) in amps.iter().enumerate() {
+                    partial[i] = term.weight * amp;
+                }
+                partial
+            })
+            .reduce(
+                || vec![zero; dim],
+                |mut a, b| {
+                    for (ai, bi) in a.iter_mut().zip(b.iter()) {
+                        *ai += bi;
+                    }
+                    a
+                },
+            );
+        return Ok(total_amps.iter().map(|a| a.norm_sqr()).collect());
+    }
+
+    let mut total_amps = vec![zero; dim];
+    for term in terms {
+        let amps = term.backend.export_statevector()?;
+        for (i, amp) in amps.iter().enumerate() {
+            total_amps[i] += term.weight * amp;
+        }
+    }
+    Ok(total_amps.iter().map(|a| a.norm_sqr()).collect())
+}
+
+/// Expand each term by T = α·I + β·Z decomposition on target qubit.
+fn expand_t(terms: &mut Vec<WeightedStabilizer>, qubit: usize, is_dagger: bool) -> Result<()> {
+    let new_count = terms
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: "term count overflow".into(),
+        })?;
+    if new_count > MAX_TERMS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!("too many terms ({} > {})", new_count, MAX_TERMS),
+        });
+    }
+
+    let (alpha, beta) = if is_dagger {
+        tdg_coefficients()
+    } else {
+        t_coefficients()
+    };
+
+    let orig_len = terms.len();
+    let mut new_terms = Vec::with_capacity(orig_len);
+
+    for term in terms.iter_mut() {
+        let mut z_backend = term.backend.clone();
+        let z_inst = Instruction::Gate {
+            gate: Gate::Z,
+            targets: SmallVec::from_slice(&[qubit]),
+        };
+        z_backend.apply(&z_inst)?;
+        new_terms.push(WeightedStabilizer {
+            weight: term.weight * beta,
+            backend: z_backend,
+        });
+
+        term.weight *= alpha;
+    }
+
+    terms.extend(new_terms);
+    Ok(())
+}
+
+/// Approximate stabilizer rank simulation with bounded term count.
+///
+/// Like [`run_stabilizer_rank`] but prunes low-weight terms after each T gate
+/// to keep term count ≤ `max_terms`. Russian roulette: below-threshold terms
+/// are killed (probability 1 - w/w_max) or promoted (w → w_max).
+pub fn run_stabilizer_rank_approx(
+    circuit: &Circuit,
+    max_terms: usize,
+    seed: u64,
+) -> Result<StabRankResult> {
+    let n = circuit.num_qubits;
+    let nc = circuit.num_classical_bits;
+
+    if n > MAX_STATEVECTOR_QUBITS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!(
+                "exact probabilities for {} qubits (max {})",
+                n, MAX_STATEVECTOR_QUBITS
+            ),
+        });
+    }
+
+    let max_terms = max_terms.max(2);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+    let mut terms: Vec<WeightedStabilizer> = vec![WeightedStabilizer {
+        weight: Complex64::new(1.0, 0.0),
+        backend: StabilizerBackend::new(seed),
+    }];
+    terms[0].backend.init(n, nc)?;
+
+    let mut t_count = 0usize;
+    let mut pruned_total = 0usize;
+
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate { gate, targets } => match gate {
+                Gate::T => {
+                    t_count += 1;
+                    expand_t_unbounded(&mut terms, targets[0], false)?;
+                    pruned_total += prune_terms(&mut terms, max_terms, &mut rng);
+                }
+                Gate::Tdg => {
+                    t_count += 1;
+                    expand_t_unbounded(&mut terms, targets[0], true)?;
+                    pruned_total += prune_terms(&mut terms, max_terms, &mut rng);
+                }
+                _ => apply_to_all_terms(&mut terms, inst)?,
+            },
+            _ => apply_to_all_terms(&mut terms, inst)?,
+        }
+    }
+
+    accumulate_probabilities(&terms, n).map(|probabilities| StabRankResult {
+        probabilities,
+        num_terms: terms.len(),
+        t_count,
+        pruned_count: pruned_total,
+    })
+}
+
+/// Expand terms without the MAX_TERMS safety check (for approximate mode).
+fn expand_t_unbounded(
+    terms: &mut Vec<WeightedStabilizer>,
+    qubit: usize,
+    is_dagger: bool,
+) -> Result<()> {
+    let (alpha, beta) = if is_dagger {
+        tdg_coefficients()
+    } else {
+        t_coefficients()
+    };
+
+    let orig_len = terms.len();
+    let mut new_terms = Vec::with_capacity(orig_len);
+
+    for term in terms.iter_mut() {
+        let mut z_backend = term.backend.clone();
+        let z_inst = Instruction::Gate {
+            gate: Gate::Z,
+            targets: SmallVec::from_slice(&[qubit]),
+        };
+        z_backend.apply(&z_inst)?;
+        new_terms.push(WeightedStabilizer {
+            weight: term.weight * beta,
+            backend: z_backend,
+        });
+        term.weight *= alpha;
+    }
+
+    terms.extend(new_terms);
+    Ok(())
+}
+
+/// Prune terms to at most `max_terms` by discarding lowest-weight terms.
+///
+/// Sorts by descending weight magnitude, keeps the top `max_terms`.
+/// Returns the number of pruned terms.
+fn prune_terms(
+    terms: &mut Vec<WeightedStabilizer>,
+    max_terms: usize,
+    _rng: &mut ChaCha8Rng,
+) -> usize {
+    if terms.len() <= max_terms {
+        return 0;
+    }
+
+    terms.sort_by(|a, b| {
+        b.weight
+            .norm_sqr()
+            .partial_cmp(&a.weight.norm_sqr())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let pruned = terms.len() - max_terms;
+    terms.truncate(max_terms);
+    pruned
+}
+
+/// Stabilizer inner product |⟨φ₁|φ₂⟩|² via combined stabilizer group method.
+///
+/// Merges generators into a 2n-row tableau, Gaussian-eliminates to find rank r.
+/// Sign conflict (P and -P both present) → 0. Otherwise |⟨φ₁|φ₂⟩|² = 2^{n-r}.
+pub fn stabilizer_overlap_sq(s1: &StabilizerBackend, s2: &StabilizerBackend, n: usize) -> f64 {
+    let nw = n.div_ceil(64);
+    let stride = 2 * nw;
+
+    let (xz1, phase1) = s1.raw_tableau();
+    let (xz2, phase2) = s2.raw_tableau();
+
+    let mut combined_x = vec![0u64; 2 * n * nw];
+    let mut combined_z = vec![0u64; 2 * n * nw];
+    let mut combined_phase = vec![false; 2 * n];
+
+    for i in 0..n {
+        let src1 = (i + n) * stride;
+        let src2 = (i + n) * stride;
+        for w in 0..nw {
+            combined_x[i * nw + w] = xz1[src1 + w];
+            combined_z[i * nw + w] = xz1[src1 + nw + w];
+            combined_x[(i + n) * nw + w] = xz2[src2 + w];
+            combined_z[(i + n) * nw + w] = xz2[src2 + nw + w];
+        }
+        combined_phase[i] = phase1[i + n];
+        combined_phase[i + n] = phase2[i + n];
+    }
+
+    // Gaussian elimination on the combined 2n × 2n Pauli system
+    let mut rank = 0usize;
+    let total_rows = 2 * n;
+
+    // Iterate over 2n columns (X-block then Z-block) for full rank determination
+    for col in 0..(2 * n) {
+        let word = (col % n) / 64;
+        let bit = 1u64 << ((col % n) % 64);
+        let is_x_col = col < n;
+
+        let mut pivot = None;
+        for row in rank..total_rows {
+            let has = if is_x_col {
+                combined_x[row * nw + word] & bit != 0
+            } else {
+                combined_z[row * nw + word] & bit != 0
+            };
+            if has {
+                pivot = Some(row);
+                break;
+            }
+        }
+
+        let pivot = match pivot {
+            Some(p) => p,
+            None => continue,
+        };
+
+        if pivot != rank {
+            for w in 0..nw {
+                combined_x.swap(rank * nw + w, pivot * nw + w);
+                combined_z.swap(rank * nw + w, pivot * nw + w);
+            }
+            combined_phase.swap(rank, pivot);
+        }
+
+        for row in 0..total_rows {
+            if row == rank {
+                continue;
+            }
+            let has_bit = if is_x_col {
+                combined_x[row * nw + word] & bit != 0
+            } else {
+                combined_z[row * nw + word] & bit != 0
+            };
+            if !has_bit {
+                continue;
+            }
+
+            // AG rowmul: row ← row × rank (exact same phase logic as stabilizer.rs)
+            let mut sum = if combined_phase[row] { 2u64 } else { 0 }
+                + if combined_phase[rank] { 2u64 } else { 0 };
+
+            for w in 0..nw {
+                let x1 = combined_x[row * nw + w];
+                let z1 = combined_z[row * nw + w];
+                let x2 = combined_x[rank * nw + w];
+                let z2 = combined_z[rank * nw + w];
+
+                let new_x = x1 ^ x2;
+                let new_z = z1 ^ z2;
+
+                if (x1 | z1 | x2 | z2) != 0 {
+                    let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+                    let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+                    sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+                    sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+                }
+
+                combined_x[row * nw + w] = new_x;
+                combined_z[row * nw + w] = new_z;
+            }
+
+            combined_phase[row] = (sum & 3) >= 2;
+        }
+
+        rank += 1;
+    }
+
+    // Check for sign conflicts: any row that is all-zero X,Z but phase=true
+    // means P and -P are both in the combined group → overlap = 0
+    for row in rank..total_rows {
+        let all_zero =
+            (0..nw).all(|w| combined_x[row * nw + w] == 0 && combined_z[row * nw + w] == 0);
+        if all_zero && combined_phase[row] {
+            return 0.0;
+        }
+    }
+
+    // |⟨φ₁|φ₂⟩|² = 2^{n-r} where r is the combined rank of the stabilizer groups.
+    // r ≥ n always (each group alone has n independent generators).
+    // r = n → identical states (overlap = 1). r = 2n → minimum nonzero overlap (2^{-n}).
+    2.0_f64.powi(n as i32 - rank as i32)
+}
+
+/// Stabilizer rank shot sampling on a Clifford+T circuit.
+///
+/// Delegates to quasi-probability shot sampling.
+pub fn run_stabilizer_rank_shots(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<super::ShotsResult> {
+    // For shots, delegate to quasi-probability shot sampling
+    // (same decomposition, different framing)
+    super::quasi_prob::run_quasi_prob_shots(circuit, num_shots, seed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pure_clifford() {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        assert_eq!(result.num_terms, 1);
+        assert_eq!(result.t_count, 0);
+        assert!((result.probabilities[0] - 0.5).abs() < 1e-10);
+        assert!((result.probabilities[3] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_single_t() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        assert_eq!(result.num_terms, 2);
+        assert_eq!(result.t_count, 1);
+
+        let p0_expected = (std::f64::consts::FRAC_PI_8).cos().powi(2);
+        assert!(
+            (result.probabilities[0] - p0_expected).abs() < 1e-10,
+            "P(0) = {}, expected {}",
+            result.probabilities[0],
+            p0_expected
+        );
+    }
+
+    #[test]
+    fn test_matches_statevector() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::H, &[2]);
+        c.add_gate(Gate::T, &[2]);
+        c.add_gate(Gate::Cx, &[2, 1]);
+
+        let sr = run_stabilizer_rank(&c, 42).unwrap();
+        let sv = crate::sim::run_with(crate::sim::BackendKind::Statevector, &c, 42).unwrap();
+        let sv_probs = sv.probabilities.unwrap().to_vec();
+
+        for (i, (sr_p, sv_p)) in sr.probabilities.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (sr_p - sv_p).abs() < 1e-10,
+                "prob[{i}]: stab_rank={sr_p}, statevector={sv_p}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tdg() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Tdg, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        assert_eq!(result.t_count, 1);
+
+        let p0_expected = (std::f64::consts::FRAC_PI_8).cos().powi(2);
+        assert!((result.probabilities[0] - p0_expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_term_count_scaling() {
+        let mut c = Circuit::new(4, 0);
+        for q in 0..4 {
+            c.add_gate(Gate::H, &[q]);
+            c.add_gate(Gate::T, &[q]);
+        }
+
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        assert_eq!(result.t_count, 4);
+        assert_eq!(result.num_terms, 16); // 2^4
+
+        let total: f64 = result.probabilities.iter().sum();
+        assert!((total - 1.0).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_overlap_identical_states() {
+        let mut b1 = StabilizerBackend::new(42);
+        b1.init(3, 0).unwrap();
+        let inst_h = Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        };
+        let inst_cx = Instruction::Gate {
+            gate: Gate::Cx,
+            targets: SmallVec::from_slice(&[0, 1]),
+        };
+        b1.apply(&inst_h).unwrap();
+        b1.apply(&inst_cx).unwrap();
+
+        let b2 = b1.clone();
+        let overlap = stabilizer_overlap_sq(&b1, &b2, 3);
+        assert!(
+            (overlap - 1.0).abs() < 1e-10,
+            "overlap of identical states should be 1, got {}",
+            overlap
+        );
+    }
+
+    #[test]
+    fn test_overlap_orthogonal_states() {
+        // |0⟩ and |1⟩ are orthogonal
+        let mut b1 = StabilizerBackend::new(42);
+        b1.init(1, 0).unwrap();
+        // b1 = |0⟩
+
+        let mut b2 = StabilizerBackend::new(42);
+        b2.init(1, 0).unwrap();
+        let inst_x = Instruction::Gate {
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[0]),
+        };
+        b2.apply(&inst_x).unwrap();
+        // b2 = |1⟩
+
+        let overlap = stabilizer_overlap_sq(&b1, &b2, 1);
+        assert!(
+            overlap < 1e-10,
+            "overlap of |0⟩ and |1⟩ should be 0, got {}",
+            overlap
+        );
+    }
+
+    #[test]
+    fn test_overlap_bell_with_basis() {
+        // |Φ+⟩ = (|00⟩+|11⟩)/√2 vs |00⟩: |⟨00|Φ+⟩|² = 1/2
+        let mut bell = StabilizerBackend::new(42);
+        bell.init(2, 0).unwrap();
+        let inst_h = Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        };
+        let inst_cx = Instruction::Gate {
+            gate: Gate::Cx,
+            targets: SmallVec::from_slice(&[0, 1]),
+        };
+        bell.apply(&inst_h).unwrap();
+        bell.apply(&inst_cx).unwrap();
+
+        let mut basis = StabilizerBackend::new(42);
+        basis.init(2, 0).unwrap();
+
+        let overlap = stabilizer_overlap_sq(&bell, &basis, 2);
+        assert!(
+            (overlap - 0.5).abs() < 1e-10,
+            "|⟨00|Φ+⟩|² should be 0.5, got {}",
+            overlap
+        );
+    }
+
+    #[test]
+    fn test_overlap_plus_with_basis() {
+        // |+⟩ vs |0⟩: |⟨0|+⟩|² = 1/2
+        let mut plus = StabilizerBackend::new(42);
+        plus.init(1, 0).unwrap();
+        let inst_h = Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        };
+        plus.apply(&inst_h).unwrap();
+
+        let mut zero = StabilizerBackend::new(42);
+        zero.init(1, 0).unwrap();
+
+        let overlap = stabilizer_overlap_sq(&plus, &zero, 1);
+        assert!(
+            (overlap - 0.5).abs() < 1e-10,
+            "|⟨0|+⟩|² should be 0.5, got {}",
+            overlap
+        );
+    }
+
+    #[test]
+    fn test_too_many_terms() {
+        let mut c = Circuit::new(1, 0);
+        // 21 T gates would need 2^21 > MAX_TERMS terms
+        for _ in 0..21 {
+            c.add_gate(Gate::T, &[0]);
+        }
+        let result = run_stabilizer_rank(&c, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_approx_small_circuit_exact() {
+        // With budget > 2^t, approximate = exact
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::T, &[1]);
+
+        let exact = run_stabilizer_rank(&c, 42).unwrap();
+        let approx = run_stabilizer_rank_approx(&c, 1024, 42).unwrap();
+
+        assert_eq!(approx.num_terms, exact.num_terms);
+        assert_eq!(approx.pruned_count, 0);
+        for (e, a) in exact.probabilities.iter().zip(approx.probabilities.iter()) {
+            assert!((e - a).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_approx_prunes_terms() {
+        let mut c = Circuit::new(4, 0);
+        for q in 0..4 {
+            c.add_gate(Gate::H, &[q]);
+            c.add_gate(Gate::T, &[q]);
+        }
+        // 4 T gates → 16 terms exact. Budget of 8 should prune.
+        let result = run_stabilizer_rank_approx(&c, 8, 42).unwrap();
+        assert!(result.num_terms <= 8);
+        assert!(result.pruned_count > 0);
+
+        let total: f64 = result.probabilities.iter().sum();
+        // Approximate, so not exactly 1.0, but should be in a reasonable range
+        assert!(total > 0.5 && total < 2.0, "total = {total}");
+    }
+
+    #[test]
+    fn test_approx_handles_many_t_gates() {
+        // 10 T gates → 1024 exact terms, budget 32 should work without error
+        let mut c = Circuit::new(3, 0);
+        for _ in 0..10 {
+            c.add_gate(Gate::H, &[0]);
+            c.add_gate(Gate::T, &[0]);
+        }
+        let result = run_stabilizer_rank_approx(&c, 32, 42).unwrap();
+        assert!(result.num_terms <= 32);
+        assert_eq!(result.t_count, 10);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Main idea**
---
Running a stabilizer backend per shot is O(n² × shots). For QEC workloads (1000q, 10K+ shots), that's brutal. The compiled sampler flips the cost model: spend O(n² × m) once at compile time to build a parity matrix that captures the full measurement correlation structure, then each shot is just O(r/8) LUT lookups where r is the number of truly random measurements (stabilizer rank). At 1000q with 10K shots that's the difference between seconds and milliseconds.

*module changes*
compiled.rs: Heisenberg-picture parity matrix sampler. Backward-propagates Z_q through the circuit for all m measurements simultaneously using a transposed bit-packed representation (each gate touches m/64 words instead of m scalar ops, 64x fewer operations). Gaussian elimination on the X-projections finds the rank r. The r "flip rows" go into a grouped LUT (groups of 8, 256 entries each, incremental XOR construction). Sampling is: generate r/8 random bytes, look up each byte, XOR into the accumulator. Three compilation paths: backward (default, n < 64), forward/column-major (n >= 64, avoids 2n per-row ops), and filtered (subsystem decomposition, compile each independent block separately). AVX2 and NEON SIMD for the batch propagation kernels.

`noise.rs`: Noisy shot sampling layered on top of the compiled sampler. Same backward propagation determines which measurements each noise event flips. At shot time, geometric sampling (floor(ln U / ln(1-p))) skips to the next error occurrence. At p=0.001 that's 1000x fewer random draws than brute force. The sensitivity vectors get the same LUT treatment as the flip rows. Also has a forward frame simulation path for shallow circuits (depth/n < 3): maintains a Pauli error frame per shot, batched in groups of 256, with a noiseless reference run providing the baseline outcomes.

`homological.rs`: For circuits where the syndrome rank (dim of the E-matrix image) is small (<=20), precomputes all 2^r class probabilities via F2 convolution. Each shot becomes: sample quantum randomness from the compiled sampler + binary search a CDF for the noise class. O(r_quantum + r) per shot regardless of how many noise events exist.

`quasi_prob.rs`: Clifford+T simulation via T = aI + bZ decomposition. Exact mode enumerates all 2^t Clifford branches (t <= 20), runs each on stabilizer, accumulates weighted amplitudes. Shot mode randomly samples branches weighted by |a| and |b|, with antithetic pairing (each pair uses branch b and its complement ~b). Also has stratified sampling (partition by Hamming weight, allocate shots proportionally) and adaptive mode (monitor TV distance, stop early on convergence).

`stabilizer_rank.rs`: Alternative formulation that maintains the state as a weighted sum of stabilizer tableaux. Same T-gate decomposition but accumulates all branches simultaneously rather than evaluating them independently. Has an approximate mode with top-k pruning. Also provides stabilizer_overlap_sq for computing the inner product via combined-tableau Gaussian elimination, useful for Born-rule sampling without statevector export.

*backend changes*
StabilizerBackend gets three new methods: apply_gates_only (advance to a checkpoint without measurements), apply_measure_with_info (returns whether the measurement was random + which destabilizer qubits were involved), and batch_measure_ref_info (batched version for end-of-circuit measurements). These exist to support the reference simulation in the frame path.

FilteredStabilizerBackend is a new Backend implementation. Cluster-based dynamic stabilizer that mirrors what FactoredBackend does for statevector. Each qubit starts in its own 1-qubit tableau; 2-qubit gates across clusters trigger merges via copy_tableau_into (handles bit-offset remapping when src and dst have different word widths).

*Dispatch*
run_shots_noisy picks the best path: homological (if syndrome rank <= 20 and shots >= 1000), frame (shallow circuits), compiled (deep circuits), or brute force (non-Clifford). Auto dispatch now routes Clifford+T circuits with t <= 12 to quasi_prob/stabilizer_rank.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
