### PR TITLE
fix(openqasm): support Qiskit and native hardware gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ dispatch time, and can be overridden with `PRISM_MAX_SV_QUBITS`.
 ## Gates and OpenQASM support
 
 Covers the standard OpenQASM `stdgates.inc` set, common controlled and multi-controlled
-variants, decomposed multi-instruction gates, and IBM legacy u1/u2/u3 syntax. Modifiers
-`inv @`, `ctrl @`, `pow(k) @` chain arbitrarily, and user-defined `gate` declarations
-are supported.
+variants, Qiskit exporter gates, IonQ and Google/Cirq native gate names, decomposed
+multi-instruction gates, and IBM legacy u1/u2/u3 syntax. Modifiers `inv @`, `ctrl @`,
+`pow(k) @` chain arbitrarily for direct gates, and user-defined `gate` declarations are
+supported.
 
 The authoritative list of supported gate keywords, language features, and modifiers
 lives in the parser at [`src/circuit/openqasm.rs`](src/circuit/openqasm.rs). See

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ See the [Architecture Glossary](./glossary.md) for definitions of terms used thr
 
 Handwritten parser targeting a practical OpenQASM 3.0 subset. It processes input line by line and converts `&str` directly to `Circuit` IR with no intermediate AST.
 
-**Supported**: `qubit`/`bit` declarations, standard gates (x, y, z, h, s, sdg, t, tdg, rx, ry, rz, cx, cz, swap, sx, sxdg, p, cy, ch, crx, cry, crz, csx, ccx/toffoli, ccz, cswap/fredkin, rzz, rxx, ryy, ecr, iswap, dcx, u1, u2, u3/u), gate modifiers (`ctrl @`, `inv @`, `pow(k) @`), user-defined `gate` blocks, classical `if` conditionals, multi-register broadcast, measure, barrier, expression evaluator with math functions. OpenQASM 2.0 backward compatibility (`qreg`/`creg`, `measure q -> c` syntax).
+**Supported**: `qubit`/`bit` declarations, OpenQASM standard gates and aliases (x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot, cy, cz, cp/cphase, crx, cry, crz, ch, swap, ccx/toffoli, cswap/fredkin, cu, u1, u2, u3/u/U), Qiskit and exporter gates (sxdg, cs, csdg, csx, ccz, r, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, c3x, c4x, mcx, rccx, rc3x/rcccx), hardware-native gates (gpi, gpi2, ms, syc, sqrt_iswap, sqrt_iswap_inv), gate modifiers (`ctrl @`, `inv @`, `pow(k) @`), user-defined `gate` blocks, classical `if` conditionals, multi-register broadcast, measure, barrier, expression evaluator with math functions. OpenQASM 2.0 backward compatibility (`qreg`/`creg`, `measure q -> c` syntax).
 
 **Unsupported**: `for`/`while` loops, subroutines, classical expressions beyond `if`.
 

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -1,4 +1,4 @@
-//! OpenQASM 3.0 parser — v0 subset.
+//! OpenQASM 3.0 parser, v0 subset.
 //!
 //! # Supported constructs
 //!
@@ -9,10 +9,11 @@
 //! | Qubit declaration | `qubit[4] q;` | OQ3 syntax (primary) |
 //! | Bit declaration | `bit[4] c;` | OQ3 syntax (primary) |
 //! | Legacy qreg/creg | `qreg q[4]; creg c[4];` | OQ2 compat |
-//! | 1-qubit gates | `h q[0]; x q[1];` | id, x, y, z, h, s, sdg, t, tdg |
-//! | Parametric gates | `rx(pi/4) q[0];` | rx, ry, rz — arithmetic expressions with `pi`, math functions |
-//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cz, swap |
-//! | Gate modifiers | `inv @ h q[0];` | `inv @`, `ctrl @` (chainable), `pow(k) @` (integer k) |
+//! | 1-qubit gates | `h q[0]; x q[1];` | id, x, y, z, h, s, sdg, t, tdg, sx, sxdg, p/phase, r, gpi, gpi2, u/U forms |
+//! | Parametric gates | `rx(pi/4) q[0];` | rx, ry, rz, cu, ms, arithmetic expressions with `pi`, math functions |
+//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
+//! | Multi-qubit gates | `ccx q[0], q[1], q[2];` | ccx/toffoli, ccz, cswap/fredkin, c3x, c4x, mcx, rccx, rc3x/rcccx |
+//! | Gate modifiers | `inv @ h q[0];` | `inv @`, `ctrl @` (chainable), `pow(k) @` (integer k) for direct gates |
 //! | Measurement (OQ3) | `c[0] = measure q[0];` | Assignment syntax (primary) |
 //! | Measurement (OQ2) | `measure q[0] -> c[0];` | Arrow syntax (compat) |
 //! | Register broadcast | `h q;` / `cx q, r;` | Applies gate to all qubits in register |
