### PR TITLE
test(correctness): complete per-backend correctness matrix

### DIFF
--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -170,7 +170,20 @@ impl FactoredBackend {
             return Ok(());
         }
         // All other gates require targets in the same sub-state.
-        let ss_idx = self.ensure_same_substate(targets);
+        // BatchPhase carries phase target qubits inside its data, not in the
+        // instruction-level `targets` list, so the merge must include them.
+        let ss_idx = if let Gate::BatchPhase(data) = gate {
+            let mut all_qubits: SmallVec<[usize; 16]> = SmallVec::new();
+            all_qubits.extend_from_slice(targets);
+            for &(q, _) in &data.phases {
+                if !all_qubits.contains(&q) {
+                    all_qubits.push(q);
+                }
+            }
+            self.ensure_same_substate(&all_qubits)
+        } else {
+            self.ensure_same_substate(targets)
+        };
 
         #[cfg(feature = "parallel")]
         {

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -5,12 +5,12 @@
 //!
 //! # Memory layout
 //!
-//! - `Vec<[Complex64; 2]>` — one state per qubit, `[α, β]` where `|ψ⟩ = α|0⟩ + β|1⟩`.
-//! - Total memory: O(n) — 32 bytes per qubit vs O(2^n) for statevector.
+//! - `Vec<[Complex64; 2]>`: one state per qubit, `[α, β]` where `|ψ⟩ = α|0⟩ + β|1⟩`.
+//! - Total memory: O(n), 32 bytes per qubit vs O(2^n) for statevector.
 //!
 //! # Gate support
 //!
-//! All single-qubit gates are applied as a 2×2 matrix–vector multiply on the
+//! All single-qubit gates are applied as a 2×2 matrix-vector multiply on the
 //! per-qubit state. Two-qubit and multi-qubit gates return `BackendUnsupported`
 //! since product states cannot represent entanglement.
 //!
@@ -28,7 +28,7 @@ use rand_chacha::ChaCha8Rng;
 use crate::backend::{Backend, MAX_PROB_QUBITS, NORM_CLAMP_MIN};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
-use crate::gates::Gate;
+use crate::gates::{DiagEntry, Gate};
 
 /// Per-qubit O(n) backend for non-entangling circuits.
 pub struct ProductStateBackend {
@@ -51,12 +51,14 @@ impl ProductStateBackend {
 
     fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         match gate {
-            Gate::Cx
+            Gate::Rzz(_)
+            | Gate::Cx
             | Gate::Cz
             | Gate::Swap
             | Gate::Cu(_)
             | Gate::Mcu(_)
             | Gate::BatchPhase(_)
+            | Gate::BatchRzz(_)
             | Gate::Fused2q(_)
             | Gate::Multi2q(_) => Err(PrismError::BackendUnsupported {
                 backend: "productstate".to_string(),
@@ -70,6 +72,25 @@ impl ProductStateBackend {
                     let [a, b] = self.qubits[target];
                     self.qubits[target] =
                         [mat[0][0] * a + mat[0][1] * b, mat[1][0] * a + mat[1][1] * b];
+                }
+                Ok(())
+            }
+            Gate::DiagonalBatch(data) => {
+                for entry in &data.entries {
+                    match entry {
+                        DiagEntry::Phase1q { qubit, d0, d1 } => {
+                            let [a, b] = self.qubits[*qubit];
+                            self.qubits[*qubit] = [*d0 * a, *d1 * b];
+                        }
+                        DiagEntry::Phase2q { .. } | DiagEntry::Parity2q { .. } => {
+                            return Err(PrismError::BackendUnsupported {
+                                backend: "productstate".to_string(),
+                                operation:
+                                    "multi-qubit diagonal batch (product state backend supports single-qubit gates only)"
+                                        .to_string(),
+                            });
+                        }
+                    }
                 }
                 Ok(())
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,8 +13,11 @@ use prism_q::sim;
 
 pub const SV_EPS: f64 = 1e-10;
 pub const STAB_EPS: f64 = 1e-12;
+pub const SPARSE_EPS: f64 = 1e-10;
 pub const MPS_EPS: f64 = 1e-9;
 pub const TN_EPS: f64 = 1e-10;
+pub const PRODUCT_EPS: f64 = 1e-12;
+pub const FACTORED_EPS: f64 = 1e-10;
 
 pub const SEED: u64 = 42;
 
@@ -51,6 +54,34 @@ pub fn assert_backend_matches_sv<B: Backend>(
     let actual = backend.probabilities().unwrap();
     let expected = sv_reference_probs(circuit);
     assert_probs_close(&actual, &expected, eps, label);
+}
+
+pub fn run_unfused_probs<B: Backend>(backend: &mut B, circuit: &Circuit) -> Vec<f64> {
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    for instr in &circuit.instructions {
+        backend.apply(instr).unwrap();
+    }
+    backend.probabilities().unwrap()
+}
+
+pub fn run_fused_probs<B: Backend>(backend: &mut B, circuit: &Circuit) -> Vec<f64> {
+    sim::run_on(backend, circuit).unwrap();
+    backend.probabilities().unwrap()
+}
+
+pub fn assert_fused_matches_unfused<B: Backend, F: Fn() -> B>(
+    new_backend: F,
+    circuit: &Circuit,
+    eps: f64,
+    label: &str,
+) {
+    let mut unfused_backend = new_backend();
+    let unfused = run_unfused_probs(&mut unfused_backend, circuit);
+    let mut fused_backend = new_backend();
+    let fused = run_fused_probs(&mut fused_backend, circuit);
+    assert_probs_close(&fused, &unfused, eps, label);
 }
 
 pub fn is_clifford(circuit: &Circuit) -> bool {

--- a/tests/factored_correctness.rs
+++ b/tests/factored_correctness.rs
@@ -1,0 +1,365 @@
+//! Cross-backend correctness tests for `FactoredBackend`.
+//!
+//! Dynamic split-state backend: handles both monolithic 2^n state vectors
+//! and independent subsystems split into blocks. Each of the 16 builders
+//! in `prism_q::circuits` runs through both an SV cross check and a
+//! fused-vs-unfused self-check on the factored backend at moderate
+//! sizes (8-12q). A second tier exercises blocked builders at 20q where
+//! the factored backend's split-state path is exercised, and monolithic
+//! builders at 16q to cover the larger fusion pipeline.
+
+mod common;
+
+use common::{assert_backend_matches_sv, assert_fused_matches_unfused, FACTORED_EPS, SEED};
+use prism_q::backend::factored::FactoredBackend;
+use prism_q::circuit::{Circuit, Instruction};
+use prism_q::circuits;
+use prism_q::gates::Gate;
+
+fn check_sv_cross(label: &str, circuit: &Circuit) {
+    let mut backend = FactoredBackend::new(SEED);
+    assert_backend_matches_sv(&mut backend, circuit, FACTORED_EPS, label);
+}
+
+fn check_fused_vs_unfused(label: &str, circuit: &Circuit) {
+    assert_fused_matches_unfused(|| FactoredBackend::new(SEED), circuit, FACTORED_EPS, label);
+}
+
+fn has_batch_phase(circuit: &Circuit) -> bool {
+    let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
+    fused.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::BatchPhase(_),
+                ..
+            }
+        )
+    })
+}
+
+// ===== qft =====
+
+#[test]
+fn factored_qft_12q_sv() {
+    check_sv_cross("qft 12q sv", &circuits::qft_circuit(12));
+}
+
+#[test]
+fn factored_qft_12q_fused() {
+    check_fused_vs_unfused("qft 12q fused", &circuits::qft_circuit(12));
+}
+
+#[test]
+fn factored_qft_16q_sv() {
+    check_sv_cross("qft 16q sv", &circuits::qft_circuit(16));
+}
+
+#[test]
+fn factored_batch_phase_phase_sensitive_16q() {
+    let mut c = Circuit::new(16, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::H, &[2]);
+    c.add_gate(Gate::cphase(0.37), &[0, 1]);
+    c.add_gate(Gate::cphase(-0.91), &[0, 2]);
+    c.add_gate(Gate::H, &[0]);
+    assert!(
+        has_batch_phase(&c),
+        "phase-sensitive 16q circuit should use BatchPhase fusion"
+    );
+    check_sv_cross("batch_phase phase-sensitive 16q sv", &c);
+    check_fused_vs_unfused("batch_phase phase-sensitive 16q fused", &c);
+}
+
+// ===== random =====
+
+#[test]
+fn factored_random_12q_sv() {
+    check_sv_cross("random 12q d10 sv", &circuits::random_circuit(12, 10, SEED));
+}
+
+#[test]
+fn factored_random_12q_fused() {
+    check_fused_vs_unfused(
+        "random 12q d10 fused",
+        &circuits::random_circuit(12, 10, SEED),
+    );
+}
+
+// ===== hardware_efficient_ansatz =====
+
+#[test]
+fn factored_hea_12q_sv() {
+    check_sv_cross(
+        "hea 12q l3 sv",
+        &circuits::hardware_efficient_ansatz(12, 3, SEED),
+    );
+}
+
+#[test]
+fn factored_hea_12q_fused() {
+    check_fused_vs_unfused(
+        "hea 12q l3 fused",
+        &circuits::hardware_efficient_ansatz(12, 3, SEED),
+    );
+}
+
+#[test]
+fn factored_hea_16q_sv() {
+    check_sv_cross(
+        "hea 16q l2 sv",
+        &circuits::hardware_efficient_ansatz(16, 2, SEED),
+    );
+}
+
+// ===== clifford_heavy =====
+
+#[test]
+fn factored_clifford_heavy_12q_sv() {
+    check_sv_cross(
+        "clifford_heavy 12q d10 sv",
+        &circuits::clifford_heavy_circuit(12, 10, SEED),
+    );
+}
+
+#[test]
+fn factored_clifford_heavy_12q_fused() {
+    check_fused_vs_unfused(
+        "clifford_heavy 12q d10 fused",
+        &circuits::clifford_heavy_circuit(12, 10, SEED),
+    );
+}
+
+// ===== clifford_random_pairs =====
+
+#[test]
+fn factored_clifford_random_pairs_12q_sv() {
+    check_sv_cross(
+        "clifford_random_pairs 12q d10 sv",
+        &circuits::clifford_random_pairs(12, 10, SEED),
+    );
+}
+
+#[test]
+fn factored_clifford_random_pairs_12q_fused() {
+    check_fused_vs_unfused(
+        "clifford_random_pairs 12q d10 fused",
+        &circuits::clifford_random_pairs(12, 10, SEED),
+    );
+}
+
+// ===== independent_bell_pairs =====
+
+#[test]
+fn factored_bell_pairs_12q_sv() {
+    check_sv_cross("bell_pairs 6 sv", &circuits::independent_bell_pairs(6));
+}
+
+#[test]
+fn factored_bell_pairs_12q_fused() {
+    check_fused_vs_unfused("bell_pairs 6 fused", &circuits::independent_bell_pairs(6));
+}
+
+#[test]
+fn factored_bell_pairs_20q_sv() {
+    check_sv_cross("bell_pairs 10 sv", &circuits::independent_bell_pairs(10));
+}
+
+#[test]
+fn factored_bell_pairs_20q_fused() {
+    check_fused_vs_unfused("bell_pairs 10 fused", &circuits::independent_bell_pairs(10));
+}
+
+// ===== independent_random_blocks =====
+
+#[test]
+fn factored_random_blocks_12q_sv() {
+    check_sv_cross(
+        "random_blocks 4x3 d5 sv",
+        &circuits::independent_random_blocks(4, 3, 5, SEED),
+    );
+}
+
+#[test]
+fn factored_random_blocks_12q_fused() {
+    check_fused_vs_unfused(
+        "random_blocks 4x3 d5 fused",
+        &circuits::independent_random_blocks(4, 3, 5, SEED),
+    );
+}
+
+#[test]
+fn factored_random_blocks_20q_sv() {
+    check_sv_cross(
+        "random_blocks 5x4 d5 sv",
+        &circuits::independent_random_blocks(5, 4, 5, SEED),
+    );
+}
+
+#[test]
+fn factored_random_blocks_20q_fused() {
+    check_fused_vs_unfused(
+        "random_blocks 5x4 d5 fused",
+        &circuits::independent_random_blocks(5, 4, 5, SEED),
+    );
+}
+
+// ===== ghz =====
+
+#[test]
+fn factored_ghz_12q_sv() {
+    check_sv_cross("ghz 12q sv", &circuits::ghz_circuit(12));
+}
+
+#[test]
+fn factored_ghz_12q_fused() {
+    check_fused_vs_unfused("ghz 12q fused", &circuits::ghz_circuit(12));
+}
+
+// ===== qaoa =====
+
+#[test]
+fn factored_qaoa_12q_sv() {
+    check_sv_cross("qaoa 12q l3 sv", &circuits::qaoa_circuit(12, 3, SEED));
+}
+
+#[test]
+fn factored_qaoa_12q_fused() {
+    check_fused_vs_unfused("qaoa 12q l3 fused", &circuits::qaoa_circuit(12, 3, SEED));
+}
+
+#[test]
+fn factored_qaoa_16q_sv() {
+    check_sv_cross("qaoa 16q l3 sv", &circuits::qaoa_circuit(16, 3, SEED));
+}
+
+// ===== single_qubit_rotation =====
+
+#[test]
+fn factored_single_qubit_rotation_12q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 12q d5 sv",
+        &circuits::single_qubit_rotation_circuit(12, 5, SEED),
+    );
+}
+
+#[test]
+fn factored_single_qubit_rotation_12q_fused() {
+    check_fused_vs_unfused(
+        "single_qubit_rotation 12q d5 fused",
+        &circuits::single_qubit_rotation_circuit(12, 5, SEED),
+    );
+}
+
+// ===== clifford_t =====
+
+#[test]
+fn factored_clifford_t_12q_sv() {
+    check_sv_cross(
+        "clifford_t 12q d10 t=0.2 sv",
+        &circuits::clifford_t_circuit(12, 10, 0.2, SEED),
+    );
+}
+
+#[test]
+fn factored_clifford_t_12q_fused() {
+    check_fused_vs_unfused(
+        "clifford_t 12q d10 t=0.2 fused",
+        &circuits::clifford_t_circuit(12, 10, 0.2, SEED),
+    );
+}
+
+// ===== w_state =====
+
+#[test]
+fn factored_w_state_8q_sv() {
+    check_sv_cross("w_state 8q sv", &circuits::w_state_circuit(8));
+}
+
+#[test]
+fn factored_w_state_8q_fused() {
+    check_fused_vs_unfused("w_state 8q fused", &circuits::w_state_circuit(8));
+}
+
+// ===== quantum_volume =====
+
+#[test]
+fn factored_quantum_volume_8q_sv() {
+    check_sv_cross(
+        "quantum_volume 8q d2 sv",
+        &circuits::quantum_volume_circuit(8, 2, SEED),
+    );
+}
+
+#[test]
+fn factored_quantum_volume_12q_fused() {
+    check_fused_vs_unfused(
+        "quantum_volume 12q d1 fused",
+        &circuits::quantum_volume_circuit(12, 1, SEED),
+    );
+}
+
+// ===== local_clifford_blocks =====
+
+#[test]
+fn factored_local_clifford_blocks_12q_sv() {
+    check_sv_cross(
+        "local_clifford_blocks 4x3 d10 sv",
+        &circuits::local_clifford_blocks(4, 3, 10, SEED),
+    );
+}
+
+#[test]
+fn factored_local_clifford_blocks_12q_fused() {
+    check_fused_vs_unfused(
+        "local_clifford_blocks 4x3 d10 fused",
+        &circuits::local_clifford_blocks(4, 3, 10, SEED),
+    );
+}
+
+#[test]
+fn factored_local_clifford_blocks_20q_sv() {
+    check_sv_cross(
+        "local_clifford_blocks 5x4 d10 sv",
+        &circuits::local_clifford_blocks(5, 4, 10, SEED),
+    );
+}
+
+#[test]
+fn factored_local_clifford_blocks_20q_fused() {
+    check_fused_vs_unfused(
+        "local_clifford_blocks 5x4 d10 fused",
+        &circuits::local_clifford_blocks(5, 4, 10, SEED),
+    );
+}
+
+// ===== cz_chain =====
+
+#[test]
+fn factored_cz_chain_12q_sv() {
+    check_sv_cross(
+        "cz_chain 12q d5 sv",
+        &circuits::cz_chain_circuit(12, 5, SEED),
+    );
+}
+
+#[test]
+fn factored_cz_chain_12q_fused() {
+    check_fused_vs_unfused(
+        "cz_chain 12q d5 fused",
+        &circuits::cz_chain_circuit(12, 5, SEED),
+    );
+}
+
+// ===== phase_estimation =====
+
+#[test]
+fn factored_phase_estimation_8q_sv() {
+    check_sv_cross("qpe 8q sv", &circuits::phase_estimation_circuit(8));
+}
+
+#[test]
+fn factored_phase_estimation_12q_fused() {
+    check_fused_vs_unfused("qpe 12q fused", &circuits::phase_estimation_circuit(12));
+}

--- a/tests/mps_correctness.rs
+++ b/tests/mps_correctness.rs
@@ -1,0 +1,224 @@
+//! Cross-backend correctness tests for `MpsBackend`.
+//!
+//! Bond dimension is sized to the circuit so MPS represents the full state
+//! exactly: `bond_dim = max(2^(n/2), 64)`. Tests cross-validate against the
+//! Statevector reference and against the unfused apply loop on the same
+//! backend at sizes ≤ 16q.
+
+mod common;
+
+use common::{assert_backend_matches_sv, assert_fused_matches_unfused, MPS_EPS, SEED};
+use prism_q::backend::mps::MpsBackend;
+use prism_q::circuit::Circuit;
+use prism_q::circuits;
+
+fn bond_dim_for(n: usize) -> usize {
+    let exact = 1usize << (n / 2);
+    exact.max(64)
+}
+
+fn check_sv_cross(label: &str, circuit: &Circuit) {
+    let bd = bond_dim_for(circuit.num_qubits);
+    let mut backend = MpsBackend::new(SEED, bd);
+    assert_backend_matches_sv(&mut backend, circuit, MPS_EPS, label);
+}
+
+fn check_fused_vs_unfused(label: &str, circuit: &Circuit) {
+    let bd = bond_dim_for(circuit.num_qubits);
+    assert_fused_matches_unfused(|| MpsBackend::new(SEED, bd), circuit, MPS_EPS, label);
+}
+
+// ===== qft =====
+
+#[test]
+fn mps_qft_4q_sv() {
+    check_sv_cross("qft 4q sv", &circuits::qft_circuit(4));
+}
+
+#[test]
+fn mps_qft_8q_sv() {
+    check_sv_cross("qft 8q sv", &circuits::qft_circuit(8));
+}
+
+#[test]
+fn mps_qft_12q_sv() {
+    check_sv_cross("qft 12q sv", &circuits::qft_circuit(12));
+}
+
+#[test]
+fn mps_qft_12q_fused() {
+    check_fused_vs_unfused("qft 12q fused", &circuits::qft_circuit(12));
+}
+
+// QFT at 16q+ is a known SVD-truncation stress case for MPS:
+// the cphase chain accumulates ~7e-6 truncation error even at bond_dim
+// 256, well above the 1e-9 cross-backend tolerance. Smaller QFT sizes
+// validate the same code paths without crossing that wall. The fusion
+// path uses bubble routing (apply_batch_phase_bubble), whose SVD chain
+// also differs from the unfused per-phase path, so even a same-backend
+// fused-vs-unfused check at 16q is not guaranteed to match at 1e-9.
+
+// ===== random =====
+
+#[test]
+fn mps_random_4q_sv() {
+    check_sv_cross("random 4q d10 sv", &circuits::random_circuit(4, 10, SEED));
+}
+
+#[test]
+fn mps_random_8q_sv() {
+    check_sv_cross("random 8q d10 sv", &circuits::random_circuit(8, 10, SEED));
+}
+
+#[test]
+fn mps_random_12q_fused() {
+    check_fused_vs_unfused(
+        "random 12q d5 fused",
+        &circuits::random_circuit(12, 5, SEED),
+    );
+}
+
+#[test]
+fn mps_random_16q_sv() {
+    check_sv_cross("random 16q d5 sv", &circuits::random_circuit(16, 5, SEED));
+}
+
+// ===== hardware_efficient_ansatz =====
+
+#[test]
+fn mps_hea_4q_sv() {
+    check_sv_cross(
+        "hea 4q l3 sv",
+        &circuits::hardware_efficient_ansatz(4, 3, SEED),
+    );
+}
+
+#[test]
+fn mps_hea_12q_fused() {
+    check_fused_vs_unfused(
+        "hea 12q l2 fused",
+        &circuits::hardware_efficient_ansatz(12, 2, SEED),
+    );
+}
+
+#[test]
+fn mps_hea_16q_sv() {
+    check_sv_cross(
+        "hea 16q l2 sv",
+        &circuits::hardware_efficient_ansatz(16, 2, SEED),
+    );
+}
+
+// ===== ghz =====
+
+#[test]
+fn mps_ghz_4q_sv() {
+    check_sv_cross("ghz 4q sv", &circuits::ghz_circuit(4));
+}
+
+#[test]
+fn mps_ghz_12q_fused() {
+    check_fused_vs_unfused("ghz 12q fused", &circuits::ghz_circuit(12));
+}
+
+#[test]
+fn mps_ghz_16q_sv() {
+    check_sv_cross("ghz 16q sv", &circuits::ghz_circuit(16));
+}
+
+// ===== qaoa =====
+
+#[test]
+fn mps_qaoa_4q_sv() {
+    check_sv_cross("qaoa 4q l2 sv", &circuits::qaoa_circuit(4, 2, SEED));
+}
+
+#[test]
+fn mps_qaoa_12q_fused() {
+    check_fused_vs_unfused("qaoa 12q l2 fused", &circuits::qaoa_circuit(12, 2, SEED));
+}
+
+// ===== clifford_heavy =====
+
+#[test]
+fn mps_clifford_8q_sv() {
+    check_sv_cross(
+        "clifford_heavy 8q d10 sv",
+        &circuits::clifford_heavy_circuit(8, 10, SEED),
+    );
+}
+
+#[test]
+fn mps_clifford_12q_fused() {
+    check_fused_vs_unfused(
+        "clifford_heavy 12q d10 fused",
+        &circuits::clifford_heavy_circuit(12, 10, SEED),
+    );
+}
+
+// ===== phase_estimation =====
+
+#[test]
+fn mps_qpe_4q_sv() {
+    check_sv_cross("qpe 4q sv", &circuits::phase_estimation_circuit(4));
+}
+
+#[test]
+fn mps_qpe_8q_sv() {
+    check_sv_cross("qpe 8q sv", &circuits::phase_estimation_circuit(8));
+}
+
+#[test]
+fn mps_qpe_12q_fused() {
+    check_fused_vs_unfused("qpe 12q fused", &circuits::phase_estimation_circuit(12));
+}
+
+// ===== w_state =====
+
+#[test]
+fn mps_w_state_4q_sv() {
+    check_sv_cross("w_state 4q sv", &circuits::w_state_circuit(4));
+}
+
+#[test]
+fn mps_w_state_8q_fused() {
+    check_fused_vs_unfused("w_state 8q fused", &circuits::w_state_circuit(8));
+}
+
+// ===== quantum_volume =====
+
+#[test]
+fn mps_qv_4q_sv() {
+    check_sv_cross(
+        "quantum_volume 4q d2 sv",
+        &circuits::quantum_volume_circuit(4, 2, SEED),
+    );
+}
+
+#[test]
+fn mps_qv_8q_fused() {
+    check_fused_vs_unfused(
+        "quantum_volume 8q d2 fused",
+        &circuits::quantum_volume_circuit(8, 2, SEED),
+    );
+}
+
+// ===== single_qubit_rotation =====
+
+#[test]
+fn mps_single_qubit_rotation_12q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 12q d5 sv",
+        &circuits::single_qubit_rotation_circuit(12, 5, SEED),
+    );
+}
+
+// ===== cz_chain =====
+
+#[test]
+fn mps_cz_chain_12q_fused() {
+    check_fused_vs_unfused(
+        "cz_chain 12q d3 fused",
+        &circuits::cz_chain_circuit(12, 3, SEED),
+    );
+}

