### PR TITLE
refactor(gpu): cache launcher metadata and reduce measure-prob on device

### DIFF
--- a/src/gpu/kernels/dense.rs
+++ b/src/gpu/kernels/dense.rs
@@ -352,6 +352,28 @@ extern "C" __global__ void measure_prob_one(
     if (tid == 0) out_partials[blockIdx.x] = sdata[0];
 }
 
+// Single-block reduction over `partials` (length `count`) into a single f64
+// at `result[0]`. Caller launches with a single block of `blockDim.x` threads;
+// each thread loops with stride `blockDim.x` over `partials` to accumulate.
+// Replaces a num_blocks-element D2H plus a host sum with one 8-byte D2H.
+extern "C" __global__ void measure_prob_one_finalize(
+    const double *partials, unsigned int count, double *result)
+{
+    extern __shared__ double sdata[];
+    unsigned int tid = threadIdx.x;
+    double s = 0.0;
+    for (unsigned int i = tid; i < count; i += blockDim.x) {
+        s += partials[i];
+    }
+    sdata[tid] = s;
+    __syncthreads();
+    for (unsigned int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) sdata[tid] += sdata[tid + stride];
+        __syncthreads();
+    }
+    if (tid == 0) result[0] = sdata[0];
+}
+
 // measure_collapse: zero amplitudes where qubit bit != outcome.
 // Launch over 2^n threads, block size BLOCK_SIZE.
 
@@ -1130,9 +1152,8 @@ pub(crate) fn launch_apply_mcu(
         block_dim: (BLOCK_SIZE, 1, 1),
         shared_mem_bytes: 0,
     };