@@ -718,6 +719,12 @@ impl<'a> Parser<'a> {
             if let Some(instrs) =
                 Self::resolve_decomposed_gate(&gate_name, &params, &qubits, line_num)?
             {
+                if !modifiers.is_empty() {
+                    return Err(PrismError::UnsupportedConstruct {
+                        construct: format!("modifier on decomposed gate `{gate_name}`"),
+                        line: line_num,
+                    });
+                }
                 return Ok(instrs);
             }
 
@@ -753,6 +760,12 @@ impl<'a> Parser<'a> {
             if let Some(mut instrs) =
                 Self::resolve_decomposed_gate(&gate_name, &params, &qubits, line_num)?
             {
+                if !modifiers.is_empty() {
+                    return Err(PrismError::UnsupportedConstruct {
+                        construct: format!("modifier on decomposed gate `{gate_name}`"),
+                        line: line_num,
+                    });
+                }
                 all_instrs.append(&mut instrs);
                 continue;
             }
@@ -1069,9 +1082,13 @@ impl<'a> Parser<'a> {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Ok(Gate::Rz(params[0]))
             }
-            "p" => {
+            "p" | "phase" => {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Ok(Gate::P(params[0]))
+            }
+            "r" => {
+                Self::expect_param_count(name, params, 2, line_num)?;
+                Ok(Gate::Fused(Box::new(Self::r_matrix(params[0], params[1]))))
             }
             "sx" => Ok(Gate::SX),
             "sxdg" => Ok(Gate::SXdg),
@@ -1085,7 +1102,15 @@ impl<'a> Parser<'a> {
             }
             "cx" | "CX" | "cnot" => Ok(Gate::Cx),
             "cy" => Ok(Gate::cu(Gate::Y.matrix_2x2())),
+            "cs" => Ok(Gate::cu(Gate::S.matrix_2x2())),
+            "csdg" => Ok(Gate::cu(Gate::Sdg.matrix_2x2())),
             "ch" => Ok(Gate::cu(Gate::H.matrix_2x2())),
+            "cu" => {
+                Self::expect_param_count(name, params, 4, line_num)?;
+                Ok(Gate::cu(Self::cu_target_matrix(
+                    params[0], params[1], params[2], params[3],
+                )))
+            }
             "crx" => {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Ok(Gate::cu(Gate::Rx(params[0]).matrix_2x2()))
@@ -1103,6 +1128,45 @@ impl<'a> Parser<'a> {
             "swap" => Ok(Gate::Swap),
             "ccx" | "toffoli" => Ok(Gate::mcu(Gate::X.matrix_2x2(), 2)),
             "ccz" => Ok(Gate::mcu(Gate::Z.matrix_2x2(), 2)),
+            "c3x" => Ok(Gate::mcu(Gate::X.matrix_2x2(), 3)),
+            "c4x" => Ok(Gate::mcu(Gate::X.matrix_2x2(), 4)),
+            "xx_plus_yy" => {
+                Self::expect_param_count(name, params, 2, line_num)?;
+                Ok(Gate::Fused2q(Box::new(Self::xx_plus_yy_matrix(
+                    params[0], params[1],
+                ))))
+            }
+            "xx_minus_yy" => {
+                Self::expect_param_count(name, params, 2, line_num)?;
+                Ok(Gate::Fused2q(Box::new(Self::xx_minus_yy_matrix(
+                    params[0], params[1],
+                ))))
+            }
+            "gpi" => {
+                Self::expect_param_count(name, params, 1, line_num)?;
+                Ok(Gate::Fused(Box::new(Self::gpi_matrix(params[0]))))
+            }
+            "gpi2" => {
+                Self::expect_param_count(name, params, 1, line_num)?;
+                Ok(Gate::Fused(Box::new(Self::gpi2_matrix(params[0]))))
+            }
+            "ms" => {
+                if !(params.len() == 2 || params.len() == 3) {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "`{name}` at line {line_num} requires 2 or 3 parameter(s), got {}",
+                            params.len()
+                        ),
+                    });
+                }
+                let theta = params.get(2).copied().unwrap_or(0.25);
+                Ok(Gate::Fused2q(Box::new(Self::ms_matrix(
+                    params[0], params[1], theta,
+                ))))
+            }
+            "syc" => Ok(Gate::Fused2q(Box::new(Self::syc_matrix()))),
+            "sqrt_iswap" => Ok(Gate::Fused2q(Box::new(Self::sqrt_iswap_matrix(1.0)))),
+            "sqrt_iswap_inv" => Ok(Gate::Fused2q(Box::new(Self::sqrt_iswap_matrix(-1.0)))),
             _ => Err(PrismError::UnsupportedConstruct {
                 construct: name.to_string(),
                 line: line_num,
@@ -1122,6 +1186,153 @@ impl<'a> Parser<'a> {
         line_num: usize,
     ) -> Result<Option<Vec<Instruction>>> {
         match name {
+            "mcx" => {
+                if qubits.len() < 2 {
+                    return Err(PrismError::GateArity {
+                        gate: name.to_string(),
+                        expected: 2,
+                        got: qubits.len(),
+                    });
+                }
+                let controls = qubits.len() - 1;
+                if controls > u8::MAX as usize {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "`{name}` at line {line_num} supports at most {} controls, got {controls}",
+                            u8::MAX
+                        ),
+                    });
+                }
+                Ok(Some(vec![Instruction::Gate {
+                    gate: Gate::mcu(Gate::X.matrix_2x2(), controls as u8),
+                    targets: SmallVec::from_slice(qubits),
+                }]))
+            }
+            "rccx" => {
+                Self::check_arity(name, qubits, 3)?;
+                let c0 = qubits[0];
+                let c1 = qubits[1];
+                let target = qubits[2];
+                Ok(Some(vec![
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c1, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c0, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c1, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                ]))
+            }
+            "rc3x" | "rcccx" => {
+                Self::check_arity(name, qubits, 4)?;
+                let c0 = qubits[0];
+                let c1 = qubits[1];
+                let c2 = qubits[2];
+                let target = qubits[3];
+                Ok(Some(vec![
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c2, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c0, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c1, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c0, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c1, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::T,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Cx,
+                        targets: smallvec![c2, target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::Tdg,
+                        targets: smallvec![target],
+                    },
+                    Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![target],
+                    },
+                ]))
+            }
             "cswap" | "fredkin" => {
                 Self::check_arity(name, qubits, 3)?;
                 let ctrl = qubits[0];
@@ -1311,21 +1522,13 @@ impl<'a> Parser<'a> {
                     targets: smallvec![qubits[0]],
                 }]))
             }
