### PR TITLE
perf(statevector): fuse repeated 2q blocks and optimize adjacent fused gates

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -335,6 +335,38 @@ fn bench_statevector_qaoa(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_statevector_qv(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statevector/qv");
+    configure_group(&mut group);
+
+    for &n in &[8, 12, 16, 20] {
+        let circuit = circuits::quantum_volume_circuit(n, n, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_statevector_w_state(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statevector/w_state");
+    configure_group(&mut group);
+
+    for &n in &[8, 12, 16, 20] {
+        let circuit = circuits::w_state_circuit(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 // ---- Statevector: depth sweep ----
 
 fn bench_statevector_depth_sweep(c: &mut Criterion) {
@@ -1366,6 +1398,8 @@ criterion_group!(
     bench_statevector_qpe,
     bench_statevector_hea,
     bench_statevector_qaoa,
+    bench_statevector_qv,
+    bench_statevector_w_state,
     bench_statevector_clifford,
     bench_statevector_depth_sweep,
     bench_statevector_entanglement,

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1389,7 +1389,7 @@ unsafe fn apply_fused_2q_loop_fma(
     }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "parallel"))]
+#[cfg(target_arch = "x86_64")]
 #[inline]
 #[target_feature(enable = "fma")]
 unsafe fn apply_fused_2q_group_fma(state: *mut f64, i: [usize; 4], mat: &Mat4x4Broadcast) {
@@ -1626,12 +1626,12 @@ impl PreparedGate2q {
         }
     }
 
-    /// Apply one group at scattered indices. Safe to call from Rayon closures.
+    /// Apply one group at scattered indices. Safe to call from Rayon closures
+    /// when callers partition indices across threads.
     ///
     /// # Safety
     /// Caller must ensure `i[0..4]` are valid indices into the state array
     /// and that no other thread is accessing the same indices.
-    #[cfg(feature = "parallel")]
     #[inline(always)]
     pub(crate) unsafe fn apply_group_ptr(&self, state: *mut f64, i: [usize; 4]) {
         #[cfg(target_arch = "x86_64")]

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -37,6 +37,25 @@ const fn max_target_for_tile(tile_size: usize) -> usize {
     t - 1
 }
 
+#[inline(always)]
+fn adjacent_2q_indices(offset: usize, stride: usize, q0_is_lo: bool) -> [usize; 4] {
+    if q0_is_lo {
+        [
+            offset,
+            offset + (stride << 1),
+            offset + stride,
+            offset + (stride * 3),
+        ]
+    } else {
+        [
+            offset,
+            offset + stride,
+            offset + (stride << 1),
+            offset + (stride * 3),
+        ]
+    }
+}
+
 pub(crate) const BATCH_PHASE_GROUP_SIZE: usize = 10;
 pub(crate) const BATCH_PHASE_TABLE_SIZE: usize = 1024;
 pub(crate) const MAX_BATCH_PHASE_GROUPS: usize = 4;
@@ -1164,6 +1183,17 @@ impl StatevectorBackend {
 
     #[inline(always)]
     pub(super) fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        if q0.max(q1) - q0.min(q1) == 1 {
+            #[cfg(feature = "parallel")]
+            if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+                self.apply_fused_2q_adjacent_par(q0, q1, mat);
+                return;
+            }
+
+            self.apply_fused_2q_adjacent(q0, q1, mat);
+            return;
+        }
+
         #[cfg(feature = "parallel")]
         if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
             self.apply_fused_2q_par(q0, q1, mat);
@@ -1172,6 +1202,55 @@ impl StatevectorBackend {
 
         let prepared = simd::PreparedGate2q::new(mat);
         prepared.apply_full(&mut self.state, self.num_qubits, q0, q1);
+    }
+
+    #[inline(always)]
+    fn apply_fused_2q_adjacent(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        let lo = q0.min(q1);
+        let stride = 1usize << lo;
+        let block_size = stride << 2;
+        let q0_is_lo = q0 == lo;
+        let prepared = simd::PreparedGate2q::new(mat);
+
+        for chunk in self.state.chunks_mut(block_size) {
+            let ptr = chunk.as_mut_ptr() as *mut f64;
+            for offset in 0..stride {
+                let i = adjacent_2q_indices(offset, stride, q0_is_lo);
+                // SAFETY: each offset maps to one disjoint 4-amplitude group in
+                // this chunk, and all indices are below block_size.
+                unsafe {
+                    prepared.apply_group_ptr(ptr, i);
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn apply_fused_2q_adjacent_group(
+        ptr: SendPtr,
+        group: usize,
+        lo: usize,
+        stride: usize,
+        block_size: usize,
+        q0_is_lo: bool,
+        prepared: &simd::PreparedGate2q,
+    ) {
+        let block = group >> lo;
+        let offset = group & (stride - 1);
+        let base = block * block_size;
+        let local = adjacent_2q_indices(offset, stride, q0_is_lo);
+        let i = [
+            base + local[0],
+            base + local[1],
+            base + local[2],
+            base + local[3],
+        ];
+        // SAFETY: adjacent group mapping partitions the state into disjoint
+        // 4-amplitude groups, and group < state.len() / 4.
+        unsafe {
+            prepared.apply_group_ptr(ptr.as_f64_ptr(), i);
+        }
     }
 
     #[cfg(feature = "parallel")]
@@ -1195,6 +1274,27 @@ impl StatevectorBackend {
                 unsafe {
                     prepared.apply_group_ptr(ptr.as_f64_ptr(), i);
                 }
+            });
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn apply_fused_2q_adjacent_par(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        let lo = q0.min(q1);
+        let stride = 1usize << lo;
+        let block_size = stride << 2;
+        let q0_is_lo = q0 == lo;
+        let n_groups = self.state.len() >> 2;
+        let ptr = SendPtr(self.state.as_mut_ptr());
+        let prepared = simd::PreparedGate2q::new(mat);
+
+        (0..n_groups)
+            .into_par_iter()
+            .with_min_len(MIN_PAR_ITERS)
+            .for_each(move |group| {
+                Self::apply_fused_2q_adjacent_group(
+                    ptr, group, lo, stride, block_size, q0_is_lo, &prepared,
+                );
             });
     }
 

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -17,6 +17,28 @@ fn assert_probs_close(actual: &[f64], expected: &[f64], eps: f64) {
     }
 }
 
+fn assert_state_close(actual: &[Complex64], expected: &[Complex64], eps: f64) {
+    assert_eq!(actual.len(), expected.len(), "state vector length mismatch");
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (*a - *e).norm() < eps,
+            "amp[{i}]: expected {e}, got {a} (diff {})",
+            (*a - *e).norm()
+        );
+    }
+}
+
+fn run_manual_state(circuit: &Circuit) -> Vec<Complex64> {
+    let mut backend = StatevectorBackend::new(42);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    for inst in &circuit.instructions {
+        backend.apply(inst).unwrap();
+    }
+    backend.export_statevector().unwrap()
+}
+
 #[test]
 fn test_x_gate() {
     let mut c = Circuit::new(1, 0);
@@ -205,6 +227,67 @@ fn test_cu_matches_cx() {
     for (a, b) in sv1.iter().zip(sv2) {
         assert!((a - b).norm() < 1e-12);
     }
+}
+
+#[test]
+fn test_adjacent_fused_2q_matches_cx_low_high() {
+    let mut fused = Circuit::new(6, 0);
+    fused.add_gate(Gate::H, &[2]);
+    fused.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[2, 3]);
+
+    let mut direct = Circuit::new(6, 0);
+    direct.add_gate(Gate::H, &[2]);
+    direct.add_gate(Gate::Cx, &[2, 3]);
+
+    let fused_state = run_manual_state(&fused);
+    let direct_state = run_manual_state(&direct);
+    assert_state_close(&fused_state, &direct_state, 1e-12);
+}
+
+#[test]
+fn test_adjacent_fused_2q_matches_cx_high_low() {
+    let mut fused = Circuit::new(6, 0);
+    fused.add_gate(Gate::H, &[3]);
+    fused.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[3, 2]);
+
+    let mut direct = Circuit::new(6, 0);
+    direct.add_gate(Gate::H, &[3]);
+    direct.add_gate(Gate::Cx, &[3, 2]);
+
+    let fused_state = run_manual_state(&fused);
+    let direct_state = run_manual_state(&direct);
+    assert_state_close(&fused_state, &direct_state, 1e-12);
+}
+
+#[test]
+fn test_nonadjacent_fused_2q_fallback_matches_cx() {
+    let mut fused = Circuit::new(6, 0);
+    fused.add_gate(Gate::H, &[0]);
+    fused.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, 2]);
+
+    let mut direct = Circuit::new(6, 0);
+    direct.add_gate(Gate::H, &[0]);
+    direct.add_gate(Gate::Cx, &[0, 2]);
+
+    let fused_state = run_manual_state(&fused);
+    let direct_state = run_manual_state(&direct);
+    assert_state_close(&fused_state, &direct_state, 1e-12);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn test_parallel_adjacent_fused_2q_20q() {
+    let mut fused = Circuit::new(20, 0);
+    fused.add_gate(Gate::H, &[17]);
+    fused.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[17, 18]);
+
+    let mut direct = Circuit::new(20, 0);
+    direct.add_gate(Gate::H, &[17]);
+    direct.add_gate(Gate::Cx, &[17, 18]);
+
+    let fused_state = run_manual_state(&fused);
+    let direct_state = run_manual_state(&direct);
+    assert_state_close(&fused_state, &direct_state, 1e-12);
 }
 
 #[cfg(feature = "parallel")]

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -810,6 +810,183 @@ fn classify_2q_tier(q0: usize, q1: usize) -> Tier2q {
     }
 }
 
+#[inline]
+fn swap_order_4x4(mat: &[[Complex64; 4]; 4]) -> [[Complex64; 4]; 4] {
+    let swap = Gate::Swap.matrix_4x4();
+    mat_mul_4x4(&swap, &mat_mul_4x4(mat, &swap))
+}
+
+#[inline]
+fn is_diagonal_4x4(mat: &[[Complex64; 4]; 4]) -> bool {
+    for (r, row) in mat.iter().enumerate() {
+        for (c, value) in row.iter().enumerate() {
+            if r != c && value.norm() >= IDENTITY_EPS {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[inline]
+fn same_unordered_pair(a0: usize, a1: usize, b0: usize, b1: usize) -> bool {
+    (a0 == b0 && a1 == b1) || (a0 == b1 && a1 == b0)
+}
+
+#[inline]
+fn orient_2q_matrix(
+    mat: &[[Complex64; 4]; 4],
+    targets: &[usize],
+    q0: usize,
+    q1: usize,
+) -> [[Complex64; 4]; 4] {
+    if targets[0] == q0 && targets[1] == q1 {
+        *mat
+    } else {
+        swap_order_4x4(mat)
+    }
+}
+
+#[inline]
+fn embed_1q_matrix(mat: &[[Complex64; 2]; 2], target: usize, q0: usize) -> [[Complex64; 4]; 4] {
+    let id = Gate::Id.matrix_2x2();
+    if target == q0 {
+        kron_2x2(mat, &id)
+    } else {
+        kron_2x2(&id, mat)
+    }
+}
+
+struct PairRun {
+    q0: usize,
+    q1: usize,
+    acc: [[Complex64; 4]; 4],
+    fused_2q_count: usize,
+    has_nondiagonal_2q: bool,
+    originals: Vec<Instruction>,
+}
+
+impl PairRun {
+    fn new(q0: usize, q1: usize, mat: [[Complex64; 4]; 4], original: Instruction) -> Self {
+        Self {
+            q0,
+            q1,
+            acc: mat,
+            fused_2q_count: 1,
+            has_nondiagonal_2q: !is_diagonal_4x4(&mat),
+            originals: vec![original],
+        }
+    }
+
+    #[inline]
+    fn can_accept_pair(&self, q0: usize, q1: usize) -> bool {
+        same_unordered_pair(self.q0, self.q1, q0, q1)
+    }
+
+    #[inline]
+    fn can_accept_1q(&self, q: usize) -> bool {
+        q == self.q0 || q == self.q1
+    }
+
+    fn push_2q(&mut self, mat: [[Complex64; 4]; 4], targets: &[usize], original: Instruction) {
+        let oriented = orient_2q_matrix(&mat, targets, self.q0, self.q1);
+        self.acc = mat_mul_4x4(&oriented, &self.acc);
+        self.fused_2q_count += 1;
+        self.has_nondiagonal_2q |= !is_diagonal_4x4(&oriented);
+        self.originals.push(original);
+    }
+
+    fn push_1q(&mut self, mat: [[Complex64; 2]; 2], target: usize, original: Instruction) {
+        let embedded = embed_1q_matrix(&mat, target, self.q0);
+        self.acc = mat_mul_4x4(&embedded, &self.acc);
+        self.originals.push(original);
+    }
+
+    fn should_fuse(&self) -> bool {
+        self.fused_2q_count >= 2 && self.has_nondiagonal_2q
+    }
+}
+
+fn flush_pair_run(run: &mut Option<PairRun>, output: &mut Vec<Instruction>, changed: &mut bool) {
+    let Some(run) = run.take() else {
+        return;
+    };
+    if run.should_fuse() {
+        output.push(Instruction::Gate {
+            gate: Gate::Fused2q(Box::new(run.acc)),
+            targets: smallvec![run.q0, run.q1],
+        });
+        *changed = true;
+    } else {
+        output.extend(run.originals);
+    }
+}
+
+/// Fuse contiguous same-pair `Fused2q` runs into one larger `Fused2q`.
+///
+/// This pass is deliberately narrow: it only consumes existing `Fused2q` gates
+/// and single-qubit gates on the same two qubits, and only emits a fused block
+/// when at least two 2q units are present. All-diagonal runs are left alone so
+/// diagonal batch passes keep their cheaper kernels.
+fn fuse_same_pair_2q_blocks(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
+    let circuit = input.as_ref();
+    let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
+    let mut run: Option<PairRun> = None;
+    let mut changed = false;
+
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate {
+                gate: Gate::Fused2q(mat),
+                targets,
+            } => {
+                if let Some(active) = &mut run {
+                    if active.can_accept_pair(targets[0], targets[1]) {
+                        active.push_2q(**mat, targets, inst.clone());
+                    } else {
+                        flush_pair_run(&mut run, &mut output, &mut changed);
+                        run = Some(PairRun::new(targets[0], targets[1], **mat, inst.clone()));
+                    }
+                } else {
+                    run = Some(PairRun::new(targets[0], targets[1], **mat, inst.clone()));
+                }
+            }
+            Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
+                if let Some(active) = &mut run {
+                    if active.can_accept_1q(targets[0]) {
+                        let mat = match gate {
+                            Gate::Fused(m) => **m,
+                            _ => gate.matrix_2x2(),
+                        };
+                        active.push_1q(mat, targets[0], inst.clone());
+                    } else {
+                        flush_pair_run(&mut run, &mut output, &mut changed);
+                        output.push(inst.clone());
+                    }
+                } else {
+                    output.push(inst.clone());
+                }
+            }
+            _ => {
+                flush_pair_run(&mut run, &mut output, &mut changed);
+                output.push(inst.clone());
+            }
+        }
+    }
+
+    flush_pair_run(&mut run, &mut output, &mut changed);
+
+    if changed {
+        Cow::Owned(Circuit {
+            num_qubits: circuit.num_qubits,
+            num_classical_bits: circuit.num_classical_bits,
+            instructions: output,
+        })
+    } else {
+        input
+    }
+}
+
 /// Batch consecutive `Fused2q` gates into `Multi2q` for cache-tiled execution.
 ///
 /// Scans for runs of consecutive `Fused2q` instructions within the same cache
@@ -1120,10 +1297,15 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
     } else {
         pass1f
     };
-    let pass2 = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_FUSION {
-        fuse_multi_1q_gates(pass_2q)
+    let pass_2qb = if circuit.num_qubits >= MIN_QUBITS_FOR_2Q_FUSION {
+        fuse_same_pair_2q_blocks(pass_2q)
     } else {
         pass_2q
+    };
+    let pass2 = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_FUSION {
+        fuse_multi_1q_gates(pass_2qb)
+    } else {
+        pass_2qb
     };
     let pass_m2q = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION {
         fuse_multi_2q_gates(pass2)
@@ -1170,6 +1352,22 @@ mod tests {
         let zero = Complex64::new(0.0, 0.0);
         let one = Complex64::new(1.0, 0.0);
         [[one, zero], [zero, one]]
+    }
+
+    fn count_fused_2q(circuit: &Circuit) -> usize {
+        circuit
+            .instructions
+            .iter()
+            .filter(|inst| {
+                matches!(
+                    inst,
+                    Instruction::Gate {
+                        gate: Gate::Fused2q(_),
+                        ..
+                    }
+                )
+            })
+            .count()
     }
 
     #[test]
@@ -2107,6 +2305,77 @@ mod tests {
             .filter(|i| matches!(i, Instruction::Gate { .. }))
             .count();
         assert_eq!(gate_count, 1, "CZ pair should cancel after reorder");
+    }
+
+    #[test]
+    fn same_pair_2q_block_fuses_w_state_pairs() {
+        let circuit = crate::circuits::w_state_circuit(20);
+        let pass_2q = fuse_2q_gates(Cow::Borrowed(&circuit));
+        let before = count_fused_2q(&pass_2q);
+        let fused = fuse_same_pair_2q_blocks(pass_2q);
+        let after = count_fused_2q(&fused);
+
+        assert!(before >= 2, "w-state should expose paired Fused2q gates");
+        assert!(
+            after < before,
+            "same-pair block fusion should reduce Fused2q count"
+        );
+    }
+
+    #[test]
+    fn same_pair_2q_block_fuses_qv_blocks() {
+        let circuit = crate::circuits::quantum_volume_circuit(20, 1, 42);
+        let pass_2q = fuse_2q_gates(Cow::Borrowed(&circuit));
+        let before = count_fused_2q(&pass_2q);
+        let fused = fuse_same_pair_2q_blocks(pass_2q);
+        let after = count_fused_2q(&fused);
+
+        assert!(before >= 2, "qv block should expose paired Fused2q gates");
+        assert!(
+            after < before,
+            "same-pair block fusion should reduce Fused2q count"
+        );
+    }
+
+    #[test]
+    fn same_pair_2q_block_accepts_reversed_targets() {
+        let mut circuit = Circuit::new(20, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_gate(Gate::Ry(0.7), &[1]);
+        circuit.add_gate(Gate::Cx, &[1, 0]);
+
+        let pass_2q = fuse_2q_gates(Cow::Borrowed(&circuit));
+        let before = count_fused_2q(&pass_2q);
+        let fused = fuse_same_pair_2q_blocks(pass_2q);
+        let after = count_fused_2q(&fused);
+
+        assert_eq!(before, 2);
+        assert_eq!(after, 1, "reversed pair order should still fuse");
+        assert!(matches!(
+            &fused.instructions[0],
+            Instruction::Gate {
+                gate: Gate::Fused2q(_),
+                targets
+            } if targets.as_slice() == [0, 1]
+        ));
+    }
+
+    #[test]
+    fn same_pair_2q_block_leaves_diagonal_runs() {
+        let mut circuit = Circuit::new(20, 0);
+        circuit.add_gate(Gate::Rz(0.3), &[0]);
+        circuit.add_gate(Gate::Cz, &[0, 1]);
+        circuit.add_gate(Gate::T, &[1]);
+        circuit.add_gate(Gate::Cz, &[1, 0]);
+
+        let pass_2q = fuse_2q_gates(Cow::Borrowed(&circuit));
+        let before = count_fused_2q(&pass_2q);
+        let fused = fuse_same_pair_2q_blocks(pass_2q);
+        let after = count_fused_2q(&fused);
+
+        assert_eq!(before, 2);
+        assert_eq!(after, 2, "all-diagonal Fused2q runs should stay split");
     }
 
     #[test]

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -5,6 +5,7 @@
 //! **unfused** execution (manual backend.apply loop) against **fused** execution
 //! (sim::run_on, which applies the full fusion pipeline internally).
 
+use num_complex::Complex64;
 use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::backend::Backend;
 use prism_q::circuit::Circuit;
@@ -33,6 +34,23 @@ fn run_fused(circuit: &Circuit) -> Vec<f64> {
     backend.probabilities().unwrap()
 }
 
+fn run_unfused_state(circuit: &Circuit) -> Vec<Complex64> {
+    let mut backend = StatevectorBackend::new(42);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    for instr in &circuit.instructions {
+        backend.apply(instr).unwrap();
+    }
+    backend.export_statevector().unwrap()
+}
+
+fn run_fused_state(circuit: &Circuit) -> Vec<Complex64> {
+    let mut backend = StatevectorBackend::new(42);
+    sim::run_on(&mut backend, circuit).unwrap();
+    backend.export_statevector().unwrap()
+}
+
 fn assert_probs_close(actual: &[f64], expected: &[f64], eps: f64) {
     assert_eq!(actual.len(), expected.len(), "length mismatch");
     for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
@@ -44,10 +62,27 @@ fn assert_probs_close(actual: &[f64], expected: &[f64], eps: f64) {
     }
 }
 
+fn assert_state_close(actual: &[Complex64], expected: &[Complex64], eps: f64) {
+    assert_eq!(actual.len(), expected.len(), "state vector length mismatch");
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (*a - *e).norm() < eps,
+            "amp[{i}]: expected {e}, got {a} (diff {})",
+            (*a - *e).norm()
+        );
+    }
+}
+
 fn assert_fusion_preserves_correctness(circuit: &Circuit) {
     let unfused = run_unfused(circuit);
     let fused = run_fused(circuit);
     assert_probs_close(&fused, &unfused, EPS);
+}
+
+fn assert_fusion_preserves_state(circuit: &Circuit) {
+    let unfused = run_unfused_state(circuit);
+    let fused = run_fused_state(circuit);
+    assert_state_close(&fused, &unfused, EPS);
 }
 
 // ===== QFT =====
@@ -528,6 +563,89 @@ fn fusion_2q_mixed_2q_gates_20q() {
         }
     }
     assert_fusion_preserves_correctness(&c);
+}
+
+#[test]
+fn fusion_same_pair_w_state_20q() {
+    assert_fusion_preserves_correctness(&circuits::w_state_circuit(20));
+}
+
+#[test]
+fn fusion_same_pair_qv_20q() {
+    assert_fusion_preserves_correctness(&circuits::quantum_volume_circuit(20, 1, 42));
+}
+
+#[test]
+fn fusion_same_pair_reversed_targets_20q() {
+    let mut c = Circuit::new(20, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Rx(0.31), &[1]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::Rz(0.7), &[0]);
+    c.add_gate(Gate::Ry(-0.4), &[1]);
+    c.add_gate(Gate::Cx, &[1, 0]);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Rx(0.2), &[1]);
+    assert_fusion_preserves_state(&c);
+}
+
+#[test]
+fn fusion_same_pair_keeps_diagonal_batch_paths() {
+    let qaoa = circuits::qaoa_circuit(20, 3, 42);
+    let qaoa_fused = prism_q::circuit::fusion::fuse_circuit(&qaoa, true);
+    let batch_rzz = qaoa_fused
+        .instructions
+        .iter()
+        .filter(|inst| {
+            matches!(
+                inst,
+                prism_q::circuit::Instruction::Gate {
+                    gate: Gate::BatchRzz(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(batch_rzz, 3, "qaoa should keep BatchRzz fusion");
+
+    let qft = circuits::qft_circuit(20);
+    let qft_fused = prism_q::circuit::fusion::fuse_circuit(&qft, true);
+    let batch_phase = qft_fused
+        .instructions
+        .iter()
+        .filter(|inst| {
+            matches!(
+                inst,
+                prism_q::circuit::Instruction::Gate {
+                    gate: Gate::BatchPhase(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert!(batch_phase > 0, "qft should keep BatchPhase fusion");
+
+    let mut diagonal = Circuit::new(20, 0);
+    diagonal.add_gate(Gate::Rzz(0.1), &[0, 1]);
+    diagonal.add_gate(Gate::Rz(0.2), &[0]);
+    let diagonal_fused = prism_q::circuit::fusion::fuse_circuit(&diagonal, true);
+    let diagonal_batch = diagonal_fused
+        .instructions
+        .iter()
+        .filter(|inst| {
+            matches!(
+                inst,
+                prism_q::circuit::Instruction::Gate {
+                    gate: Gate::DiagonalBatch(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert!(
+        diagonal_batch > 0,
+        "diagonal runs should keep DiagonalBatch fusion"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a conservative statevector fusion pass for repeated same-pair `Fused2q` blocks and a CPU fast path for adjacent fused 2q gates. The change targets W-state and QV-style workloads by reducing repeated 4x4 applications and avoiding the generic non-adjacent index path when qubits are adjacent.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Command:
`cargo bench --bench circuits --features parallel -- "statevector/(random_d10|hea_l5|qft_textbook|qaoa_l3|qv|w_state)/20"`

Environment:
Windows 10.0.19045.0, rustc 1.93.0, Criterion default timing, `parallel` enabled, no `bench-fast`. CPU identifier: Intel64 Family 6 Model 94 Stepping 3, GenuineIntel.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- |
| `statevector/w_state/20` | 74.46 ms | 24.00 ms | 67.8% faster | Yes |
| `statevector/qv/20` | 637.40 ms | 345.45 ms | 45.8% faster | Yes |
| `statevector/random_d10/20` | 6.52 ms | 4.68 ms | 28.1% faster | Yes |
| `statevector/qaoa_l3/20` | 62.78 ms | 49.14 ms | 21.7% faster | Yes |
| `statevector/qft_textbook/20` | 62.69 ms | 49.35 ms | 21.3% faster | Yes |
| `statevector/hea_l5/20` | 119.50 ms | 94.85 ms | 20.6% faster | Yes |

Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional local checks:
- `cargo test -q --lib`
- `cargo test -q --lib --features parallel`
- `cargo test -q --test fusion_correctness`
- `cargo test -q --test fusion_correctness --features parallel`
- `cargo test -q --benches --features parallel --no-run`
- `cargo clippy --all-targets --features parallel -- -D warnings`
- `git diff --check`

## Hotspot notes

Touched hot-path functions:
- `fuse_same_pair_2q_blocks`
- `StatevectorBackend::apply_fused_2q`
- `StatevectorBackend::apply_fused_2q_adjacent`
- `StatevectorBackend::apply_fused_2q_adjacent_par`
- `PreparedGate2q::apply_group_ptr`

No flamegraph attached. Criterion timings above show the main target wins on W-state and QV workloads.

## Architecture or design changes

- [ ] `docs/architecture.md` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No public API or backend trait changes. This is an internal fusion and kernel dispatch optimization.

## Breaking changes

None.

## Risks and rollback

Risk is concentrated in matrix composition order for reversed same-pair targets and adjacent 2q index mapping. Tests cover W-state, QV-style blocks, reversed target order, diagonal batch guards, adjacent target order, parallel adjacent application, and non-adjacent fallback.

Rollback can remove the `fuse_same_pair_2q_blocks` call from `fuse_circuit` and the adjacent fast-path branch from `apply_fused_2q`, leaving existing generic `PreparedGate2q` behavior intact.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