-    let sorted_dev = stream
-        .clone_htod(&sorted)
-        .map_err(|e| launch_err("upload mcu sorted", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let sorted_buf = super::ensure_scratch(&mut scratch.u32_a, device, &sorted)?;
     let m00r = matrix[0][0].re;
     let m00i = matrix[0][0].im;
     let m01r = matrix[0][1].re;
@@ -1146,7 +1167,7 @@ pub(crate) fn launch_apply_mcu(
     builder
         .arg(buffer)
         .arg(&iter_count)
-        .arg(&sorted_dev)
+        .arg(sorted_buf.raw())
         .arg(&num_sorted)
         .arg(&ctrl_mask)
         .arg(&tgt_mask)
@@ -1158,7 +1179,8 @@ pub(crate) fn launch_apply_mcu(
         .arg(&m10i)
         .arg(&m11r)
         .arg(&m11i);
-    // SAFETY: signature matches; sorted_dev lives until launch returns (kept in scope).
+    // SAFETY: signature matches; sorted_buf lives in the launcher scratch and is held by
+    // the mutex guard until after the launch is queued on the stream.
     unsafe {
         builder
             .launch(cfg)
@@ -1191,9 +1213,8 @@ pub(crate) fn launch_apply_mcu_phase(
         block_dim: (BLOCK_SIZE, 1, 1),
         shared_mem_bytes: 0,
     };
-    let sorted_dev = stream
-        .clone_htod(&sorted)
-        .map_err(|e| launch_err("upload mcu_phase sorted", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let sorted_buf = super::ensure_scratch(&mut scratch.u32_a, device, &sorted)?;
     let pr = phase.re;
     let pi = phase.im;
     let mut builder = stream.launch_builder(&func);
@@ -1201,12 +1222,12 @@ pub(crate) fn launch_apply_mcu_phase(
     builder
         .arg(buffer)
         .arg(&iter_count)
-        .arg(&sorted_dev)
+        .arg(sorted_buf.raw())
         .arg(&num_sorted)
         .arg(&all_mask)
         .arg(&pr)
         .arg(&pi);
-    // SAFETY: signature matches kernel; sorted_dev retained.
+    // SAFETY: signature matches; sorted_buf is held by the launcher scratch guard.
     unsafe {
         builder
             .launch(cfg)
@@ -1245,9 +1266,8 @@ pub(crate) fn launch_apply_fused_2q(
             flat[2 * (row * 4 + col) + 1] = matrix[row][col].im;
         }
     }
-    let mat_dev = stream
-        .clone_htod(&flat)
-        .map_err(|e| launch_err("upload fused_2q mat", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let mat_buf = super::ensure_scratch(&mut scratch.f64_a, device, &flat)?;
     let q0_i = q0 as i32;
     let q1_i = q1 as i32;
     let mut builder = stream.launch_builder(&func);
@@ -1257,8 +1277,8 @@ pub(crate) fn launch_apply_fused_2q(
         .arg(&pair_count)
         .arg(&q0_i)
         .arg(&q1_i)
-        .arg(&mat_dev);
-    // SAFETY: signature matches; mat_dev retained until after launch.
+        .arg(mat_buf.raw());
+    // SAFETY: signature matches; mat_buf is held by the launcher scratch guard.
     unsafe {
         builder
             .launch(cfg)
@@ -1276,41 +1296,71 @@ pub(crate) fn measure_prob_one(ctx: &GpuContext, state: &GpuState, qubit: usize)
         });
     }
     let dim: u64 = 1u64 << n;
-    // Each block processes 2*BLOCK_SIZE elements.
+    // Each block of stage 1 processes 2*BLOCK_SIZE elements.
     let elems_per_block = 2u64 * BLOCK_SIZE as u64;
     let num_blocks = dim.div_ceil(elems_per_block).max(1) as u32;
 
     let device = ctx.device();
     let stream = device.stream()?;
-    let func = device.function("measure_prob_one")?;
-    let cfg = LaunchConfig {
+    let stage1 = device.function("measure_prob_one")?;
+    let stage2 = device.function("measure_prob_one_finalize")?;
+    let stage1_cfg = LaunchConfig {
         grid_dim: (num_blocks, 1, 1),
         block_dim: (BLOCK_SIZE, 1, 1),
         shared_mem_bytes: BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
     };
-    let mut partials = stream
-        .alloc_zeros::<f64>(num_blocks as usize)
-        .map_err(|e| launch_err("alloc partials", e))?;
+    let stage2_cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
+    };
+
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let partials =
+        super::ensure_capacity(&mut scratch.measure_partials, device, num_blocks as usize)?;
 
     let qubit_i = qubit as i32;
-    let mut builder = stream.launch_builder(&func);
-    let state_buf = state.buffer().raw();
-    builder
-        .arg(state_buf)
-        .arg(&dim)
-        .arg(&qubit_i)
-        .arg(&mut partials);
-    // SAFETY: signature matches kernel; num_blocks × 2*BLOCK_SIZE covers dim.
-    unsafe {
+    {
+        let mut builder = stream.launch_builder(&stage1);
+        let state_buf = state.buffer().raw();
         builder
-            .launch(cfg)
-            .map_err(|e| launch_err("measure_prob_one", e))?;
+            .arg(state_buf)
+            .arg(&dim)
+            .arg(&qubit_i)
+            .arg(partials.raw_mut());
+        // SAFETY: signature matches kernel; num_blocks * 2*BLOCK_SIZE covers dim.
+        unsafe {
+            builder
+                .launch(stage1_cfg)
+                .map_err(|e| launch_err("measure_prob_one", e))?;
+        }
     }
-    let mut host_partials = vec![0.0_f64; num_blocks as usize];
-    stream
-        .memcpy_dtoh(&partials, &mut host_partials)
-        .map_err(|e| launch_err("measure partials dtoh", e))?;
-    let prob_raw: f64 = host_partials.iter().sum();
+
+    let result = super::ensure_capacity(&mut scratch.measure_result, device, 1)?;
+    let count_u32 = num_blocks;
+    {
+        let mut builder = stream.launch_builder(&stage2);
+        builder
+            .arg(scratch.measure_partials.as_ref().unwrap().raw())
+            .arg(&count_u32)
+            .arg(result.raw_mut());
+        // SAFETY: signature matches kernel; one block of BLOCK_SIZE threads, grid-stride
+        // loop over `count_u32` partials. Both buffers held by the scratch guard.
+        unsafe {
+            builder
+                .launch(stage2_cfg)
+                .map_err(|e| launch_err("measure_prob_one_finalize", e))?;
+        }
+    }
+
+    let mut host_result = [0.0_f64];
+    scratch
+        .measure_result
+        .as_ref()
+        .unwrap()
+        .copy_to_host(device, &mut host_result)?;
+    let prob_raw = host_result[0];
     let norm_sq = state.pending_norm() * state.pending_norm();
     Ok((prob_raw * norm_sq).clamp(0.0, 1.0))
 }
@@ -1393,12 +1443,10 @@ pub(crate) fn launch_apply_multi_fused_diagonal(
         shared_mem_bytes: 0,
     };
 
-    let targets_dev = stream
-        .clone_htod(&targets)
-        .map_err(|e| launch_err("upload targets", e))?;
-    let diags_dev = stream
-        .clone_htod(&diags)
-        .map_err(|e| launch_err("upload diags", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let targets_buf = super::ensure_scratch(&mut scratch.i32_a, device, &targets)?;
+    let diags_buf = super::ensure_scratch(&mut scratch.f64_a, device, &diags)?;
 
     let num_gates_i = num_gates as i32;
     let mut builder = stream.launch_builder(&func);
@@ -1406,11 +1454,11 @@ pub(crate) fn launch_apply_multi_fused_diagonal(
     builder
         .arg(buffer)
         .arg(&dim)
-        .arg(&targets_dev)
-        .arg(&diags_dev)
+        .arg(targets_buf.raw())
+        .arg(diags_buf.raw())
         .arg(&num_gates_i);
     // SAFETY: signature matches; targets has num_gates i32s; diags has 2*num_gates double2s
-    // (= 4*num_gates f64s); grid covers dim.
+    // (= 4*num_gates f64s); grid covers dim. Buffers held by the scratch guard.
     unsafe {
         builder
             .launch(cfg)
@@ -1490,15 +1538,11 @@ pub(crate) fn launch_apply_batch_phase(
         shared_mem_bytes: 0,
     };
 
-    let tables_dev = stream
-        .clone_htod(&tables_flat)
-        .map_err(|e| launch_err("upload batch_phase tables", e))?;
-    let shifts_dev = stream
-        .clone_htod(&shifts_flat)
-        .map_err(|e| launch_err("upload batch_phase shifts", e))?;
-    let lens_dev = stream
-        .clone_htod(&lens)
-        .map_err(|e| launch_err("upload batch_phase lens", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let tables_buf = super::ensure_scratch(&mut scratch.f64_a, device, &tables_flat)?;
+    let shifts_buf = super::ensure_scratch(&mut scratch.i32_a, device, &shifts_flat)?;
+    let lens_buf = super::ensure_scratch(&mut scratch.i32_b, device, &lens)?;
 
     let control_i = control as i32;
     let num_groups_i = num_groups as i32;
@@ -1508,11 +1552,12 @@ pub(crate) fn launch_apply_batch_phase(
         .arg(buffer)
         .arg(&half_count)
         .arg(&control_i)
-        .arg(&tables_dev)
-        .arg(&shifts_dev)
-        .arg(&lens_dev)
+        .arg(tables_buf.raw())
+        .arg(shifts_buf.raw())
+        .arg(lens_buf.raw())
         .arg(&num_groups_i);
     // SAFETY: signature matches kernel; device slices sized for num_groups; grid covers half.
+    // Scratch guard keeps all three buffers alive.
     unsafe {
         builder
             .launch(cfg)
@@ -1581,18 +1626,12 @@ pub(crate) fn launch_apply_batch_rzz(
         shared_mem_bytes: 0,
     };
 
-    let tables_dev = stream
-        .clone_htod(&tables_flat)
-        .map_err(|e| launch_err("upload batch_rzz tables", e))?;
-    let q0s_dev = stream
-        .clone_htod(&q0s_flat)
-        .map_err(|e| launch_err("upload batch_rzz q0s", e))?;
-    let q1s_dev = stream
-        .clone_htod(&q1s_flat)
-        .map_err(|e| launch_err("upload batch_rzz q1s", e))?;
-    let lens_dev = stream
-        .clone_htod(&lens)
-        .map_err(|e| launch_err("upload batch_rzz lens", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let tables_buf = super::ensure_scratch(&mut scratch.f64_a, device, &tables_flat)?;
+    let q0s_buf = super::ensure_scratch(&mut scratch.i32_a, device, &q0s_flat)?;
+    let q1s_buf = super::ensure_scratch(&mut scratch.i32_b, device, &q1s_flat)?;
+    let lens_buf = super::ensure_scratch(&mut scratch.i32_c, device, &lens)?;
 
     let num_groups_i = num_groups as i32;
     let mut builder = stream.launch_builder(&func);
@@ -1600,12 +1639,13 @@ pub(crate) fn launch_apply_batch_rzz(
     builder
         .arg(buffer)
         .arg(&dim)
-        .arg(&tables_dev)
-        .arg(&q0s_dev)
-        .arg(&q1s_dev)
-        .arg(&lens_dev)
+        .arg(tables_buf.raw())
+        .arg(q0s_buf.raw())
+        .arg(q1s_buf.raw())
+        .arg(lens_buf.raw())
         .arg(&num_groups_i);
     // SAFETY: signature matches kernel; device slices sized for num_groups; grid covers dim.
+    // Scratch guard keeps all four buffers alive.
     unsafe {
         builder
             .launch(cfg)
@@ -1692,15 +1732,11 @@ pub(crate) fn launch_apply_diagonal_batch(
         shared_mem_bytes: 0,
     };
 
-    let tables_dev = stream
-        .clone_htod(&tables_flat)
-        .map_err(|e| launch_err("upload diag_batch tables", e))?;
-    let shifts_dev = stream
-        .clone_htod(&shifts_flat)
-        .map_err(|e| launch_err("upload diag_batch shifts", e))?;
-    let lens_dev = stream
-        .clone_htod(&lens)
-        .map_err(|e| launch_err("upload diag_batch lens", e))?;
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let tables_buf = super::ensure_scratch(&mut scratch.f64_a, device, &tables_flat)?;
+    let shifts_buf = super::ensure_scratch(&mut scratch.i32_a, device, &shifts_flat)?;
+    let lens_buf = super::ensure_scratch(&mut scratch.i32_b, device, &lens)?;
 
     let num_groups_i = num_groups as i32;
     let mut builder = stream.launch_builder(&func);
@@ -1708,11 +1744,12 @@ pub(crate) fn launch_apply_diagonal_batch(
     builder
         .arg(buffer)
         .arg(&dim)
-        .arg(&tables_dev)
-        .arg(&shifts_dev)
-        .arg(&lens_dev)
+        .arg(tables_buf.raw())
+        .arg(shifts_buf.raw())
+        .arg(lens_buf.raw())
         .arg(&num_groups_i);
     // SAFETY: signature matches kernel; device slices sized for num_groups; grid covers dim.
+    // Scratch guard keeps all three buffers alive.
     unsafe {
         builder
             .launch(cfg)
@@ -1813,32 +1850,35 @@ pub(crate) fn launch_apply_multi_fused_nondiag(
         shared_mem_bytes: 0,
     };
 
-    let targets_dev = stream
-        .clone_htod(&tile_targets)
-        .map_err(|e| launch_err("upload tiled targets", e))?;
-    let matrices_dev = stream
-        .clone_htod(&tile_matrices)
-        .map_err(|e| launch_err("upload tiled matrices", e))?;
-
     let num_gates_i = tile_targets.len() as i32;
-    let mut builder = stream.launch_builder(&func);
-    let buffer = state.buffer_mut().raw_mut();
-    builder
-        .arg(buffer)
-        .arg(&dim)
-        .arg(&targets_dev)
-        .arg(&matrices_dev)
-        .arg(&num_gates_i);
-    // SAFETY: signature matches kernel; num_tiles * TILE_SIZE = dim; device slices sized
-    // for num_gates; all targets checked < MULTI_FUSED_TILE_Q above.
-    unsafe {
+    {
+        let mut scratch = ctx.launcher_scratch();
+        let scratch = &mut *scratch;
+        let targets_buf = super::ensure_scratch(&mut scratch.i32_a, device, &tile_targets)?;
+        let matrices_buf = super::ensure_scratch(&mut scratch.f64_a, device, &tile_matrices)?;
+
+        let mut builder = stream.launch_builder(&func);
+        let buffer = state.buffer_mut().raw_mut();
         builder
-            .launch(cfg)
-            .map_err(|e| launch_err("apply_multi_fused_tiled", e))?;
+            .arg(buffer)
+            .arg(&dim)
+            .arg(targets_buf.raw())
+            .arg(matrices_buf.raw())
+            .arg(&num_gates_i);
+        // SAFETY: signature matches; num_tiles * TILE_SIZE = dim; device slices sized for
+        // num_gates; all targets checked < MULTI_FUSED_TILE_Q above. Scratch guard holds
+        // both buffers alive.
+        unsafe {
+            builder
+                .launch(cfg)
+                .map_err(|e| launch_err("apply_multi_fused_tiled", e))?;
+        }
     }
 
     // Third pass: launch per-gate kernels for the external (target >= TILE_Q) sub-gates
     // whose pairs span tiles. Order matters; these must run after the tiled kernel.
+    // The scratch guard from the tiled launch is dropped before re-acquiring it inside
+    // each per-gate launcher, avoiding deadlock.
     for &(target, mat) in gates {
         if target >= MULTI_FUSED_TILE_Q {
             launch_apply_gate_1q(ctx, state, target, mat)?;

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -10,6 +10,78 @@ pub(crate) mod bts;
 pub(crate) mod dense;
 pub(crate) mod stabilizer;
 
+use cudarc::driver::{DeviceRepr, ValidAsZeroBits};
+
+use crate::error::Result;
+use crate::gpu::device::GpuDevice;
+use crate::gpu::memory::GpuBuffer;
+
+/// Scratch buffers reused across launches that need to upload small per-call
+/// metadata (sorted-qubit lists, packed lookup tables, fused gate matrices).
+///
+/// Replaces the per-call `clone_htod` allocate-and-upload pattern with a
+/// grow-only resident allocation that callers fill via `copy_from_host`. The
+/// allocation is tied to the `GpuContext`; access is serialised through a
+/// `Mutex` because all dense launches share the same CUDA stream anyway.
+///
+/// Worst case across the dense launchers is one f64 buffer plus three i32
+/// buffers (`launch_apply_batch_rzz`); the four named slots cover every
+/// existing call site without sharing across overlapping arguments.
+#[derive(Default)]
+pub(crate) struct LauncherScratch {
+    pub(crate) f64_a: Option<GpuBuffer<f64>>,
+    pub(crate) i32_a: Option<GpuBuffer<i32>>,
+    pub(crate) i32_b: Option<GpuBuffer<i32>>,
+    pub(crate) i32_c: Option<GpuBuffer<i32>>,
+    pub(crate) u32_a: Option<GpuBuffer<u32>>,
+    /// Per-block partials for [`super::dense::measure_prob_one`]. Sized by the
+    /// number of grid blocks at the largest qubit count seen so far.
+    pub(crate) measure_partials: Option<GpuBuffer<f64>>,
+    /// One-element output for the measure-prob finalize reduction.
+    pub(crate) measure_result: Option<GpuBuffer<f64>>,
+}
+
+/// Ensure `slot` has at least `host.len()` elements allocated, growing if not,
+/// and copy `host` into the slot. Returns the device buffer for argument
+/// passing.
+pub(crate) fn ensure_scratch<'a, T: DeviceRepr + ValidAsZeroBits>(
+    slot: &'a mut Option<GpuBuffer<T>>,
+    device: &GpuDevice,
+    host: &[T],
+) -> Result<&'a GpuBuffer<T>> {
+    let needed = host.len().max(1);
+    let realloc = match slot.as_ref() {
+        Some(buf) => buf.len() < needed,
+        None => true,
+    };
+    if realloc {
+        *slot = Some(GpuBuffer::<T>::alloc_zeros(device, needed)?);
+    }
+    if !host.is_empty() {
+        slot.as_mut().unwrap().copy_from_host(device, host)?;
+    }
+    Ok(slot.as_ref().unwrap())
+}
+
+/// Ensure `slot` has at least `needed` elements allocated, growing if not.
+/// Returns a mutable reference suitable for kernel write-targets. Unlike
+/// [`ensure_scratch`], does not perform any host-to-device copy.
+pub(crate) fn ensure_capacity<'a, T: DeviceRepr + ValidAsZeroBits>(
+    slot: &'a mut Option<GpuBuffer<T>>,
+    device: &GpuDevice,
+    needed: usize,
+) -> Result<&'a mut GpuBuffer<T>> {
+    let needed = needed.max(1);
+    let realloc = match slot.as_ref() {
+        Some(buf) => buf.len() < needed,
+        None => true,
+    };
+    if realloc {
+        *slot = Some(GpuBuffer::<T>::alloc_zeros(device, needed)?);
+    }
+    Ok(slot.as_mut().unwrap())
+}
+
 /// Combined CUDA C source for the GPU PTX module.
 ///
 /// Concatenates each backend's kernel source. Any new backend that adds its own
@@ -44,6 +116,7 @@ pub(crate) const KERNEL_NAMES: &[&str] = &[
     "apply_mcu_phase",
     "apply_fused_2q",
     "measure_prob_one",
+    "measure_prob_one_finalize",
     "measure_collapse",
     "compute_probabilities",
     "scale_state",

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -162,9 +162,17 @@ pub fn stabilizer_min_qubits() -> usize {
 /// Holds the device handle and compiled kernel module. Cheap to clone via `Arc`. Pass by
 /// `Arc<GpuContext>` so multiple backends or multiple simulations can share one device
 /// initialisation.
-#[derive(Debug)]
 pub struct GpuContext {
     device: Arc<GpuDevice>,
+    launcher_scratch: std::sync::Mutex<kernels::LauncherScratch>,
+}
+
+impl std::fmt::Debug for GpuContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GpuContext")
+            .field("device", &self.device)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GpuContext {
@@ -173,7 +181,10 @@ impl GpuContext {
     /// Compiles the kernel module at construction. Subsequent calls reuse the cached PTX.
     pub fn new(device_id: usize) -> Result<Arc<Self>> {
         let device = Arc::new(GpuDevice::new(device_id)?);
-        Ok(Arc::new(Self { device }))
+        Ok(Arc::new(Self {
+            device,
+            launcher_scratch: std::sync::Mutex::new(kernels::LauncherScratch::default()),
+        }))
     }
 
     /// Whether a CUDA device is present and usable.
@@ -225,10 +236,17 @@ impl GpuContext {
         &self.device
     }
 
+    pub(crate) fn launcher_scratch(&self) -> std::sync::MutexGuard<'_, kernels::LauncherScratch> {
+        self.launcher_scratch
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[cfg(test)]
     pub(crate) fn stub_for_tests() -> Arc<Self> {
         Arc::new(Self {
             device: Arc::new(GpuDevice::stub_for_tests()),
+            launcher_scratch: std::sync::Mutex::new(kernels::LauncherScratch::default()),
         })
     }
 }


### PR DESCRIPTION
## Summary

Cache small GPU launcher metadata in `GpuContext` scratch buffers instead of allocating fresh device buffers for every dense launch. Move the final measurement probability partials sum onto the GPU so the hot path reads back one `f64` instead of the full partials buffer.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| gpu/qaoa_l3/16 | 1.51 ms | 1.22 ms | 14.9% faster, p = 0.00 | Yes |
| gpu/mid_measure/16 | 11.22 ms | 6.75 ms | 39.5% faster, p = 0.00 | Yes |
| gpu/qft_textbook/16 | 1.41 ms | 1.45 ms | 2.4%, within noise | Yes |
| gpu/random_d10/16 | 0.811 ms | 0.833 ms | 1.8%, within noise | Yes |
| gpu/hea_l5/16 | 2.02 ms | 2.05 ms | wide CI, not significant | Yes |
| 10q rows | various | various | within noise | Yes |


## Correctness

- [x] `cargo test --all-features` passes locally, 825 library tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes
- [x] New public API has docstrings, N/A
- [x] New gate, backend, or fusion pass has golden tests, N/A
- [x] `cargo test --features "parallel gpu" --test golden_gpu` passes

## Hotspot notes

Affected hot paths include dense GPU metadata launchers, `kernels::LauncherScratch`, `kernels::ensure_scratch`, `kernels::ensure_capacity`, `dense::launch_apply_batch_rzz`, and `dense::measure_prob_one`.

No separate profiler output attached.

## Breaking changes

None.

## Risks and rollback

Risk is limited to dense GPU launch paths that reuse context-level scratch buffers. The shared CUDA stream preserves copy, launch, and readback ordering. Future multi-stream dispatch must use per-stream scratch or stronger metadata buffer ownership.

Measurement probability now uses a different floating-point reduction order, so tiny rounding differences can occur within existing tolerances.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [x] CI is green