-            "u3" | "u" => {
+            "u3" | "u" | "U" => {
                 Self::expect_param_count(name, params, 3, line_num)?;
                 Self::check_arity(name, qubits, 1)?;
                 let theta = params[0];
                 let phi = params[1];
                 let lam = params[2];
-                let c = (theta / 2.0).cos();
-                let s = (theta / 2.0).sin();
-                let mat = [
-                    [Complex64::new(c, 0.0), -Complex64::from_polar(s, lam)],
-                    [
-                        Complex64::from_polar(s, phi),
-                        Complex64::from_polar(c, phi + lam),
-                    ],
-                ];
+                let mat = Self::u_matrix(theta, phi, lam);
                 Ok(Some(vec![Instruction::Gate {
                     gate: Gate::Fused(Box::new(mat)),
                     targets: smallvec![qubits[0]],
@@ -1344,6 +1547,155 @@ impl<'a> Parser<'a> {
             });
         }
         Ok(())
+    }
+
+    fn u_matrix(theta: f64, phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
+        let c = (theta / 2.0).cos();
+        let s = (theta / 2.0).sin();
+        [
+            [Complex64::new(c, 0.0), -Complex64::from_polar(s, lam)],
+            [
+                Complex64::from_polar(s, phi),
+                Complex64::from_polar(c, phi + lam),
+            ],
+        ]
+    }
+
+    fn r_matrix(theta: f64, phi: f64) -> [[Complex64; 2]; 2] {
+        let zero_phase = Complex64::new((theta / 2.0).cos(), 0.0);
+        let off = Complex64::new(0.0, -1.0) * (theta / 2.0).sin();
+        [
+            [zero_phase, off * Complex64::from_polar(1.0, -phi)],
+            [off * Complex64::from_polar(1.0, phi), zero_phase],
+        ]
+    }
+
+    fn cu_target_matrix(theta: f64, phi: f64, lam: f64, gamma: f64) -> [[Complex64; 2]; 2] {
+        let phase = Complex64::from_polar(1.0, gamma);
+        let u = Self::u_matrix(theta, phi, lam);
+        [
+            [phase * u[0][0], phase * u[0][1]],
+            [phase * u[1][0], phase * u[1][1]],
+        ]
+    }
+
+    fn xx_plus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let c = Complex64::new((theta / 2.0).cos(), 0.0);
+        let s = Complex64::new(0.0, -(theta / 2.0).sin());
+        [
+            [one, zero, zero, zero],
+            [zero, c, s * Complex64::from_polar(1.0, -beta), zero],
+            [zero, s * Complex64::from_polar(1.0, beta), c, zero],
+            [zero, zero, zero, one],
+        ]
+    }
+
+    fn xx_minus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let c = Complex64::new((theta / 2.0).cos(), 0.0);
+        let s = Complex64::new(0.0, -(theta / 2.0).sin());
+        [
+            [c, zero, zero, s * Complex64::from_polar(1.0, -beta)],
+            [zero, one, zero, zero],
+            [zero, zero, one, zero],
+            [s * Complex64::from_polar(1.0, beta), zero, zero, c],
+        ]
+    }
+
+    fn gpi_matrix(phi: f64) -> [[Complex64; 2]; 2] {
+        let zero = Complex64::new(0.0, 0.0);
+        [
+            [
+                zero,
+                Complex64::from_polar(1.0, -std::f64::consts::TAU * phi),
+            ],
+            [
+                Complex64::from_polar(1.0, std::f64::consts::TAU * phi),
+                zero,
+            ],
+        ]
+    }
+
+    fn gpi2_matrix(phi: f64) -> [[Complex64; 2]; 2] {
+        let one = Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+        let off = Complex64::new(0.0, -std::f64::consts::FRAC_1_SQRT_2);
+        [
+            [
+                one,
+                off * Complex64::from_polar(1.0, -std::f64::consts::TAU * phi),
+            ],
+            [
+                off * Complex64::from_polar(1.0, std::f64::consts::TAU * phi),
+                one,
+            ],
+        ]
+    }
+
+    fn ms_matrix(phi0: f64, phi1: f64, theta: f64) -> [[Complex64; 4]; 4] {
+        let zero = Complex64::new(0.0, 0.0);
+        let c = Complex64::new((std::f64::consts::PI * theta).cos(), 0.0);
+        let s = Complex64::new(0.0, -(std::f64::consts::PI * theta).sin());
+        let sum = phi0 + phi1;
+        let diff = phi0 - phi1;
+        [
+            [
+                c,
+                zero,
+                zero,
+                s * Complex64::from_polar(1.0, -std::f64::consts::TAU * sum),
+            ],
+            [
+                zero,
+                c,
+                s * Complex64::from_polar(1.0, -std::f64::consts::TAU * diff),
+                zero,
+            ],
+            [
+                zero,
+                s * Complex64::from_polar(1.0, std::f64::consts::TAU * diff),
+                c,
+                zero,
+            ],
+            [
+                s * Complex64::from_polar(1.0, std::f64::consts::TAU * sum),
+                zero,
+                zero,
+                c,
+            ],
+        ]
+    }
+
+    fn syc_matrix() -> [[Complex64; 4]; 4] {
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let neg_i = Complex64::new(0.0, -1.0);
+        [
+            [one, zero, zero, zero],
+            [zero, zero, neg_i, zero],
+            [zero, neg_i, zero, zero],
+            [
+                zero,
+                zero,
+                zero,
+                Complex64::from_polar(1.0, -std::f64::consts::PI / 6.0),
+            ],
+        ]
+    }
+
+    fn sqrt_iswap_matrix(sign: f64) -> [[Complex64; 4]; 4] {
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let half = Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+        let off = Complex64::new(0.0, sign * std::f64::consts::FRAC_1_SQRT_2);
+        [
+            [one, zero, zero, zero],
+            [zero, half, off, zero],
+            [zero, off, half, zero],
+            [zero, zero, zero, one],
+        ]
     }
 
     fn expect_param_count(

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+fn assert_complex_close(actual: num_complex::Complex64, expected: num_complex::Complex64) {
+    assert!(
+        (actual - expected).norm() < 1e-12,
+        "expected {expected:?}, got {actual:?}"
+    );
+}
+
+fn assert_mat2_close(
+    actual: &[[num_complex::Complex64; 2]; 2],
+    expected: [[num_complex::Complex64; 2]; 2],
+) {
+    for i in 0..2 {
+        for j in 0..2 {
+            assert_complex_close(actual[i][j], expected[i][j]);
+        }
+    }
+}
+
+fn assert_mat4_close(
+    actual: &[[num_complex::Complex64; 4]; 4],
+    expected: [[num_complex::Complex64; 4]; 4],
+) {
+    for i in 0..4 {
+        for j in 0..4 {
+            assert_complex_close(actual[i][j], expected[i][j]);
+        }
+    }
+}
+
 #[test]
 fn test_oq3_minimal_circuit() {
     let qasm = "OPENQASM 3.0;\nqubit[1] q;\nh q[0];";
@@ -421,6 +450,76 @@ fn test_p_gate() {
 }
 
 #[test]
+fn test_phase_alias() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nphase(pi/4) q[0];";
+    let c = parse(qasm).unwrap();
+    if let Instruction::Gate { gate, .. } = &c.instructions[0] {
+        assert_eq!(*gate, Gate::P(std::f64::consts::FRAC_PI_4));
+    } else {
+        panic!("expected gate");
+    }
+}
+
+#[test]
+fn test_uppercase_u_gate() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nU(pi/2, 0, pi) q[0];";
+    let c = parse(qasm).unwrap();
+    if let Instruction::Gate { gate, .. } = &c.instructions[0] {
+        if let Gate::Fused(mat) = gate {
+            assert_mat2_close(mat, Gate::H.matrix_2x2());
+        } else {
+            panic!("expected Fused");
+        }
+    } else {
+        panic!("expected gate");
+    }
+}
+
+#[test]
+fn test_qiskit_exported_r_definition_uses_uppercase_u() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        gate r(p0, p1) _gate_q_0 {
+          U(p0, -pi/2 + p1, pi/2 - p1) _gate_q_0;
+        }
+        qubit[1] q;
+        r(pi/3, pi/7) q[0];
+    "#;
+    let c = parse(qasm).unwrap();
+    assert_eq!(c.gate_count(), 1);
+    assert!(matches!(
+        &c.instructions[0],
+        Instruction::Gate {
+            gate: Gate::Fused(_),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_r_gate_matrix() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nr(pi/2, pi/4) q[0];";
+    let c = parse(qasm).unwrap();
+    let theta = std::f64::consts::FRAC_PI_2;
+    let phi = std::f64::consts::FRAC_PI_4;
+    let c0 = num_complex::Complex64::new((theta / 2.0).cos(), 0.0);
+    let off = num_complex::Complex64::new(0.0, -1.0) * (theta / 2.0).sin();
+    let expected = [
+        [c0, off * num_complex::Complex64::from_polar(1.0, -phi)],
+        [off * num_complex::Complex64::from_polar(1.0, phi), c0],
+    ];
+    if let Instruction::Gate { gate, .. } = &c.instructions[0] {
+        if let Gate::Fused(mat) = gate {
+            assert_mat2_close(mat, expected);
+        } else {
+            panic!("expected Fused");
+        }
+    } else {
+        panic!("expected gate");
+    }
+}
+
+#[test]
 fn test_cy_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\ncy q[0], q[1];";
     let c = parse(qasm).unwrap();
@@ -434,6 +533,58 @@ fn test_cy_gate() {
                     assert!((mat[i][j] - expected[i][j]).norm() < 1e-12);
                 }
             }
+        } else {
+            panic!("expected Cu");
+        }
+    } else {
+        panic!("expected gate");
+    }
+}
+
+#[test]
+fn test_cs_and_csdg_gates() {
+    let qasm = "OPENQASM 3.0;\nqubit[2] q;\ncs q[0], q[1];\ncsdg q[0], q[1];";
+    let c = parse(qasm).unwrap();
+    let expected = [Gate::S.matrix_2x2(), Gate::Sdg.matrix_2x2()];
+    for (inst, expected_mat) in c.instructions.iter().zip(expected) {
+        if let Instruction::Gate { gate, targets } = inst {
+            assert_eq!(targets.as_slice(), &[0, 1]);
+            if let Gate::Cu(mat) = gate {
+                assert_mat2_close(mat, expected_mat);
+            } else {
+                panic!("expected Cu");
+            }
+        } else {
+            panic!("expected gate");
+        }
+    }
+}
+
+#[test]
+fn test_cu_gate_matrix() {
+    let qasm = "OPENQASM 3.0;\nqubit[2] q;\ncu(pi/2, pi/5, pi/7, pi/11) q[0], q[1];";
+    let c = parse(qasm).unwrap();
+    let theta = std::f64::consts::FRAC_PI_2;
+    let phi = std::f64::consts::PI / 5.0;
+    let lam = std::f64::consts::PI / 7.0;
+    let gamma = std::f64::consts::PI / 11.0;
+    let c0 = (theta / 2.0).cos();
+    let s0 = (theta / 2.0).sin();
+    let phase = num_complex::Complex64::from_polar(1.0, gamma);
+    let expected = [
+        [
+            phase * num_complex::Complex64::new(c0, 0.0),
+            -phase * num_complex::Complex64::from_polar(s0, lam),
+        ],
+        [
+            phase * num_complex::Complex64::from_polar(s0, phi),
+            phase * num_complex::Complex64::from_polar(c0, phi + lam),
+        ],
+    ];
+    if let Instruction::Gate { gate, targets } = &c.instructions[0] {
+        assert_eq!(targets.as_slice(), &[0, 1]);
+        if let Gate::Cu(mat) = gate {
+            assert_mat2_close(mat, expected);
         } else {
             panic!("expected Cu");
         }
@@ -508,6 +659,63 @@ fn test_ccz_gate() {
 }
 
 #[test]
+fn test_multi_controlled_x_aliases() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        qubit[6] q;
+        c3x q[0], q[1], q[2], q[3];
+        c4x q[0], q[1], q[2], q[3], q[4];
+        mcx q[0], q[1], q[2], q[3], q[4], q[5];
+    "#;
+    let c = parse(qasm).unwrap();
+    let expected_controls = [3, 4, 5];
+    for (inst, expected) in c.instructions.iter().zip(expected_controls) {
+        if let Instruction::Gate { gate, .. } = inst {
+            if let Gate::Mcu(data) = gate {
+                assert_eq!(data.num_controls, expected);
+                assert_mat2_close(&data.mat, Gate::X.matrix_2x2());
+            } else {
+                panic!("expected Mcu");
+            }
+        } else {
+            panic!("expected gate");
+        }
+    }
+}
+
+#[test]
+fn test_relative_phase_x_decompositions() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        qubit[4] q;
+        rccx q[0], q[1], q[2];
+        rcccx q[0], q[1], q[2], q[3];
+        rc3x q[0], q[1], q[2], q[3];
+    "#;
+    let c = parse(qasm).unwrap();
+    assert_eq!(c.instructions.len(), 45);
+    assert!(
+        matches!(&c.instructions[0], Instruction::Gate { gate: Gate::H, targets } if targets.as_slice() == [2])
+    );
+    assert!(
+        matches!(&c.instructions[8], Instruction::Gate { gate: Gate::H, targets } if targets.as_slice() == [2])
+    );
+    assert!(
+        matches!(&c.instructions[9], Instruction::Gate { gate: Gate::H, targets } if targets.as_slice() == [3])
+    );
+    assert!(
+        matches!(&c.instructions[27], Instruction::Gate { gate: Gate::H, targets } if targets.as_slice() == [3])
+    );
+}
+
+#[test]
+fn test_modifier_on_decomposed_gate_rejected() {
+    let qasm = "OPENQASM 3.0;\nqubit[2] q;\ninv @ rxx(pi/4) q[0], q[1];";
+    let err = parse(qasm).unwrap_err();
+    assert!(matches!(err, PrismError::UnsupportedConstruct { .. }));
+}
+
+#[test]
 fn test_cswap_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[3] q;\ncswap q[0], q[1], q[2];";
     let c = parse(qasm).unwrap();
