### PR TITLE
ci: add benchmark regression workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ env:
   # cudarc's dynamic-linking mode and can't build on hosts that don't have the NVIDIA
   # toolkit installed, so we enumerate features instead of using --all-features.
   CI_FEATURES: parallel,serialization
+  CI_BENCH_FEATURES: parallel,bench-fast
+  REGRESSION_THRESHOLD: ${{ vars.REGRESSION_THRESHOLD || '5.0' }}
 
 jobs:
   check:
@@ -37,6 +39,98 @@ jobs:
         run: cargo doc --no-deps --features "$CI_FEATURES"
         env:
           RUSTDOCFLAGS: -D warnings
+
+  benchmark-regression:
+    name: Benchmark Regression
+    runs-on: ubuntu-latest
+    needs: check
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          fetch-depth: 1
+
+      - name: Checkout head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            base -> target
+            head -> target
+
+      - name: Install benchmark tools
+        run: sudo apt-get update && sudo apt-get install -y bc jq
+
+      - name: Benchmark base
+        working-directory: base
+        run: bash ../head/scripts/bench_ci.sh
+        env:
+          PRISM_BENCH_PROJECT_DIR: ${{ github.workspace }}/base
+
+      - name: Save base baseline
+        working-directory: base
+        run: bash scripts/bench_check.sh save --name ci-base
+
+      - name: Copy base baseline
+        run: |
+          mkdir -p head/bench_results/baselines
+          cp base/bench_results/baselines/ci-base.json head/bench_results/baselines/ci-base.json
+
+      - name: Benchmark head
+        working-directory: head
+        run: bash scripts/bench_ci.sh
+
+      - name: Compare benchmark results
+        working-directory: head
+        run: |
+          set +e
+          bash scripts/bench_check.sh table --baseline ci-base | tee ../benchmark-summary.md
+          table_status=${PIPESTATUS[0]}
+          bash scripts/bench_check.sh compare --baseline ci-base | tee ../benchmark-compare.txt
+          compare_status=${PIPESTATUS[0]}
+
+          {
+            echo "## Benchmark Regression Gate"
+            echo ""
+            cat ../benchmark-summary.md
+            echo ""
+            echo '```text'
+            cat ../benchmark-compare.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$table_status" -ne 0 ]]; then
+            exit "$table_status"
+          fi
+          exit "$compare_status"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-regression
+          if-no-files-found: ignore
+          path: |
+            benchmark-summary.md
+            benchmark-compare.txt
+            base/bench_results/baselines/ci-base.json
+            head/bench_results/baselines/ci-base.json
+            head/target/criterion/**/benchmark.json
+            head/target/criterion/**/new/estimates.json
 
   coverage:
     name: Coverage

--- a/benches/README.md
+++ b/benches/README.md
@@ -78,11 +78,40 @@ cargo bench -- --baseline my_baseline
 REGRESSION_THRESHOLD=10 ./scripts/bench_compare.sh
 ```
 
+## CI regression gate
+
+Pull requests run a focused benchmark gate after lint and tests pass. The job
+checks out the base commit and PR head on the same runner, runs
+`scripts/bench_ci.sh` in both worktrees, saves the base results with
+`scripts/bench_check.sh`, then fails if any matching benchmark regresses beyond
+the configured threshold.
+
+The CI subset uses `CI_BENCH_FEATURES=parallel,bench-fast` and covers
+representative statevector kernels, measurement, OpenQASM parse plus simulate,
+macro circuit fusion, stabilizer dispatch, auto dispatch, and compiled sampling.
+It is a smoke gate, not a replacement for the full local benchmark suite required
+for performance-sensitive changes.
+
+Local reproduction:
+
+```bash
+CI_BENCH_FEATURES=parallel,bench-fast ./scripts/bench_ci.sh
+./scripts/bench_check.sh save --name ci-base
+
+# After applying changes:
+CI_BENCH_FEATURES=parallel,bench-fast ./scripts/bench_ci.sh
+./scripts/bench_check.sh table --baseline ci-base
+./scripts/bench_check.sh compare --baseline ci-base
+```
+
 ## Regression detection
 
 Default threshold: **5%** per benchmark (configurable via `REGRESSION_THRESHOLD`).
 
-Criterion reports regressions in its console output. The compare scripts parse this output and exit with code 1 if any regression is detected.
+`bench_check.*` reads Criterion JSON from `target/criterion/`, compares matching
+benchmark means, and exits with code 1 when any benchmark exceeds the threshold.
+The older `bench_compare.*` wrappers still parse Criterion console output for
+quick baseline checks.
 
 ## Reproducibility checklist
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -86,11 +86,13 @@ checks out the base commit and PR head on the same runner, runs
 `scripts/bench_check.sh`, then fails if any matching benchmark regresses beyond
 the configured threshold.
 
-The CI subset uses `CI_BENCH_FEATURES=parallel,bench-fast` and covers
-representative statevector kernels, measurement, OpenQASM parse plus simulate,
-macro circuit fusion, stabilizer dispatch, auto dispatch, and compiled sampling.
-It is a smoke gate, not a replacement for the full local benchmark suite required
-for performance-sensitive changes.
+The CI subset uses `CI_BENCH_FEATURES=parallel,bench-fast` and covers specific
+larger parameter points for representative statevector kernels, gate kernels,
+measurement, OpenQASM parse plus simulate, stabilizer dispatch, auto dispatch,
+and compiled sampling. The filters are intentionally narrow so GitHub hosted
+runner noise from tiny parameter sweeps does not dominate the gate. It is a
+smoke gate, not a replacement for the full local benchmark suite required for
+performance-sensitive changes.
 
 Local reproduction:
 

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run the benchmark subset used by the CI regression gate.
+#
+# This intentionally covers representative hot paths without running the full
+# Criterion suite. Use `CI_BENCH_FEATURES` to override the default feature set.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${PRISM_BENCH_PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
+FEATURES="${CI_BENCH_FEATURES:-parallel,bench-fast}"
+
+cd "$PROJECT_DIR"
+
+echo "=== PRISM-Q CI benchmark subset ==="
+echo "Features: $FEATURES"
+echo ""
+
+rm -rf "$PROJECT_DIR/target/criterion"
+
+run_bench() {
+    local bench="$1"
+    local filter="$2"
+
+    echo ">>> cargo bench --bench $bench --features $FEATURES -- $filter"
+    cargo bench --bench "$bench" --features "$FEATURES" -- "$filter"
+    echo ""
+}
+
+BENCH_DRIVER_FILTERS=(
+    "single_qubit_gates/h_gate"
+    "two_qubit_gates/cx_gate"
+    "measurement/measure_superposition"
+    "e2e_qasm"
+)
+
+CIRCUITS_FILTERS=(
+    "statevector/random_d10/16"
+    "statevector/qft_textbook/16"
+    "statevector/qaoa_l3/16"
+    "stabilizer/scaling/1000"
+    "auto/clifford_d10/20"
+    "compiled_sampler/noiseless"
+)
+
+for filter in "${BENCH_DRIVER_FILTERS[@]}"; do
+    run_bench "bench_driver" "$filter"
+done
+
+for filter in "${CIRCUITS_FILTERS[@]}"; do
+    run_bench "circuits" "$filter"
+done

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -18,29 +18,47 @@ echo ""
 
 rm -rf "$PROJECT_DIR/target/criterion"
 
+count_estimates() {
+    if [[ ! -d "$PROJECT_DIR/target/criterion" ]]; then
+        echo 0
+        return
+    fi
+
+    find "$PROJECT_DIR/target/criterion" -path "*/new/estimates.json" | wc -l | tr -d ' '
+}
+
 run_bench() {
     local bench="$1"
     local filter="$2"
+    local before_count
+    local after_count
+
+    before_count="$(count_estimates)"
 
     echo ">>> cargo bench --bench $bench --features $FEATURES -- $filter"
     cargo bench --bench "$bench" --features "$FEATURES" -- "$filter"
+    after_count="$(count_estimates)"
+    if (( after_count <= before_count )); then
+        echo "Error: benchmark filter produced no Criterion estimates: $bench $filter" >&2
+        exit 1
+    fi
     echo ""
 }
 
 BENCH_DRIVER_FILTERS=(
-    "single_qubit_gates/h_gate"
-    "two_qubit_gates/cx_gate"
-    "measurement/measure_superposition"
-    "e2e_qasm"
+    "single_qubit_gates/h_gate/20"
+    "two_qubit_gates/cx_gate/20"
+    "measurement/measure_superposition/20"
+    "e2e_qasm/ghz_5"
 )
 
 CIRCUITS_FILTERS=(
-    "statevector/random_d10/16"
-    "statevector/qft_textbook/16"
-    "statevector/qaoa_l3/16"
+    "statevector/random_d10/20"
+    "statevector/qft_textbook/20"
+    "statevector/qaoa_l3/20"
     "stabilizer/scaling/1000"
     "auto/clifford_d10/20"
-    "compiled_sampler/noiseless"
+    "compiled_sampler/noiseless/noiseless_1000q_10k"
 )
 
 for filter in "${BENCH_DRIVER_FILTERS[@]}"; do


### PR DESCRIPTION
This is adding a regression workflow. The workflow is set to a threshold of 5%. Currently, this will just be a trial to include it over several pull requests. Given the variance on the Github Action runners, I will be monitoring any changes coming in to see how the runners perform.

The aim is to have a performance regression check for functional changes. Unfortunately, with the current free runners, there is only CPU checks. My next step(s) will be to expand the CPU architecture coverage.