### PR TITLE
feat(gpu): dispatch-level crossover and decomposition-aware routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,21 @@ covered by a dedicated kernel, including batched kernels for `BatchPhase`, `Batc
 [`tests/golden_gpu.rs`](tests/golden_gpu.rs) verify amplitude equivalence against the
 CPU statevector within 1e-10.
 
-The backend-level crossover between CPU and GPU is still in progress, so
-`BackendKind::Auto` does not yet route to GPU. Opt in explicitly:
+`BackendKind::Auto` does not yet route to GPU. Opt in explicitly. The recommended
+entry point is `BackendKind::StatevectorGpu`, which inherits the fusion pipeline plus
+independent-subsystem decomposition and applies a size-aware crossover (default: GPU
+only for ≥14 qubit sub-circuits, overridable via `PRISM_GPU_MIN_QUBITS`):
 
 ```rust
-use prism_q::{gpu::GpuContext, StatevectorBackend};
+use prism_q::{gpu::GpuContext, run_with, BackendKind};
 
 let ctx = GpuContext::new(0)?;
-let mut backend = StatevectorBackend::new(42).with_gpu(ctx);
+let result = run_with(BackendKind::StatevectorGpu { context: ctx }, &circuit, 42)?;
 ```
+
+For kernel-level experiments where every gate must hit the device, use the low-level
+`StatevectorBackend::new(seed).with_gpu(ctx)` builder instead — this bypasses the
+dispatch crossover by design.
 
 See [`docs/architecture.md`](docs/architecture.md) for the kernel design and crossover
 analysis.
@@ -232,8 +238,9 @@ SVGs land in `bench_results/` (gitignored).
 - Expanded OpenQASM 3.0: `reset` instruction, `for` loop unrolling, `def` subroutines.
 - Expectation values: `<psi|O|psi>` for Pauli strings (VQE and QAOA).
 - Density matrix backend: mixed-state simulation for noise and decoherence modeling.
-- GPU auto-dispatch: size-aware crossover so `BackendKind::Auto` can route to GPU when
-  it wins. Blocked on reconciling `run_decomposed` with the GPU entry point.
+- GPU auto-dispatch: thread a GPU context into `BackendKind::Auto` so large circuits
+  route to GPU without an explicit `BackendKind::StatevectorGpu`. Crossover and
+  decomposition already work through the explicit variant.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,10 +227,20 @@ Dynamic split-state simulation. Starts with n independent 1-qubit states, merges
 
 ## GPU backend (optional, `gpu` feature)
 
-CUDA statevector acceleration layered onto the primary backend. Opt in via
-`StatevectorBackend::new(seed).with_gpu(ctx)` where `ctx` is an `Arc<GpuContext>`. When a
-GPU context is attached, `Backend::init` allocates a device-resident state instead of a
-host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
+CUDA statevector acceleration layered onto the primary backend. Two entry points:
+
+- **`BackendKind::StatevectorGpu { context }`** (recommended) — routes through
+  `sim::run_with`, so the circuit picks up fusion plus independent-subsystem
+  decomposition, and each sub-block consults `gpu_min_qubits()` (default 14,
+  `PRISM_GPU_MIN_QUBITS` env override) to decide between the GPU path and a host
+  statevector. Disconnected sub-circuits below the threshold run on CPU regardless of
+  total qubit count.
+- **`StatevectorBackend::new(seed).with_gpu(ctx)`** — direct opt-in. Every instruction
+  routes to a CUDA kernel once the context is attached; no crossover, no decomposition.
+  Use this for kernel-level benchmarks and targeted correctness tests.
+
+When a GPU context is attached, `Backend::init` allocates a device-resident state
+instead of a host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
 
 **Module layout** (`src/gpu/`):
 
@@ -255,17 +265,20 @@ launches. `Multi2q` still launches once per sub-gate; rare in practice.
 `{{TILE_Q}}`. The `kernel_source()` function substitutes them at device construction from
 the Rust constants in `src/backend/statevector/kernels.rs`, keeping CPU and GPU in sync.
 
-**Correctness:** `tests/golden_gpu.rs` drives 19 cross-checks comparing GPU amplitudes
-against the CPU statevector within 1e-10. Covers every gate variant plus fusion paths.
+**Correctness:** `tests/golden_gpu.rs` drives 20 cross-checks comparing GPU amplitudes
+against the CPU statevector within 1e-10. Covers every gate variant, fusion paths, and
+the `BackendKind::StatevectorGpu` end-to-end dispatch at the crossover boundary.
 
 **Current limits:**
 
-- `BackendKind::Auto` does not yet dispatch to GPU. Opt in explicitly on
-  `StatevectorBackend`.
-- The GPU entry point does not honor `run_decomposed`, so circuits whose qubit graph
-  splits into independent blocks run at full size on device when dispatched through the
-  `prismq_runner` harness. Resolving this is the primary blocker before Auto dispatch
-  can add a GPU branch.
+- `BackendKind::Auto` does not yet dispatch to GPU. The `StatevectorGpu` variant is the
+  explicit opt-in; wiring a default GPU context into `Auto`.
+- Several fused launchers (`launch_apply_fused_2q`, `launch_apply_mcu`,
+  `launch_apply_mcu_phase`, `launch_apply_batch_phase`, `launch_apply_batch_rzz`,
+  `launch_apply_diagonal_batch`, `launch_apply_multi_fused_nondiag`) upload small
+  metadata tables per dispatch via `clone_htod`; the next launch-tax target.
+- `measure_prob_one` allocates a device partials buffer and reduces on the host every
+  call. Matters for measurement-heavy circuits.
 - Kernel design and crossover analysis live in the module docstrings on
   `src/gpu/kernels/dense.rs`. Cross-simulator comparison scripts are provided outside
   the public surface of the crate.

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -152,13 +152,15 @@ impl StatevectorBackend {
             self.gpu_state.is_some(),
             "apply_gpu called without gpu_state (callers must check self.gpu_state.is_some() first)"
         );
-        // GPU dispatch is unconditional here: every instruction routes to GPU when
-        // `gpu_state` is Some. Two known caveats:
-        //   1. Multi2q launches one kernel per sub-gate (rare in practice).
-        //   2. sim::run_with's run_decomposed path is CPU-only, so circuits whose
-        //      qubit graph splits into independent blocks run larger on GPU than
-        //      on CPU. A dispatch-level crossover that honors decomposition (or
-        //      routes small circuits back to CPU) is future work.
+        // Unconditional GPU dispatch: every instruction routes to a kernel once
+        // `gpu_state` is Some. This path is the explicit opt-in surface
+        // (`StatevectorBackend::with_gpu(ctx)`) and intentionally skips the
+        // dispatch-level crossover — users calling `with_gpu` directly are asking
+        // for kernel-level behavior. For size-aware crossover + decomposition-
+        // aware routing, enter via `sim::run_with(BackendKind::StatevectorGpu
+        // { context })`, which honors `gpu_min_qubits()` per sub-block.
+        //
+        // Caveat: Multi2q launches one kernel per sub-gate (rare in practice).
         match instruction {
             Instruction::Gate { gate, targets } => self.dispatch_gate_gpu(gate, targets),
             Instruction::Measure {

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -8,6 +8,12 @@ use crate::backend::Backend;
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
+#[cfg(feature = "gpu")]
+use std::sync::Arc;
+
+#[cfg(feature = "gpu")]
+use crate::gpu::GpuContext;
+
 use super::{Probabilities, SimulationResult};
 
 pub(super) enum DispatchAction {
@@ -117,6 +123,32 @@ pub(super) const MIN_FACTORED_STABILIZER_QUBITS: usize = 128;
 
 pub(super) const MIN_BLOCK_FOR_FACTORED_STAB: usize = 16;
 
+/// Minimum qubit count to route a sub-circuit to GPU when
+/// [`BackendKind::StatevectorGpu`] is selected.
+///
+/// Below this threshold the dispatch layer builds a plain host-side
+/// `StatevectorBackend` instead, keeping PCIe round-trips and kernel launch
+/// latency off the critical path for circuits that fit comfortably in L3.
+/// Empirically (GTX 1080 Ti, 2026-04-18), 10q random-depth-20 is 0.18x on
+/// GPU vs CPU while 14q is 9.37x. 14 is the lowest known-win point; users
+/// with faster GPUs or different workloads can override via the
+/// `PRISM_GPU_MIN_QUBITS` environment variable.
+#[cfg(feature = "gpu")]
+pub(super) const GPU_MIN_QUBITS_DEFAULT: usize = 14;
+
+#[cfg(feature = "gpu")]
+pub(super) fn gpu_min_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        if let Ok(val) = std::env::var("PRISM_GPU_MIN_QUBITS") {
+            if let Ok(n) = val.parse::<usize>() {
+                return n;
+            }
+        }
+        GPU_MIN_QUBITS_DEFAULT
+    })
+}
+
 /// Automatically select the optimal backend based on circuit analysis.
 ///
 /// Decision tree:
@@ -133,15 +165,37 @@ pub enum BackendKind {
     Statevector,
     Stabilizer,
     Sparse,
-    Mps { max_bond_dim: usize },
+    Mps {
+        max_bond_dim: usize,
+    },
     ProductState,
     TensorNetwork,
     Factored,
     StabilizerRank,
     FilteredStabilizer,
     FactoredStabilizer,
-    StochasticPauli { num_samples: usize },
-    DeterministicPauli { epsilon: f64, max_terms: usize },
+    StochasticPauli {
+        num_samples: usize,
+    },
+    DeterministicPauli {
+        epsilon: f64,
+        max_terms: usize,
+    },
+    /// Statevector backed by a CUDA GPU execution context.
+    ///
+    /// Circuits (or decomposed sub-blocks) with fewer than 14 qubits
+    /// (tunable via `PRISM_GPU_MIN_QUBITS`) transparently fall back to the
+    /// host-side statevector path — small states do not survive PCIe and
+    /// launch-latency overhead. Larger circuits allocate a device-resident
+    /// state and route gate application through GPU kernels.
+    ///
+    /// Compose with [`crate::sim::run_with`] to get fusion + independent-
+    /// subsystem decomposition for free; each sub-block is evaluated against
+    /// the crossover independently.
+    #[cfg(feature = "gpu")]
+    StatevectorGpu {
+        context: Arc<GpuContext>,
+    },
 }
 
 pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
@@ -183,6 +237,23 @@ pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> 
         | BackendKind::DeterministicPauli { .. } => false,
         BackendKind::Auto => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
         _ => true,
+    }
+}
+
+/// Build a `StatevectorBackend` configured for GPU execution if the circuit
+/// is large enough to clear the crossover, otherwise a plain host-side
+/// backend. Called from `select_dispatch` (which runs per sub-block after
+/// decomposition) so small blocks transparently stay on CPU.
+#[cfg(feature = "gpu")]
+fn statevector_gpu_with_crossover(
+    context: &Arc<GpuContext>,
+    circuit: &Circuit,
+    seed: u64,
+) -> StatevectorBackend {
+    if circuit.num_qubits >= gpu_min_qubits() {
+        StatevectorBackend::new(seed).with_gpu(context.clone())
+    } else {
+        StatevectorBackend::new(seed)
     }
 }
 