@@ -552,10 +760,246 @@ fn test_ryy_gate() {
 }
 
 #[test]
+fn test_xx_plus_minus_yy_matrices() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        qubit[2] q;
+        xx_plus_yy(pi/3, pi/5) q[0], q[1];
+        xx_minus_yy(pi/7, pi/11) q[0], q[1];
+    "#;
+    let c = parse(qasm).unwrap();
+
+    let zero = num_complex::Complex64::new(0.0, 0.0);
+    let one = num_complex::Complex64::new(1.0, 0.0);
+    let plus_theta = std::f64::consts::PI / 3.0;
+    let plus_beta = std::f64::consts::PI / 5.0;
+    let plus_c = num_complex::Complex64::new((plus_theta / 2.0).cos(), 0.0);
+    let plus_s = num_complex::Complex64::new(0.0, -(plus_theta / 2.0).sin());
+    let expected_plus = [
+        [one, zero, zero, zero],
+        [
+            zero,
+            plus_c,
+            plus_s * num_complex::Complex64::from_polar(1.0, -plus_beta),
+            zero,
+        ],
+        [
+            zero,
+            plus_s * num_complex::Complex64::from_polar(1.0, plus_beta),
+            plus_c,
+            zero,
+        ],
+        [zero, zero, zero, one],
+    ];
+
+    let minus_theta = std::f64::consts::PI / 7.0;
+    let minus_beta = std::f64::consts::PI / 11.0;
+    let minus_c = num_complex::Complex64::new((minus_theta / 2.0).cos(), 0.0);
+    let minus_s = num_complex::Complex64::new(0.0, -(minus_theta / 2.0).sin());
+    let expected_minus = [
+        [
+            minus_c,
+            zero,
+            zero,
+            minus_s * num_complex::Complex64::from_polar(1.0, -minus_beta),
+        ],
+        [zero, one, zero, zero],
+        [zero, zero, one, zero],
+        [
+            minus_s * num_complex::Complex64::from_polar(1.0, minus_beta),
+            zero,
+            zero,
+            minus_c,
+        ],
+    ];
+
+    if let Instruction::Gate { gate, targets } = &c.instructions[0] {
+        assert_eq!(targets.as_slice(), &[0, 1]);
+        if let Gate::Fused2q(mat) = gate {
+            assert_mat4_close(mat, expected_plus);
+        } else {
+            panic!("expected Fused2q");
+        }
+    } else {
+        panic!("expected gate");
+    }
+    if let Instruction::Gate { gate, targets } = &c.instructions[1] {
+        assert_eq!(targets.as_slice(), &[0, 1]);
+        if let Gate::Fused2q(mat) = gate {
+            assert_mat4_close(mat, expected_minus);
+        } else {
+            panic!("expected Fused2q");
+        }
+    } else {
+        panic!("expected gate");
+    }
+}
+
+#[test]
 fn test_iswap_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\niswap q[0], q[1];";
     let c = parse(qasm).unwrap();
     assert_eq!(c.instructions.len(), 6);
