### PR TITLE
perf(statevector): AVX2 paired-group 2q kernel and Fused2q reorder

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ Targets use `SmallVec<[usize; 4]>`, inline storage for up to 4 qubits, no heap a
 
 ## Fusion pipeline
 
-Thirteen-pass gate optimization before execution, gated by qubit count thresholds. Every pass returns `Cow<Circuit>`. `Borrowed` when no optimization applies, so circuits that do not benefit pay zero overhead.
+Gate optimizations before execution, gated by qubit count thresholds. Every pass returns `Cow<Circuit>`. `Borrowed` when no optimization applies, so circuits that do not benefit pay zero overhead.
 
 ```text
   Input Circuit
@@ -101,9 +101,11 @@ Thirteen-pass gate optimization before execution, gated by qubit count threshold
     ├─ pass1c: cancel_self_inverse_pairs     (≥10q)    re-cancel after reorder
     ├─ pass1f: fuse_single_qubit_gates       (≥10q)    re-fuse after reorder
     │
-    ├─ pass_2q:  fuse_2q_gates              (≥20q)    CX + adjacent 1q → Fused2q
+    ├─ pass_2q:  fuse_2q_gates              (≥12q)    CX/CZ + adjacent 1q → Fused2q
+    ├─ pass_2qb: fuse_same_pair_2q_blocks   (≥12q)    same-pair Fused2q blocks → Fused2q
     ├─ pass2:    fuse_multi_1q_gates        (≥14q)    1q batch → MultiFused
-    ├─ pass_m2q: fuse_multi_2q_gates        (≥20q)    2q batch → Multi2q
+    ├─ pass_2qr: reorder_disjoint_fused2q   (≥12q)    disjoint Fused2q tier grouping
+    ├─ pass_m2q: fuse_multi_2q_gates        (≥12q)    2q batch → Multi2q
     ├─ pass_cp:  fuse_controlled_phases     (≥16q)    cphase batch → BatchPhase
     ├─ pass_db:  fuse_diagonal_batch        (≥16q)    mixed diagonal → DiagonalBatch
     └─ pass_pp:  batch_post_phase_1q        (≥18q)    re-batch 1q after cphase
@@ -119,8 +121,8 @@ Thirteen-pass gate optimization before execution, gated by qubit count threshold
 | `MIN_QUBITS_FOR_MULTI_FUSION` | 14 | MultiFused tiling overhead vs benefit |
 | `MIN_QUBITS_FOR_DIAG_BATCH` | 16 | Diagonal batch, cphase, and Rzz batching |
 | `MIN_QUBITS_FOR_POST_PHASE_BATCH` | 18 | Post-phase 1q re-batching |
-| `MIN_QUBITS_FOR_2Q_FUSION` | 20 | Generic 4×4 kernel only beats specialized at DRAM-bound sizes |
-| `MIN_QUBITS_FOR_MULTI_2Q_FUSION` | 20 | Same as 2q fusion |
+| `MIN_QUBITS_FOR_2Q_FUSION` | 12 | Benchmarked QV and random sweeps show memory-pass reduction wins from 12q |
+| `MIN_QUBITS_FOR_MULTI_2Q_FUSION` | 12 | Same as 2q fusion |
 
 ## Backend trait
 
@@ -410,11 +412,14 @@ Thread pool defaults to all logical cores (HT helps at 24q+ by hiding memory lat
 Two key SIMD structs hoist matrix broadcast at construction time, avoiding per-element dispatch:
 
 - **`PreparedGate1q`**: Broadcasts 2×2 matrix into SIMD registers. Methods: `apply_full_sequential` (full state), `apply_tiled` (cache-resident tile, no AVX2 throttle guard), `apply_slice_pairs` (MPS bond-dimension slices), `apply_pair_ptr` (Cu/Mcu parallel).
-- **`PreparedGate2q`**: Broadcasts 4×4 matrix. Methods: `apply_full` (mask-based iteration), `apply_group_ptr` (4 scattered indices).
+- **`PreparedGate2q`**: Broadcasts 4×4 matrix. Methods: `apply_full` (mask-based iteration), `apply_tiled` (cache-resident Multi2q tiles, AVX2 paired-group kernel when available), `apply_group_ptr` (4 scattered indices).
+
+The 2q tiled AVX2 path processes paired `k` and `k + 1` groups when the lower target qubit is above 0, which makes each row load contiguous. It falls back to the 128-bit FMA kernel for `lo == 0` and when AVX2+FMA is unavailable. Set `PRISM_NO_AVX2_2Q` to compare against the 128-bit FMA path, or `PRISM_NO_REORDER` to disable disjoint Fused2q tier grouping for A/B timing.
 
 ### Determinism
 
 Same circuit + same seed = same result, regardless of thread count. Parallel backends use deterministic work partitioning.
+
 
 ## Backend dispatch
 

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1874,13 +1874,12 @@ impl PreparedGate2q {
         q0: usize,
         q1: usize,
     ) {
-        let mask0 = 1usize << q0;
-        let mask1 = 1usize << q1;
-        let (lo, hi) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
-        let n_iter = 1usize << (num_qubits - 2);
-
         #[cfg(target_arch = "x86_64")]
         {
+            let mask0 = 1usize << q0;
+            let mask1 = 1usize << q1;
+            let (lo, hi) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
+            let n_iter = 1usize << (num_qubits - 2);
             let base = state.as_mut_ptr() as *mut f64;
             unsafe {
                 match self.tier {

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -483,6 +483,19 @@ enum SimdTier {
     Sse2,
 }
 
+/// Bench-only kill switch for the AVX2 paired-group 2q kernel.
+///
+/// Reads `PRISM_NO_AVX2_2Q` once and caches the result. Set the variable
+/// to disable the kernel and exercise the 128-bit FMA fallback for A/B
+/// timing comparison without rebuilding.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn avx2_2q_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PRISM_NO_AVX2_2Q").is_none())
+}
+
 /// Precomputed single-qubit gate ready for repeated application.
 ///
 /// Create once per gate via [`PreparedGate1q::new`], then call [`apply`]
@@ -1406,6 +1419,34 @@ struct Mat4x4Broadcast {
     ii: [__m128d; 16],
 }
 
+/// 256-bit broadcast variant of [`Mat4x4Broadcast`] for AVX2 paired-group kernels.
+///
+/// Each register holds the same `re` (or `im`) value broadcast across 4 lanes,
+/// so a single `_mm256_fmaddsub_pd` performs the complex multiply for two
+/// 4-element groups simultaneously.
+#[cfg(target_arch = "x86_64")]
+struct Mat4x4Broadcast256 {
+    rr: [__m256d; 16],
+    ii: [__m256d; 16],
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Mat4x4Broadcast256 {
+    #[inline(always)]
+    unsafe fn from_matrix(mat: &[[Complex64; 4]; 4]) -> Self {
+        let mut rr = [_mm256_setzero_pd(); 16];
+        let mut ii = [_mm256_setzero_pd(); 16];
+        for (r, row) in mat.iter().enumerate() {
+            for (c, elem) in row.iter().enumerate() {
+                let idx = r * 4 + c;
+                rr[idx] = _mm256_set1_pd(elem.re);
+                ii[idx] = _mm256_set1_pd(elem.im);
+            }
+        }
+        Self { rr, ii }
+    }
+}
+
 #[cfg(target_arch = "x86_64")]
 impl Mat4x4Broadcast {
     #[inline(always)]
@@ -1486,6 +1527,88 @@ unsafe fn apply_fused_2q_loop_fma(
 #[target_feature(enable = "fma")]
 unsafe fn apply_fused_2q_group_fma(state: *mut f64, i: [usize; 4], mat: &Mat4x4Broadcast) {
     apply_fused_2q_group_fma_inner(state, i, mat);
+}
+
+/// Apply two consecutive 4-element groups (k and k+1) of a 2q gate using AVX2.
+///
+/// Precondition: `iA[r]` and `iA[r] + 1` must be the indices of group A's row r
+/// and group B's row r respectively, so a single 256-bit load reads both
+/// `state[iA[r]]` and `state[iB[r]]` contiguously. This holds when the lower
+/// gate qubit `lo` is > 0 and the caller pairs `k` with `k+1`.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn apply_fused_2q_pair_avx2_inner(state: *mut f64, i: [usize; 4], mat: &Mat4x4Broadcast256) {
+    let s0 = _mm256_loadu_pd(state.add(i[0] * 2));
+    let s1 = _mm256_loadu_pd(state.add(i[1] * 2));
+    let s2 = _mm256_loadu_pd(state.add(i[2] * 2));
+    let s3 = _mm256_loadu_pd(state.add(i[3] * 2));
+
+    let sf0 = _mm256_shuffle_pd(s0, s0, 0b0101);
+    let sf1 = _mm256_shuffle_pd(s1, s1, 0b0101);
+    let sf2 = _mm256_shuffle_pd(s2, s2, 0b0101);
+    let sf3 = _mm256_shuffle_pd(s3, s3, 0b0101);
+
+    macro_rules! row {
+        ($r:expr) => {{
+            let off = $r * 4;
+            let t = _mm256_mul_pd(mat.ii[off], sf0);
+            let mut acc = _mm256_fmaddsub_pd(mat.rr[off], s0, t);
+            let t = _mm256_mul_pd(mat.ii[off + 1], sf1);
+            acc = _mm256_add_pd(acc, _mm256_fmaddsub_pd(mat.rr[off + 1], s1, t));
+            let t = _mm256_mul_pd(mat.ii[off + 2], sf2);
+            acc = _mm256_add_pd(acc, _mm256_fmaddsub_pd(mat.rr[off + 2], s2, t));
+            let t = _mm256_mul_pd(mat.ii[off + 3], sf3);
+            acc = _mm256_add_pd(acc, _mm256_fmaddsub_pd(mat.rr[off + 3], s3, t));
+            _mm256_storeu_pd(state.add(i[$r] * 2), acc);
+        }};
+    }
+    row!(0);
+    row!(1);
+    row!(2);
+    row!(3);
+}
+
+/// Pair-batched 2q kernel main loop. Requires `lo > 0` so that paired k/k+1
+/// values map to adjacent state positions; falls back to the 128-bit FMA
+/// kernel when `lo == 0`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn apply_fused_2q_loop_avx2(
+    state: *mut f64,
+    n_iter: usize,
+    lo: usize,
+    hi: usize,
+    mask0: usize,
+    mask1: usize,
+    mat256: &Mat4x4Broadcast256,
+    mat128: &Mat4x4Broadcast,
+) {
+    use crate::backend::statevector::insert_zero_bit;
+
+    if lo == 0 {
+        for k in 0..n_iter {
+            let base = insert_zero_bit(insert_zero_bit(k, lo), hi);
+            let i = [base, base | mask1, base | mask0, base | mask0 | mask1];
+            apply_fused_2q_group_fma_inner(state, i, mat128);
+        }
+        return;
+    }
+
+    let pairs = n_iter / 2;
+    for pk in 0..pairs {
+        let k = pk * 2;
+        let base = insert_zero_bit(insert_zero_bit(k, lo), hi);
+        let i = [base, base | mask1, base | mask0, base | mask0 | mask1];
+        apply_fused_2q_pair_avx2_inner(state, i, mat256);
+    }
+    if n_iter & 1 == 1 {
+        let k = n_iter - 1;
+        let base = insert_zero_bit(insert_zero_bit(k, lo), hi);
+        let i = [base, base | mask1, base | mask0, base | mask0 | mask1];
+        apply_fused_2q_group_fma_inner(state, i, mat128);
+    }
 }
 
 /// Apply one 4-element group of a 2q gate using SSE2 intrinsics.
@@ -1631,7 +1754,9 @@ pub(crate) struct PreparedGate2q {
     #[cfg(target_arch = "x86_64")]
     broadcast: Mat4x4Broadcast,
     #[cfg(target_arch = "x86_64")]
-    use_fma: bool,
+    broadcast256: Option<Mat4x4Broadcast256>,
+    #[cfg(target_arch = "x86_64")]
+    tier: SimdTier,
     #[cfg(target_arch = "aarch64")]
     broadcast: Mat4x4Broadcast,
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
@@ -1643,9 +1768,24 @@ impl PreparedGate2q {
     pub(crate) fn new(mat: &[[Complex64; 4]; 4]) -> Self {
         #[cfg(target_arch = "x86_64")]
         {
+            let broadcast = Mat4x4Broadcast::from_matrix(mat);
+            let has_avx2_fma = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+            let tier = if has_avx2_fma {
+                SimdTier::Avx2Fma
+            } else if is_x86_feature_detected!("fma") {
+                SimdTier::Fma
+            } else {
+                SimdTier::Sse2
+            };
+            let broadcast256 = if has_avx2_fma {
+                Some(unsafe { Mat4x4Broadcast256::from_matrix(mat) })
+            } else {
+                None
+            };
             Self {
-                broadcast: Mat4x4Broadcast::from_matrix(mat),
-                use_fma: is_x86_feature_detected!("fma"),
+                broadcast,
+                broadcast256,
+                tier,
             }
         }
         #[cfg(target_arch = "aarch64")]
@@ -1661,6 +1801,10 @@ impl PreparedGate2q {
     }
 
     /// Apply the full 2q gate to the statevector sequentially.
+    ///
+    /// Uses 128-bit FMA on x86_64 even when AVX2 is available; the AVX2
+    /// paired-group kernel is reserved for [`apply_tiled`] where the slice
+    /// is known to be cache-resident.
     pub(crate) fn apply_full(
         &self,
         state: &mut [Complex64],
@@ -1676,13 +1820,12 @@ impl PreparedGate2q {
         #[cfg(target_arch = "x86_64")]
         {
             let base = state.as_mut_ptr() as *mut f64;
-            if self.use_fma {
+            if !matches!(self.tier, SimdTier::Sse2) {
                 unsafe {
                     apply_fused_2q_loop_fma(base, n_iter, lo, hi, mask0, mask1, &self.broadcast);
                 }
                 return;
             }
-            // SSE2 fallback (always available on x86_64)
             unsafe {
                 use crate::backend::statevector::insert_zero_bit;
                 for k in 0..n_iter {
@@ -1718,6 +1861,72 @@ impl PreparedGate2q {
         }
     }
 
+    /// Apply the 2q gate to a slice that is known to be cache-resident.
+    ///
+    /// Prefers the AVX2 paired-group kernel when available and `lo > 0`,
+    /// falling back to 128-bit FMA per-group otherwise. Use from `Multi2q`
+    /// tile loops where the slice fits in L2/L3 and the kernel is
+    /// compute-bound; the AVX2 throttle is justified by ~2× FMA throughput.
+    pub(crate) fn apply_tiled(
+        &self,
+        state: &mut [Complex64],
+        num_qubits: usize,
+        q0: usize,
+        q1: usize,
+    ) {
+        let mask0 = 1usize << q0;
+        let mask1 = 1usize << q1;
+        let (lo, hi) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
+        let n_iter = 1usize << (num_qubits - 2);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            let base = state.as_mut_ptr() as *mut f64;
+            unsafe {
+                match self.tier {
+                    SimdTier::Avx2Fma if avx2_2q_enabled() => {
+                        // SAFETY: broadcast256 is Some whenever tier is Avx2Fma (constructor invariant).
+                        let mat256 = self.broadcast256.as_ref().unwrap_unchecked();
+                        apply_fused_2q_loop_avx2(
+                            base,
+                            n_iter,
+                            lo,
+                            hi,
+                            mask0,
+                            mask1,
+                            mat256,
+                            &self.broadcast,
+                        );
+                    }
+                    SimdTier::Avx2Fma | SimdTier::Fma => {
+                        apply_fused_2q_loop_fma(
+                            base,
+                            n_iter,
+                            lo,
+                            hi,
+                            mask0,
+                            mask1,
+                            &self.broadcast,
+                        );
+                    }
+                    SimdTier::Sse2 => {
+                        use crate::backend::statevector::insert_zero_bit;
+                        for k in 0..n_iter {
+                            let idx = insert_zero_bit(insert_zero_bit(k, lo), hi);
+                            let i = [idx, idx | mask1, idx | mask0, idx | mask0 | mask1];
+                            apply_fused_2q_group_sse2(base, i, &self.broadcast);
+                        }
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            self.apply_full(state, num_qubits, q0, q1);
+        }
+    }
+
     /// Apply one group at scattered indices. Safe to call from Rayon closures
     /// when callers partition indices across threads.
     ///
@@ -1728,7 +1937,7 @@ impl PreparedGate2q {
     pub(crate) unsafe fn apply_group_ptr(&self, state: *mut f64, i: [usize; 4]) {
         #[cfg(target_arch = "x86_64")]
         {
-            if self.use_fma {
+            if !matches!(self.tier, SimdTier::Sse2) {
                 apply_fused_2q_group_fma(state, i, &self.broadcast);
             } else {
                 apply_fused_2q_group_sse2(state, i, &self.broadcast);
@@ -2085,6 +2294,109 @@ mod tests {
         apply_2q_reference(&mut ref_state, &mat, 0, 2);
         for (i, (a, e)) in state.iter().zip(ref_state.iter()).enumerate() {
             assert!((a - e).norm() < EPS, "state[{i}]: expected {e}, got {a}");
+        }
+    }
+
+    /// A dense, asymmetric 4×4 matrix that exercises every coefficient slot.
+    /// Built from a non-special unitary so any indexing bug in the AVX2
+    /// paired-group kernel surfaces as a numerical mismatch.
+    fn dense_4x4() -> [[Complex64; 4]; 4] {
+        let s = FRAC_1_SQRT_2;
+        let h2 = [
+            [c(0.5, 0.0), c(0.5, 0.0), c(0.5, 0.0), c(0.5, 0.0)],
+            [c(0.5, 0.0), c(-0.5, 0.0), c(0.5, 0.0), c(-0.5, 0.0)],
+            [c(0.5, 0.0), c(0.5, 0.0), c(-0.5, 0.0), c(-0.5, 0.0)],
+            [c(0.5, 0.0), c(-0.5, 0.0), c(-0.5, 0.0), c(0.5, 0.0)],
+        ];
+        let phase = [
+            [c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0)],
+            [c(0.0, 0.0), c(s, s), c(0.0, 0.0), c(0.0, 0.0)],
+            [c(0.0, 0.0), c(0.0, 0.0), c(0.0, 1.0), c(0.0, 0.0)],
+            [c(0.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(-s, s)],
+        ];
+        let mut out = [[c(0.0, 0.0); 4]; 4];
+        for r in 0..4 {
+            for col in 0..4 {
+                let mut acc = c(0.0, 0.0);
+                for k in 0..4 {
+                    acc += phase[r][k] * h2[k][col];
+                }
+                out[r][col] = acc;
+            }
+        }
+        out
+    }
+
+    fn random_state(num_qubits: usize, seed: u64) -> Vec<Complex64> {
+        use rand::Rng;
+        use rand::SeedableRng;
+        use rand_chacha::ChaCha8Rng;
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let n = 1usize << num_qubits;
+        let mut s = Vec::with_capacity(n);
+        let mut norm = 0.0;
+        for _ in 0..n {
+            let re: f64 = rng.random_range(-1.0..1.0);
+            let im: f64 = rng.random_range(-1.0..1.0);
+            norm += re * re + im * im;
+            s.push(c(re, im));
+        }
+        let inv = norm.sqrt().recip();
+        for v in &mut s {
+            v.re *= inv;
+            v.im *= inv;
+        }
+        s
+    }
+
+    fn assert_state_close(actual: &[Complex64], expected: &[Complex64], label: &str) {
+        assert_eq!(actual.len(), expected.len(), "{label}: length mismatch");
+        for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+            let d = (*a - *e).norm();
+            assert!(
+                d < 1e-10,
+                "{label} state[{i}]: expected {e}, got {a} (diff {d:.2e})"
+            );
+        }
+    }
+
+    /// Reference test: AVX2 paired-group kernel must agree with the 128-bit
+    /// FMA per-group kernel across (q0, q1) configurations covering adjacent,
+    /// non-adjacent, reversed-order, and the lo == 0 fallback path.
+    #[test]
+    fn test_prepared_2q_apply_tiled_matches_apply_full() {
+        let mat = dense_4x4();
+        let configs: &[(usize, usize, usize)] = &[
+            (4, 0, 1),  // adjacent, lo == 0 (forces 128-bit fallback inside apply_tiled)
+            (4, 1, 0),  // reversed, lo == 0
+            (4, 1, 2),  // adjacent, lo > 0 (AVX2 path)
+            (4, 2, 1),  // reversed, lo > 0
+            (5, 0, 4),  // far apart, lo == 0
+            (5, 4, 0),  // reversed, lo == 0
+            (5, 1, 4),  // far apart, lo > 0
+            (5, 4, 1),  // reversed, lo > 0
+            (6, 2, 5),  // mid-range, lo > 0
+            (8, 0, 7),  // 8-qubit, span entire register, lo == 0
+            (8, 1, 7),  // 8-qubit, span entire register, lo > 0
+            (8, 7, 1),  // reversed
+            (10, 3, 6), // 10-qubit AVX2 path
+        ];
+
+        for &(nq, q0, q1) in configs {
+            let state_init = random_state(nq, 0xCAFE_F00D);
+            let prepared = PreparedGate2q::new(&mat);
+
+            let mut via_full = state_init.clone();
+            prepared.apply_full(&mut via_full, nq, q0, q1);
+
+            let mut via_tiled = state_init.clone();
+            prepared.apply_tiled(&mut via_tiled, nq, q0, q1);
+
+            assert_state_close(
+                &via_tiled,
+                &via_full,
+                &format!("nq={nq} q0={q0} q1={q1} apply_tiled vs apply_full"),
+            );
         }
     }
 }

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -1876,8 +1876,9 @@ impl StatevectorBackend {
             let tile_size = MULTI_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             for tile in self.state.chunks_mut(tile_size) {
+                let n = tile.len().trailing_zeros() as usize;
                 for &(q0, q1, ref prepared) in &small_gates {
-                    prepared.apply_full(tile, tile_qubits, q0, q1);
+                    prepared.apply_tiled(tile, n.min(tile_qubits), q0, q1);
                 }
             }
         }
@@ -1886,8 +1887,9 @@ impl StatevectorBackend {
             let tile_size = L3_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             for tile in self.state.chunks_mut(tile_size) {
+                let n = tile.len().trailing_zeros() as usize;
                 for &(q0, q1, ref prepared) in &medium_gates {
-                    prepared.apply_full(tile, tile_qubits, q0, q1);
+                    prepared.apply_tiled(tile, n.min(tile_qubits), q0, q1);
                 }
             }
         }
@@ -1929,7 +1931,7 @@ impl StatevectorBackend {
                 .for_each(|tile| {
                     let n = tile.len().trailing_zeros() as usize;
                     for &(q0, q1, ref prepared) in &small_gates {
-                        prepared.apply_full(tile, n.min(tile_qubits), q0, q1);
+                        prepared.apply_tiled(tile, n.min(tile_qubits), q0, q1);
                     }
                 });
         }
@@ -1943,7 +1945,7 @@ impl StatevectorBackend {
                 .for_each(|tile| {
                     let n = tile.len().trailing_zeros() as usize;
                     for &(q0, q1, ref prepared) in &medium_gates {
-                        prepared.apply_full(tile, n.min(tile_qubits), q0, q1);
+                        prepared.apply_tiled(tile, n.min(tile_qubits), q0, q1);
                     }
                 });
         }

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -60,13 +60,23 @@ const MIN_QUBITS_FOR_POST_PHASE_BATCH: usize = 18;
 /// Minimum qubit count for two-qubit gate fusion (absorb 1q into CX/CZ) to be profitable.
 ///
 /// The generic 4×4 kernel does ~4x the FLOPs of specialized CX/CZ + SIMD 1q kernels.
-/// Below this threshold, extra compute cost exceeds memory-pass savings.
-const MIN_QUBITS_FOR_2Q_FUSION: usize = 20;
+/// Benchmarked QV and random sweeps show memory-pass reduction wins from 12q.
+const MIN_QUBITS_FOR_2Q_FUSION: usize = 12;
+
+/// Bench-only kill switch for `reorder_disjoint_fused2q`. Reads
+/// `PRISM_NO_REORDER` once and caches the result. Toggle for A/B timing
+/// comparisons without rebuilding.
+#[inline]
+fn reorder_2q_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PRISM_NO_REORDER").is_none())
+}
 
 /// Minimum qubit count for multi-2q tiled fusion to be profitable.
 ///
 /// Batches consecutive Fused2q gates into a single cache-tiled pass. Only
-/// created when Fused2q gates exist (which requires ≥20q), so threshold matches.
+/// created when Fused2q gates exist, so threshold matches.
 const MIN_QUBITS_FOR_MULTI_2Q_FUSION: usize = MIN_QUBITS_FOR_2Q_FUSION;
 
 /// Minimum batch size for multi-2q fusion (single gate not worth wrapping).
@@ -987,6 +997,83 @@ fn fuse_same_pair_2q_blocks(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     }
 }
 
+/// Reorder consecutive `Fused2q` gates with pairwise-disjoint qubit supports
+/// so that gates of the same `Tier2q` are grouped together. Disjoint-support
+/// 2q gates commute, so reordering is identity-preserving.
+///
+/// Random pair circuits (notably Quantum Volume) emit `Fused2q` streams whose
+/// tiers are interleaved. The downstream `fuse_multi_2q_gates` only batches
+/// consecutive same-tier gates, so without this pass tier transitions break
+/// the run after every one or two gates.
+///
+/// Returns `Cow::Borrowed` when no reorder happens.
+pub fn reorder_disjoint_fused2q(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
+    let circuit = input.as_ref();
+    let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
+    let mut window: Vec<(Tier2q, Instruction)> = Vec::new();
+    let mut window_qubits = vec![false; circuit.num_qubits];
+    let mut changed = false;
+
+    for inst in &circuit.instructions {
+        if let Instruction::Gate {
+            gate: Gate::Fused2q(_),
+            targets,
+        } = inst
+        {
+            let q0 = targets[0];
+            let q1 = targets[1];
+            if window_qubits[q0] || window_qubits[q1] {
+                flush_disjoint_window(&mut window, &mut window_qubits, &mut output, &mut changed);
+            }
+            window_qubits[q0] = true;
+            window_qubits[q1] = true;
+            window.push((classify_2q_tier(q0, q1), inst.clone()));
+        } else {
+            flush_disjoint_window(&mut window, &mut window_qubits, &mut output, &mut changed);
+            output.push(inst.clone());
+        }
+    }
+    flush_disjoint_window(&mut window, &mut window_qubits, &mut output, &mut changed);
+
+    if changed {
+        Cow::Owned(Circuit {
+            num_qubits: circuit.num_qubits,
+            num_classical_bits: circuit.num_classical_bits,
+            instructions: output,
+        })
+    } else {
+        input
+    }
+}
+
+fn flush_disjoint_window(
+    window: &mut Vec<(Tier2q, Instruction)>,
+    window_qubits: &mut [bool],
+    output: &mut Vec<Instruction>,
+    changed: &mut bool,
+) {
+    if window.len() >= 2 {
+        let mut tier_counts = [0u32; 3];
+        for (t, _) in window.iter() {
+            tier_counts[*t as usize] += 1;
+        }
+        let any_tier_batchable = tier_counts.iter().any(|&c| c >= MIN_MULTI_2Q_BATCH as u32);
+        if any_tier_batchable {
+            let already_sorted = window.windows(2).all(|w| (w[0].0 as u8) <= (w[1].0 as u8));
+            if !already_sorted {
+                window.sort_by_key(|(t, _)| *t as u8);
+                *changed = true;
+            }
+        }
+    }
+    for (_, inst) in window.drain(..) {
+        output.push(inst);
+    }
+    for q in window_qubits.iter_mut() {
+        *q = false;
+    }
+}
+
 /// Batch consecutive `Fused2q` gates into `Multi2q` for cache-tiled execution.
 ///
 /// Scans for runs of consecutive `Fused2q` instructions within the same cache
@@ -1272,7 +1359,7 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
         return pass0b;
     }
 
-    // 1q fusion + reorder — clone cost justified at ≥10q
+    // 1q fusion plus reorder, clone cost justified at 10q and above.
     let pass1 = match pass0b {
         Cow::Borrowed(c) => fuse_single_qubit_gates(c),
         Cow::Owned(c) => Cow::Owned(fuse_single_qubit_gates(&c).into_owned()),
@@ -1307,10 +1394,15 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
     } else {
         pass_2qb
     };
-    let pass_m2q = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION {
-        fuse_multi_2q_gates(pass2)
+    let pass_2qr = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION && reorder_2q_enabled() {
+        reorder_disjoint_fused2q(pass2)
     } else {
         pass2
+    };
+    let pass_m2q = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION {
+        fuse_multi_2q_gates(pass_2qr)
+    } else {
+        pass_2qr
     };
     let pass_cp = if circuit.num_qubits >= MIN_QUBITS_FOR_DIAG_BATCH {
         fuse_controlled_phases(pass_m2q)
@@ -2412,6 +2504,26 @@ mod tests {
             .count();
         assert_eq!(batch_rzz_count, 3);
         assert_eq!(multi_fused_count, 3);
+    }
+
+    #[test]
+    fn qv_12_uses_multi_2q_fusion() {
+        let circuit = crate::circuits::quantum_volume_circuit(12, 1, 42);
+        let fused = fuse_circuit(&circuit, true);
+        let multi_2q_count = fused
+            .instructions
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i,
+                    Instruction::Gate {
+                        gate: Gate::Multi2q(_),
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(multi_2q_count > 0, "QV 12q should use Multi2q fusion");
     }
 
     #[test]

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -8,7 +8,7 @@
 use num_complex::Complex64;
 use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::backend::Backend;
-use prism_q::circuit::Circuit;
+use prism_q::circuit::{Circuit, Instruction};
 use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::sim;
@@ -83,6 +83,19 @@ fn assert_fusion_preserves_state(circuit: &Circuit) {
     let unfused = run_unfused_state(circuit);
     let fused = run_fused_state(circuit);
     assert_state_close(&fused, &unfused, EPS);
+}
+
+fn has_2q_fusion(circuit: &Circuit) -> bool {
+    let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
+    fused.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::Fused2q(_) | Gate::Multi2q(_),
+                ..
+            }
+        )
+    })
 }
 
 // ===== QFT =====
@@ -440,13 +453,13 @@ fn fusion_random_18q() {
 
 // ===== 2q fusion specific tests =====
 // These test circuits where 1q gates are absorbed into adjacent 2q gates.
-// The fuse_2q_gates pass activates at ≥20 qubits.
+// The fuse_2q_gates pass activates at 12 qubits and above.
 
 #[test]
-fn fusion_2q_hea_pattern_20q() {
-    // HEA: Ry-Rz per qubit, then CX ladder — classic 2q fusion target
-    // At 20q, 2q fusion is active (MIN_QUBITS_FOR_2Q_FUSION = 20)
-    assert_fusion_preserves_correctness(&circuits::hardware_efficient_ansatz(20, 3, 42));
+fn fusion_2q_hea_pattern_12q() {
+    let circuit = circuits::hardware_efficient_ansatz(12, 3, 42);
+    assert!(has_2q_fusion(&circuit), "12q HEA should use 2q fusion");
+    assert_fusion_preserves_correctness(&circuit);
 }
 
 #[test]
@@ -473,8 +486,7 @@ fn fusion_2q_cx_sandwich_20q() {
 
 #[test]
 fn fusion_2q_cz_with_1q_gates_12q() {
-    // CZ gates are NOT absorbed by 2q fusion (specialized SIMD kernel is faster),
-    // but correctness should still hold through other fusion passes.
+    // CZ gates are absorbed by 2q fusion like CX.
     let mut c = Circuit::new(12, 0);
     for _ in 0..3 {
         for q in 0..12 {
@@ -528,20 +540,22 @@ fn fusion_2q_cu_with_1q_gates_12q() {
 }
 
 #[test]
-fn fusion_2q_threshold_19q_no_2q_fusion() {
-    // 19q: below MIN_QUBITS_FOR_2Q_FUSION (20), should still work
-    assert_fusion_preserves_correctness(&circuits::hardware_efficient_ansatz(19, 3, 42));
+fn fusion_2q_threshold_11q_no_2q_fusion() {
+    let circuit = circuits::hardware_efficient_ansatz(11, 3, 42);
+    assert!(!has_2q_fusion(&circuit), "11q HEA should skip 2q fusion");
+    assert_fusion_preserves_correctness(&circuit);
 }
 
 #[test]
-fn fusion_2q_threshold_20q_2q_fusion_active() {
-    // 20q: at threshold, 2q fusion is active
-    assert_fusion_preserves_correctness(&circuits::hardware_efficient_ansatz(20, 3, 42));
+fn fusion_2q_threshold_12q_2q_fusion_active() {
+    let circuit = circuits::hardware_efficient_ansatz(12, 3, 42);
+    assert!(has_2q_fusion(&circuit), "12q HEA should use 2q fusion");
+    assert_fusion_preserves_correctness(&circuit);
 }
 
 #[test]
 fn fusion_2q_mixed_2q_gates_20q() {
-    // Mix of CX, CZ, SWAP, Cu — only CX gets 2q-fused at ≥20q
+    // Mix of CX, CZ, SWAP, Cu. CX and CZ get 2q-fused at 12q and above.
     let h_mat = Gate::H.matrix_2x2();
     let mut c = Circuit::new(20, 0);
     for _ in 0..3 {
@@ -571,8 +585,32 @@ fn fusion_same_pair_w_state_20q() {
 }
 
 #[test]
+fn fusion_same_pair_qv_8q() {
+    assert_fusion_preserves_correctness(&circuits::quantum_volume_circuit(8, 1, 42));
+}
+
+#[test]
+fn fusion_same_pair_qv_12q() {
+    assert_fusion_preserves_correctness(&circuits::quantum_volume_circuit(12, 1, 42));
+}
+
+#[test]
+fn fusion_same_pair_qv_16q() {
+    assert_fusion_preserves_correctness(&circuits::quantum_volume_circuit(16, 1, 42));
+}
+
+#[test]
 fn fusion_same_pair_qv_20q() {
     assert_fusion_preserves_correctness(&circuits::quantum_volume_circuit(20, 1, 42));
+}
+
+#[test]
+fn fusion_qv_20q_depth_4() {
+    // Multi-layer QV at 20q exercises `reorder_disjoint_fused2q`: each layer
+    // emits ~10 disjoint Fused2q gates with mixed L2/L3/Individual tiers,
+    // and the reorder must commute them into tier-grouped order without
+    // changing the final state.
+    assert_fusion_preserves_state(&circuits::quantum_volume_circuit(20, 4, 42));
 }
 
 #[test]
@@ -774,7 +812,8 @@ fn fusion_non_adjacent_cancel_blocked_by_conflict() {
 // ===== Multi-2q fusion threshold tests =====
 
 #[test]
-fn fusion_multi_2q_threshold_19q_not_active() {
-    // 19q < MIN_QUBITS_FOR_2Q_FUSION(20) — 2q fusion should not fire
-    assert_fusion_preserves_correctness(&circuits::hardware_efficient_ansatz(19, 3, 42));
+fn fusion_multi_2q_threshold_12q_active() {
+    let circuit = circuits::quantum_volume_circuit(12, 1, 42);
+    assert!(has_2q_fusion(&circuit), "12q QV should use Multi2q fusion");
+    assert_fusion_preserves_correctness(&circuit);
 }


### PR DESCRIPTION
## Summary

Adds an AVX2 kernel for tiled Fused2q execution and reorders disjoint Fused2q gates by cache tier before Multi2q batching. The change reduces memory passes for qv type random pair circuits and improves tiled 2q throughput on x86_64 AVX2+FMA targets.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Three-variant timing: Intel Core i7-6700K, Windows NT 10.0.19045.0, rustc 1.93.0, `--features parallel`, same compile, back to back timing, minimum over runs.

| Benchmark | Baseline | Reorder only | Reorder + AVX2 | Combined Change | Within 5% threshold? |
| --- | ---: | ---: | ---: | ---: | --- |
| QV 16q d=16 | 10.98 ms | 11.75 ms | 8.01 ms | -27% | Yes |
| HEA 16q d=5 | 5.47 ms | 5.61 ms | 3.81 ms | -30% | Yes |
| QV 20q d=20 | 231.24 ms | 196.93 ms | 181.45 ms | -22% | Yes |
| HEA 20q d=5 | 74.02 ms | 73.14 ms | 64.62 ms | -13% | Yes |

Regression verdict: PASS

Reorder is QV-specific: about 15% on QV 20q and no material benefit on HEA. AVX2 is general: about 13% to 30% across both circuit families. Stacked result is about 22% on the original target benchmark.

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [x] New gate, backend, or fusion pass has correctness tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional local checks:
- `cargo test --features parallel --lib --tests`
- `cargo clippy --all-targets --features parallel -- -D warnings`

## Hotspot notes

Affected hot-path functions:
- `reorder_disjoint_fused2q`
- `fuse_multi_2q_gates`
- `StatevectorBackend::apply_multi_2q`
- `PreparedGate2q::apply_tiled`
- `apply_fused_2q_loop_avx2`
- `apply_fused_2q_pair_avx2_inner`

Timing evidence above covers the changed QV and HEA statevector paths. No flamegraph attached.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems

## Breaking changes

None.

## Risks and rollback

Risk is limited to statevector fused 2q execution and Multi2q batching behavior. Correctness is guarded by fused versus unfused state comparisons and SIMD parity tests. `PRISM_NO_REORDER` disables the Fused2q reorder pass for timing comparison, and `PRISM_NO_AVX2_2Q` disables the AVX2 paired-group 2q kernel without rebuilding.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
