### PR TITLE
feat(statevector): add optional CUDA GPU backend for processing gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Features exercised on runners without CUDA. The `gpu` feature links against CUDA via
+  # cudarc's dynamic-linking mode and can't build on hosts that don't have the NVIDIA
+  # toolkit installed, so we enumerate features instead of using --all-features.
+  CI_FEATURES: parallel,serialization
 
 jobs:
   check:
@@ -24,13 +28,13 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --features "$CI_FEATURES" -- -D warnings
 
       - name: Tests
-        run: cargo test --all-features
+        run: cargo test --features "$CI_FEATURES"
 
       - name: Doc build
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --no-deps --features "$CI_FEATURES"
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -45,7 +49,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        run: cargo llvm-cov --features "$CI_FEATURES" --lcov --output-path lcov.info
       - name: Extract coverage percentage
         id: cov
         run: |
@@ -82,8 +86,8 @@ jobs:
         run: cargo check --target aarch64-unknown-linux-gnu
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      - name: Check (all features)
-        run: cargo check --target aarch64-unknown-linux-gnu --all-features
+      - name: Check (CI features)
+        run: cargo check --target aarch64-unknown-linux-gnu --features "$CI_FEATURES"
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
@@ -97,9 +101,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --features "$CI_FEATURES" -- -D warnings
       - name: Tests
-        run: cargo test --all-features
+        run: cargo test --features "$CI_FEATURES"
 
   security:
     name: Security & Licenses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ num_cpus = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 faer = { version = "0.20", optional = true, default-features = false, features = ["std", "rayon", "linalg"] }
-cudarc = { version = "0.19", optional = true, default-features = false, features = ["cuda-13020", "dynamic-linking", "driver", "nvrtc", "std"] }
+cudarc = { version = "0.19", optional = true, default-features = false, features = ["cuda-12040", "dynamic-linking", "driver", "nvrtc", "std"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/examples/bench_gpu_vs_cpu.rs
+++ b/examples/bench_gpu_vs_cpu.rs
@@ -1,0 +1,112 @@
+//! Quick GPU-vs-CPU timing for statevector simulation across qubit counts.
+//!
+//! Runs each (backend, qubits) pair three times, reports the minimum. Fusion is disabled on
+//! the CPU side by calling `apply` in a loop so the kernels compared are apples-to-apples
+//! (no fusion passes to bias CPU timing).
+//!
+//! Build + run:
+//!
+//! ```text
+//! CUDA_PATH=... LIB=... cargo run --release \
+//!     --features "parallel gpu" --example bench_gpu_vs_cpu
+//! ```
+
+use std::time::Instant;
+
+use prism_q::backend::Backend;
+use prism_q::circuits::random_circuit;
+use prism_q::StatevectorBackend;
+
+#[cfg(feature = "gpu")]
+use prism_q::gpu::GpuContext;
+
+const SEED: u64 = 0xDEAD_BEEF;
+const REPS: usize = 3;
+
+fn time_cpu(num_qubits: usize, depth: usize) -> f64 {
+    let circuit = random_circuit(num_qubits, depth, SEED);
+    let mut best = f64::INFINITY;
+    for _ in 0..REPS {
+        let mut b = StatevectorBackend::new(42);
+        b.init(num_qubits, 0).unwrap();
+        let start = Instant::now();
+        for inst in &circuit.instructions {
+            b.apply(inst).unwrap();
+        }
+        let _ = b.probabilities().unwrap();
+        let secs = start.elapsed().as_secs_f64();
+        if secs < best {
+            best = secs;
+        }
+    }
+    best
+}
+
+#[cfg(feature = "gpu")]
+fn time_gpu(num_qubits: usize, depth: usize) -> Option<f64> {
+    let ctx = match GpuContext::new(0) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("gpu ctx init failed: {e}");
+            return None;
+        }
+    };
+    let circuit = random_circuit(num_qubits, depth, SEED);
+    let mut best = f64::INFINITY;
+    for _ in 0..REPS {
+        let mut b = StatevectorBackend::new(42).with_gpu(ctx.clone());
+        b.init(num_qubits, 0).unwrap();
+        let start = Instant::now();
+        for inst in &circuit.instructions {
+            b.apply(inst).unwrap();
+        }
+        let _ = b.probabilities().unwrap();
+        let secs = start.elapsed().as_secs_f64();
+        if secs < best {
+            best = secs;
+        }
+    }
+    Some(best)
+}
+
+#[cfg(not(feature = "gpu"))]
+fn time_gpu(_num_qubits: usize, _depth: usize) -> Option<f64> {
+    None
+}
+
+fn main() {
+    println!(
+        "{:>7} {:>7} {:>14} {:>14} {:>10}",
+        "qubits", "depth", "cpu (ms)", "gpu (ms)", "speedup"
+    );
+    println!("{}", "-".repeat(60));
+
+    let configs: &[(usize, usize)] = &[(10, 20), (14, 20), (16, 20), (18, 20), (20, 20), (22, 20)];
+
+    for &(n, d) in configs {
+        let cpu_sec = time_cpu(n, d);
+        let gpu_sec = time_gpu(n, d);
+        match gpu_sec {
+            Some(g) => {
+                println!(
+                    "{:>7} {:>7} {:>14.3} {:>14.3} {:>9.2}x",
+                    n,
+                    d,
+                    cpu_sec * 1e3,
+                    g * 1e3,
+                    cpu_sec / g
+                );
+            }
+            None => {
+                println!(
+                    "{:>7} {:>7} {:>14.3} {:>14} {:>10}",
+                    n,
+                    d,
+                    cpu_sec * 1e3,
+                    "-",
+                    "n/a"
+                );
+            }
+        }
+    }
+}

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -51,8 +51,6 @@ use std::sync::Arc;
 use crate::backend::simd;
 use crate::backend::Backend;
 use crate::circuit::Instruction;
-#[cfg(feature = "gpu")]
-use crate::error::PrismError;
 use crate::error::Result;
 use crate::gates::Gate;
 
@@ -149,10 +147,198 @@ impl StatevectorBackend {
     }
 
     #[cfg(feature = "gpu")]