+}
+
+#[test]
+fn test_google_cirq_native_matrices() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        qubit[2] q;
+        syc q[0], q[1];
+        sqrt_iswap q[0], q[1];
+        sqrt_iswap_inv q[0], q[1];
+    "#;
+    let c = parse(qasm).unwrap();
+    let zero = num_complex::Complex64::new(0.0, 0.0);
+    let one = num_complex::Complex64::new(1.0, 0.0);
+    let neg_i = num_complex::Complex64::new(0.0, -1.0);
+    let half = num_complex::Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+    let pos_half_i = num_complex::Complex64::new(0.0, std::f64::consts::FRAC_1_SQRT_2);
+    let neg_half_i = num_complex::Complex64::new(0.0, -std::f64::consts::FRAC_1_SQRT_2);
+    let expected = [
+        [
+            [one, zero, zero, zero],
+            [zero, zero, neg_i, zero],
+            [zero, neg_i, zero, zero],
+            [
+                zero,
+                zero,
+                zero,
+                num_complex::Complex64::from_polar(1.0, -std::f64::consts::PI / 6.0),
+            ],
+        ],
+        [
+            [one, zero, zero, zero],
+            [zero, half, pos_half_i, zero],
+            [zero, pos_half_i, half, zero],
+            [zero, zero, zero, one],
+        ],
+        [
+            [one, zero, zero, zero],
+            [zero, half, neg_half_i, zero],
+            [zero, neg_half_i, half, zero],
+            [zero, zero, zero, one],
+        ],
+    ];
+
+    for (inst, expected_mat) in c.instructions.iter().zip(expected) {
+        if let Instruction::Gate { gate, targets } = inst {
+            assert_eq!(targets.as_slice(), &[0, 1]);
+            if let Gate::Fused2q(mat) = gate {
+                assert_mat4_close(mat, expected_mat);
+            } else {
+                panic!("expected Fused2q");
+            }
+        } else {
+            panic!("expected gate");
+        }
+    }
+}
+
+#[test]
+fn test_ionq_native_gate_matrices() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        qubit[2] q;
+        gpi(0.25) q[0];
+        gpi2(0.5) q[0];
+        ms(0.125, 0.25, 0.125) q[0], q[1];
+        ms(0.0, 0.0) q[0], q[1];
+    "#;
+    let c = parse(qasm).unwrap();
+    let zero = num_complex::Complex64::new(0.0, 0.0);
+    let i = num_complex::Complex64::new(0.0, 1.0);
+    if let Instruction::Gate { gate, .. } = &c.instructions[0] {
+        if let Gate::Fused(mat) = gate {
+            assert_mat2_close(mat, [[zero, -i], [i, zero]]);
+        } else {
+            panic!("expected Fused");
+        }
+    } else {
+        panic!("expected gate");
+    }
+
+    if let Instruction::Gate { gate, .. } = &c.instructions[1] {
+        if let Gate::Fused(mat) = gate {
+            let h = std::f64::consts::FRAC_1_SQRT_2;
+            let expected = [
+                [
+                    num_complex::Complex64::new(h, 0.0),
+                    num_complex::Complex64::new(0.0, h),
+                ],
+                [
+                    num_complex::Complex64::new(0.0, h),
+                    num_complex::Complex64::new(h, 0.0),
+                ],
+            ];
+            assert_mat2_close(mat, expected);
+        } else {
+            panic!("expected Fused");
+        }
+    } else {
+        panic!("expected gate");
+    }
+
+    let theta = 0.125;
+    let phi0 = 0.125;
+    let phi1 = 0.25;
+    let c0 = num_complex::Complex64::new((std::f64::consts::PI * theta).cos(), 0.0);
+    let s0 = num_complex::Complex64::new(0.0, -(std::f64::consts::PI * theta).sin());
+    let expected_ms = [
+        [
+            c0,
+            zero,
+            zero,
+            s0 * num_complex::Complex64::from_polar(1.0, -std::f64::consts::TAU * (phi0 + phi1)),
+        ],
+        [
+            zero,
+            c0,
+            s0 * num_complex::Complex64::from_polar(1.0, -std::f64::consts::TAU * (phi0 - phi1)),
+            zero,
+        ],
+        [
+            zero,
+            s0 * num_complex::Complex64::from_polar(1.0, std::f64::consts::TAU * (phi0 - phi1)),
+            c0,
+            zero,
+        ],
+        [
+            s0 * num_complex::Complex64::from_polar(1.0, std::f64::consts::TAU * (phi0 + phi1)),
+            zero,
+            zero,
+            c0,
+        ],
+    ];
+    if let Instruction::Gate { gate, .. } = &c.instructions[2] {
+        if let Gate::Fused2q(mat) = gate {
+            assert_mat4_close(mat, expected_ms);
+        } else {
+            panic!("expected Fused2q");
+        }
+    } else {
+        panic!("expected gate");
+    }
+
+    let c_default = num_complex::Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+    let s_default = num_complex::Complex64::new(0.0, -std::f64::consts::FRAC_1_SQRT_2);
+    let expected_default_ms = [
+        [c_default, zero, zero, s_default],
+        [zero, c_default, s_default, zero],
+        [zero, s_default, c_default, zero],
+        [s_default, zero, zero, c_default],
+    ];
+    if let Instruction::Gate { gate, .. } = &c.instructions[3] {
+        if let Gate::Fused2q(mat) = gate {
+            assert_mat4_close(mat, expected_default_ms);
+        } else {
+            panic!("expected Fused2q");
+        }
+    } else {
+        panic!("expected gate");
+    }
 }
 
 #[test]