--- a/tests/product_correctness.rs
+++ b/tests/product_correctness.rs
@@ -1,0 +1,261 @@
+//! Cross-backend correctness tests for `ProductStateBackend`.
+//!
+//! Product state stores per-qubit `[α, β]` and rejects entangling
+//! gates. Tests cover separable circuits only: `single_qubit_rotation_circuit`
+//! and hand-built 1q-only patterns. Each runs both fused vs unfused on
+//! the product backend and SV cross at the same precision.
+
+mod common;
+
+use common::{
+    assert_backend_matches_sv, assert_fused_matches_unfused, run_unfused_probs, PRODUCT_EPS, SEED,
+};
+use num_complex::Complex64;
+use prism_q::backend::product::ProductStateBackend;
+use prism_q::backend::Backend;
+use prism_q::circuit::{Circuit, Instruction};
+use prism_q::circuits;
+use prism_q::gates::{DiagEntry, DiagonalBatchData, Gate};
+use prism_q::sim;
+
+fn check_sv_cross(label: &str, circuit: &Circuit) {
+    let mut backend = ProductStateBackend::new(SEED);
+    assert_backend_matches_sv(&mut backend, circuit, PRODUCT_EPS, label);
+}
+
+fn check_fused_vs_unfused(label: &str, circuit: &Circuit) {
+    assert_fused_matches_unfused(
+        || ProductStateBackend::new(SEED),
+        circuit,
+        PRODUCT_EPS,
+        label,
+    );
+}
+
+fn has_gate<F: Fn(&Gate) -> bool>(circuit: &Circuit, matches_gate: F) -> bool {
+    let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
+    fused.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate { gate, .. } if matches_gate(gate)
+        )
+    })
+}
+
+// ===== single_qubit_rotation_circuit =====
+
+#[test]
+fn product_single_qubit_rotations_4q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 4q d5 sv",
+        &circuits::single_qubit_rotation_circuit(4, 5, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_rotations_4q_fused() {
+    check_fused_vs_unfused(
+        "single_qubit_rotation 4q d5 fused",
+        &circuits::single_qubit_rotation_circuit(4, 5, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_rotations_8q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 8q d10 sv",
+        &circuits::single_qubit_rotation_circuit(8, 10, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_rotations_8q_fused() {
+    check_fused_vs_unfused(
+        "single_qubit_rotation 8q d10 fused",
+        &circuits::single_qubit_rotation_circuit(8, 10, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_rotations_12q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 12q d10 sv",
+        &circuits::single_qubit_rotation_circuit(12, 10, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_rotations_16q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 16q d5 sv",
+        &circuits::single_qubit_rotation_circuit(16, 5, SEED),
+    );
+}
+
+#[test]
+fn product_single_qubit_diagonal_batch_direct() {
+    let mut c = Circuit::new(16, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(
+        Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+            entries: vec![
+                DiagEntry::Phase1q {
+                    qubit: 0,
+                    d0: Complex64::new(1.0, 0.0),
+                    d1: Complex64::from_polar(1.0, 0.37),
+                },
+                DiagEntry::Phase1q {
+                    qubit: 1,
+                    d0: Complex64::new(1.0, 0.0),
+                    d1: Complex64::from_polar(1.0, -0.53),
+                },
+            ],
+        })),
+        &[0, 1],
+    );
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    check_sv_cross("single_qubit_diagonal_batch direct sv", &c);
+    check_fused_vs_unfused("single_qubit_diagonal_batch direct fused", &c);
+}
+
+// ===== Hand-built separable circuits =====
+
+#[test]
+fn product_mixed_clifford_t_4q() {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::S, &[0]);
+    c.add_gate(Gate::T, &[1]);
+    c.add_gate(Gate::X, &[2]);
+    c.add_gate(Gate::Y, &[3]);
+    c.add_gate(Gate::Sdg, &[1]);
+    c.add_gate(Gate::Tdg, &[2]);
+    c.add_gate(Gate::H, &[3]);
+    check_sv_cross("mixed_clifford_t 4q sv", &c);
+    check_fused_vs_unfused("mixed_clifford_t 4q fused", &c);
+}
+
+#[test]
+fn product_full_rotation_chain_8q() {
+    let mut c = Circuit::new(8, 0);
+    for q in 0..8 {
+        c.add_gate(Gate::Rx(0.1 * (q + 1) as f64), &[q]);
+        c.add_gate(Gate::Ry(0.2 * (q + 1) as f64), &[q]);
+        c.add_gate(Gate::Rz(0.3 * (q + 1) as f64), &[q]);
+        c.add_gate(Gate::P(0.05 * (q + 1) as f64), &[q]);
+    }
+    check_sv_cross("full_rotation_chain 8q sv", &c);
+    check_fused_vs_unfused("full_rotation_chain 8q fused", &c);
+}
+
+#[test]
+fn product_sx_sxdg_8q() {
+    let mut c = Circuit::new(8, 0);
+    for q in 0..8 {
+        c.add_gate(Gate::SX, &[q]);
+        c.add_gate(Gate::T, &[q]);
+        c.add_gate(Gate::SXdg, &[q]);
+    }
+    check_sv_cross("sx_sxdg 8q sv", &c);
+    check_fused_vs_unfused("sx_sxdg 8q fused", &c);
+}
+
+// ===== Applicability gate =====
+
+#[test]
+fn product_rejects_cx() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(result.is_err(), "ProductState must reject Cx");
+}
+
+#[test]
+fn product_rejects_cz() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cz, &[0, 1]);
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(result.is_err(), "ProductState must reject Cz");
+}
+
+#[test]
+fn product_rejects_swap() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::X, &[0]);
+    c.add_gate(Gate::Swap, &[0, 1]);
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(result.is_err(), "ProductState must reject Swap");
+}
+
+#[test]
+fn product_rejects_rzz() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::Rzz(0.37), &[0, 1]);
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(result.is_err(), "ProductState must reject Rzz");
+}
+
+#[test]
+fn product_rejects_batch_rzz_fusion_16q() {
+    let c = circuits::qaoa_circuit(16, 1, SEED);
+    assert!(
+        has_gate(&c, |gate| matches!(gate, Gate::BatchRzz(_))),
+        "16q QAOA circuit should use BatchRzz fusion"
+    );
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(result.is_err(), "ProductState must reject BatchRzz");
+}
+
+#[test]
+fn product_rejects_entangling_diagonal_batch_16q() {
+    let mut c = Circuit::new(16, 0);
+    c.add_gate(Gate::Cz, &[0, 1]);
+    c.add_gate(Gate::Cz, &[2, 3]);
+    assert!(
+        has_gate(&c, |gate| matches!(gate, Gate::DiagonalBatch(_))),
+        "16q CZ run should use DiagonalBatch fusion"
+    );
+    let mut backend = ProductStateBackend::new(SEED);
+    let result = sim::run_on(&mut backend, &c);
+    assert!(
+        result.is_err(),
+        "ProductState must reject multi-qubit DiagonalBatch"
+    );
+}
+
+#[test]
+fn product_unfused_apply_is_separable_only() {
+    // The unfused path (init + apply loop) must also reject entangling gates,
+    // proving the rejection is in the kernel, not just a fusion-pass guard.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    let mut backend = ProductStateBackend::new(SEED);
+    backend.init(c.num_qubits, c.num_classical_bits).unwrap();
+    let mut had_err = false;
+    for instr in &c.instructions {
+        if backend.apply(instr).is_err() {
+            had_err = true;
+            break;
+        }
+    }
+    assert!(had_err, "raw apply must reject Cx on ProductStateBackend");
+}
+
+#[test]
+fn product_unfused_runs_separable_circuit() {
+    // Sanity: the unfused helper itself must succeed on a separable circuit.
+    let c = circuits::single_qubit_rotation_circuit(6, 5, SEED);
+    let mut backend = ProductStateBackend::new(SEED);
+    let _ = run_unfused_probs(&mut backend, &c);
+}

