### PR TITLE
fix: enforce qubit bounds and finite gate parameters in release builds

### DIFF
--- a/src/circuit/expr.rs
+++ b/src/circuit/expr.rs
@@ -275,6 +275,17 @@ pub(super) fn eval_expr(
             ),
         });
     }
+    if !val.is_finite() {
+        return Err(PrismError::Parse {
+            line: line_num,
+            message: format!(
+                "expression `{}` evaluates to {} (must be finite); this typically \
+                 means a divide by zero, log/sqrt of a non-positive value, or an \
+                 overflow",
+                s, val
+            ),
+        });
+    }
     Ok(val)
 }
 

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -47,12 +47,14 @@ impl Circuit {
 
     /// Append a gate operation.
     ///
-    /// # Panics (debug only)
-    /// Debug-asserts that all target indices are within bounds and that the
-    /// gate arity matches the target count.
+    /// # Panics
+    /// Panics if any target index is out of bounds or if the gate's arity
+    /// does not match `targets.len()`. Bounds checks run in both debug and
+    /// release builds: a bad index propagates into kernel pointer math and
+    /// would corrupt or read uninitialised memory otherwise.
     #[inline]
     pub fn add_gate(&mut self, gate: Gate, targets: &[usize]) {
-        debug_assert_eq!(
+        assert_eq!(
             gate.num_qubits(),
             targets.len(),
             "gate `{}` expects {} qubits, got {}",
@@ -60,10 +62,14 @@ impl Circuit {
             gate.num_qubits(),
             targets.len()
         );
-        debug_assert!(
-            targets.iter().all(|&t| t < self.num_qubits),
-            "qubit index out of bounds"
-        );
+        for &t in targets {
+            assert!(
+                t < self.num_qubits,
+                "qubit index {} out of bounds (circuit has {} qubits)",
+                t,
+                self.num_qubits
+            );
+        }
         self.instructions.push(Instruction::Gate {
             gate,
             targets: SmallVec::from_slice(targets),
@@ -71,12 +77,22 @@ impl Circuit {
     }
 
     /// Append a measurement operation.
+    ///
+    /// # Panics
+    /// Panics if `qubit` or `classical_bit` is out of bounds.
     #[inline]
     pub fn add_measure(&mut self, qubit: usize, classical_bit: usize) {
-        debug_assert!(qubit < self.num_qubits, "qubit index out of bounds");
-        debug_assert!(
+        assert!(
+            qubit < self.num_qubits,
+            "qubit index {} out of bounds (circuit has {} qubits)",
+            qubit,
+            self.num_qubits
+        );
+        assert!(
             classical_bit < self.num_classical_bits,
-            "classical bit index out of bounds"
+            "classical bit index {} out of bounds (circuit has {} classical bits)",
+            classical_bit,
+            self.num_classical_bits
         );
         self.instructions.push(Instruction::Measure {
             qubit,
@@ -85,15 +101,34 @@ impl Circuit {
     }
 
     /// Append a reset operation, returning the qubit to |0⟩.
+    ///
+    /// # Panics
+    /// Panics if `qubit` is out of bounds.
     #[inline]
     pub fn add_reset(&mut self, qubit: usize) {
-        debug_assert!(qubit < self.num_qubits, "qubit index out of bounds");
+        assert!(
+            qubit < self.num_qubits,
+            "qubit index {} out of bounds (circuit has {} qubits)",
+            qubit,
+            self.num_qubits
+        );
         self.instructions.push(Instruction::Reset { qubit });
     }
 
     /// Append a barrier (scheduling hint, no physical operation).
+    ///
+    /// # Panics
+    /// Panics if any qubit index is out of bounds.
     #[inline]
     pub fn add_barrier(&mut self, qubits: &[usize]) {
+        for &q in qubits {
+            assert!(
+                q < self.num_qubits,
+                "qubit index {} out of bounds (circuit has {} qubits)",
+                q,
+                self.num_qubits
+            );
+        }
         self.instructions.push(Instruction::Barrier {
             qubits: SmallVec::from_slice(qubits),
         });
@@ -942,5 +977,54 @@ mod tests {
         } else {
             panic!("expected gate instruction");
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "qubit index 5 out of bounds (circuit has 3 qubits)")]
+    fn add_gate_panics_on_out_of_bounds_target_in_release() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "qubit index 4 out of bounds (circuit has 3 qubits)")]
+    fn add_gate_panics_on_second_target_out_of_bounds() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::Cx, &[0, 4]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expects 2 qubits, got 1")]
+    fn add_gate_panics_on_arity_mismatch() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::Cx, &[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "qubit index 2 out of bounds (circuit has 2 qubits)")]
+    fn add_measure_panics_on_out_of_bounds_qubit() {
+        let mut c = Circuit::new(2, 2);
+        c.add_measure(2, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "classical bit index 5 out of bounds (circuit has 2 classical bits)")]
+    fn add_measure_panics_on_out_of_bounds_classical_bit() {
+        let mut c = Circuit::new(2, 2);
+        c.add_measure(0, 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "qubit index 9 out of bounds (circuit has 2 qubits)")]
+    fn add_reset_panics_on_out_of_bounds() {
+        let mut c = Circuit::new(2, 0);
+        c.add_reset(9);
+    }
+
+    #[test]
+    #[should_panic(expected = "qubit index 7 out of bounds (circuit has 4 qubits)")]
+    fn add_barrier_panics_on_out_of_bounds() {
+        let mut c = Circuit::new(4, 0);
+        c.add_barrier(&[0, 7]);
     }
 }

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -1435,3 +1435,82 @@ fn test_split_top_level_commas_simple() {
     let parts = split_top_level_commas("pi/2, pi/4, 0.1");
     assert_eq!(parts.len(), 3);
 }
+
+#[test]
+fn rx_with_arithmetic_overflow_rejected_as_non_finite() {
+    // Pure arithmetic overflow: each literal is finite, but the product
+    // exceeds f64::MAX. The top-level eval_expr finiteness check catches this
+    // path; the per-function and per-literal checks do not.
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        rx(1e308 * 1e308) q[0];
+    "#;
+    let err = parse(qasm).expect_err("expected non-finite parameter rejection");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("must be finite"),
+        "expected finiteness error, got: {msg}"
+    );
+}
+
+#[test]
+fn rx_with_sqrt_of_negative_rejected_as_non_finite() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        rx(sqrt(-1)) q[0];
+    "#;
+    let err = parse(qasm).expect_err("expected non-finite parameter rejection");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("non-finite"),
+        "expected finiteness error, got: {msg}"
+    );
+}
+
+#[test]
+fn rx_with_acos_out_of_domain_rejected_as_non_finite() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        rx(acos(2)) q[0];
+    "#;
+    let err = parse(qasm).expect_err("expected non-finite parameter rejection");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("non-finite"),
+        "expected finiteness error, got: {msg}"
+    );
+}
+
+#[test]
+fn rx_with_division_by_zero_rejected() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        rx(1.0 / (1.0 - 1.0)) q[0];
+    "#;
+    let err = parse(qasm).expect_err("expected division-by-zero rejection");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("division by zero"),
+        "expected division-by-zero error, got: {msg}"
+    );
+}
+
+#[test]
+fn rx_with_finite_expression_still_parses() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[1] q;
+        rx(pi/4) q[0];
+    "#;
+    let c = parse(qasm).unwrap();
+    assert_eq!(c.gate_count(), 1);
+}


### PR DESCRIPTION
Being lazy, this is just a fix for qubit and gate parameter bounds.