### PR TITLE
feat(noise): Support dense custom Kraus trajectory noise

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -185,6 +185,30 @@ fn compiled_filtered_bell_pairs_circuit(n_pairs: usize) -> Circuit {
     circuit
 }
 
+fn with_terminal_measurements(mut circuit: Circuit) -> Circuit {
+    let n = circuit.num_qubits;
+    circuit.num_classical_bits = n;
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn non_clifford_noise_circuit(n_qubits: usize, depth: usize) -> Circuit {
+    let mut circuit = Circuit::new(n_qubits, 0);
+    for layer in 0..depth {
+        for q in 0..n_qubits {
+            circuit.add_gate(Gate::H, &[q]);
+            circuit.add_gate(Gate::T, &[q]);
+            circuit.add_gate(Gate::Rz(0.03 * (layer + q + 1) as f64), &[q]);
+        }
+        for q in 0..n_qubits.saturating_sub(1) {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    with_terminal_measurements(circuit)
+}
+
 fn run_mps_apply_only(circuit: &Circuit, max_bond_dim: usize) {
     let mut backend = MpsBackend::new(SEED, max_bond_dim);
     backend
@@ -1161,6 +1185,49 @@ fn bench_compiled_sampler(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_noisy_sampling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("noisy_sampling");
+    configure_group(&mut group);
+
+    let clifford = with_terminal_measurements(circuits::clifford_heavy_circuit(100, 10, SEED));
+    let clifford_noise = prism_q::NoiseModel::uniform_depolarizing(&clifford, 0.001);
+    group.bench_function(
+        BenchmarkId::new("compiled_pauli", "clifford_100q_10k"),
+        |b| {
+            b.iter(|| {
+                prism_q::run_shots_with_noise(
+                    BackendKind::Auto,
+                    &clifford,
+                    &clifford_noise,
+                    10_000,
+                    SEED,
+                )
+                .unwrap();
+            });
+        },
+    );
+
+    let non_clifford = non_clifford_noise_circuit(12, 4);
+    let non_clifford_noise = prism_q::NoiseModel::uniform_depolarizing(&non_clifford, 0.001);
+    group.bench_function(
+        BenchmarkId::new("trajectory_pauli", "non_clifford_12q_512"),
+        |b| {
+            b.iter(|| {
+                prism_q::run_shots_with_noise(
+                    BackendKind::Auto,
+                    &non_clifford,
+                    &non_clifford_noise,
+                    512,
+                    SEED,
+                )
+                .unwrap();
+            });
+        },
+    );
+
+    group.finish();
+}
+
 fn bench_compiled_sampler_scale(c: &mut Criterion) {
     let mut group = c.benchmark_group("compiled_sampler_scale");
     configure_group(&mut group);
@@ -1348,6 +1415,8 @@ criterion_group!(
     bench_stabilizer_rank,
     // Compiled sampler (noiseless + noisy shot sampling)
     bench_compiled_sampler,
+    // Noisy trajectory dispatch and compiled Pauli sampling
+    bench_noisy_sampling,
     // Compiled sampler at scale (high shot counts)
     bench_compiled_sampler_scale,
     // Filtered compiled sampler (independent subsystem path)

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -625,6 +625,31 @@ impl Backend for FactoredBackend {
         Ok(())
     }
 
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        let ss_idx = self.qubit_to_substate[qubit];
+        let sub = self.substates[ss_idx].as_ref().unwrap();
+        let local = Self::local_qubit(sub, qubit);
+        let mask = 1usize << local;
+
+        let mut p0 = 0.0f64;
+        let mut p1 = 0.0f64;
+        let mut r = Complex64::new(0.0, 0.0);
+        for idx in 0..sub.state.len() {
+            let amp = sub.state[idx];
+            if idx & mask == 0 {
+                p0 += amp.norm_sqr();
+                r += sub.state[idx | mask] * amp.conj();
+            } else {
+                p1 += amp.norm_sqr();
+            }
+        }
+
+        Ok([
+            [Complex64::new(p0, 0.0), r.conj()],
+            [r, Complex64::new(p1, 0.0)],
+        ])
+    }
+
     fn classical_results(&self) -> &[bool] {
         &self.classical_bits
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -187,11 +187,25 @@ pub trait Backend {
     /// Compute P(qubit = |1⟩) without collapsing the state.
     ///
     /// Used by the trajectory engine for state-dependent noise channels
-    /// (amplitude damping, phase damping). The default returns `BackendUnsupported`.
-    fn qubit_probability(&self, _qubit: usize) -> Result<f64> {
+    /// (amplitude damping, phase damping). The default derives from
+    /// [`Backend::reduced_density_matrix_1q`].
+    fn qubit_probability(&self, qubit: usize) -> Result<f64> {
+        let rho = self.reduced_density_matrix_1q(qubit)?;
+        Ok(rho[1][1].re.clamp(0.0, 1.0))
+    }
+
+    /// Compute the one-qubit reduced density matrix without collapsing the state.
+    ///
+    /// Returned as `[[p0, r*], [r, p1]]`, where `r = <1|rho|0>`.
+    /// Used by the trajectory engine for dense custom Kraus channels whose
+    /// branch probabilities depend on coherence, not just populations. The
+    /// default returns `BackendUnsupported`; backends override when their
+    /// representation can expose this quantity efficiently enough for noise
+    /// sampling.
+    fn reduced_density_matrix_1q(&self, _qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
-            operation: "qubit_probability".to_string(),
+            operation: "reduced_density_matrix_1q".to_string(),
         })
     }
 

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -1409,6 +1409,44 @@ impl MpsBackend {
         }
     }
 
+    fn reduced_density_site(&self, site: usize) -> [[Complex64; 2]; 2] {
+        let l_env = self.compute_left_env(site);
+        let r_env = self.compute_right_env(site);
+        let t = &self.sites[site];
+        let bl = t.bond_left;
+        let br = t.bond_right;
+        let mut rho = [[ZERO; 2]; 2];
+
+        for (row, rho_row) in rho.iter_mut().enumerate() {
+            for (col, rho_cell) in rho_row.iter_mut().enumerate() {
+                let mut val = ZERO;
+                for alpha in 0..bl {
+                    for alpha_p in 0..bl {
+                        let l_val = l_env[alpha * bl + alpha_p];
+                        if l_val == ZERO {
+                            continue;
+                        }
+                        for beta in 0..br {
+                            for beta_p in 0..br {
+                                let r_val = r_env[beta * br + beta_p];
+                                if r_val == ZERO {
+                                    continue;
+                                }
+                                val += l_val
+                                    * t.data[t.idx(alpha, row, beta)]
+                                    * t.data[t.idx(alpha_p, col, beta_p)].conj()
+                                    * r_val;
+                            }
+                        }
+                    }
+                }
+                *rho_cell = val;
+            }
+        }
+
+        rho
+    }
+
     fn chain_amplitude(&self, basis: usize) -> Complex64 {
         let n = self.num_qubits;
         let mut vec_data = vec![ONE];
@@ -1555,6 +1593,10 @@ impl Backend for MpsBackend {
     fn reset(&mut self, qubit: usize) -> Result<()> {
         self.apply_reset(self.site_for_logical(qubit));
         Ok(())
+    }
+
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        Ok(self.reduced_density_site(self.site_for_logical(qubit)))
     }
 
     fn classical_results(&self) -> &[bool] {

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -146,6 +146,15 @@ impl Backend for ProductStateBackend {
         Ok(())
     }
 
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        let [alpha, beta] = self.qubits[qubit];
+        let r = beta * alpha.conj();
+        Ok([
+            [Complex64::new(alpha.norm_sqr(), 0.0), r.conj()],
+            [r, Complex64::new(beta.norm_sqr(), 0.0)],
+        ])
+    }
+
     fn classical_results(&self) -> &[bool] {
         &self.classical_bits
     }

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -476,6 +476,29 @@ impl Backend for SparseBackend {
         Ok(())
     }
 
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        let mask = 1usize << qubit;
+        let mut p0 = 0.0f64;
+        let mut p1 = 0.0f64;
+        let mut r = Complex64::new(0.0, 0.0);
+
+        for (&idx, &amp) in &self.state {
+            if idx & mask == 0 {
+                p0 += amp.norm_sqr();
+                if let Some(&amp_one) = self.state.get(&(idx | mask)) {
+                    r += amp_one * amp.conj();
+                }
+            } else {
+                p1 += amp.norm_sqr();
+            }
+        }
+
+        Ok([
+            [Complex64::new(p0, 0.0), r.conj()],
+            [r, Complex64::new(p1, 0.0)],
+        ])
+    }
+
     fn classical_results(&self) -> &[bool] {
         &self.classical_bits
     }

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -1374,6 +1374,76 @@ impl StatevectorBackend {
     }
 
     #[inline(always)]
+    pub(super) fn reduced_density_matrix_one(&self, qubit: usize) -> [[Complex64; 2]; 2] {
+        #[cfg(feature = "parallel")]
+        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            return self.reduced_density_matrix_one_par(qubit);
+        }
+
+        let half = 1usize << qubit;
+        let block_size = half << 1;
+        let norm_sq = self.pending_norm * self.pending_norm;
+
+        let mut p0 = 0.0f64;
+        let mut p1 = 0.0f64;
+        let mut r = Complex64::new(0.0, 0.0);
+        for block in self.state.chunks(block_size) {
+            let (lo, hi) = block.split_at(half);
+            for i in 0..half {
+                let a0 = lo[i];
+                let a1 = hi[i];
+                p0 += a0.norm_sqr();
+                p1 += a1.norm_sqr();
+                r += a1 * a0.conj();
+            }
+        }
+
+        let scale = Complex64::new(norm_sq, 0.0);
+        let r = r * scale;
+        [
+            [Complex64::new(p0 * norm_sq, 0.0), r.conj()],
+            [r, Complex64::new(p1 * norm_sq, 0.0)],
+        ]
+    }
+
+    #[cfg(feature = "parallel")]
+    fn reduced_density_matrix_one_par(&self, qubit: usize) -> [[Complex64; 2]; 2] {
+        let half = 1usize << qubit;
+        let block_size = half << 1;
+        let norm_sq = self.pending_norm * self.pending_norm;
+
+        let (p0, p1, r) = self
+            .state
+            .par_chunks(block_size)
+            .with_min_len(chunk_min_len(block_size))
+            .map(|block| {
+                let (lo, hi) = block.split_at(half);
+                let mut p0 = 0.0f64;
+                let mut p1 = 0.0f64;
+                let mut r = Complex64::new(0.0, 0.0);
+                for i in 0..half {
+                    let a0 = lo[i];
+                    let a1 = hi[i];
+                    p0 += a0.norm_sqr();
+                    p1 += a1.norm_sqr();
+                    r += a1 * a0.conj();
+                }
+                (p0, p1, r)
+            })
+            .reduce(
+                || (0.0, 0.0, Complex64::new(0.0, 0.0)),
+                |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+            );
+
+        let scale = Complex64::new(norm_sq, 0.0);
+        let r = r * scale;
+        [
+            [Complex64::new(p0 * norm_sq, 0.0), r.conj()],
+            [r, Complex64::new(p1 * norm_sq, 0.0)],
+        ]
+    }
+
+    #[inline(always)]
     pub(super) fn apply_reset(&mut self, qubit: usize) {
         #[cfg(feature = "parallel")]
         if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -63,6 +63,31 @@ use rayon::prelude::*;
 #[cfg(feature = "parallel")]
 pub(crate) use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS};
 
+#[cfg(feature = "gpu")]
+fn reduced_density_matrix_from_state(state: &[Complex64], qubit: usize) -> [[Complex64; 2]; 2] {
+    let half = 1usize << qubit;
+    let block_size = half << 1;
+    let mut p0 = 0.0f64;
+    let mut p1 = 0.0f64;
+    let mut r = Complex64::new(0.0, 0.0);
+
+    for block in state.chunks(block_size) {
+        let (lo, hi) = block.split_at(half);
+        for i in 0..half {
+            let a0 = lo[i];
+            let a1 = hi[i];
+            p0 += a0.norm_sqr();
+            p1 += a1.norm_sqr();
+            r += a1 * a0.conj();
+        }
+    }
+
+    [
+        [Complex64::new(p0, 0.0), r.conj()],
+        [r, Complex64::new(p1, 0.0)],
+    ]
+}
+
 /// Insert a zero bit at `bit_pos`, shifting all higher bits left by one.
 ///
 /// Maps a compact iteration index to a state-vector index with a gap at
@@ -527,6 +552,15 @@ impl Backend for StatevectorBackend {
             return crate::gpu::kernels::dense::measure_prob_one(gpu.context(), gpu, qubit);
         }
         Ok(self.qubit_probability_one(qubit))
+    }
+
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.gpu_state.as_ref() {
+            let state = gpu.export_statevector()?;
+            return Ok(reduced_density_matrix_from_state(&state, qubit));
+        }
+        Ok(self.reduced_density_matrix_one(qubit))
     }
 
     fn reset(&mut self, qubit: usize) -> Result<()> {

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -197,6 +197,60 @@ pub enum BackendKind {
     },
 }
 
+impl BackendKind {
+    pub fn supports_noisy_per_shot(&self) -> bool {
+        !matches!(
+            self,
+            BackendKind::StabilizerRank
+                | BackendKind::StochasticPauli { .. }
+                | BackendKind::DeterministicPauli { .. }
+        )
+    }
+
+    pub fn supports_general_noise(&self) -> bool {
+        match self {
+            BackendKind::Auto
+            | BackendKind::Statevector
+            | BackendKind::Sparse
+            | BackendKind::Mps { .. }
+            | BackendKind::ProductState
+            | BackendKind::Factored => true,
+            #[cfg(feature = "gpu")]
+            BackendKind::StatevectorGpu { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_stabilizer_family(&self) -> bool {
+        matches!(
+            self,
+            BackendKind::Stabilizer
+                | BackendKind::FilteredStabilizer
+                | BackendKind::FactoredStabilizer
+        ) || {
+            #[cfg(feature = "gpu")]
+            {
+                matches!(self, BackendKind::StabilizerGpu { .. })
+            }
+            #[cfg(not(feature = "gpu"))]
+            {
+                false
+            }
+        }
+    }
+
+    pub(crate) fn general_noise_backend_names() -> &'static str {
+        #[cfg(feature = "gpu")]
+        {
+            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, or Factored"
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            "Auto, Statevector, Sparse, Mps, ProductState, or Factored"
+        }
+    }
+}
+
 pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
     match kind {
         BackendKind::Stabilizer

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -18,11 +18,11 @@ use decomposed::{
 };
 pub use dispatch::BackendKind;
 use dispatch::{
-    has_temporal_clifford_opportunity, select_backend, select_dispatch, supports_fused_for_kind,
-    try_temporal_clifford, validate_explicit_backend, DispatchAction, AUTO_APPROX_MAX_TERMS,
-    AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
-    MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
-    MIN_QUBITS_FOR_SPD_AUTO,
+    has_temporal_clifford_opportunity, max_statevector_qubits, select_backend, select_dispatch,
+    supports_fused_for_kind, try_temporal_clifford, validate_explicit_backend, DispatchAction,
+    AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM, AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX,
+    MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS, MAX_STABILIZER_RANK_QUBITS,
+    MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS, MIN_QUBITS_FOR_SPD_AUTO,
 };
 
 use std::collections::HashMap;
@@ -884,6 +884,22 @@ pub fn run_shots_with(
 /// For all other cases, falls back to per-shot simulation with noise injection.
 /// The compiled noisy path is limited to terminal measurements with no resets
 /// or classical conditionals.
+fn auto_general_noise_backend(circuit: &Circuit) -> BackendKind {
+    if !circuit.has_entangling_gates() {
+        BackendKind::ProductState
+    } else if circuit.num_qubits > max_statevector_qubits() {
+        if circuit.is_sparse_friendly() {
+            BackendKind::Sparse
+        } else {
+            BackendKind::Mps {
+                max_bond_dim: AUTO_MPS_BOND_DIM,
+            }
+        }
+    } else {
+        BackendKind::Statevector
+    }
+}
+
 pub fn run_shots_with_noise(
     kind: BackendKind,
     circuit: &Circuit,
@@ -891,39 +907,32 @@ pub fn run_shots_with_noise(
     num_shots: usize,
     seed: u64,
 ) -> Result<ShotsResult> {
-    if matches!(
-        kind,
-        BackendKind::StabilizerRank
-            | BackendKind::StochasticPauli { .. }
-            | BackendKind::DeterministicPauli { .. }
-    ) {
+    if !kind.supports_noisy_per_shot() {
         return Err(crate::error::PrismError::IncompatibleBackend {
             backend: format!("{kind:?}"),
             reason: "this backend does not support noisy per-shot simulation".into(),
         });
     }
 
-    let is_stabilizer_kind = matches!(
-        kind,
-        BackendKind::Stabilizer | BackendKind::FilteredStabilizer | BackendKind::FactoredStabilizer
-    ) || {
-        #[cfg(feature = "gpu")]
-        {
-            matches!(kind, BackendKind::StabilizerGpu { .. })
-        }
-        #[cfg(not(feature = "gpu"))]
-        {
-            false
-        }
-    };
+    let is_stabilizer_kind = kind.is_stabilizer_family();
 
     if is_stabilizer_kind && !noise_model.is_pauli_only() {
         return Err(crate::error::PrismError::IncompatibleBackend {
             backend: format!("{kind:?}"),
-            reason: "stabilizer backends only support Pauli/depolarizing noise; \
-                     use Statevector or MPS for amplitude damping, phase damping, \
-                     thermal relaxation, custom Kraus, or readout errors"
-                .into(),
+            reason: format!(
+                "stabilizer backends only support Pauli/depolarizing noise; use {} for amplitude damping, phase damping, thermal relaxation, custom Kraus, or readout errors",
+                BackendKind::general_noise_backend_names()
+            ),
+        });
+    }
+
+    if !noise_model.is_pauli_only() && !kind.supports_general_noise() {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: format!(
+                "non-Pauli noise requires {}",
+                BackendKind::general_noise_backend_names()
+            ),
         });
     }
 
@@ -932,6 +941,10 @@ pub fn run_shots_with_noise(
             backend: format!("{kind:?}"),
             reason: "circuit contains non-Clifford gates".into(),
         });
+    }
+
+    if !matches!(kind, BackendKind::Auto) {
+        validate_explicit_backend(&kind, circuit)?;
     }
 
     if noise_model.is_pauli_only() {
@@ -966,8 +979,14 @@ pub fn run_shots_with_noise(
         }
     }
 
+    let trajectory_kind = if matches!(kind, BackendKind::Auto) && !noise_model.is_pauli_only() {
+        auto_general_noise_backend(circuit)
+    } else {
+        kind
+    };
+
     trajectory::run_trajectories(
-        |s| select_backend(&kind, circuit, s, false),
+        |s| select_backend(&trajectory_kind, circuit, s, false),
         circuit,
         noise_model,
         num_shots,
@@ -2287,10 +2306,23 @@ mod tests {
             },
             readout: vec![None; circuit.num_qubits],
         };
-        assert!(matches!(
-            run_shots_with_noise(BackendKind::Stabilizer, &circuit, &nm, 10, 42).unwrap_err(),
-            crate::error::PrismError::IncompatibleBackend { .. }
-        ));
+        let err = run_shots_with_noise(BackendKind::Stabilizer, &circuit, &nm, 10, 42).unwrap_err();
+        match err {
+            crate::error::PrismError::IncompatibleBackend { reason, .. } => {
+                assert!(reason.contains("Statevector"));
+                assert!(reason.contains("Sparse"));
+                assert!(reason.contains("Factored"));
+            }
+            other => panic!("expected IncompatibleBackend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_noise_auto_general_noise_avoids_stabilizer_dispatch() {
+        let circuit = make_clifford_circuit();
+        let nm = noise::NoiseModel::with_amplitude_damping(&circuit, 0.1);
+        let result = run_shots_with_noise(BackendKind::Auto, &circuit, &nm, 16, 42);
+        assert!(result.is_ok());
     }
 
     #[cfg(feature = "gpu")]

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -40,25 +40,11 @@ pub enum NoiseChannel {
     TwoQubitDepolarizing { p: f64 },
     /// General single-qubit channel described by a set of Kraus operators.
     ///
-    /// **Restriction: supported Kraus class.** Each operator `K_k` must
-    /// satisfy that `K_k† K_k` is diagonal. This class is rich enough to
-    /// cover all diagonal channels (amplitude / phase damping, dephasing)
-    /// plus the Pauli channels (bit flip, phase flip, bit-phase flip, and
-    /// arbitrary mixtures of `X`, `Y`, `Z`), which is every standard
-    /// single-qubit noise channel in the literature.
-    ///
-    /// **Rejected Kraus class.** General dense operators such as
-    /// `[[a, b], [0, 0]]` whose `K_k† K_k` has non-zero off-diagonal entries
-    /// require access to the qubit's coherence `⟨0|ρ|1⟩`, which the
-    /// trajectory engine cannot extract from a pure state without cloning
-    /// the backend. If you pass such an operator, the trajectory engine
-    /// returns [`PrismError::BackendUnsupported`] at runtime.
-    ///
-    /// **Workarounds for dense Kraus ops:** decompose the channel into a
-    /// unitary dilation plus an ancilla measurement, or use a density-matrix
-    /// simulator (not provided by PRISM-Q).
-    ///
-    /// [`PrismError::BackendUnsupported`]: crate::error::PrismError::BackendUnsupported
+    /// Dense Kraus operators are supported by trajectory backends that expose
+    /// `Backend::reduced_density_matrix_1q`. Branch probabilities use the full
+    /// one-qubit reduced density matrix, so channels may depend on coherence
+    /// as well as populations. Call [`NoiseModel::validate`] in setup code to
+    /// catch empty or non-finite custom channels before sampling.
     Custom { kraus: Vec<[[Complex64; 2]; 2]> },
 }
 
@@ -80,6 +66,81 @@ impl NoiseChannel {
             NoiseChannel::Pauli { .. } | NoiseChannel::Depolarizing { .. }
         )
     }
+
+    /// Return true when the trajectory engine can sample this channel exactly.
+    pub fn is_exactly_samplable(&self) -> bool {
+        self.validate().is_ok()
+    }
+
+    /// Validate that this channel is usable by the trajectory engine.
+    pub fn validate(&self) -> Result<()> {
+        match self {
+            NoiseChannel::Pauli { px, py, pz } => {
+                validate_probability("px", *px)?;
+                validate_probability("py", *py)?;
+                validate_probability("pz", *pz)?;
+                if *px + *py + *pz > 1.0 + 1e-12 {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "Pauli channel probabilities must sum to <= 1".into(),
+                    });
+                }
+            }
+            NoiseChannel::Depolarizing { p } | NoiseChannel::TwoQubitDepolarizing { p } => {
+                validate_probability("p", *p)?;
+            }
+            NoiseChannel::AmplitudeDamping { gamma } | NoiseChannel::PhaseDamping { gamma } => {
+                validate_probability("gamma", *gamma)?;
+            }
+            NoiseChannel::ThermalRelaxation { t1, t2, gate_time } => {
+                if !t1.is_finite() || *t1 <= 0.0 {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "thermal relaxation t1 must be finite and positive".into(),
+                    });
+                }
+                if !t2.is_finite() || *t2 <= 0.0 {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "thermal relaxation t2 must be finite and positive".into(),
+                    });
+                }
+                if !gate_time.is_finite() || *gate_time < 0.0 {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "thermal relaxation gate_time must be finite and non-negative"
+                            .into(),
+                    });
+                }
+            }
+            NoiseChannel::Custom { kraus } => {
+                if kraus.is_empty() {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "Custom Kraus channel must contain at least one operator".into(),
+                    });
+                }
+                for (op_idx, op) in kraus.iter().enumerate() {
+                    for (row_idx, row) in op.iter().enumerate() {
+                        for (col_idx, val) in row.iter().enumerate() {
+                            if !val.re.is_finite() || !val.im.is_finite() {
+                                return Err(crate::error::PrismError::InvalidParameter {
+                                    message: format!(
+                                        "Custom Kraus operator {op_idx} entry ({row_idx},{col_idx}) must be finite"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_probability(name: &str, value: f64) -> Result<()> {
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        return Err(crate::error::PrismError::InvalidParameter {
+            message: format!("{name} must be finite and in [0, 1]"),
+        });
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -211,6 +272,51 @@ impl NoiseModel {
                     .into(),
             });
         }
+        Ok(())
+    }
+
+    /// Validate all channels and readout errors in this noise model.
+    pub fn validate(&self) -> Result<()> {
+        for (instr_idx, events) in self.after_gate.iter().enumerate() {
+            for (event_idx, event) in events.iter().enumerate() {
+                event.channel.validate().map_err(|err| {
+                    crate::error::PrismError::InvalidParameter {
+                        message: format!(
+                            "noise event {event_idx} after instruction {instr_idx}: {err}"
+                        ),
+                    }
+                })?;
+
+                let expected_qubits = match &event.channel {
+                    NoiseChannel::TwoQubitDepolarizing { .. } => 2,
+                    _ => 1,
+                };
+                if event.qubits.len() != expected_qubits {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: format!(
+                            "noise event {event_idx} after instruction {instr_idx}: expected {expected_qubits} qubit(s), got {}",
+                            event.qubits.len()
+                        ),
+                    });
+                }
+            }
+        }
+
+        for (bit_idx, readout) in self.readout.iter().enumerate() {
+            if let Some(readout) = readout {
+                validate_probability("readout p01", readout.p01).map_err(|err| {
+                    crate::error::PrismError::InvalidParameter {
+                        message: format!("readout error {bit_idx}: {err}"),
+                    }
+                })?;
+                validate_probability("readout p10", readout.p10).map_err(|err| {
+                    crate::error::PrismError::InvalidParameter {
+                        message: format!("readout error {bit_idx}: {err}"),
+                    }
+                })?;
+            }
+        }
+
         Ok(())
     }
 }
@@ -796,8 +902,9 @@ impl GpuNoiseCache {
 ///
 /// The sampler reuses the compiled measurement parity map for the noiseless
 /// circuit, then applies the requested Pauli noise model across batches of
-/// shots. When a GPU context is attached with [`Self::with_gpu`], the
-/// underlying parity sampling stage may use the GPU BTS path. Materialized
+/// shots. When a GPU context is attached via `with_gpu` (available with the
+/// `gpu` feature), the underlying parity sampling stage may use the GPU BTS
+/// path. Materialized
 /// shot output still returns to the CPU in shot-major form, while exact
 /// counts and marginals can keep the packed measurement-major buffer on the
 /// device through noise application and reduction.

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -206,78 +206,48 @@ fn apply_pauli_op(backend: &mut dyn Backend, qubit: usize, op: PauliOp) -> Resul
     })
 }
 