--- a/tests/sparse_correctness.rs
+++ b/tests/sparse_correctness.rs
@@ -1,0 +1,189 @@
+//! Cross-backend correctness tests for `SparseBackend`.
+//!
+//! Sparse stores `HashMap<usize, Complex64>` and supports the full
+//! gate set. Tests cross-validate against the Statevector reference
+//! and against the unfused apply loop on the same backend, across
+//! eight circuit families at sizes `≤ 12q`.
+
+mod common;
+
+use common::{assert_backend_matches_sv, assert_fused_matches_unfused, SEED, SPARSE_EPS};
+use prism_q::backend::sparse::SparseBackend;
+use prism_q::circuit::Circuit;
+use prism_q::circuits;
+
+fn check_sv_cross(label: &str, circuit: &Circuit) {
+    let mut backend = SparseBackend::new(SEED);
+    assert_backend_matches_sv(&mut backend, circuit, SPARSE_EPS, label);
+}
+
+fn check_fused_vs_unfused(label: &str, circuit: &Circuit) {
+    assert_fused_matches_unfused(|| SparseBackend::new(SEED), circuit, SPARSE_EPS, label);
+}
+
+// ===== qft =====
+
+#[test]
+fn sparse_qft_4q_sv() {
+    check_sv_cross("qft 4q sv", &circuits::qft_circuit(4));
+}
+
+#[test]
+fn sparse_qft_4q_fused() {
+    check_fused_vs_unfused("qft 4q fused", &circuits::qft_circuit(4));
+}
+
+#[test]
+fn sparse_qft_8q_sv() {
+    check_sv_cross("qft 8q sv", &circuits::qft_circuit(8));
+}
+
+#[test]
+fn sparse_qft_12q_sv() {
+    check_sv_cross("qft 12q sv", &circuits::qft_circuit(12));
+}
+
+#[test]
+fn sparse_qft_12q_fused() {
+    check_fused_vs_unfused("qft 12q fused", &circuits::qft_circuit(12));
+}
+
+// ===== random =====
+
+#[test]
+fn sparse_random_4q_sv() {
+    check_sv_cross("random 4q d10 sv", &circuits::random_circuit(4, 10, SEED));
+}
+
+#[test]
+fn sparse_random_8q_sv() {
+    check_sv_cross("random 8q d10 sv", &circuits::random_circuit(8, 10, SEED));
+}
+
+#[test]
+fn sparse_random_12q_sv() {
+    check_sv_cross("random 12q d10 sv", &circuits::random_circuit(12, 10, SEED));
+}
+
+#[test]
+fn sparse_random_12q_fused() {
+    check_fused_vs_unfused(
+        "random 12q d10 fused",
+        &circuits::random_circuit(12, 10, SEED),
+    );
+}
+
+// ===== hardware_efficient_ansatz =====
+
+#[test]
+fn sparse_hea_4q_sv() {
+    check_sv_cross(
+        "hea 4q l3 sv",
+        &circuits::hardware_efficient_ansatz(4, 3, SEED),
+    );
+}
+
+#[test]
+fn sparse_hea_12q_sv() {
+    check_sv_cross(
+        "hea 12q l3 sv",
+        &circuits::hardware_efficient_ansatz(12, 3, SEED),
+    );
+}
+
+#[test]
+fn sparse_hea_12q_fused() {
+    check_fused_vs_unfused(
+        "hea 12q l3 fused",
+        &circuits::hardware_efficient_ansatz(12, 3, SEED),
+    );
+}
+
+// ===== ghz =====
+
+#[test]
+fn sparse_ghz_4q_sv() {
+    check_sv_cross("ghz 4q sv", &circuits::ghz_circuit(4));
+}
+
+#[test]
+fn sparse_ghz_8q_sv() {
+    check_sv_cross("ghz 8q sv", &circuits::ghz_circuit(8));
+}
+
+#[test]
+fn sparse_ghz_12q_sv() {
+    check_sv_cross("ghz 12q sv", &circuits::ghz_circuit(12));
+}
+
+#[test]
+fn sparse_ghz_12q_fused() {
+    check_fused_vs_unfused("ghz 12q fused", &circuits::ghz_circuit(12));
+}
+
+// ===== qaoa =====
+
+#[test]
+fn sparse_qaoa_4q_sv() {
+    check_sv_cross("qaoa 4q l3 sv", &circuits::qaoa_circuit(4, 3, SEED));
+}
+
+#[test]
+fn sparse_qaoa_12q_sv() {
+    check_sv_cross("qaoa 12q l3 sv", &circuits::qaoa_circuit(12, 3, SEED));
+}
+
+#[test]
+fn sparse_qaoa_12q_fused() {
+    check_fused_vs_unfused("qaoa 12q l3 fused", &circuits::qaoa_circuit(12, 3, SEED));
+}
+
+// ===== clifford_heavy =====
+
+#[test]
+fn sparse_clifford_8q_sv() {
+    check_sv_cross(
+        "clifford_heavy 8q d10 sv",
+        &circuits::clifford_heavy_circuit(8, 10, SEED),
+    );
+}
+
+#[test]
+fn sparse_clifford_12q_fused() {
+    check_fused_vs_unfused(
+        "clifford_heavy 12q d10 fused",
+        &circuits::clifford_heavy_circuit(12, 10, SEED),
+    );
+}
+
+// ===== phase_estimation =====
+
+#[test]
+fn sparse_qpe_4q_sv() {
+    check_sv_cross("qpe 4q sv", &circuits::phase_estimation_circuit(4));
+}
+
+#[test]
+fn sparse_qpe_8q_sv() {
+    check_sv_cross("qpe 8q sv", &circuits::phase_estimation_circuit(8));
+}
+
+#[test]
+fn sparse_qpe_12q_fused() {
+    check_fused_vs_unfused("qpe 12q fused", &circuits::phase_estimation_circuit(12));
+}
+
+// ===== cz_chain =====
+
+#[test]
+fn sparse_cz_chain_8q_sv() {
+    check_sv_cross("cz_chain 8q d5 sv", &circuits::cz_chain_circuit(8, 5, SEED));
+}
+
+#[test]
+fn sparse_cz_chain_12q_fused() {
+    check_fused_vs_unfused(
+        "cz_chain 12q d5 fused",
+        &circuits::cz_chain_circuit(12, 5, SEED),
+    );
+}