-    fn gpu_unsupported(op: &str) -> PrismError {
-        PrismError::BackendUnsupported {
-            backend: "statevector/gpu".to_string(),
-            operation: format!("{op} (GPU kernels not yet wired)"),
+    fn apply_gpu(&mut self, instruction: &Instruction) -> Result<()> {
+        debug_assert!(
+            self.gpu_state.is_some(),
+            "apply_gpu called without gpu_state (callers must check self.gpu_state.is_some() first)"
+        );
+        // TODO(gpu-crossover): dispatch here is unconditional — every instruction routes to
+        // GPU when `gpu_state` is Some. This is wrong for small states that fit in L3 and
+        // for post-fusion instructions (MultiFused / BatchPhase) where the CPU path runs
+        // the whole batch in a single tiled pass while the GPU path currently launches one
+        // kernel per sub-gate. Until a crossover heuristic (or batched GPU fused kernels)
+        // lands, users opting into `with_gpu()` on small or heavily-fused workloads can
+        // see regressions versus plain CPU.
+        match instruction {
+            Instruction::Gate { gate, targets } => self.dispatch_gate_gpu(gate, targets),
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => self.apply_measure_gpu(*qubit, *classical_bit),
+            Instruction::Reset { qubit } => self.apply_reset_gpu(*qubit),
+            Instruction::Barrier { .. } => Ok(()),
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => {
+                if condition.evaluate(&self.classical_bits) {
+                    self.dispatch_gate_gpu(gate, targets)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    fn dispatch_gate_gpu(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        use crate::gates::DiagEntry;
+        use crate::gpu::kernels::dense as k;
+
+        let gpu = self
+            .gpu_state
+            .as_mut()
+            .expect("dispatch_gate_gpu called without gpu_state");
+        let ctx = gpu.context().clone();
+
+        match gate {
+            Gate::Rzz(theta) => k::launch_apply_rzz(&ctx, gpu, targets[0], targets[1], *theta),
+            Gate::Cx => k::launch_apply_cx(&ctx, gpu, targets[0], targets[1]),
+            Gate::Cz => k::launch_apply_cz(&ctx, gpu, targets[0], targets[1]),
+            Gate::Swap => k::launch_apply_swap(&ctx, gpu, targets[0], targets[1]),
+            Gate::Cu(mat) => {
+                if let Some(phase) = gate.controlled_phase() {
+                    k::launch_apply_cu_phase(&ctx, gpu, targets[0], targets[1], phase)
+                } else {
+                    k::launch_apply_cu(&ctx, gpu, targets[0], targets[1], **mat)
+                }
+            }
+            Gate::Mcu(data) => {
+                let num_ctrl = data.num_controls as usize;
+                let controls = &targets[..num_ctrl];
+                let target = targets[num_ctrl];
+                if let Some(phase) = gate.controlled_phase() {
+                    k::launch_apply_mcu_phase(&ctx, gpu, controls, target, phase)
+                } else {
+                    k::launch_apply_mcu(&ctx, gpu, controls, target, data.mat)
+                }
+            }
+            Gate::BatchPhase(data) => {
+                let control = targets[0];
+                for &(tgt, phase) in &data.phases {
+                    k::launch_apply_cu_phase(&ctx, gpu, control, tgt, phase)?;
+                }
+                Ok(())
+            }
+            Gate::BatchRzz(data) => {
+                for &(q0, q1, theta) in &data.edges {
+                    k::launch_apply_rzz(&ctx, gpu, q0, q1, theta)?;
+                }
+                Ok(())
+            }
+            Gate::DiagonalBatch(data) => {
+                for entry in &data.entries {
+                    match *entry {
+                        DiagEntry::Phase1q { qubit, d0, d1 } => {
+                            k::launch_apply_diagonal_1q(&ctx, gpu, qubit, d0, d1)?;
+                        }
+                        DiagEntry::Phase2q { q0, q1, phase } => {
+                            k::launch_apply_cu_phase(&ctx, gpu, q0, q1, phase)?;
+                        }
+                        DiagEntry::Parity2q { q0, q1, same, diff } => {
+                            k::launch_apply_parity_phase(&ctx, gpu, q0, q1, same, diff)?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Gate::MultiFused(data) => {
+                if data.all_diagonal {
+                    for &(tgt, mat) in &data.gates {
+                        k::launch_apply_diagonal_1q(&ctx, gpu, tgt, mat[0][0], mat[1][1])?;
+                    }
+                } else {
+                    for &(tgt, mat) in &data.gates {
+                        k::launch_apply_gate_1q(&ctx, gpu, tgt, mat)?;
+                    }
+                }
+                Ok(())
+            }
+            Gate::Fused2q(mat) => k::launch_apply_fused_2q(&ctx, gpu, targets[0], targets[1], mat),
+            Gate::Multi2q(data) => {
+                for &(q0, q1, mat) in &data.gates {
+                    k::launch_apply_fused_2q(&ctx, gpu, q0, q1, &mat)?;
+                }
+                Ok(())
+            }
+            _ => {
+                let mat = gate.matrix_2x2();
+                if gate.is_diagonal_1q() {
+                    k::launch_apply_diagonal_1q(&ctx, gpu, targets[0], mat[0][0], mat[1][1])
+                } else {
+                    k::launch_apply_gate_1q(&ctx, gpu, targets[0], mat)
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_measure_gpu(&mut self, qubit: usize, classical_bit: usize) -> Result<()> {
+        use crate::gpu::kernels::dense as k;
+        use rand::Rng;
+
+        let gpu = self
+            .gpu_state
+            .as_mut()
+            .expect("apply_measure_gpu called without gpu_state");
+        let ctx = gpu.context().clone();
+
+        let prob_one = k::measure_prob_one(&ctx, gpu, qubit)?;
+        let u: f64 = self.rng.random();
+        let outcome = u < prob_one;
+        self.classical_bits[classical_bit] = outcome;
+
+        k::measure_collapse(&ctx, gpu, qubit, outcome)?;
+
+        let inv_sqrt = crate::backend::measurement_inv_norm(outcome, prob_one);
+        gpu.set_pending_norm(gpu.pending_norm() * inv_sqrt);
+        Ok(())
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_reset_gpu(&mut self, qubit: usize) -> Result<()> {
+        use crate::gpu::kernels::dense as k;
+
+        let gpu = self
+            .gpu_state
+            .as_mut()
+            .expect("apply_reset_gpu called without gpu_state");
+        let ctx = gpu.context().clone();
+
+        // Match CPU semantics (src/backend/statevector/kernels.rs::apply_reset):
+        // deterministic projection onto |0⟩ irrespective of the current amplitude on |1⟩.
+        let prob_one = k::measure_prob_one(&ctx, gpu, qubit)?;
+        let prob_zero = (1.0 - prob_one).clamp(0.0, 1.0);
+
+        k::measure_collapse(&ctx, gpu, qubit, false)?;
+
+        if prob_zero > crate::backend::NORM_CLAMP_MIN {
+            let inv_norm = 1.0 / prob_zero.sqrt();
+            gpu.set_pending_norm(gpu.pending_norm() * inv_norm);
+        } else {
+            // |0⟩ half was empty — reinitialise to |0…0⟩ (CPU does the same).
+            k::launch_set_initial_state(&ctx, gpu)?;
+            gpu.set_pending_norm(1.0);
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "gpu")]
+    fn apply_1q_matrix_gpu(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        use crate::gpu::kernels::dense as k;
+
+        let gpu = self
+            .gpu_state
+            .as_mut()
+            .expect("apply_1q_matrix_gpu called without gpu_state");
+        let ctx = gpu.context().clone();
+
+        let is_diagonal = matrix[0][1].norm() < 1e-14 && matrix[1][0].norm() < 1e-14;
+        if is_diagonal {
+            k::launch_apply_diagonal_1q(&ctx, gpu, qubit, matrix[0][0], matrix[1][1])
+        } else {
+            k::launch_apply_gate_1q(&ctx, gpu, qubit, *matrix)
         }
     }
 
@@ -282,16 +468,7 @@ impl Backend for StatevectorBackend {
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         #[cfg(feature = "gpu")]
         if self.gpu_state.is_some() {
-            let op = match instruction {
-                Instruction::Gate { gate, .. } => format!("gate `{}`", gate.name()),
-                Instruction::Measure { .. } => "measure".to_string(),
-                Instruction::Reset { .. } => "reset".to_string(),
-                Instruction::Barrier { .. } => return Ok(()),
-                Instruction::Conditional { gate, .. } => {
-                    format!("conditional gate `{}`", gate.name())
-                }
-            };
-            return Err(Self::gpu_unsupported(&op));
+            return self.apply_gpu(instruction);
         }
         match instruction {
             Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets),
@@ -324,8 +501,8 @@ impl Backend for StatevectorBackend {
 
     fn probabilities(&self) -> Result<Vec<f64>> {
         #[cfg(feature = "gpu")]
-        if self.gpu_state.is_some() {
-            return Err(Self::gpu_unsupported("probabilities"));
+        if let Some(gpu) = self.gpu_state.as_ref() {
+            return gpu.probabilities();
         }
         let norm_sq = self.pending_norm * self.pending_norm;
         let dim = self.state.len();
@@ -361,8 +538,8 @@ impl Backend for StatevectorBackend {
 
     fn export_statevector(&self) -> crate::error::Result<Vec<Complex64>> {
         #[cfg(feature = "gpu")]
-        if self.gpu_state.is_some() {
-            return Err(Self::gpu_unsupported("export_statevector"));
+        if let Some(gpu) = self.gpu_state.as_ref() {
+            return gpu.export_statevector();
         }
         if self.pending_norm == 1.0 {
             return Ok(self.state.clone());
@@ -373,8 +550,8 @@ impl Backend for StatevectorBackend {
 
     fn qubit_probability(&self, qubit: usize) -> crate::error::Result<f64> {
         #[cfg(feature = "gpu")]
-        if self.gpu_state.is_some() {
-            return Err(Self::gpu_unsupported("qubit_probability"));
+        if let Some(gpu) = self.gpu_state.as_ref() {
+            return crate::gpu::kernels::dense::measure_prob_one(gpu.context(), gpu, qubit);
         }
         Ok(self.qubit_probability_one(qubit))
     }
@@ -382,7 +559,7 @@ impl Backend for StatevectorBackend {
     fn reset(&mut self, qubit: usize) -> Result<()> {
         #[cfg(feature = "gpu")]
         if self.gpu_state.is_some() {
-            return Err(Self::gpu_unsupported("reset"));
+            return self.apply_reset_gpu(qubit);
         }
         self.apply_reset(qubit);
         Ok(())
@@ -391,7 +568,7 @@ impl Backend for StatevectorBackend {
     fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
         #[cfg(feature = "gpu")]
         if self.gpu_state.is_some() {
-            return Err(Self::gpu_unsupported("apply_1q_matrix"));
+            return self.apply_1q_matrix_gpu(qubit, matrix);
         }
         let is_diagonal = matrix[0][1].norm() < 1e-14 && matrix[1][0].norm() < 1e-14;
         if is_diagonal {

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1262,4 +1262,88 @@ mod gpu_scaffold {
         assert!(backend.init(4, 0).is_ok());
         assert_eq!(backend.num_qubits(), 4);
     }
+
+    /// Real-device smoke test: |0000⟩ state round-trips correctly through the GPU path.
+    ///
+    /// When CUDA is not available or the driver rejects the PTX, prints a SKIP message and
+    /// returns without failing. This avoids fighting CI on machines without a usable GPU.
+    #[test]
+    fn gpu_init_and_readback_zero_state() {
+        let ctx = match GpuContext::new(0) {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                eprintln!("SKIP: no usable GPU ({e})");
+                return;
+            }
+        };
+        let mut backend = StatevectorBackend::new(42).with_gpu(ctx);
+        backend.init(4, 0).expect("GPU init failed");
+
+        let probs = backend.probabilities().expect("GPU probabilities failed");
+        assert_eq!(probs.len(), 16);
+        assert!((probs[0] - 1.0).abs() < 1e-12, "p[0] = {}", probs[0]);
+        for (i, &p) in probs.iter().enumerate().skip(1) {
+            assert!(p.abs() < 1e-12, "p[{}] = {} should be 0", i, p);
+        }
+
+        let sv = backend.export_statevector().expect("GPU export failed");
+        assert_eq!(sv.len(), 16);
+        assert!((sv[0].re - 1.0).abs() < 1e-12 && sv[0].im.abs() < 1e-12);
+        for amp in &sv[1..] {
+            assert!(amp.norm() < 1e-12);
+        }
+    }
+
+    /// Bell state end-to-end on GPU, comparing against CPU. Exercises H (1q) + CX (2q)
+    /// kernels, host↔device transfer, and the full dispatcher.
+    #[test]
+    fn gpu_bell_state_matches_cpu() {
+        let ctx = match GpuContext::new(0) {
+            Ok(ctx) => ctx,
+            Err(_) => return,
+        };
+        use crate::circuit::{Circuit, Instruction};
+        use crate::gates::Gate;
+
+        let mut circuit = Circuit::new(2, 0);
+        circuit.instructions.push(Instruction::Gate {
+            gate: Gate::H,
+            targets: crate::circuit::smallvec![0],
+        });
+        circuit.instructions.push(Instruction::Gate {
+            gate: Gate::Cx,
+            targets: crate::circuit::smallvec![0, 1],
+        });
+
+        let mut cpu = StatevectorBackend::new(42);
+        cpu.init(2, 0).unwrap();
+        for inst in &circuit.instructions {
+            cpu.apply(inst).unwrap();
+        }
+        let cpu_probs = cpu.probabilities().unwrap();
+
+        let mut gpu = StatevectorBackend::new(42).with_gpu(ctx);
+        gpu.init(2, 0).unwrap();
+        for inst in &circuit.instructions {
+            gpu.apply(inst).unwrap();
+        }
+        let gpu_probs = gpu.probabilities().unwrap();
+
+        assert_eq!(cpu_probs.len(), gpu_probs.len());
+        for (i, (c, g)) in cpu_probs.iter().zip(gpu_probs.iter()).enumerate() {
+            assert!(
+                (c - g).abs() < 1e-12,
+                "p[{}]: cpu={}, gpu={}, diff={}",
+                i,
+                c,
+                g,
+                (c - g).abs()
+            );
+        }
+        // Bell state: p[00] ≈ p[11] ≈ 0.5; p[01] = p[10] = 0.
+        assert!((gpu_probs[0] - 0.5).abs() < 1e-12);
+        assert!((gpu_probs[3] - 0.5).abs() < 1e-12);
+        assert!(gpu_probs[1].abs() < 1e-12);
+        assert!(gpu_probs[2].abs() < 1e-12);
+    }
 }

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -1,60 +1,171 @@
 //! CUDA device wrapper. Isolates cudarc so alternative backends (wgpu, ROCm) can be substituted
 //! by replacing this file.
-//!
-//! Scaffold only: every method returns `PrismError::BackendUnsupported`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use cudarc::driver::{CudaContext, CudaFunction, CudaModule, CudaStream};
+use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
 
 use crate::error::{PrismError, Result};
 
+use super::kernels::{KERNEL_NAMES, KERNEL_SOURCE};
+
 /// Handle to a CUDA-capable device.
 ///
-/// Owns the `CudaDevice` (cheap to clone via `Arc` internally) and the stream used for all
-/// kernel launches.
+/// Owns the CUDA context, default stream, and compiled PTX module. The `Stub` variant exists
+/// so unit tests can exercise the `with_gpu()` builder path without CUDA available.
 #[derive(Debug)]
 pub struct GpuDevice {
-    device_id: usize,
+    inner: DeviceInner,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+enum DeviceInner {
+    Real {
+        context: Arc<CudaContext>,
+        stream: Arc<CudaStream>,
+        module: Arc<CudaModule>,
+        functions: HashMap<&'static str, CudaFunction>,
+    },
+    Stub,
 }
 
 impl GpuDevice {
-    /// Open the device with the given ordinal.
+    /// Open the device with the given ordinal and compile the kernel module.
+    ///
+    /// PTX is compiled targeting the device's compute capability so the running NVIDIA
+    /// driver can load it regardless of the toolkit NVRTC version.
     pub fn new(device_id: usize) -> Result<Self> {
-        let _ = device_id;
-        Err(Self::unsupported("device initialization"))
+        let context = CudaContext::new(device_id).map_err(|e| Self::driver_err("init", e))?;
+        let stream = context.default_stream();
+        let arch = detect_arch(&context).unwrap_or("compute_60");
+        let opts = CompileOptions {
+            arch: Some(arch),
+            ..Default::default()
+        };
+        let ptx = compile_ptx_with_opts(KERNEL_SOURCE, opts).map_err(|e| {
+            PrismError::BackendUnsupported {
+                backend: "gpu".to_string(),
+                operation: format!("PTX compilation (arch={arch}): {e}"),
+            }
+        })?;
+        let module = context
+            .load_module(ptx)
+            .map_err(|e| Self::driver_err("load_module", e))?;
+        // Pre-resolve every kernel once, to amortise driver lookups away from the gate
+        // dispatch hot path.
+        let mut functions = HashMap::with_capacity(KERNEL_NAMES.len());
+        for &name in KERNEL_NAMES {
+            let func = module
+                .load_function(name)
+                .map_err(|e| Self::driver_err(&format!("load_function `{name}`"), e))?;
+            functions.insert(name, func);
+        }
+        Ok(Self {
+            inner: DeviceInner::Real {
+                context,
+                stream,
+                module,
+                functions,
+            },
+        })
     }
 
     /// Query whether any CUDA-capable GPU is available on this system.
     ///
     /// Safe to call without a device; returns `false` if detection fails for any reason.
     pub fn is_available() -> bool {
-        false
+        CudaContext::new(0).is_ok()
     }
 
     /// Total VRAM on the selected device in bytes.
     pub fn vram_bytes(&self) -> Result<usize> {
-        Err(Self::unsupported("vram_bytes"))
+        match &self.inner {
+            DeviceInner::Real { context, .. } => context
+                .total_mem()
+                .map_err(|e| Self::driver_err("vram_bytes", e)),
+            DeviceInner::Stub => Err(Self::stub_unsupported("vram_bytes")),
+        }
     }
 
     /// Maximum qubits representable as a Complex64 statevector in the available VRAM.
     ///
     /// Computed as `floor(log2(vram_bytes / 16))` — each amplitude is two f64s = 16 bytes.
     pub fn max_qubits_for_statevector(&self) -> Result<usize> {
-        Err(Self::unsupported("max_qubits_for_statevector"))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn device_id(&self) -> usize {
-        self.device_id
+        let bytes = self.vram_bytes()?;
+        let elements = bytes / 16;
+        if elements == 0 {
+            return Ok(0);
+        }
+        Ok(63 - elements.leading_zeros() as usize)
     }
 
     #[cfg(test)]
     pub(crate) fn stub_for_tests() -> Self {
-        Self { device_id: 0 }
+        Self {
+            inner: DeviceInner::Stub,
+        }
     }
 
-    fn unsupported(op: &str) -> PrismError {
+    pub(crate) fn stream(&self) -> Result<&Arc<CudaStream>> {
+        match &self.inner {
+            DeviceInner::Real { stream, .. } => Ok(stream),
+            DeviceInner::Stub => Err(Self::stub_unsupported("stream access")),
+        }
+    }
+
+    pub(crate) fn function(&self, name: &str) -> Result<CudaFunction> {
+        match &self.inner {
+            DeviceInner::Real { functions, .. } => {
+                functions
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| PrismError::BackendUnsupported {
+                        backend: "gpu".to_string(),
+                        operation: format!("unknown kernel `{name}` (not in KERNEL_NAMES)"),
+                    })
+            }
+            DeviceInner::Stub => Err(Self::stub_unsupported(&format!("function `{name}`"))),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_stub(&self) -> bool {
+        matches!(self.inner, DeviceInner::Stub)
+    }
+
+    fn driver_err(op: &str, err: impl std::fmt::Display) -> PrismError {
         PrismError::BackendUnsupported {
             backend: "gpu".to_string(),
-            operation: format!("{op} (scaffold only)"),
+            operation: format!("{op}: {err}"),
         }
+    }
+
+    fn stub_unsupported(op: &str) -> PrismError {
+        PrismError::BackendUnsupported {
+            backend: "gpu".to_string(),
+            operation: format!("{op} (stub device)"),
+        }
+    }
+}
+
+fn detect_arch(context: &Arc<CudaContext>) -> Option<&'static str> {
+    let (major, minor) = context.compute_capability().ok()?;
+    match (major, minor) {
+        (6, 0) => Some("compute_60"),
+        (6, 1) => Some("compute_61"),
+        (6, 2) => Some("compute_62"),
+        (7, 0) => Some("compute_70"),
+        (7, 2) => Some("compute_72"),
+        (7, 5) => Some("compute_75"),
+        (8, 0) => Some("compute_80"),
+        (8, 6) => Some("compute_86"),
+        (8, 7) => Some("compute_87"),
+        (8, 9) => Some("compute_89"),
+        (9, 0) => Some("compute_90"),
+        _ => None,
     }
 }
 
@@ -63,15 +174,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_returns_unsupported() {
-        assert!(matches!(
-            GpuDevice::new(0).unwrap_err(),
-            PrismError::BackendUnsupported { .. }
-        ));
+    fn stub_reports_as_stub() {
+        let dev = GpuDevice::stub_for_tests();
+        assert!(dev.is_stub());
     }
 
     #[test]
-    fn is_available_false_in_scaffold() {
-        assert!(!GpuDevice::is_available());
+    fn stub_stream_returns_unsupported() {
+        let dev = GpuDevice::stub_for_tests();
+        assert!(matches!(
+            dev.stream().unwrap_err(),
+            PrismError::BackendUnsupported { .. }
+        ));
     }
 }

--- a/src/gpu/kernels/dense.rs
+++ b/src/gpu/kernels/dense.rs
@@ -1,0 +1,1074 @@
+//! Dense statevector kernels — CUDA C source compiled to PTX at runtime, plus Rust-side
+//! launch helpers.
+//!
+//! The state buffer is `2 * 2^n` f64s laid out as interleaved (re, im) pairs matching
+//! `num_complex::Complex64` and CUDA's `double2` builtin. All kernels take the buffer as
+//! `double2 *` for 16-byte aligned vector loads.
+//!
+//! # Fused-gate strategy
+//!
+//! Fused variants (`MultiFused`, `Multi2q`, `BatchPhase`, `BatchRzz`, `DiagonalBatch`) are
+//! decomposed on the host into the appropriate per-element kernel launches. This avoids
+//! host-side variable-length data uploads and keeps the PTX surface small. Optimised batched
+//! kernels are a future refinement.
+
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+use num_complex::Complex64;
+
+use crate::error::{PrismError, Result};
+
+use super::super::{GpuContext, GpuState};
+
+const BLOCK_SIZE: u32 = 256;
+
+pub(crate) const KERNEL_SOURCE: &str = r#"
+// ============================================================================
+// Initialisation
+// ============================================================================
+
+extern "C" __global__ void set_initial_state(double2 *state) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) {
+        state[0] = make_double2(1.0, 0.0);
+    }
+}
+
+// ============================================================================
+// Single-qubit gate: generic 2x2
+// ============================================================================
+//
+// Launch: 2^(n-1) threads. Each thread handles one (lo, hi) amplitude pair.
+
+extern "C" __global__ void apply_gate_1q(
+    double2 *state, unsigned long long pair_count, int target,
+    double m00r, double m00i, double m01r, double m01i,
+    double m10r, double m10i, double m11r, double m11i)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+
+    unsigned long long mask = (1ULL << target) - 1;
+    unsigned long long i0 = ((k & ~mask) << 1) | (k & mask);
+    unsigned long long i1 = i0 | (1ULL << target);
+
+    double2 a = state[i0];
+    double2 b = state[i1];
+    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
+    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
+    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
+    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+}
+
+// Diagonal 2x2 specialisation.
+// state[i0] *= d0, state[i1] *= d1 — no cross terms.
+
+extern "C" __global__ void apply_diagonal_1q(
+    double2 *state, unsigned long long pair_count, int target,
+    double d0r, double d0i, double d1r, double d1i)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+
+    unsigned long long mask = (1ULL << target) - 1;
+    unsigned long long i0 = ((k & ~mask) << 1) | (k & mask);
+    unsigned long long i1 = i0 | (1ULL << target);
+
+    double2 a = state[i0];
+    double2 b = state[i1];
+    state[i0].x = d0r*a.x - d0i*a.y;
+    state[i0].y = d0r*a.y + d0i*a.x;
+    state[i1].x = d1r*b.x - d1i*b.y;
+    state[i1].y = d1r*b.y + d1i*b.x;
+}
+
+// ============================================================================
+// Two-qubit gates (CX / CZ / SWAP)
+// ============================================================================
+//
+// All take `pair_count = 2^(n-2)` threads. Each thread computes a compressed index
+// and expands via chained insert_zero_bit (q0, q1 sorted).
+
+__device__ inline unsigned long long expand_2q(unsigned long long k, int lo_q, int hi_q) {
+    unsigned long long lo_mask = (1ULL << lo_q) - 1;
+    unsigned long long lo = k & lo_mask;
+    unsigned long long mid_hi = k >> lo_q;
+    mid_hi = (mid_hi << 1);                                 // insert 0 at lo_q
+    unsigned long long base = (mid_hi << lo_q) | lo;        // reassemble with gap at lo_q
+    // second insertion at hi_q (already accounts for +1 shift from first)
+    unsigned long long hi_mask = (1ULL << hi_q) - 1;
+    unsigned long long low = base & hi_mask;
+    unsigned long long high = base >> hi_q;
+    return (high << (hi_q + 1)) | low;
+}
+
+extern "C" __global__ void apply_cx(
+    double2 *state, unsigned long long pair_count, int control, int target)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = control < target ? control : target;
+    int hi_q = control < target ? target : control;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+    unsigned long long i0 = idx | (1ULL << control);
+    unsigned long long i1 = i0 | (1ULL << target);
+    double2 tmp = state[i0];
+    state[i0] = state[i1];
+    state[i1] = tmp;
+}
+
+extern "C" __global__ void apply_cz(
+    double2 *state, unsigned long long pair_count, int q0, int q1)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = q0 < q1 ? q0 : q1;
+    int hi_q = q0 < q1 ? q1 : q0;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+    unsigned long long i = idx | (1ULL << q0) | (1ULL << q1);
+    state[i].x = -state[i].x;
+    state[i].y = -state[i].y;
+}
+
+extern "C" __global__ void apply_swap(
+    double2 *state, unsigned long long pair_count, int q0, int q1)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = q0 < q1 ? q0 : q1;
+    int hi_q = q0 < q1 ? q1 : q0;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+    unsigned long long i01 = idx | (1ULL << q0);
+    unsigned long long i10 = idx | (1ULL << q1);
+    double2 tmp = state[i01];
+    state[i01] = state[i10];
+    state[i10] = tmp;
+}
+
+// Parity-dependent phase (Rzz and DiagEntry::Parity2q).
+// state[i] *= same when ((i>>q0) ^ (i>>q1)) & 1 == 0, else state[i] *= diff.
+// Launch over 2^n threads.
+
+extern "C" __global__ void apply_parity_phase(
+    double2 *state, unsigned long long dim, int q0, int q1,
+    double same_r, double same_i, double diff_r, double diff_i)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= dim) return;
+    unsigned long long parity = ((i >> q0) ^ (i >> q1)) & 1ULL;
+    double pr = parity ? diff_r : same_r;
+    double pi = parity ? diff_i : same_i;
+    double2 a = state[i];
+    state[i].x = pr*a.x - pi*a.y;
+    state[i].y = pr*a.y + pi*a.x;
+}
+
+// ============================================================================
+// Controlled-unitary gates
+// ============================================================================
+
+extern "C" __global__ void apply_cu(
+    double2 *state, unsigned long long pair_count, int control, int target,
+    double m00r, double m00i, double m01r, double m01i,
+    double m10r, double m10i, double m11r, double m11i)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = control < target ? control : target;
+    int hi_q = control < target ? target : control;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+    unsigned long long i0 = idx | (1ULL << control);
+    unsigned long long i1 = i0 | (1ULL << target);
+
+    double2 a = state[i0];
+    double2 b = state[i1];
+    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
+    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
+    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
+    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+}
+
+// Controlled-phase optimisation: state[both_set] *= phase.
+// Launch over pair_count = 2^(n-2) threads. Only acts on ctrl=1, tgt=1.
+
+extern "C" __global__ void apply_cu_phase(
+    double2 *state, unsigned long long pair_count, int control, int target,
+    double pr, double pi)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = control < target ? control : target;
+    int hi_q = control < target ? target : control;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+    unsigned long long i = idx | (1ULL << control) | (1ULL << target);
+    double2 a = state[i];
+    state[i].x = pr*a.x - pi*a.y;
+    state[i].y = pr*a.y + pi*a.x;
+}
+
+// Multi-controlled unitary. `sorted` contains all controls + target, sorted ascending.
+// `num_sorted = num_controls + 1`. `ctrl_mask` has bits set at control positions only;
+// `tgt_mask = 1 << target`.
+// Launch over 2^(n - num_sorted) threads.
+
+extern "C" __global__ void apply_mcu(
+    double2 *state, unsigned long long iter_count,
+    const unsigned int *sorted, int num_sorted,
+    unsigned long long ctrl_mask, unsigned long long tgt_mask,
+    double m00r, double m00i, double m01r, double m01i,
+    double m10r, double m10i, double m11r, double m11i)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= iter_count) return;
+    unsigned long long idx = k;
+    for (int i = 0; i < num_sorted; ++i) {
+        int bit = (int)sorted[i];
+        unsigned long long mask_lo = (1ULL << bit) - 1;
+        unsigned long long lo = idx & mask_lo;
+        unsigned long long hi = idx >> bit;
+        idx = (hi << (bit + 1)) | lo;
+    }
+    unsigned long long i0 = idx | ctrl_mask;
+    unsigned long long i1 = i0 | tgt_mask;
+
+    double2 a = state[i0];
+    double2 b = state[i1];
+    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
+    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
+    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
+    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+}
+
+extern "C" __global__ void apply_mcu_phase(
+    double2 *state, unsigned long long iter_count,
+    const unsigned int *sorted, int num_sorted,
+    unsigned long long all_mask,
+    double pr, double pi)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= iter_count) return;
+    unsigned long long idx = k;
+    for (int i = 0; i < num_sorted; ++i) {
+        int bit = (int)sorted[i];
+        unsigned long long mask_lo = (1ULL << bit) - 1;
+        unsigned long long lo = idx & mask_lo;
+        unsigned long long hi = idx >> bit;
+        idx = (hi << (bit + 1)) | lo;
+    }
+    unsigned long long i = idx | all_mask;
+    double2 a = state[i];
+    state[i].x = pr*a.x - pi*a.y;
+    state[i].y = pr*a.y + pi*a.x;
+}
+
+// ============================================================================
+// Fused 2q: generic 4x4 matrix. mat is row-major 16 Complex64 = 32 f64.
+// Launch over pair_count = 2^(n-2) threads; each processes one 4-element group.
+// ============================================================================
+
+extern "C" __global__ void apply_fused_2q(
+    double2 *state, unsigned long long pair_count, int q0, int q1,
+    const double *mat)
+{
+    unsigned long long k = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (k >= pair_count) return;
+    int lo_q = q0 < q1 ? q0 : q1;
+    int hi_q = q0 < q1 ? q1 : q0;
+    unsigned long long idx = expand_2q(k, lo_q, hi_q);
+
+    // Basis ordering matches CPU (src/backend/simd.rs PreparedGate2q::apply_full, line 1598):
+    //   basis index b = (q0_bit << 1) | q1_bit   i.e. q1 is LSB of the 4-element basis.
+    //   b=0 → (q0=0, q1=0); b=1 → (q0=0, q1=1); b=2 → (q0=1, q1=0); b=3 → (q0=1, q1=1).
+    unsigned long long i00 = idx;
+    unsigned long long i01 = idx | (1ULL << q1);
+    unsigned long long i10 = idx | (1ULL << q0);
+    unsigned long long i11 = idx | (1ULL << q0) | (1ULL << q1);
+
+    double2 in[4] = {state[i00], state[i01], state[i10], state[i11]};
+    unsigned long long indices[4] = {i00, i01, i10, i11};
+
+    for (int row = 0; row < 4; ++row) {
+        double rr = 0.0, ri = 0.0;
+        for (int col = 0; col < 4; ++col) {
+            // mat row-major: 32 f64s, row r col c → mat[2*(r*4+c)]=re, mat[2*(r*4+c)+1]=im
+            double mr = mat[2*(row*4 + col)];
+            double mi = mat[2*(row*4 + col) + 1];
+            rr += mr*in[col].x - mi*in[col].y;
+            ri += mr*in[col].y + mi*in[col].x;
+        }
+        state[indices[row]].x = rr;
+        state[indices[row]].y = ri;
+    }
+}
+
+// ============================================================================
+// Measurement
+// ============================================================================
+//
+// measure_prob_one: per-block reduction of sum(|amp|^2) over elements where qubit bit is 1.
+// Each block reduces 2*BLOCK_SIZE elements (using shared memory). Host sums the
+// out_partials array afterward.
+
+extern "C" __global__ void measure_prob_one(
+    const double2 *state, unsigned long long dim, int qubit, double *out_partials)
+{
+    extern __shared__ double sdata[];
+    unsigned long long tid = threadIdx.x;
+    unsigned long long i = (unsigned long long)blockIdx.x * (blockDim.x * 2) + tid;
+    double s = 0.0;
+    if (i < dim && ((i >> qubit) & 1ULL)) {
+        double2 a = state[i];
+        s += a.x*a.x + a.y*a.y;
+    }
+    unsigned long long i2 = i + blockDim.x;
+    if (i2 < dim && ((i2 >> qubit) & 1ULL)) {
+        double2 a = state[i2];
+        s += a.x*a.x + a.y*a.y;
+    }
+    sdata[tid] = s;
+    __syncthreads();
+    for (unsigned long long stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) sdata[tid] += sdata[tid + stride];
+        __syncthreads();
+    }
+    if (tid == 0) out_partials[blockIdx.x] = sdata[0];
+}
+
+// measure_collapse: zero amplitudes where qubit bit != outcome.
+// Launch over 2^n threads, block size BLOCK_SIZE.
+
+extern "C" __global__ void measure_collapse(
+    double2 *state, unsigned long long dim, int qubit, int outcome)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= dim) return;
+    int bit = (int)((i >> qubit) & 1ULL);
+    if (bit != outcome) {
+        state[i].x = 0.0;
+        state[i].y = 0.0;
+    }
+}
+
+// compute_probabilities: out[i] = (amp.x² + amp.y²) * norm_sq for every basis state.
+// Launched over 2^n threads. Saves half the PCIe traffic compared to dtoh'ing raw amplitudes
+// and squaring host-side.
+
+extern "C" __global__ void compute_probabilities(
+    const double2 *state, unsigned long long dim, double norm_sq, double *out)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= dim) return;
+    double2 a = state[i];
+    out[i] = (a.x * a.x + a.y * a.y) * norm_sq;
+}
+
+// scale_state: state[i] *= s. Used to fold deferred pending_norm into the device buffer before
+// export. Launched over 2^n threads.
+
+extern "C" __global__ void scale_state(
+    double2 *state, unsigned long long dim, double s)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= dim) return;
+    state[i].x *= s;
+    state[i].y *= s;
+}
+"#;
+
+// ============================================================================
+// Rust-side launchers
+// ============================================================================
+
+fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
+    PrismError::BackendUnsupported {
+        backend: "gpu".to_string(),
+        operation: format!("{op}: {err}"),
+    }
+}
+
+fn grid_for(count: u64) -> u32 {
+    count.div_ceil(BLOCK_SIZE as u64).max(1) as u32
+}
+
+pub(crate) fn launch_set_initial_state(ctx: &GpuContext, state: &mut GpuState) -> Result<()> {
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("set_initial_state")?;
+    let cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (1, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder.arg(buffer);
+    // SAFETY: kernel signature is (double2*); single-thread write within allocated range.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("set_initial_state", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_compute_probabilities(ctx: &GpuContext, state: &GpuState) -> Result<Vec<f64>> {
+    use super::super::GpuBuffer;
+    let n = state.num_qubits();
+    let dim: u64 = 1u64 << n;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("compute_probabilities")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(dim), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    // Reuse the cached scratch buffer when large enough; grow if num_qubits increased.
+    let mut scratch_slot = state.probs_scratch();
+    if scratch_slot
+        .as_ref()
+        .map_or(true, |b| b.len() < dim as usize)
+    {
+        *scratch_slot = Some(GpuBuffer::<f64>::alloc_zeros(device, dim as usize)?);
+    }
+    let scratch = scratch_slot.as_mut().unwrap();
+
+    let norm_sq = state.pending_norm() * state.pending_norm();
+    let mut builder = stream.launch_builder(&func);
+    let state_buf = state.buffer().raw();
+    let out = scratch.raw_mut();
+    builder.arg(state_buf).arg(&dim).arg(&norm_sq).arg(out);
+    // SAFETY: signature matches; grid covers dim; scratch is at least dim elements.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("compute_probabilities", e))?;
+    }
+    let mut host = vec![0.0_f64; dim as usize];
+    scratch.copy_to_host(device, &mut host)?;
+    Ok(host)
+}
+
+#[allow(dead_code)]
+pub(crate) fn launch_scale_state(ctx: &GpuContext, state: &mut GpuState, s: f64) -> Result<()> {
+    let n = state.num_qubits();
+    let dim: u64 = 1u64 << n;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("scale_state")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(dim), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder.arg(buffer).arg(&dim).arg(&s);
+    // SAFETY: signature matches; grid covers dim.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("scale_state", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_gate_1q(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    target: usize,
+    matrix: [[Complex64; 2]; 2],
+) -> Result<()> {
+    let n = state.num_qubits();
+    if target >= n {
+        return Err(PrismError::InvalidQubit {
+            index: target,
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 1);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_gate_1q")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let m00r = matrix[0][0].re;
+    let m00i = matrix[0][0].im;
+    let m01r = matrix[0][1].re;
+    let m01i = matrix[0][1].im;
+    let m10r = matrix[1][0].re;
+    let m10i = matrix[1][0].im;
+    let m11r = matrix[1][1].re;
+    let m11i = matrix[1][1].im;
+    let target_i = target as i32;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&pair_count)
+        .arg(&target_i)
+        .arg(&m00r)
+        .arg(&m00i)
+        .arg(&m01r)
+        .arg(&m01i)
+        .arg(&m10r)
+        .arg(&m10i)
+        .arg(&m11r)
+        .arg(&m11i);
+    // SAFETY: signature matches kernel declaration; grid/block sized so threads <= pair_count.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_gate_1q", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_diagonal_1q(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    target: usize,
+    d0: Complex64,
+    d1: Complex64,
+) -> Result<()> {
+    let n = state.num_qubits();
+    if target >= n {
+        return Err(PrismError::InvalidQubit {
+            index: target,
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 1);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_diagonal_1q")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let target_i = target as i32;
+    let d0r = d0.re;
+    let d0i = d0.im;
+    let d1r = d1.re;
+    let d1i = d1.im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&pair_count)
+        .arg(&target_i)
+        .arg(&d0r)
+        .arg(&d0i)
+        .arg(&d1r)
+        .arg(&d1i);
+    // SAFETY: signature matches; grid sized to pair_count.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_diagonal_1q", e))?;
+    }
+    Ok(())
+}
+
+fn launch_2q(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    kernel: &str,
+    q0: usize,
+    q1: usize,
+) -> Result<()> {
+    let n = state.num_qubits();
+    if q0 >= n || q1 >= n || q0 == q1 {
+        return Err(PrismError::InvalidQubit {
+            index: q0.max(q1),
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 2);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function(kernel)?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let q0_i = q0 as i32;
+    let q1_i = q1 as i32;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder.arg(buffer).arg(&pair_count).arg(&q0_i).arg(&q1_i);
+    // SAFETY: signature matches kernel (state, pair_count, q0, q1); grid covers iter space.
+    unsafe {
+        builder.launch(cfg).map_err(|e| launch_err(kernel, e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_cx(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    control: usize,
+    target: usize,
+) -> Result<()> {
+    launch_2q(ctx, state, "apply_cx", control, target)
+}
+
+pub(crate) fn launch_apply_cz(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    q0: usize,
+    q1: usize,
+) -> Result<()> {
+    launch_2q(ctx, state, "apply_cz", q0, q1)
+}
+
+pub(crate) fn launch_apply_swap(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    q0: usize,
+    q1: usize,
+) -> Result<()> {
+    launch_2q(ctx, state, "apply_swap", q0, q1)
+}
+
+pub(crate) fn launch_apply_parity_phase(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    q0: usize,
+    q1: usize,
+    same: Complex64,
+    diff: Complex64,
+) -> Result<()> {
+    let n = state.num_qubits();
+    if q0 >= n || q1 >= n || q0 == q1 {
+        return Err(PrismError::InvalidQubit {
+            index: q0.max(q1),
+            register_size: n,
+        });
+    }
+    let dim: u64 = 1u64 << n;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_parity_phase")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(dim), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let q0_i = q0 as i32;
+    let q1_i = q1 as i32;
+    let sr = same.re;
+    let si = same.im;
+    let dr = diff.re;
+    let di = diff.im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&dim)
+        .arg(&q0_i)
+        .arg(&q1_i)
+        .arg(&sr)
+        .arg(&si)
+        .arg(&dr)
+        .arg(&di);
+    // SAFETY: signature matches kernel; dim covers whole state.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_parity_phase", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_rzz(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    q0: usize,
+    q1: usize,
+    theta: f64,
+) -> Result<()> {
+    let c = (theta / 2.0).cos();
+    let s = (theta / 2.0).sin();
+    // e^{-iθ/2} = cos - i sin (parity even: both bits same)
+    // e^{iθ/2}  = cos + i sin (parity odd: bits differ)
+    let same = Complex64::new(c, -s);
+    let diff = Complex64::new(c, s);
+    launch_apply_parity_phase(ctx, state, q0, q1, same, diff)
+}
+
+pub(crate) fn launch_apply_cu(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    control: usize,
+    target: usize,
+    matrix: [[Complex64; 2]; 2],
+) -> Result<()> {
+    let n = state.num_qubits();
+    if control >= n || target >= n || control == target {
+        return Err(PrismError::InvalidQubit {
+            index: control.max(target),
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 2);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_cu")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let ctrl_i = control as i32;
+    let tgt_i = target as i32;
+    let m00r = matrix[0][0].re;
+    let m00i = matrix[0][0].im;
+    let m01r = matrix[0][1].re;
+    let m01i = matrix[0][1].im;
+    let m10r = matrix[1][0].re;
+    let m10i = matrix[1][0].im;
+    let m11r = matrix[1][1].re;
+    let m11i = matrix[1][1].im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&pair_count)
+        .arg(&ctrl_i)
+        .arg(&tgt_i)
+        .arg(&m00r)
+        .arg(&m00i)
+        .arg(&m01r)
+        .arg(&m01i)
+        .arg(&m10r)
+        .arg(&m10i)
+        .arg(&m11r)
+        .arg(&m11i);
+    // SAFETY: signature matches kernel; grid covers pair_count.
+    unsafe {
+        builder.launch(cfg).map_err(|e| launch_err("apply_cu", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_cu_phase(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    control: usize,
+    target: usize,
+    phase: Complex64,
+) -> Result<()> {
+    let n = state.num_qubits();
+    if control >= n || target >= n || control == target {
+        return Err(PrismError::InvalidQubit {
+            index: control.max(target),
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 2);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_cu_phase")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let ctrl_i = control as i32;
+    let tgt_i = target as i32;
+    let pr = phase.re;
+    let pi = phase.im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&pair_count)
+        .arg(&ctrl_i)
+        .arg(&tgt_i)
+        .arg(&pr)
+        .arg(&pi);
+    // SAFETY: signature matches kernel; grid covers pair_count.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_cu_phase", e))?;
+    }
+    Ok(())
+}
+
+fn validate_mcu_qubits(n: usize, controls: &[usize], target: usize) -> Result<Vec<u32>> {
+    for &c in controls {
+        if c >= n {
+            return Err(PrismError::InvalidQubit {
+                index: c,
+                register_size: n,
+            });
+        }
+        if c == target {
+            return Err(PrismError::InvalidParameter {
+                message: "control qubit equals target".to_string(),
+            });
+        }
+    }
+    if target >= n {
+        return Err(PrismError::InvalidQubit {
+            index: target,
+            register_size: n,
+        });
+    }
+    let mut sorted: Vec<u32> = controls.iter().map(|&q| q as u32).collect();
+    sorted.push(target as u32);
+    sorted.sort_unstable();
+    Ok(sorted)
+}
+
+pub(crate) fn launch_apply_mcu(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    controls: &[usize],
+    target: usize,
+    matrix: [[Complex64; 2]; 2],
+) -> Result<()> {
+    let n = state.num_qubits();
+    let sorted = validate_mcu_qubits(n, controls, target)?;
+    let num_sorted = sorted.len() as i32;
+    let iter_count: u64 = 1u64 << (n - sorted.len());
+    let mut ctrl_mask: u64 = 0;
+    for &c in controls {
+        ctrl_mask |= 1u64 << c;
+    }
+    let tgt_mask: u64 = 1u64 << target;
+
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_mcu")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(iter_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let sorted_dev = stream
+        .clone_htod(&sorted)
+        .map_err(|e| launch_err("upload mcu sorted", e))?;
+    let m00r = matrix[0][0].re;
+    let m00i = matrix[0][0].im;
+    let m01r = matrix[0][1].re;
+    let m01i = matrix[0][1].im;
+    let m10r = matrix[1][0].re;
+    let m10i = matrix[1][0].im;
+    let m11r = matrix[1][1].re;
+    let m11i = matrix[1][1].im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&iter_count)
+        .arg(&sorted_dev)
+        .arg(&num_sorted)
+        .arg(&ctrl_mask)
+        .arg(&tgt_mask)
+        .arg(&m00r)
+        .arg(&m00i)
+        .arg(&m01r)
+        .arg(&m01i)
+        .arg(&m10r)
+        .arg(&m10i)
+        .arg(&m11r)
+        .arg(&m11i);
+    // SAFETY: signature matches; sorted_dev lives until launch returns (kept in scope).
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_mcu", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_mcu_phase(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    controls: &[usize],
+    target: usize,
+    phase: Complex64,
+) -> Result<()> {
+    let n = state.num_qubits();
+    let sorted = validate_mcu_qubits(n, controls, target)?;
+    let num_sorted = sorted.len() as i32;
+    let iter_count: u64 = 1u64 << (n - sorted.len());
+    let mut all_mask: u64 = 1u64 << target;
+    for &c in controls {
+        all_mask |= 1u64 << c;
+    }
+
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_mcu_phase")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(iter_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let sorted_dev = stream
+        .clone_htod(&sorted)
+        .map_err(|e| launch_err("upload mcu_phase sorted", e))?;
+    let pr = phase.re;
+    let pi = phase.im;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&iter_count)
+        .arg(&sorted_dev)
+        .arg(&num_sorted)
+        .arg(&all_mask)
+        .arg(&pr)
+        .arg(&pi);
+    // SAFETY: signature matches kernel; sorted_dev retained.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_mcu_phase", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn launch_apply_fused_2q(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    q0: usize,
+    q1: usize,
+    matrix: &[[Complex64; 4]; 4],
+) -> Result<()> {
+    let n = state.num_qubits();
+    if q0 >= n || q1 >= n || q0 == q1 {
+        return Err(PrismError::InvalidQubit {
+            index: q0.max(q1),
+            register_size: n,
+        });
+    }
+    let pair_count: u64 = 1u64 << (n - 2);
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("apply_fused_2q")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(pair_count), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let mut flat = [0.0_f64; 32];
+    for row in 0..4 {
+        for col in 0..4 {
+            flat[2 * (row * 4 + col)] = matrix[row][col].re;
+            flat[2 * (row * 4 + col) + 1] = matrix[row][col].im;
+        }
+    }
+    let mat_dev = stream
+        .clone_htod(&flat)
+        .map_err(|e| launch_err("upload fused_2q mat", e))?;
+    let q0_i = q0 as i32;
+    let q1_i = q1 as i32;
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder
+        .arg(buffer)
+        .arg(&pair_count)
+        .arg(&q0_i)
+        .arg(&q1_i)
+        .arg(&mat_dev);
+    // SAFETY: signature matches; mat_dev retained until after launch.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("apply_fused_2q", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn measure_prob_one(ctx: &GpuContext, state: &GpuState, qubit: usize) -> Result<f64> {
+    let n = state.num_qubits();
+    if qubit >= n {
+        return Err(PrismError::InvalidQubit {
+            index: qubit,
+            register_size: n,
+        });
+    }
+    let dim: u64 = 1u64 << n;
+    // Each block processes 2*BLOCK_SIZE elements.
+    let elems_per_block = 2u64 * BLOCK_SIZE as u64;
+    let num_blocks = dim.div_ceil(elems_per_block).max(1) as u32;
+
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("measure_prob_one")?;
+    let cfg = LaunchConfig {
+        grid_dim: (num_blocks, 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
+    };
+    let mut partials = stream
+        .alloc_zeros::<f64>(num_blocks as usize)
+        .map_err(|e| launch_err("alloc partials", e))?;
+
+    let qubit_i = qubit as i32;
+    let mut builder = stream.launch_builder(&func);
+    let state_buf = state.buffer().raw();
+    builder
+        .arg(state_buf)
+        .arg(&dim)
+        .arg(&qubit_i)
+        .arg(&mut partials);
+    // SAFETY: signature matches kernel; num_blocks × 2*BLOCK_SIZE covers dim.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("measure_prob_one", e))?;
+    }
+    let mut host_partials = vec![0.0_f64; num_blocks as usize];
+    stream
+        .memcpy_dtoh(&partials, &mut host_partials)
+        .map_err(|e| launch_err("measure partials dtoh", e))?;
+    let prob_raw: f64 = host_partials.iter().sum();
+    let norm_sq = state.pending_norm() * state.pending_norm();
+    Ok((prob_raw * norm_sq).clamp(0.0, 1.0))
+}
+
+pub(crate) fn measure_collapse(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    qubit: usize,
+    outcome: bool,
+) -> Result<()> {
+    let n = state.num_qubits();
+    if qubit >= n {
+        return Err(PrismError::InvalidQubit {
+            index: qubit,
+            register_size: n,
+        });
+    }
+    let dim: u64 = 1u64 << n;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let func = device.function("measure_collapse")?;
+    let cfg = LaunchConfig {
+        grid_dim: (grid_for(dim), 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let qubit_i = qubit as i32;
+    let outcome_i: i32 = if outcome { 1 } else { 0 };
+    let mut builder = stream.launch_builder(&func);
+    let buffer = state.buffer_mut().raw_mut();
+    builder.arg(buffer).arg(&dim).arg(&qubit_i).arg(&outcome_i);
+    // SAFETY: signature matches kernel; grid covers dim.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("measure_collapse", e))?;
+    }
+    Ok(())
+}

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -1,0 +1,29 @@
+//! GPU kernels — PTX source, compiled once at device construction, plus per-operation
+//! launcher functions.
+
+pub(crate) mod dense;
+
+pub(crate) use dense::KERNEL_SOURCE;
+
+/// Every kernel entry point that appears in `KERNEL_SOURCE`.
+///
+/// `GpuDevice::new` pre-resolves each name once so gate dispatch does not pay the
+/// driver-lookup cost per launch.
+pub(crate) const KERNEL_NAMES: &[&str] = &[
+    "set_initial_state",
+    "apply_gate_1q",
+    "apply_diagonal_1q",
+    "apply_cx",
+    "apply_cz",
+    "apply_swap",
+    "apply_parity_phase",
+    "apply_cu",
+    "apply_cu_phase",
+    "apply_mcu",
+    "apply_mcu_phase",
+    "apply_fused_2q",
+    "measure_prob_one",
+    "measure_collapse",
+    "compute_probabilities",
+    "scale_state",
+];

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -1,70 +1,80 @@
 //! Typed GPU memory allocation wrapper.
 //!
-//! Scaffold only: every method returns `PrismError::BackendUnsupported`. Real cudarc-backed
-//! allocation lands when device kernels are wired.
+//! `GpuBuffer<T>` owns a [`cudarc::driver::CudaSlice<T>`] and exposes a minimal htod/dtoh
+//! interface. Additional element types can be supported by extending the `T: DeviceRepr`
+//! bound as needed; today only `f64` is exercised.
 
-use std::marker::PhantomData;
+use cudarc::driver::{CudaSlice, DeviceRepr, ValidAsZeroBits};
 
 use crate::error::{PrismError, Result};
 
 use super::device::GpuDevice;
 
 /// RAII wrapper over a typed device allocation.
-///
-/// Pairs a typed view with the underlying device memory; drop releases the allocation.
-#[derive(Debug)]
-pub struct GpuBuffer<T> {
-    len: usize,
-    _phantom: PhantomData<T>,
+pub struct GpuBuffer<T: DeviceRepr> {
+    slice: CudaSlice<T>,
 }
 
-impl<T> GpuBuffer<T> {
+impl<T: DeviceRepr + ValidAsZeroBits> GpuBuffer<T> {
     /// Allocate `len` elements of `T` on the given device, zero-initialised.
     pub fn alloc_zeros(device: &GpuDevice, len: usize) -> Result<Self> {
-        let _ = device;
-        let _ = len;
-        Err(PrismError::BackendUnsupported {
-            backend: "gpu".to_string(),
-            operation: "alloc_zeros (scaffold only)".to_string(),
-        })
+        let stream = device.stream()?;
+        let slice = stream
+            .alloc_zeros::<T>(len)
+            .map_err(|e| driver_err("alloc_zeros", e))?;
+        Ok(Self { slice })
     }
+}
 
-    /// Copy `host.len()` elements from host to device.
-    pub fn copy_from_host(&mut self, host: &[T]) -> Result<()> {
-        let _ = host;
-        Err(PrismError::BackendUnsupported {
-            backend: "gpu".to_string(),
-            operation: "copy_from_host (scaffold only)".to_string(),
-        })
+impl<T: DeviceRepr> GpuBuffer<T> {
+    /// Copy `host.len()` elements from host to device (in-place).
+    pub fn copy_from_host(&mut self, device: &GpuDevice, host: &[T]) -> Result<()> {
+        let stream = device.stream()?;
+        stream
+            .memcpy_htod(host, &mut self.slice)
+            .map_err(|e| driver_err("copy_from_host", e))
     }
 
     /// Copy `host.len()` elements from device into the provided host buffer.
-    pub fn copy_to_host(&self, host: &mut [T]) -> Result<()> {
-        let _ = host;
-        Err(PrismError::BackendUnsupported {
-            backend: "gpu".to_string(),
-            operation: "copy_to_host (scaffold only)".to_string(),
-        })
+    pub fn copy_to_host(&self, device: &GpuDevice, host: &mut [T]) -> Result<()> {
+        let stream = device.stream()?;
+        stream
+            .memcpy_dtoh(&self.slice, host)
+            .map_err(|e| driver_err("copy_to_host", e))
     }
+}
 
+impl<T: DeviceRepr> GpuBuffer<T> {
     /// Number of elements allocated.
     pub fn len(&self) -> usize {
-        self.len
+        self.slice.len()
     }
 
     /// Whether the allocation is zero-length.
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.slice.len() == 0
+    }
+
+    pub(crate) fn raw(&self) -> &CudaSlice<T> {
+        &self.slice
+    }
+
+    pub(crate) fn raw_mut(&mut self) -> &mut CudaSlice<T> {
+        &mut self.slice
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl<T: DeviceRepr> std::fmt::Debug for GpuBuffer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GpuBuffer")
+            .field("len", &self.slice.len())
+            .finish()
+    }
+}
 
-    #[test]
-    fn alloc_returns_unsupported_in_scaffold() {
-        let dev_err = GpuDevice::new(0).unwrap_err();
-        assert!(matches!(dev_err, PrismError::BackendUnsupported { .. }));
+fn driver_err(op: &str, err: impl std::fmt::Display) -> PrismError {
+    PrismError::BackendUnsupported {
+        backend: "gpu".to_string(),
+        operation: format!("{op}: {err}"),
     }
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,40 +1,40 @@
 //! Shared GPU execution resource.
 //!
-//! GPU support in PRISM-Q is not a standalone backend. It is an execution context that
-//! existing CPU backends (Statevector first, MPS and TensorNetwork later) can opt into for
-//! their hot operations. Each backend that wants GPU acceleration holds an
-//! `Option<Arc<GpuContext>>` (or owns a `GpuState`) and routes through this module's kernel
-//! namespaces when the context is present.
+//! GPU support in PRISM-Q is not a standalone backend. It is an execution context that CPU
+//! backends (Statevector first, MPS and TensorNetwork later) opt into for their hot
+//! operations. Each backend that wants GPU acceleration holds an `Option<Arc<GpuContext>>`
+//! and routes through this module's kernel namespaces when the context is present.
 //!
 //! # Module layout
 //!
 //! - [`device`] — cudarc device wrapper, availability checks, VRAM queries
 //! - [`memory`] — [`GpuBuffer`] RAII wrapper over device allocations
-//! - (future) `kernels::dense` — statevector 1q/2q/Cu/Mcu/measurement/fused kernels
-//! - (future) `kernels::svd` — MPS SVD via cuSolver
-//! - (future) `kernels::tn` — TensorNetwork contraction via cuBLAS
+//! - `kernels::dense` — statevector kernels (CUDA C source + launch helpers)
 //!
-//! # Scaffold status
+//! # Device state layout
 //!
-//! All structures and methods in this module are stubs that return
-//! `PrismError::BackendUnsupported`. Real cudarc integration arrives with the first kernel
-//! milestone.
+//! The statevector lives on device as a `CudaSlice<f64>` of length `2 * 2^n` holding
+//! interleaved (re, im) pairs. This matches `num_complex::Complex64` and CUDA's `double2`
+//! builtin, allowing zero-cost reinterpretation at kernel boundaries.
 
 pub mod device;
+pub(crate) mod kernels;
 pub mod memory;
 
 use std::sync::Arc;
 
-use crate::error::{PrismError, Result};
+use num_complex::Complex64;
 
-use self::device::GpuDevice;
-use self::memory::GpuBuffer;
+use crate::error::Result;
+
+pub use self::device::GpuDevice;
+pub use self::memory::GpuBuffer;
 
 /// Shared GPU execution context.
 ///
-/// Holds the device handle and (eventually) the compiled kernel module registry. Cheap to
-/// clone via `Arc`. Pass by `Arc<GpuContext>` so multiple backends or multiple simulations
-/// can share one device initialisation.
+/// Holds the device handle and compiled kernel module. Cheap to clone via `Arc`. Pass by
+/// `Arc<GpuContext>` so multiple backends or multiple simulations can share one device
+/// initialisation.
 #[derive(Debug)]
 pub struct GpuContext {
     device: Arc<GpuDevice>,
@@ -43,7 +43,7 @@ pub struct GpuContext {
 impl GpuContext {
     /// Initialise the context for the given CUDA device ordinal.
     ///
-    /// Loads any required kernel modules (none yet in the scaffold).
+    /// Compiles the kernel module at construction. Subsequent calls reuse the cached PTX.
     pub fn new(device_id: usize) -> Result<Arc<Self>> {
         let device = Arc::new(GpuDevice::new(device_id)?);
         Ok(Arc::new(Self { device }))
@@ -64,7 +64,6 @@ impl GpuContext {
         self.device.max_qubits_for_statevector()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn device(&self) -> &GpuDevice {
         &self.device
     }
@@ -79,28 +78,39 @@ impl GpuContext {
 
 /// Per-simulation device-resident state.
 ///
-/// Owns a `GpuBuffer<f64>` holding `2 * 2^num_qubits` f64s (interleaved re/im, matching
-/// `Complex64` layout and CUDA's `double2` alignment). Tracks `pending_norm` the same way the
-/// CPU statevector backend does — measurement collapse accumulates into this scalar and the
-/// final scale is applied at `export_statevector` or `probabilities` time.
+/// Owns a `GpuBuffer<f64>` holding `2 * 2^num_qubits` f64s (interleaved re/im). Tracks
+/// `pending_norm` the same way the CPU statevector backend does — measurement collapse
+/// accumulates into this scalar and the final scale is applied at `export_statevector` or
+/// `probabilities` time.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct GpuState {
     context: Arc<GpuContext>,
     buffer: GpuBuffer<f64>,
     num_qubits: usize,
     pending_norm: f64,
+    /// Device-side scratch buffer for `probabilities()` output, reused across calls so
+    /// shot-sampling workflows don't re-allocate `2^n` f64s on every read.
+    probs_scratch: std::cell::RefCell<Option<GpuBuffer<f64>>>,
 }
 
 impl GpuState {
     /// Allocate a fresh |0…0⟩ state on the device bound to `context`.
     pub fn new(context: Arc<GpuContext>, num_qubits: usize) -> Result<Self> {
-        let _ = &context;
-        let _ = num_qubits;
-        Err(PrismError::BackendUnsupported {
-            backend: "gpu".to_string(),
-            operation: "state allocation (scaffold only)".to_string(),
-        })
+        let len = 2usize.checked_shl(num_qubits as u32).ok_or_else(|| {
+            crate::error::PrismError::InvalidParameter {
+                message: format!("num_qubits={num_qubits} overflows addressable memory"),
+            }
+        })?;
+        let buffer = GpuBuffer::<f64>::alloc_zeros(context.device(), len)?;
+        let mut state = Self {
+            context: context.clone(),
+            buffer,
+            num_qubits,
+            pending_norm: 1.0,
+            probs_scratch: std::cell::RefCell::new(None),
+        };
+        kernels::dense::launch_set_initial_state(&context, &mut state)?;
+        Ok(state)
     }
 
     /// Number of qubits the buffer is sized for.
@@ -113,41 +123,72 @@ impl GpuState {
         self.pending_norm
     }
 
-    #[allow(dead_code)]
+    /// Read the raw (unnormalised) amplitude buffer back to host, as interleaved f64 pairs.
+    pub fn copy_to_host_raw(&self) -> Result<Vec<f64>> {
+        let mut host = vec![0.0_f64; self.buffer.len()];
+        self.buffer.copy_to_host(self.context.device(), &mut host)?;
+        Ok(host)
+    }
+
+    /// Read the amplitude buffer as `Vec<Complex64>` with the deferred `pending_norm`
+    /// already applied.
+    pub fn export_statevector(&self) -> Result<Vec<Complex64>> {
+        let raw = self.copy_to_host_raw()?;
+        let norm = self.pending_norm;
+        let out = raw
+            .chunks_exact(2)
+            .map(|p| Complex64::new(p[0] * norm, p[1] * norm))
+            .collect();
+        Ok(out)
+    }
+
+    /// Compute per-basis-state probabilities with `pending_norm²` scaling, via a GPU
+    /// reduction kernel. Only `2^n` f64s cross PCIe (vs `2·2^n` for raw amplitudes).
+    pub fn probabilities(&self) -> Result<Vec<f64>> {
+        kernels::dense::launch_compute_probabilities(&self.context, self)
+    }
+
     pub(crate) fn context(&self) -> &Arc<GpuContext> {
         &self.context
     }
 
-    #[allow(dead_code)]
     pub(crate) fn buffer(&self) -> &GpuBuffer<f64> {
         &self.buffer
     }
 
-    #[allow(dead_code)]
     pub(crate) fn buffer_mut(&mut self) -> &mut GpuBuffer<f64> {
         &mut self.buffer
     }
 
-    #[allow(dead_code)]
     pub(crate) fn set_pending_norm(&mut self, norm: f64) {
         self.pending_norm = norm;
+    }
+
+    /// Access (and lazily allocate) the cached device-side probabilities buffer. Returned as
+    /// a `RefMut` so the caller can pass it to a kernel launch for the duration of the call.
+    pub(crate) fn probs_scratch(&self) -> std::cell::RefMut<'_, Option<GpuBuffer<f64>>> {
+        self.probs_scratch.borrow_mut()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::PrismError;
 
     #[test]
-    fn context_new_returns_unsupported() {
-        assert!(matches!(
-            GpuContext::new(0).unwrap_err(),
-            PrismError::BackendUnsupported { .. }
-        ));
+    fn stub_context_reports_available_false() {
+        // Even if a device is present, this test only uses the stub path.
+        let ctx = GpuContext::stub_for_tests();
+        assert!(ctx.device().is_stub());
     }
 
     #[test]
-    fn context_is_available_false_in_scaffold() {
-        assert!(!GpuContext::is_available());
+    fn state_new_on_stub_returns_unsupported() {
+        let ctx = GpuContext::stub_for_tests();
+        assert!(matches!(
+            GpuState::new(ctx, 4).unwrap_err(),
+            PrismError::BackendUnsupported { .. }
+        ));
     }
 }

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -1,0 +1,425 @@
+//! Per-kernel GPU vs CPU amplitude equivalence tests.
+//!
+//! Runs each gate-dispatch path on both backends starting from |0…0⟩ (or a deliberately
+//! chosen non-trivial initial state) and compares the resulting amplitudes within 1e-12.
+//!
+//! Skips with a printed message when no usable GPU is available. This keeps the suite green
+//! on CPU-only machines and catches real kernel regressions on CUDA-capable runners.
+
+#![cfg(feature = "gpu")]
+
+use num_complex::Complex64;
+
+use prism_q::backend::Backend;
+use prism_q::circuit::{smallvec, Instruction, SmallVec};
+use prism_q::gates::{DiagEntry, DiagonalBatchData, Gate, McuData, MultiFusedData};
+use prism_q::gpu::GpuContext;
+use prism_q::StatevectorBackend;
+
+const EPS: f64 = 1e-12;
+
+struct Fixture {
+    ctx: std::sync::Arc<GpuContext>,
+}
+
+impl Fixture {
+    fn try_new() -> Option<Self> {
+        match GpuContext::new(0) {
+            Ok(ctx) => Some(Self { ctx }),
+            Err(e) => {
+                eprintln!("SKIP: no usable GPU ({e})");
+                None
+            }
+        }
+    }
+
+    fn compare(&self, num_qubits: usize, instructions: &[Instruction]) {
+        let mut cpu = StatevectorBackend::new(42);
+        cpu.init(num_qubits, 0).unwrap();
+        let mut gpu = StatevectorBackend::new(42).with_gpu(self.ctx.clone());
+        gpu.init(num_qubits, 0).unwrap();
+        for inst in instructions {
+            cpu.apply(inst).unwrap();
+            gpu.apply(inst).unwrap();
+        }
+        let cpu_sv = cpu.export_statevector().unwrap();
+        let gpu_sv = gpu.export_statevector().unwrap();
+        assert_eq!(cpu_sv.len(), gpu_sv.len());
+        for (i, (c, g)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
+            let diff = (c - g).norm();
+            assert!(
+                diff < EPS,
+                "amplitude mismatch at index {i}: cpu={c:?}, gpu={g:?}, |diff|={diff}"
+            );
+        }
+    }
+}
+
+fn g(gate: Gate, targets: &[usize]) -> Instruction {
+    let mut tv: SmallVec<[usize; 4]> = smallvec![];
+    tv.extend_from_slice(targets);
+    Instruction::Gate { gate, targets: tv }
+}
+
+// ============================================================================
+// Single-qubit kernels
+// ============================================================================
+
+#[test]
+fn single_qubit_gates_all_targets() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    // Seed with a non-trivial superposition so each gate has something to act on.
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    // Exercise every 1q variant on each target.
+    let targets = [0usize, 1, 2, 3];
+    let gates_1q = [
+        Gate::X,
+        Gate::Y,
+        Gate::Z,
+        Gate::H,
+        Gate::S,
+        Gate::Sdg,
+        Gate::T,
+        Gate::Tdg,
+        Gate::SX,
+        Gate::SXdg,
+        Gate::Rx(0.37),
+        Gate::Ry(1.11),
+        Gate::Rz(-0.62),
+        Gate::P(0.44),
+    ];
+    for t in targets {
+        for gate in &gates_1q {
+            insts.push(g(gate.clone(), &[t]));
+        }
+    }
+    f.compare(n, &insts);
+}
+
+#[test]
+fn fused_1q_matrix_arbitrary() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    // Non-unitary coefficients are fine here; we only compare CPU==GPU, not a unitary property.
+    let mat = [
+        [Complex64::new(0.3, 0.1), Complex64::new(-0.2, 0.4)],
+        [Complex64::new(0.5, -0.3), Complex64::new(0.1, 0.2)],
+    ];
+    let mut insts = vec![g(Gate::H, &[0]), g(Gate::H, &[1])];
+    for t in 0..n {
+        insts.push(g(Gate::Fused(Box::new(mat)), &[t]));
+    }
+    f.compare(n, &insts);
+}
+
+// ============================================================================
+// Two-qubit kernels
+// ============================================================================
+
+#[test]
+fn cx_cz_swap_various_pairs() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    // Pairs covering q0<q1 and q0>q1.
+    let pairs: &[(usize, usize)] = &[(0, 1), (1, 2), (0, 3), (3, 0), (2, 1)];
+    for &(a, b) in pairs {
+        insts.push(g(Gate::Cx, &[a, b]));
+        insts.push(g(Gate::Cz, &[a, b]));
+        insts.push(g(Gate::Swap, &[a, b]));
+    }
+    f.compare(n, &insts);
+}
+
+#[test]
+fn rzz_various_pairs() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mut insts = vec![g(Gate::H, &[0]), g(Gate::H, &[1]), g(Gate::H, &[2])];
+    for (a, b, theta) in [(0, 1, 0.3), (2, 0, -1.1), (3, 2, 1.7), (1, 3, 0.9)] {
+        insts.push(g(Gate::Rzz(theta), &[a, b]));
+    }
+    f.compare(n, &insts);
+}
+
+// ============================================================================
+// Controlled-unitary kernels
+// ============================================================================
+
+#[test]
+fn cu_arbitrary_matrix() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mat = [
+        [Complex64::new(0.6, -0.1), Complex64::new(-0.3, 0.2)],
+        [Complex64::new(0.2, 0.4), Complex64::new(0.7, -0.2)],
+    ];
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    insts.push(g(Gate::Cu(Box::new(mat)), &[0, 2]));
+    insts.push(g(Gate::Cu(Box::new(mat)), &[3, 1]));
+    f.compare(n, &insts);
+}
+
+#[test]
+fn cu_controlled_phase_shortcut() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    // A diagonal CU is treated as a controlled-phase (cu_phase kernel).
+    let phase = Complex64::from_polar(1.0, 0.73);
+    let diag = [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), phase],
+    ];
+    let mut insts = vec![g(Gate::H, &[0]), g(Gate::H, &[2]), g(Gate::X, &[3])];
+    insts.push(g(Gate::Cu(Box::new(diag)), &[0, 2]));
+    insts.push(g(Gate::Cu(Box::new(diag)), &[3, 1]));
+    f.compare(n, &insts);
+}
+
+#[test]
+fn mcu_toffoli_and_generic() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 5;
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    // Toffoli (2 controls, X target) via Mcu with an X matrix.
+    let x_mat = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let mcu_toffoli = Gate::Mcu(Box::new(McuData {
+        mat: x_mat,
+        num_controls: 2,
+    }));
+    insts.push(g(mcu_toffoli, &[0, 1, 2]));
+
+    // Three-control arbitrary unitary.
+    let mat = [
+        [Complex64::new(0.4, 0.3), Complex64::new(-0.2, 0.5)],
+        [Complex64::new(0.5, -0.2), Complex64::new(0.3, 0.4)],
+    ];
+    let mcu_3 = Gate::Mcu(Box::new(McuData {
+        mat,
+        num_controls: 3,
+    }));
+    insts.push(g(mcu_3, &[0, 1, 3, 4]));
+    f.compare(n, &insts);
+}
+
+#[test]
+fn mcu_phase_shortcut() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 5;
+    let phase = Complex64::from_polar(1.0, -1.2);
+    let diag = [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), phase],
+    ];
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    let mcu = Gate::Mcu(Box::new(McuData {
+        mat: diag,
+        num_controls: 3,
+    }));
+    insts.push(g(mcu, &[0, 1, 2, 4]));
+    f.compare(n, &insts);
+}
+
+// ============================================================================
+// Fused / batched gates
+// ============================================================================
+
+#[test]
+fn fused_2q_asymmetric_matrix() {
+    // Critical: non-diagonal 4x4 with all 16 entries distinct detects any basis-ordering bug
+    // between CPU (PreparedGate2q) and GPU apply_fused_2q.
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mut mat = [[Complex64::new(0.0, 0.0); 4]; 4];
+    for (r, row) in mat.iter_mut().enumerate() {
+        for (c, entry) in row.iter_mut().enumerate() {
+            *entry = Complex64::new(0.1 * (r as f64 + 1.0), 0.07 * (c as f64 + 1.0));
+        }
+    }
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    insts.push(g(Gate::Fused2q(Box::new(mat)), &[0, 2]));
+    insts.push(g(Gate::Fused2q(Box::new(mat)), &[3, 1]));
+    f.compare(n, &insts);
+}
+
+#[test]
+fn multi_fused_mixed_gates() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mat_a = [
+        [Complex64::new(0.3, 0.1), Complex64::new(-0.2, 0.4)],
+        [Complex64::new(0.5, -0.3), Complex64::new(0.1, 0.2)],
+    ];
+    let mat_b = [
+        [Complex64::new(0.9, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(0.0, 1.0)],
+    ];
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    insts.push(g(
+        Gate::MultiFused(Box::new(MultiFusedData {
+            gates: vec![(0, mat_a), (1, mat_b), (2, mat_a), (3, mat_b)],
+            all_diagonal: false,
+        })),
+        &[0, 1, 2, 3],
+    ));
+    f.compare(n, &insts);
+}
+
+#[test]
+fn diagonal_batch_all_entry_kinds() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 4;
+    let mut insts = vec![];
+    for q in 0..n {
+        insts.push(g(Gate::H, &[q]));
+    }
+    let entries = vec![
+        DiagEntry::Phase1q {
+            qubit: 0,
+            d0: Complex64::from_polar(1.0, 0.2),
+            d1: Complex64::from_polar(1.0, -0.3),
+        },
+        DiagEntry::Phase2q {
+            q0: 1,
+            q1: 2,
+            phase: Complex64::from_polar(1.0, 0.5),
+        },
+        DiagEntry::Parity2q {
+            q0: 0,
+            q1: 3,
+            same: Complex64::from_polar(1.0, 0.1),
+            diff: Complex64::from_polar(1.0, -0.4),
+        },
+    ];
+    insts.push(g(
+        Gate::DiagonalBatch(Box::new(DiagonalBatchData { entries })),
+        &[0, 1, 2, 3],
+    ));
+    f.compare(n, &insts);
+}
+
+// ============================================================================
+// Measurement + reset
+// ============================================================================
+
+#[test]
+fn measurement_deterministic_with_fixed_seed() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 3;
+    let mut cpu = StatevectorBackend::new(42);
+    cpu.init(n, n).unwrap();
+    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    gpu.init(n, n).unwrap();
+
+    let prep = [g(Gate::H, &[0]), g(Gate::Cx, &[0, 1]), g(Gate::H, &[2])];
+    for inst in &prep {
+        cpu.apply(inst).unwrap();
+        gpu.apply(inst).unwrap();
+    }
+    for q in 0..n {
+        cpu.apply(&Instruction::Measure {
+            qubit: q,
+            classical_bit: q,
+        })
+        .unwrap();
+        gpu.apply(&Instruction::Measure {
+            qubit: q,
+            classical_bit: q,
+        })
+        .unwrap();
+    }
+    assert_eq!(cpu.classical_results(), gpu.classical_results());
+    // Export statevectors and verify residual state matches (post-collapse).
+    let cpu_sv = cpu.export_statevector().unwrap();
+    let gpu_sv = gpu.export_statevector().unwrap();
+    for (i, (c, g_)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
+        let diff = (c - g_).norm();
+        assert!(
+            diff < EPS,
+            "post-measurement amplitude mismatch at {i}: {c:?} vs {g_:?}"
+        );
+    }
+}
+
+#[test]
+fn reset_to_zero() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 3;
+    let mut cpu = StatevectorBackend::new(42);
+    cpu.init(n, 0).unwrap();
+    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    gpu.init(n, 0).unwrap();
+
+    // Put the register into |1⟩|+⟩|1⟩, then reset q0 and q2.
+    let prep = [g(Gate::X, &[0]), g(Gate::H, &[1]), g(Gate::X, &[2])];
+    for inst in &prep {
+        cpu.apply(inst).unwrap();
+        gpu.apply(inst).unwrap();
+    }
+    cpu.apply(&Instruction::Reset { qubit: 0 }).unwrap();
+    gpu.apply(&Instruction::Reset { qubit: 0 }).unwrap();
+    cpu.apply(&Instruction::Reset { qubit: 2 }).unwrap();
+    gpu.apply(&Instruction::Reset { qubit: 2 }).unwrap();
+
+    let cpu_sv = cpu.export_statevector().unwrap();
+    let gpu_sv = gpu.export_statevector().unwrap();
+    for (i, (c, g_)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
+        let diff = (c - g_).norm();
+        assert!(
+            diff < EPS,
+            "reset amplitude mismatch at {i}: {c:?} vs {g_:?}"
+        );
+    }
+}
+
+// ============================================================================
+// Probabilities readback
+// ============================================================================
+
+#[test]
+fn probabilities_match_cpu_on_random_circuit() {
+    let Some(f) = Fixture::try_new() else { return };
+    let circuit = prism_q::circuits::random_circuit(6, 30, 42);
+    let mut cpu = StatevectorBackend::new(42);
+    cpu.init(circuit.num_qubits, 0).unwrap();
+    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    gpu.init(circuit.num_qubits, 0).unwrap();
+    for inst in &circuit.instructions {
+        cpu.apply(inst).unwrap();
+        gpu.apply(inst).unwrap();
+    }
+    let cpu_p = cpu.probabilities().unwrap();
+    let gpu_p = gpu.probabilities().unwrap();
+    assert_eq!(cpu_p.len(), gpu_p.len());
+    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
+        assert!(
+            (c - g_).abs() < EPS,
+            "prob[{i}] mismatch: cpu={c}, gpu={g_}"
+        );
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is the next change in the series of changes to support GPU state vectoring simulation through the package. I am working with an old GPU which support is dropped for in 13.x of cuda. I will look into ways to support both versions but for now, it will be 12.x. There is much more work planned in this workstream before I am calling it complete. This is a bit of a monolith and some further testing will be added in. In particular, correctness testing. This provides gate implementations, although, there is a small bug noted in the implementation. Later, I will fix up the dispatch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