--- a/tests/smoke_openqasm.rs
+++ b/tests/smoke_openqasm.rs
@@ -193,6 +193,40 @@ fn all_two_qubit_gates_parse() {
     assert_eq!(circuit.gate_count(), 3);
 }
 
+#[test]
+fn ecosystem_gate_bundle_parses_and_runs() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[5] q;
+        h q[0];
+        r(pi/3, pi/7) q[0];
+        phase(pi/9) q[1];
+        gpi(0.25) q[2];
+        gpi2(0.5) q[3];
+        xx_plus_yy(pi/5, pi/11) q[0], q[1];
+        xx_minus_yy(pi/7, pi/13) q[1], q[2];
+        syc q[2], q[3];
+        sqrt_iswap q[3], q[4];
+        sqrt_iswap_inv q[3], q[4];
+        ms(0.125, 0.25, 0.125) q[0], q[4];
+        cs q[0], q[1];
+        csdg q[1], q[2];
+        cu(pi/3, pi/5, pi/7, pi/11) q[2], q[3];
+        c3x q[0], q[1], q[2], q[3];
+        c4x q[0], q[1], q[2], q[3], q[4];
+        rccx q[0], q[1], q[2];
+        rcccx q[0], q[1], q[2], q[3];
+    "#;
+
+    let circuit = openqasm::parse(qasm).unwrap();
+    let mut backend = StatevectorBackend::new(42);
+    let result = sim::run_on(&mut backend, &circuit).unwrap();
+    let probabilities = result.probabilities.unwrap();
+    let total: f64 = probabilities.iter().sum();
+    assert!((total - 1.0).abs() < 1e-10);
+}
+
 // -- Gate modifier tests --
 
 #[test]


### PR DESCRIPTION
## Summary

Add parser support for ecosystem OpenQASM gate coverage used by Qiskit exporters, IonQ native circuits, and Google/Cirq native circuits. The change adds exact matrix or existing-IR decompositions for the new parser gates, documents the supported coverage, and adds focused parser plus statevector smoke coverage.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. Parser-only compatibility and documentation updates.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| N/A | N/A | N/A | N/A | N/A |

Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional checks run:

- [x] `cargo test openqasm --lib`
- [x] `cargo test --test smoke_openqasm`
- [x] `cargo clippy --all-targets -- -D warnings`

## Hotspot notes

N/A. No simulation kernels, fusion passes, or backend hot paths changed.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

## Breaking changes

None.

## Risks and rollback

Risk is limited to OpenQASM parser behavior for newly recognized gate names and modifier handling on decomposed gates. Rollback is a single parser and test revert if importer compatibility regresses.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