--- a/tests/tensornetwork_correctness.rs
+++ b/tests/tensornetwork_correctness.rs
@@ -1,0 +1,186 @@
+//! Cross-backend correctness tests for `TensorNetworkBackend`.
+//!
+//! Deferred contraction with greedy min-size heuristic. Tests cross-validate
+//! against the Statevector reference at sizes ≤ 16q (the backend's
+//! `MAX_PROB_QUBITS = 25` cap is well above the slowest contraction covered
+//! by the unit-test suite).
+
+mod common;
+
+use common::{assert_backend_matches_sv, SEED, TN_EPS};
+use prism_q::backend::tensornetwork::TensorNetworkBackend;
+use prism_q::circuit::Circuit;
+use prism_q::circuits;
+
+fn check_sv_cross(label: &str, circuit: &Circuit) {
+    let mut backend = TensorNetworkBackend::new(SEED);
+    assert_backend_matches_sv(&mut backend, circuit, TN_EPS, label);
+}
+
+// ===== qft =====
+
+#[test]
+fn tn_qft_4q_sv() {
+    check_sv_cross("qft 4q sv", &circuits::qft_circuit(4));
+}
+
+#[test]
+fn tn_qft_8q_sv() {
+    check_sv_cross("qft 8q sv", &circuits::qft_circuit(8));
+}
+
+#[test]
+fn tn_qft_12q_sv() {
+    check_sv_cross("qft 12q sv", &circuits::qft_circuit(12));
+}
+
+// ===== random =====
+
+#[test]
+fn tn_random_4q_sv() {
+    check_sv_cross("random 4q d10 sv", &circuits::random_circuit(4, 10, SEED));
+}
+
+#[test]
+fn tn_random_8q_sv() {
+    check_sv_cross("random 8q d10 sv", &circuits::random_circuit(8, 10, SEED));
+}
+
+#[test]
+fn tn_random_12q_sv() {
+    check_sv_cross("random 12q d5 sv", &circuits::random_circuit(12, 5, SEED));
+}
+
+// ===== hardware_efficient_ansatz =====
+
+#[test]
+fn tn_hea_4q_sv() {
+    check_sv_cross(
+        "hea 4q l3 sv",
+        &circuits::hardware_efficient_ansatz(4, 3, SEED),
+    );
+}
+
+#[test]
+fn tn_hea_12q_sv() {
+    check_sv_cross(
+        "hea 12q l2 sv",
+        &circuits::hardware_efficient_ansatz(12, 2, SEED),
+    );
+}
+
+// ===== ghz =====
+
+#[test]
+fn tn_ghz_4q_sv() {
+    check_sv_cross("ghz 4q sv", &circuits::ghz_circuit(4));
+}
+
+#[test]
+fn tn_ghz_12q_sv() {
+    check_sv_cross("ghz 12q sv", &circuits::ghz_circuit(12));
+}
+
+#[test]
+fn tn_ghz_16q_sv() {
+    check_sv_cross("ghz 16q sv", &circuits::ghz_circuit(16));
+}
+
+// ===== qaoa =====
+
+#[test]
+fn tn_qaoa_4q_sv() {
+    check_sv_cross("qaoa 4q l2 sv", &circuits::qaoa_circuit(4, 2, SEED));
+}
+
+#[test]
+fn tn_qaoa_8q_sv() {
+    check_sv_cross("qaoa 8q l2 sv", &circuits::qaoa_circuit(8, 2, SEED));
+}
+
+// ===== clifford_heavy =====
+
+#[test]
+fn tn_clifford_8q_sv() {
+    check_sv_cross(
+        "clifford_heavy 8q d10 sv",
+        &circuits::clifford_heavy_circuit(8, 10, SEED),
+    );
+}
+
+#[test]
+fn tn_clifford_12q_sv() {
+    check_sv_cross(
+        "clifford_heavy 12q d10 sv",
+        &circuits::clifford_heavy_circuit(12, 10, SEED),
+    );
+}
+
+// ===== phase_estimation =====
+
+#[test]
+fn tn_qpe_4q_sv() {
+    check_sv_cross("qpe 4q sv", &circuits::phase_estimation_circuit(4));
+}
+
+#[test]
+fn tn_qpe_8q_sv() {
+    check_sv_cross("qpe 8q sv", &circuits::phase_estimation_circuit(8));
+}
+
+// ===== w_state =====
+
+#[test]
+fn tn_w_state_4q_sv() {
+    check_sv_cross("w_state 4q sv", &circuits::w_state_circuit(4));
+}
+
+#[test]
+fn tn_w_state_8q_sv() {
+    check_sv_cross("w_state 8q sv", &circuits::w_state_circuit(8));
+}
+
+// ===== single_qubit_rotation =====
+
+#[test]
+fn tn_single_qubit_rotation_8q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 8q d5 sv",
+        &circuits::single_qubit_rotation_circuit(8, 5, SEED),
+    );
+}
+
+#[test]
+fn tn_single_qubit_rotation_16q_sv() {
+    check_sv_cross(
+        "single_qubit_rotation 16q d3 sv",
+        &circuits::single_qubit_rotation_circuit(16, 3, SEED),
+    );
+}
+
+// ===== cz_chain =====
+
+#[test]
+fn tn_cz_chain_8q_sv() {
+    check_sv_cross("cz_chain 8q d5 sv", &circuits::cz_chain_circuit(8, 5, SEED));
+}
+
+#[test]
+fn tn_cz_chain_12q_sv() {
+    check_sv_cross(
+        "cz_chain 12q d3 sv",
+        &circuits::cz_chain_circuit(12, 3, SEED),
+    );
+}
+
+// ===== independent_bell_pairs =====
+
+#[test]
+fn tn_bell_pairs_4q_sv() {
+    check_sv_cross("bell_pairs 4q sv", &circuits::independent_bell_pairs(2));
+}
+
+#[test]
+fn tn_bell_pairs_12q_sv() {
+    check_sv_cross("bell_pairs 12q sv", &circuits::independent_bell_pairs(6));
+}