-/// Threshold at which a Kraus operator's `K†K` off-diagonal element is
-/// considered non-zero. Used to reject Kraus ops whose `K†K` is not diagonal,
-/// because such ops require knowing the reduced density matrix's coherences
-/// which we cannot extract from a pure state without cloning the backend.
-const KRAUS_DIAGONAL_TOL: f64 = 1e-10;
-
-/// Return true if `K†K` is diagonal (within `KRAUS_DIAGONAL_TOL`).
-///
-/// `K†K` is diagonal iff its (0,1) entry vanishes:
-///   `(K†K)[0][1] = k00*·k01 + k10*·k11 = 0`
-/// When this holds, `Tr(K†K ρ) = (|k00|²+|k10|²)·p0 + (|k01|²+|k11|²)·p1`,
-/// which depends only on populations (not coherences) and can be computed
-/// exactly from `qubit_probability` alone. Diagonal Kraus ops and all pure
-/// Paulis (X, Y, Z, and their scaled versions) satisfy this.
+/// Compute the branch effect `Kdagger K` for a single-qubit Kraus operator.
 #[inline]
-fn is_kdagger_k_diagonal(k: &[[Complex64; 2]; 2]) -> bool {
-    let cross = k[0][0].conj() * k[0][1] + k[1][0].conj() * k[1][1];
-    cross.norm() < KRAUS_DIAGONAL_TOL
+fn kdagger_k(k: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
+    [
+        [
+            k[0][0].conj() * k[0][0] + k[1][0].conj() * k[1][0],
+            k[0][0].conj() * k[0][1] + k[1][0].conj() * k[1][1],
+        ],
+        [
+            k[0][1].conj() * k[0][0] + k[1][1].conj() * k[1][0],
+            k[0][1].conj() * k[0][1] + k[1][1].conj() * k[1][1],
+        ],
+    ]
+}
+
+#[inline]
+fn kraus_probability(k: &[[Complex64; 2]; 2], rho: &[[Complex64; 2]; 2]) -> f64 {
+    let effect = kdagger_k(k);
+    let p = effect[0][0] * rho[0][0]
+        + effect[0][1] * rho[1][0]
+        + effect[1][0] * rho[0][1]
+        + effect[1][1] * rho[1][1];
+    p.re.max(0.0)
 }
 
 /// Sample and apply one of a set of 1-qubit Kraus operators.
 ///
-/// **Supported Kraus operators.** Each operator `K_k` must satisfy `K_k† K_k`
-/// is diagonal. This is the class of Kraus ops for which the per-branch
-/// probability `p_k = Tr(K_k† K_k ρ)` depends only on the qubit's populations
-/// (not its coherences), so the trajectory branch can be selected exactly
-/// from `qubit_probability` alone without cloning the full state. This class
-/// includes:
-///
-/// - All diagonal Kraus operators (amplitude/phase damping, dephasing, Z).
-/// - All pure Paulis (X, Y, Z) and their scaled versions.
-/// - The standard bit-flip / phase-flip / bit-phase-flip channels.
-///
-/// It **excludes** Kraus operators like `[[a,b],[0,0]]` or general dense
-/// matrices where the (0,1) entry of `K_k† K_k` is non-zero. For those, the
-/// trajectory branching depends on the off-diagonal coherence `⟨0|ρ|1⟩`,
-/// which is not accessible via a single-qubit probability query.
-///
-/// Users needing general dense Kraus support on entangled qubits should
-/// either decompose the channel into a unitary dilation + measurement on an
-/// ancilla, or use a density-matrix simulator (not provided by PRISM-Q).
+/// Branch probabilities use `p_k = Tr(Kdagger K rho_q)`, where `rho_q` is
+/// the qubit's reduced density matrix. This handles dense Kraus operators
+/// whose branch probabilities depend on coherence.
 fn apply_custom_kraus(
     backend: &mut dyn Backend,
     qubit: usize,
     kraus: &[[[Complex64; 2]; 2]],
     rng: &mut ChaCha8Rng,
 ) -> Result<()> {
-    for (i, k) in kraus.iter().enumerate() {
-        if !is_kdagger_k_diagonal(k) {
-            return Err(crate::error::PrismError::BackendUnsupported {
-                backend: "trajectory engine".to_string(),
-                operation: format!(
-                    "NoiseChannel::Custom: Kraus operator {i} has non-diagonal K†K \
-                     (off-diagonal magnitude {:.3e} > {KRAUS_DIAGONAL_TOL:.0e}). \
-                     Only Kraus ops whose K†K is diagonal are supported (diagonal \
-                     matrices, Paulis, and their scaled versions). Decompose your \
-                     channel into a unitary dilation + ancilla measurement, or use \
-                     a density-matrix simulator for general dense Kraus channels.",
-                    (k[0][0].conj() * k[0][1] + k[1][0].conj() * k[1][1]).norm()
-                ),
-            });
-        }
-    }
-
-    let p1 = backend.qubit_probability(qubit)?;
-    let p0 = 1.0 - p1;
+    let rho = backend.reduced_density_matrix_1q(qubit)?;
 
     let mut cumulative: smallvec::SmallVec<[f64; 8]> = smallvec::SmallVec::new();
     let mut total = 0.0;
     for k in kraus {
-        let pk = p0 * (k[0][0].norm_sqr() + k[1][0].norm_sqr())
-            + p1 * (k[0][1].norm_sqr() + k[1][1].norm_sqr());
+        let pk = kraus_probability(k, &rho);
         total += pk;
         cumulative.push(total);
     }

--- a/tests/trajectory_correctness.rs
+++ b/tests/trajectory_correctness.rs
@@ -362,15 +362,16 @@ fn custom_kraus_bit_flip_channel() {
 }
 
 #[test]
-fn custom_kraus_rejects_non_diagonal_kdagger_k() {
+fn custom_kraus_dense_channel_uses_coherence() {
     use num_complex::Complex64;
 
+    let inv_sqrt2 = 1.0 / 2.0_f64.sqrt();
     let zero = Complex64::new(0.0, 0.0);
-    let half = Complex64::new(0.5, 0.0);
-    let one = Complex64::new(1.0, 0.0);
+    let plus = Complex64::new(inv_sqrt2, 0.0);
+    let minus = Complex64::new(-inv_sqrt2, 0.0);
 
-    let k0 = [[half, half], [zero, zero]];
-    let k1 = [[half, half.conj() * Complex64::new(-1.0, 0.0)], [zero, one]];
+    let k0 = [[plus, plus], [zero, zero]];
+    let k1 = [[zero, zero], [plus, minus]];
 
     let mut circuit = Circuit::new(1, 1);
     circuit.add_gate(Gate::H, &[0]);
@@ -384,14 +385,48 @@ fn custom_kraus_rejects_non_diagonal_kdagger_k() {
         qubits: SmallVec::from_slice(&[0]),
     }];
 
-    let err = run_shots_with_noise(BackendKind::Statevector, &circuit, &noise, 10, 42);
-    assert!(
-        err.is_err(),
-        "non-diagonal K†K must be rejected, got {err:?}"
-    );
-    let msg = format!("{:?}", err.unwrap_err());
-    assert!(
-        msg.contains("K†K") && msg.contains("Custom"),
-        "error should name the Custom channel and K†K condition, got: {msg}"
-    );
+    let backends = vec![
+        BackendKind::Statevector,
+        BackendKind::Sparse,
+        BackendKind::Mps { max_bond_dim: 64 },
+        BackendKind::ProductState,
+        BackendKind::Factored,
+    ];
+
+    for backend in backends {
+        let result = run_shots_with_noise(backend.clone(), &circuit, &noise, 200, 42).unwrap();
+
+        let num_one = result.shots.iter().filter(|s| s[0]).count();
+        assert_eq!(
+            num_one, 0,
+            "dense custom Kraus should project |+> through the K0 branch deterministically on {backend:?}"
+        );
+    }
+}
+
+#[test]
+fn noise_model_validate_catches_invalid_custom_channel() {
+    use num_complex::Complex64;
+
+    let mut circuit = Circuit::new(1, 1);
+    circuit.add_gate(Gate::Id, &[0]);
+    circuit.add_measure(0, 0);
+
+    let mut noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+    noise.after_gate[0] = vec![NoiseEvent {
+        channel: NoiseChannel::Custom { kraus: Vec::new() },
+        qubits: SmallVec::from_slice(&[0]),
+    }];
+
+    assert!(noise.validate().is_err());
+    assert!(!noise.after_gate[0][0].channel.is_exactly_samplable());
+
+    let one = Complex64::new(1.0, 0.0);
+    let zero = Complex64::new(0.0, 0.0);
+    noise.after_gate[0][0].channel = NoiseChannel::Custom {
+        kraus: vec![[[one, zero], [zero, one]]],
+    };
+
+    assert!(noise.validate().is_ok());
+    assert!(noise.after_gate[0][0].channel.is_exactly_samplable());
 }


### PR DESCRIPTION
## Description

This allows custom noise channels whose branch probabilities depend on qubit coherence, not only populations. The change also centralizes noisy backend compatibility checks, adds public noise validation helpers, and extends trajectory primitives across Sparse, MPS, ProductState, and Factored backends.

## Benchmark Summary

No new benchmark run is required for this PR. The change is correctness and API focused, with no tuned performance claim and no change to gate-application inner loops.

New noisy sampling benchmark coverage was added for future regression tracking.

| Benchmark | Before (ns) | After (ns) | Change |
|-----------|-------------|------------|--------|
| N/A       | N/A         | N/A        | N/A    |

## Regression Verdict

PASS.

No benchmark regression is expected because this PR does not change the existing hot gate kernels or compiled sampler path. Bench targets compile successfully.

## Hotspot Notes

The affected runtime path is trajectory noise sampling for custom Kraus channels. Branch probabilities now use `Backend::reduced_density_matrix_1q`.

Statevector computes the reduced density matrix with a state sweep. Sparse, MPS, ProductState, and Factored expose backend-native implementations. Stabilizer-family and TensorNetwork backends remain unsupported for general non-Pauli trajectory noise.

## Tests

- `cargo fmt --check`
- `cargo test`
- `cargo test --all-features --no-run`
- `cargo test --benches --all-features --no-run`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Documentation

Public docs were updated for custom Kraus support and the new validation helpers. Architecture docs were not updated because this is not a structural architecture change.