@@ -245,6 +316,10 @@ pub(super) fn select_dispatch(
                 max_terms: *max_terms,
             }
         }
+        #[cfg(feature = "gpu")]
+        BackendKind::StatevectorGpu { context } => DispatchAction::Backend(Box::new(
+            statevector_gpu_with_crossover(context, circuit, seed),
+        )),
     }
 }
 
@@ -341,4 +416,73 @@ pub(super) fn try_temporal_clifford(
         classical_bits: sv.classical_results().to_vec(),
         probabilities: probs,
     }))
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod gpu_crossover_tests {
+    use super::*;
+    use crate::gates::Gate;
+    use crate::sim::run_with;
+
+    fn stub_kind() -> BackendKind {
+        BackendKind::StatevectorGpu {
+            context: GpuContext::stub_for_tests(),
+        }
+    }
+
+    /// A 4q circuit is far below the default 14q threshold. If the dispatch
+    /// layer were to build a GPU backend anyway, `GpuState::new` on the stub
+    /// context would return `BackendUnsupported`. Success proves the
+    /// crossover in `select_dispatch` is routing small circuits to the host
+    /// path.
+    #[test]
+    fn small_circuit_routes_to_cpu() {
+        let mut circuit = Circuit::new(4, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_gate(Gate::H, &[2]);
+        circuit.add_gate(Gate::Cx, &[2, 3]);
+
+        let result = run_with(stub_kind(), &circuit, 42)
+            .expect("stub context must not be touched for a 4q circuit");
+        let probs = result
+            .probabilities
+            .expect("probabilities missing")
+            .to_vec();
+
+        let mut expected = [0.0_f64; 16];
+        expected[0b0000] = 0.25;
+        expected[0b0011] = 0.25;
+        expected[0b1100] = 0.25;
+        expected[0b1111] = 0.25;
+        for (i, (p, e)) in probs.iter().zip(&expected).enumerate() {
+            assert!((p - e).abs() < 1e-10, "p[{i}] = {p}, expected {e}");
+        }
+    }
+
+    /// `independent_bell_pairs(8)` spans 16 qubits but decomposes into 8
+    /// independent 2q blocks. With `BackendKind::StatevectorGpu`, each
+    /// sub-block is below the 14q threshold and must route to CPU. If
+    /// decomposition failed to fire, the 16q monolithic path would attempt
+    /// `GpuState::new` through the stub and return `BackendUnsupported`.
+    /// Success here proves decomposition survives across the GPU dispatch.
+    #[test]
+    fn decomposable_16q_circuit_runs_per_block_on_cpu() {
+        let circuit = crate::circuits::independent_bell_pairs(8);
+        assert_eq!(circuit.num_qubits, 16);
+
+        let cpu = run_with(BackendKind::Statevector, &circuit, 42).expect("cpu baseline");
+        let gpu = run_with(stub_kind(), &circuit, 42).expect("stub must stay out of the way");
+
+        let cpu_p = cpu.probabilities.expect("cpu probs").to_vec();
+        let gpu_p = gpu.probabilities.expect("gpu probs").to_vec();
+        assert_eq!(cpu_p.len(), gpu_p.len());
+        for (i, (c, g)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
+            assert!(
+                (c - g).abs() < 1e-10,
+                "prob[{i}] cpu={c}, gpu={g}, diff={}",
+                (c - g).abs()
+            );
+        }
+    }
 }

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -599,3 +599,41 @@ fn probabilities_match_cpu_on_random_circuit() {
         );
     }
 }