### PR DESCRIPTION
## Summary

Completes the per-backend correctness matrix across factored, MPS, product, sparse, and tensor-network backends. The product backend now returns `BackendUnsupported` for entangling fused diagonal paths instead of panicking, while separable single-qubit `DiagonalBatch` entries are handled directly.

## Scope

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no performance-sensitive hot-path changes. Changes cover correctness tests, unsupported-gate error handling, and product-backend compatibility for single-qubit diagonal batches.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| N/A | N/A | N/A | N/A | N/A |

Regression verdict: PASS

## Correctness

- [x] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional targeted checks:

- `cargo test --test product_correctness --test factored_correctness`
- `cargo test --test tensornetwork_correctness`
- `cargo test --features parallel --test factored_correctness factored_batch_phase_phase_sensitive_16q`

## Hotspot notes

N/A. Gate kernels are unchanged. Product backend changes are limited to dispatching unsupported entangling gate variants to errors and applying separable single-qubit diagonal batch entries.

## Architecture or design changes

- [ ] `docs/architecture.md` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No structural design changes.

## Breaking changes

None. Product backend behavior changes from panic to `BackendUnsupported` for unsupported fused entangling diagonal operations.

## Risks and rollback

Risk is limited to product backend fused diagonal dispatch and expanded correctness test coverage. Rollback can revert the product backend dispatch changes and the new correctness tests.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