+
+// ============================================================================
+// BackendKind::StatevectorGpu end-to-end (real GPU required)
+// ============================================================================
+
+/// `run_with(BackendKind::StatevectorGpu)` on a non-decomposable random
+/// circuit at 14q (at the crossover threshold) must match CPU to within
+/// 1e-10. Exercises the dispatch → fusion → GPU kernel → probabilities path.
+#[test]
+fn statevector_gpu_run_with_matches_cpu_random() {
+    use prism_q::BackendKind;
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let circuit = prism_q::circuits::random_circuit(14, 10, 0xDEAD_BEEF);
+
+    let cpu = prism_q::sim::run_with(BackendKind::Statevector, &circuit, 42)
+        .expect("cpu run_with failed");
+    let gpu = prism_q::sim::run_with(
+        BackendKind::StatevectorGpu {
+            context: f.ctx.clone(),
+        },
+        &circuit,
+        42,
+    )
+    .expect("gpu run_with failed");
+
+    let cpu_p = cpu.probabilities.expect("cpu probs missing").to_vec();
+    let gpu_p = gpu.probabilities.expect("gpu probs missing").to_vec();
+    assert_eq!(cpu_p.len(), gpu_p.len());
+    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
+        assert!(
+            (c - g_).abs() < 1e-10,
+            "prob[{i}] cpu={c}, gpu={g_}, diff={}",
+            (c - g_).abs()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add `BackendKind::StatevectorGpu { context: Arc<GpuContext> }` so the GPU path
enters through `sim::run_with`. This routes small sub-circuits to the host
statevector, closing the small-state regression where GPU launch and PCIe
overhead exceeded the compute payoff. 

## Scope

- [x] New feature
- [x] Performance improvement
- [x] Documentation

## Benchmarks

GTX 1080 Ti, Windows, release build, `--features "parallel gpu"`, 3 reps per
cell, minimum reported.

| Benchmark | Before (ms) | After (ms) | Change |
| --- | --- | --- | --- |
| random 10q d10 | 0.429 | 0.052 | 0.121× |
| random 14q d10 | 0.647 | 0.440 | 0.680× |
| random 16q d10 | 1.170 | 0.738 | 0.631× |
| random 18q d10 | 5.774 | 0.179 | 0.031× |
| random 20q d10 | 25.061 | 0.789 | 0.031× |
| bell_pairs 16q | 0.288 | 0.030 | 0.104× |

Before column: GPU via `StatevectorBackend::new(seed).with_gpu(ctx)` direct
builder (no fusion, no decomposition, no crossover). After column: GPU via
`run_with(BackendKind::StatevectorGpu { context: ctx }, ..)`.

Baselines for the unchanged paths:

| Path | Behaviour |
| --- | --- |
| `run_with(BackendKind::Statevector, ..)` | Unchanged. CPU dispatch branch untouched. |
| `StatevectorBackend::new(seed).with_gpu(ctx)` | Unchanged. Direct builder kept for kernel-level use. |

Regression verdict: PASS.

## Correctness

- [x] `cargo test --all-features` 
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 
- [x] `cargo fmt --check` 
- [x] `cargo doc --no-deps --all-features`
- [x] New public API has docstring
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu` 

New tests:

- `src/sim/dispatch.rs::gpu_crossover_tests::small_circuit_routes_to_cpu`. Uses
  a stub GPU context. Success proves the dispatch never allocates device
  memory for a 4q circuit.
- `src/sim/dispatch.rs::gpu_crossover_tests::decomposable_16q_circuit_runs_per_block_on_cpu`.
  Same technique for a 16q circuit that decomposes into 8 blocks of 2 qubits.
- `tests/golden_gpu.rs::statevector_gpu_run_with_matches_cpu_random`. Real
  GPU, 14q random at the crossover boundary, verifies probabilities match CPU
  within 1e-10.

## Hotspot notes

Does not touch CPU or direct-GPU hot paths. The new `StatevectorGpu` variant
adds one branch to `select_dispatch`, called once per top-level or per-block
dispatch. Inside that branch, `statevector_gpu_with_crossover` is a single
integer compare against `gpu_min_qubits()` plus one of two trivial
constructors. `gpu_min_qubits()` is cached via `OnceLock` so the
`std::env::var` read happens at most once per process.

## Architecture or design changes

- [x] `docs/architecture.md` updated. 
- [x] Research or design notes: N/A. 

## Breaking changes

Under `feature = "gpu"` only: adds a new `#[cfg(feature = "gpu")]` variant to
`BackendKind`. The enum is not `#[non_exhaustive]`, so downstream code that
matches `BackendKind` exhaustively under `feature = "gpu"` will need to add an
arm. Pre-1.0 semver treats this as a minor bump. No changes under
`--no-default-features` or the `parallel`-only build.

No behavioural change to existing APIs:

- `StatevectorBackend::new(seed).with_gpu(ctx)` still sends every instruction
  to the device. This is the explicit kernel-level opt-in and intentionally
  skips crossover.
- `BackendKind::Auto`, `Statevector`, and every other existing variant
  dispatch identically to before.

## Risks and rollback

Blast radius is contained to the new `StatevectorGpu` dispatch arm. Users on
CPU, `Auto`, or the direct `.with_gpu()` builder see no change.

Rollback is a single-commit revert. No schema changes, no on-disk format
changes, no public-API removals. Downstream users who adopted
`BackendKind::StatevectorGpu` can migrate back to the direct builder for
kernel-level use, or `BackendKind::Statevector` for CPU use, with a single
line edit.

The variant is gated on `feature = "gpu"`, inheriting the crate's existing GPU
feature gate. Dropping `--features gpu` removes the variant entirely.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [x] CI is green (pending push)
