### PR TITLE
feat(qec): add native Clifford QEC program runner with Pauli noise

### DIFF
--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -1,10 +1,10 @@
 //! Focused benchmark for shot-sampling and counting performance.
 //!
 //! Measures:
-//! 1. `sample_shots` (Dense path) — per-shot bit extraction
-//! 2. `ShotsResult::counts()` — histogram building from Vec<Vec<bool>>
-//! 3. `PackedShots::counts()` — histogram from packed u64 representation
-//! 4. `run_shots_compiled` round-trip — compile + sample + to_shots
+//! 1. `sample_shots` (Dense path): per-shot bit extraction
+//! 2. `ShotsResult::counts()`: histogram building from Vec<Vec<bool>>
+//! 3. `PackedShots::counts()`: histogram from packed u64 representation
+//! 4. `run_shots_compiled` round-trip: compile + sample + to_shots
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use prism_q::circuit::Circuit;
@@ -12,7 +12,9 @@ use prism_q::gates::Gate;
 use prism_q::sim;
 use prism_q::sim::noise::NoiseModel;
 use prism_q::BackendKind;
-use prism_q::HomologicalSampler;
+use prism_q::{
+    run_qec_program, HomologicalSampler, QecNoise, QecOptions, QecPauli, QecProgram, QecRecordRef,
+};
 use std::time::Duration;
 
 const SEED: u64 = 0xDEAD_BEEF;
@@ -199,6 +201,97 @@ fn clifford_circuit_with_measurements(n_qubits: usize, depth: usize) -> Circuit 
     c
 }
 
+fn qec_repetition_program(
+    n_data: usize,
+    rounds: usize,
+    shots: usize,
+    noise_rate: Option<f64>,
+) -> QecProgram {
+    assert!(n_data > 0);
+    let options = QecOptions {
+        shots,
+        seed: SEED,
+        chunk_size: Some(10_000),
+        keep_measurements: false,
+    };
+    let mut program = QecProgram::with_options(n_data, options);
+    let checks = n_data.saturating_sub(1);
+    let mut previous_round = Vec::with_capacity(checks);
+
+    for _ in 0..rounds {
+        let mut current_round = Vec::with_capacity(checks);
+        for q in 0..checks {
+            if let Some(p) = noise_rate {
+                program
+                    .noise(QecNoise::Depolarize1(p), &[q, q + 1])
+                    .unwrap();
+            }
+            let record = program
+                .measure_pauli_product(&[QecPauli::z(q), QecPauli::z(q + 1)])
+                .unwrap();
+            if let Some(previous) = previous_round.get(q) {
+                program
+                    .detector(&[
+                        QecRecordRef::absolute(*previous),
+                        QecRecordRef::absolute(record),
+                    ])
+                    .unwrap();
+            }
+            current_round.push(record);
+        }
+        previous_round = current_round;
+    }
+
+    let logical = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(logical)])
+        .unwrap();
+    program
+}
+
+fn bench_qec_clifford_runner(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_clifford_runner");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &(n_data, rounds, shots) in &[(25, 5, 10_000), (25, 5, 100_000), (100, 3, 100_000)] {
+        let program = qec_repetition_program(n_data, rounds, shots, None);
+        let label = format!("{n_data}q_r{rounds}");
+        group.bench_with_input(BenchmarkId::new(&label, shots), &program, |b, program| {
+            b.iter(|| run_qec_program(program).unwrap());
+        });
+    }
+
+    let zero_noise_program = qec_repetition_program(25, 5, 100_000, Some(0.0));
+    group.bench_with_input(
+        BenchmarkId::new("25q_r5_p0", 100_000),
+        &zero_noise_program,
+        |b, program| {
+            b.iter(|| run_qec_program(program).unwrap());
+        },
+    );
+
+    group.finish();
+}
+
+fn bench_qec_noisy_runner(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_noisy_runner");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &(n_data, rounds, shots) in &[(25, 5, 10_000), (25, 5, 100_000)] {
+        let program = qec_repetition_program(n_data, rounds, shots, Some(0.001));
+        let label = format!("{n_data}q_r{rounds}_p001");
+        group.bench_with_input(BenchmarkId::new(&label, shots), &program, |b, program| {
+            b.iter(|| run_qec_program(program).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_homological_compile(c: &mut Criterion) {
     let mut group = c.benchmark_group("homological_compile");
     group.sample_size(10);
@@ -353,6 +446,8 @@ criterion_group!(
     bench_histogram_counts,
     bench_rank_space_counts,
     bench_sparse_deterministic,
+    bench_qec_clifford_runner,
+    bench_qec_noisy_runner,
     bench_homological_compile,
     bench_homological_sample,
     bench_analytical_marginals,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,62 @@ Handwritten parser targeting a practical OpenQASM 3.0 subset. It processes input
 
 Targets use `SmallVec<[usize; 4]>`, inline storage for up to 4 qubits, no heap allocation for typical gates.
 
+## Native QEC Program IR
+
+`QecProgram` in `src/qec/mod.rs` is a measurement-record IR for QEC workloads
+that need detectors, logical observables, postselection, expectation metadata,
+and Pauli-noise annotations before sampler lowering. It is separate from
+`Circuit` so measurement-record programs do not need to fit final-measurement
+OpenQASM semantics.
+
+`QecOp` stores gates, basis measurements, MPP-style Pauli-product
+measurements, resets, detector rows, observable includes, expectation-value
+metadata, postselection predicates, noise annotations, and tick separators.
+Record references can be absolute indices or `rec[-k]` style lookbacks.
+Construction validates qubit bounds, gate arity, finite coordinates and
+coefficients, finite probabilities, and measurement-record scope. Detector,
+observable, and postselection rows can be resolved to absolute measurement
+indices for later compilation into packed samplers.
+
+`parse_qec_program` and `QecProgram::from_text` parse the native QEC text
+subset used by current benchmark planning: `H`, `S`, `S_DAG`, `T`, `T_DAG`,
+`CX`, `CZ`, `R`/`RX`/`RY`, `M`/`MX`/`MY`, `MR` variants, `MPP`, `DETECTOR`,
+`OBSERVABLE_INCLUDE`, `POSTSELECT`, `EXP_VAL`, Pauli-noise instructions, `TICK`,
+`QUBIT_COORDS`, `SHIFT_COORDS`, and flattened `REPEAT` blocks. The parser
+resolves `rec[-k]` references while building the program. Numeric arguments on
+basis measurements, such as `M(0.001)`, lower to pre-measurement Pauli flips
+that affect the measurement record.
+
+`compile_qec_program_rows` lowers basis measurements and `MPP` records into the
+same packed X/Z Pauli row representation used by the compiled sampler internals.
+It also carries detector, observable, and postselection rows forward as
+absolute measurement-record indices. Detector, observable, and postselection
+projection uses `PackedShots::parity_rows`, so the QEC layer reuses the existing
+packed parity engine instead of maintaining a second one. This is a
+sampler-lowering artifact, not an execution engine. Gate, reset, and noise
+execution lives in `run_qec_program`; `EXP_VAL` remains unsupported in the
+packed runner until estimator semantics land.
+
+`run_qec_program` is the scalable native QEC execution path. It lowers
+Clifford-compatible QEC programs into the existing packed compiled sampler, so
+sampling uses packed measurement records instead of dense amplitudes. It
+supports Clifford gates, basis resets and measurements, `MPP`, detectors,
+observables, postselection, Pauli-noise annotations, and optional
+raw-measurement retention. Noisy Clifford programs compile `X_ERROR`,
+`Z_ERROR`, `DEPOLARIZE1`, and correlated `DEPOLARIZE2` events into packed
+sensitivity rows, then XOR those rows into the packed measurement records.
+Non-Clifford gates and `EXP_VAL` reject clearly until their production
+strategies land. V1 requires a reset before any later gate reuse of a measured
+qubit because the compiled lowering defers measurements to terminal records.
+`QecOptions::chunk_size` bounds compiled-runner shot batches. When raw
+measurements are omitted, chunking avoids materializing the full measurement
+record matrix before detector, observable, postselection, and logical-error
+accounting.
+
+`run_qec_program_reference` is the small-program correctness oracle. It runs one
+state-vector simulation per shot and supports Pauli-noise annotations, but it is
+not the production performance path.
+
 ### Gate enum
 
 `Gate` is a `Clone` enum kept at **16 bytes**. Simple variants carry parameters inline. Composite variants use `Box` to stay within the 16-byte budget for cache-friendly dispatch.
@@ -498,6 +554,9 @@ Top-level re-exports from `src/lib.rs`:
 **Compiled sampling:**
 `compile_measurements`, `compile_forward`, `compile_detector_sampler`, `compile_noisy`, `run_shots_compiled`, `run_shots_noisy`, `run_shots_homological`, `noisy_marginals_analytical`
 
+**Native QEC:**
+`parse_qec_program`, `compile_qec_program_rows`, `run_qec_program`, `run_qec_program_reference`, `QecProgram`, `QecOp`, `QecOptions`, `QecSampleResult`, `QecBasis`, `QecPauli`, `QecRecordRef`, `QecNoise`, `QecMeasurementRow`, `QecCompiledRows`
+
 **Clifford+T:**
 `run_stabilizer_rank`, `run_stabilizer_rank_approx`, `stabilizer_overlap_sq`, `run_spp`, `run_spd`, `spp_to_probabilities`, `spd_to_probabilities`
 
@@ -511,4 +570,4 @@ Top-level re-exports from `src/lib.rs`:
 `ShotAccumulator`, `HistogramAccumulator`, `MarginalsAccumulator`, `PauliExpectationAccumulator`, `CorrelatorAccumulator`, `NullAccumulator`, `PackedShots`, `ShotLayout`
 
 **Data types:**
-`CompiledSampler`, `CompiledDetectorSampler`, `DetectorSampleBatch`, `NoisyCompiledSampler`, `HomologicalSampler`, `ErrorChainComplex`, `NoiseModel`, `NoiseOp`, `StabRankResult`, `SppResult`, `SpdResult`, `SparseParity`, `ParityStats`, `PauliVec`, `MultiFusedData`, `BatchPhaseData`, `McuData`, `Multi2qData`
+`CompiledSampler`, `CompiledDetectorSampler`, `DetectorSampleBatch`, `NoisyCompiledSampler`, `HomologicalSampler`, `ErrorChainComplex`, `NoiseModel`, `NoiseOp`, `QecProgram`, `QecOp`, `QecSampleResult`, `StabRankResult`, `SppResult`, `SpdResult`, `SparseParity`, `ParityStats`, `PauliVec`, `MultiFusedData`, `BatchPhaseData`, `McuData`, `Multi2qData`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! PRISM-Q — Performance Rust Interoperable Simulator for Quantum
+//! PRISM-Q: Performance Rust Interoperable Simulator for Quantum
 //!
 //! A performance-first quantum circuit simulator with pluggable backends.
 //!
@@ -18,7 +18,7 @@
 //!
 //! let result = run_qasm(qasm, 42).expect("parse/sim failed");
 //! let probs = result.probabilities.expect("no probabilities").to_vec();
-//! // Bell state: ~50% |00⟩, ~50% |11⟩
+//! // Bell state: ~50% |00>, ~50% |11>
 //! assert!((probs[0] - 0.5).abs() < 1e-10);
 //! assert!((probs[3] - 0.5).abs() < 1e-10);
 //! ```
@@ -30,13 +30,20 @@
 //!
 //! # Backends
 //!
-//! - [`StatevectorBackend`] — full state-vector simulation (implemented)
-//! - [`StabilizerBackend`] — Clifford-only O(n²) simulation (implemented)
-//! - [`SparseBackend`] — sparse state-vector O(k) simulation (implemented)
-//! - [`MpsBackend`] — Matrix Product State O(nχ²) simulation (implemented)
-//! - [`ProductStateBackend`] — per-qubit O(n) simulation for non-entangling circuits (implemented)
-//! - [`TensorNetworkBackend`] — deferred contraction for low-treewidth circuits (implemented)
-//! - [`FactoredBackend`] — dynamic split-state simulation for sparse-entanglement circuits (implemented)
+//! - [`StatevectorBackend`]: full state-vector simulation (implemented)
+//! - [`StabilizerBackend`]: Clifford-only O(n^2) simulation (implemented)
+//! - [`SparseBackend`]: sparse state-vector O(k) simulation (implemented)
+//! - [`MpsBackend`]: Matrix Product State O(n * chi^2) simulation (implemented)
+//! - [`ProductStateBackend`]: per-qubit O(n) simulation for non-entangling circuits (implemented)
+//! - [`TensorNetworkBackend`]: deferred contraction for low-treewidth circuits (implemented)
+//! - [`FactoredBackend`]: dynamic split-state simulation for sparse-entanglement circuits (implemented)
+//!
+//! # Native QEC
+//!
+//! Measurement-record QEC programs use [`QecProgram`] or [`parse_qec_program`].
+//! [`run_qec_program`] executes supported Clifford QEC programs through packed
+//! compiled sampling with Pauli-noise annotations. [`run_qec_program_reference`]
+//! runs small correctness checks through the reference path.
 
 pub mod backend;
 pub mod circuit;
@@ -45,6 +52,7 @@ pub mod error;
 pub mod gates;
 #[cfg(feature = "gpu")]
 pub mod gpu;
+pub mod qec;
 pub mod sim;
 
 pub use backend::factored::FactoredBackend;
@@ -59,6 +67,11 @@ pub use circuit::builder::CircuitBuilder;
 pub use circuit::{Circuit, ClassicalCondition, Instruction, SvgOptions, TextOptions};
 pub use error::{PrismError, Result};
 pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
+pub use qec::{
+    compile_qec_program_rows, parse_qec_program, run_qec_program, run_qec_program_reference,
+    QecBasis, QecCompiledRows, QecMeasurementRow, QecNoise, QecOp, QecOptions, QecPauli,
+    QecProgram, QecRecordRef, QecSampleResult,
+};
 pub use sim::compiled::{
     compile_detector_sampler, compile_forward, compile_measurements, run_shots_compiled,
     CompiledDetectorSampler, CompiledSampler, CorrelatorAccumulator, DetectorSampleBatch,

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -1,0 +1,963 @@
+//! Native measurement-record QEC program IR, parser, and runners.
+//!
+//! Models QEC workloads that need measurement records, detectors, observables,
+//! postselection, expectation metadata, and Pauli-noise annotations. The IR is
+//! separate from `Circuit` so measurement records do not have to fit
+//! final-measurement OpenQASM semantics.
+//!
+//! # Public surface
+//!
+//! - [`QecProgram`] is the IR. Construct via [`QecProgram::new`] /
+//!   [`QecProgram::with_options`] and the typed `push_*` methods, or load
+//!   from text via [`parse_qec_program`] / [`QecProgram::from_text`].
+//! - [`run_qec_program`] is the scalable Clifford execution path. Lowers
+//!   programs into the packed compiled sampler and supports Pauli noise by
+//!   XORing sensitivity rows onto packed measurement records.
+//! - [`run_qec_program_reference`] is the correctness oracle. One state-vector
+//!   simulation per shot. Use it for small semantic cross-checks, not bulk
+//!   sampling.
+//! - [`compile_qec_program_rows`] lowers basis measurements and `MPP` records
+//!   into the packed X/Z Pauli row representation used by sampler internals.
+//!   It does not execute gates, resets, or active noise.
+//!
+//! [`QecSampleResult`] carries packed measurement, detector, and observable
+//! shots, plus accepted and discarded shot counts after postselection and
+//! per-observable logical-error counts.
+
+mod noise;
+mod parse;
+mod result;
+mod runner;
+
+pub use parse::parse_qec_program;
+pub use result::QecSampleResult;
+pub use runner::{run_qec_program, run_qec_program_reference};
+
+use crate::circuit::Circuit;
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::compiled::{get_bit, set_bit, PackedShots, PauliVec};
+
+/// Pauli basis used by QEC measurements and Pauli products.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QecBasis {
+    /// X basis.
+    X,
+    /// Y basis.
+    Y,
+    /// Z basis.
+    Z,
+}
+
+/// One Pauli term in an MPP-style measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QecPauli {
+    /// Pauli basis for this term.
+    pub basis: QecBasis,
+    /// Qubit acted on by this term.
+    pub qubit: usize,
+}
+
+impl QecPauli {
+    /// Create a Pauli term.
+    pub fn new(basis: QecBasis, qubit: usize) -> Self {
+        Self { basis, qubit }
+    }
+
+    /// Create an X term.
+    pub fn x(qubit: usize) -> Self {
+        Self::new(QecBasis::X, qubit)
+    }
+
+    /// Create a Y term.
+    pub fn y(qubit: usize) -> Self {
+        Self::new(QecBasis::Y, qubit)
+    }
+
+    /// Create a Z term.
+    pub fn z(qubit: usize) -> Self {
+        Self::new(QecBasis::Z, qubit)
+    }
+}
+
+/// Reference to a previous measurement record.
+///
+/// Lookbacks are resolved against the count of measurement records that exist
+/// at the moment the referencing operation is appended (or, for queries like
+/// [`QecProgram::detector_rows`], at the moment that operation is reached
+/// during the walk). `Lookback(1)` is the most recent measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QecRecordRef {
+    /// Absolute measurement record index.
+    Absolute(usize),
+    /// Relative lookback into prior records, where `Lookback(1)` is the most recent.
+    Lookback(usize),
+}
+
+impl QecRecordRef {
+    /// Create an absolute measurement reference.
+    pub fn absolute(index: usize) -> Self {
+        Self::Absolute(index)
+    }
+
+    /// Create a relative measurement reference.
+    pub fn lookback(distance: usize) -> Result<Self> {
+        if distance == 0 {
+            return Err(PrismError::InvalidParameter {
+                message: "measurement lookback distance must be at least 1".to_string(),
+            });
+        }
+        Ok(Self::Lookback(distance))
+    }
+
+    fn resolve(self, next_measurement: usize) -> Result<usize> {
+        match self {
+            Self::Absolute(index) if index < next_measurement => Ok(index),
+            Self::Absolute(index) => Err(PrismError::InvalidParameter {
+                message: format!(
+                    "measurement record {index} out of bounds for {next_measurement} existing records"
+                ),
+            }),
+            Self::Lookback(distance) if distance > 0 && distance <= next_measurement => {
+                Ok(next_measurement - distance)
+            }
+            Self::Lookback(distance) => Err(PrismError::InvalidParameter {
+                message: format!(
+                    "measurement lookback {distance} out of bounds for {next_measurement} existing records"
+                ),
+            }),
+        }
+    }
+}
+
+/// Pauli-noise annotation for native QEC programs.
+///
+/// Probabilities are validated when the annotation is appended to a
+/// [`QecProgram`]. Probability zero is treated as an inactive annotation by
+/// runner APIs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum QecNoise {
+    /// With probability `p`, apply X to each target.
+    XError(f64),
+    /// With probability `p`, apply Z to each target.
+    ZError(f64),
+    /// For each target, with total probability `p`, apply a uniformly random
+    /// non-identity single-qubit Pauli. Each of X, Y, Z fires with probability
+    /// `p / 3`.
+    Depolarize1(f64),
+    /// For each target pair, with total probability `p`, apply a uniformly
+    /// random non-identity two-qubit Pauli. Each of the 15 non-identity
+    /// two-qubit Paulis fires with probability `p / 15`. The target list is
+    /// consumed in pairs and must have even length.
+    Depolarize2(f64),
+}
+
+impl QecNoise {
+    /// Channel probability.
+    pub fn probability(self) -> f64 {
+        match self {
+            Self::XError(p) | Self::ZError(p) | Self::Depolarize1(p) | Self::Depolarize2(p) => p,
+        }
+    }
+
+    /// Native text instruction name for this channel.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::XError(_) => "X_ERROR",
+            Self::ZError(_) => "Z_ERROR",
+            Self::Depolarize1(_) => "DEPOLARIZE1",
+            Self::Depolarize2(_) => "DEPOLARIZE2",
+        }
+    }
+}
+
+/// One operation in a native QEC program.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QecOp {
+    /// Standard PRISM-Q gate operation. The compiled runner requires Clifford
+    /// gates; the reference runner accepts any gate the statevector backend
+    /// supports.
+    Gate { gate: Gate, targets: Vec<usize> },
+    /// Single-qubit measurement in the requested basis. Produces one
+    /// measurement record.
+    Measure { basis: QecBasis, qubit: usize },
+    /// Pauli-product (`MPP`) measurement. Produces one measurement record
+    /// equal to the parity of the listed Pauli terms.
+    MeasurePauliProduct { terms: Vec<QecPauli> },
+    /// Reset a qubit to the +1 eigenstate of the requested basis.
+    Reset { basis: QecBasis, qubit: usize },
+    /// Detector: parity over the listed measurement records. `coords` is
+    /// arbitrary passthrough metadata for visualization and downstream
+    /// decoders; it does not affect sampling.
+    Detector {
+        records: Vec<QecRecordRef>,
+        coords: Vec<f64>,
+    },
+    /// Logical observable parity contribution. Multiple includes for the same
+    /// `observable` index XOR into a single observable row.
+    ObservableInclude {
+        observable: usize,
+        records: Vec<QecRecordRef>,
+    },
+    /// Expectation-value metadata. Both runners reject programs containing
+    /// this op until estimator semantics land.
+    ExpectationValue {
+        terms: Vec<QecPauli>,
+        coefficient: f64,
+    },
+    /// Postselection predicate. The shot is accepted only when the parity over
+    /// `records` matches `expected`.
+    Postselect {
+        records: Vec<QecRecordRef>,
+        expected: bool,
+    },
+    /// Pauli-noise annotation applied at this point in the program. Zero
+    /// probability is treated as inactive.
+    Noise {
+        channel: QecNoise,
+        targets: Vec<usize>,
+    },
+    /// Scheduling separator. No semantic effect; carried forward for parity
+    /// with native QEC text formats.
+    Tick,
+}
+
+/// Packed Pauli row for one QEC measurement record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QecMeasurementRow {
+    num_qubits: usize,
+    pauli: PauliVec,
+    weight: usize,
+}
+
+impl QecMeasurementRow {
+    /// Create a row from Pauli-product terms.
+    pub fn from_terms(num_qubits: usize, terms: &[QecPauli]) -> Result<Self> {
+        if terms.is_empty() {
+            return Err(PrismError::InvalidParameter {
+                message: "QEC measurement row requires at least one Pauli term".to_string(),
+            });
+        }
+        validate_pauli_terms(terms, num_qubits)?;
+
+        let row_words = num_qubits.div_ceil(64);
+        let mut pauli = PauliVec::new(row_words);
+
+        for term in terms {
+            match term.basis {
+                QecBasis::X => set_bit(&mut pauli.x, term.qubit, true),
+                QecBasis::Y => {
+                    set_bit(&mut pauli.x, term.qubit, true);
+                    set_bit(&mut pauli.z, term.qubit, true);
+                }
+                QecBasis::Z => set_bit(&mut pauli.z, term.qubit, true),
+            }
+        }
+
+        Ok(Self {
+            num_qubits,
+            pauli,
+            weight: terms.len(),
+        })
+    }
+
+    /// Create a single-qubit measurement row.
+    pub fn single(num_qubits: usize, basis: QecBasis, qubit: usize) -> Result<Self> {
+        Self::from_terms(num_qubits, &[QecPauli::new(basis, qubit)])
+    }
+
+    /// Number of qubits covered by this row.
+    pub fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    /// Number of non-identity Pauli terms.
+    pub fn weight(&self) -> usize {
+        self.weight
+    }
+
+    /// Packed X mask.
+    pub fn x_mask(&self) -> &[u64] {
+        &self.pauli.x
+    }
+
+    /// Packed Z mask.
+    pub fn z_mask(&self) -> &[u64] {
+        &self.pauli.z
+    }
+
+    /// Pauli term on one qubit, or `None` for identity (or when `qubit` is
+    /// outside this row's qubit range).
+    pub fn pauli_at(&self, qubit: usize) -> Option<QecBasis> {
+        if qubit >= self.num_qubits {
+            return None;
+        }
+        match (get_bit(&self.pauli.x, qubit), get_bit(&self.pauli.z, qubit)) {
+            (true, false) => Some(QecBasis::X),
+            (true, true) => Some(QecBasis::Y),
+            (false, true) => Some(QecBasis::Z),
+            (false, false) => None,
+        }
+    }
+
+    /// Return non-identity Pauli terms in ascending qubit order.
+    pub fn terms(&self) -> Vec<QecPauli> {
+        let mut terms = Vec::with_capacity(self.weight);
+        for qubit in 0..self.num_qubits {
+            if let Some(basis) = self.pauli_at(qubit) {
+                terms.push(QecPauli::new(basis, qubit));
+            }
+        }
+        terms
+    }
+
+    /// Packed row storage in bytes.
+    pub fn packed_bytes(&self) -> usize {
+        (self.pauli.x.len() + self.pauli.z.len()) * std::mem::size_of::<u64>()
+    }
+}
+
+/// Compiled QEC record rows ready for sampler lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QecCompiledRows {
+    num_qubits: usize,
+    measurement_rows: Vec<QecMeasurementRow>,
+    detector_rows: Vec<Vec<usize>>,
+    observable_rows: Vec<Vec<usize>>,
+    postselection_rows: Vec<Vec<usize>>,
+    postselection_expected: Vec<bool>,
+}
+
+impl QecCompiledRows {
+    /// Number of qubits in the source program.
+    pub fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    /// Measurement rows in record order.
+    pub fn measurement_rows(&self) -> &[QecMeasurementRow] {
+        &self.measurement_rows
+    }
+
+    /// Detector parity rows over measurement records.
+    pub fn detector_rows(&self) -> &[Vec<usize>] {
+        &self.detector_rows
+    }
+
+    /// Observable parity rows over measurement records.
+    pub fn observable_rows(&self) -> &[Vec<usize>] {
+        &self.observable_rows
+    }
+
+    /// Postselection parity rows.
+    pub fn postselection_rows(&self) -> &[Vec<usize>] {
+        &self.postselection_rows
+    }
+
+    /// Expected parity for each postselection row.
+    pub fn postselection_expected(&self) -> &[bool] {
+        &self.postselection_expected
+    }
+
+    /// Postselection parity rows paired with expected values.
+    pub fn postselection_predicates(&self) -> impl ExactSizeIterator<Item = (&[usize], bool)> + '_ {
+        self.postselection_rows
+            .iter()
+            .map(Vec::as_slice)
+            .zip(self.postselection_expected.iter().copied())
+    }
+
+    /// Number of measurement records.
+    pub fn num_measurements(&self) -> usize {
+        self.measurement_rows.len()
+    }
+
+    /// Number of detector rows.
+    pub fn num_detectors(&self) -> usize {
+        self.detector_rows.len()
+    }
+
+    /// Number of observable rows.
+    pub fn num_observables(&self) -> usize {
+        self.observable_rows.len()
+    }
+
+    /// Number of postselection predicates.
+    pub fn num_postselections(&self) -> usize {
+        self.postselection_rows.len()
+    }
+
+    /// Packed words per X or Z mask.
+    pub fn packed_row_words(&self) -> usize {
+        self.num_qubits.div_ceil(64)
+    }
+
+    /// Packed measurement row storage in bytes.
+    pub fn measurement_mask_bytes(&self) -> usize {
+        self.measurement_rows
+            .len()
+            .saturating_mul(self.packed_row_words())
+            .saturating_mul(2)
+            .saturating_mul(std::mem::size_of::<u64>())
+    }
+
+    /// Compute detector records from packed measurement records.
+    pub fn detector_parities(&self, measurements: &PackedShots) -> Result<PackedShots> {
+        measurements.parity_rows(&self.detector_rows)
+    }
+
+    /// Compute logical observable records from packed measurement records.
+    pub fn observable_parities(&self, measurements: &PackedShots) -> Result<PackedShots> {
+        measurements.parity_rows(&self.observable_rows)
+    }
+
+    /// Compute postselection predicate parities from packed measurement records.
+    pub fn postselection_parities(&self, measurements: &PackedShots) -> Result<PackedShots> {
+        measurements.parity_rows(&self.postselection_rows)
+    }
+}
+
+/// Options for running a native QEC program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QecOptions {
+    /// Number of shots requested by runner APIs.
+    pub shots: usize,
+    /// RNG seed used by stochastic samplers and Pauli-noise dispatch.
+    pub seed: u64,
+    /// Optional chunk size for the compiled runner. When `Some(n)`, sampling
+    /// proceeds in batches of at most `n` shots and intermediate measurement
+    /// matrices are not held in memory together. `None` is equivalent to
+    /// `Some(shots)`. `Some(0)` is rejected. Has no effect on the reference
+    /// runner.
+    pub chunk_size: Option<usize>,
+    /// When `false`, [`QecSampleResult::measurements`] is returned with zero
+    /// shots (only the column count is preserved). Detector and observable
+    /// records are always populated. Set to `false` to avoid materializing
+    /// large measurement-record matrices when only detectors and observables
+    /// are needed.
+    pub keep_measurements: bool,
+}
+
+impl Default for QecOptions {
+    fn default() -> Self {
+        Self {
+            shots: 1024,
+            seed: 42,
+            chunk_size: None,
+            keep_measurements: true,
+        }
+    }
+}
+
+/// Native QEC program expressed as measurement-record operations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QecProgram {
+    num_qubits: usize,
+    ops: Vec<QecOp>,
+    options: QecOptions,
+}
+
+impl QecProgram {
+    /// Create an empty program.
+    pub fn new(num_qubits: usize) -> Self {
+        Self::with_options(num_qubits, QecOptions::default())
+    }
+
+    /// Create an empty program with explicit options.
+    pub fn with_options(num_qubits: usize, options: QecOptions) -> Self {
+        Self {
+            num_qubits,
+            ops: Vec::new(),
+            options,
+        }
+    }
+
+    /// Create a program from operations, validating record references as
+    /// operations are appended.
+    pub fn from_ops(num_qubits: usize, options: QecOptions, ops: Vec<QecOp>) -> Result<Self> {
+        let mut program = Self::with_options(num_qubits, options);
+        let mut next_measurement = 0usize;
+        for op in ops {
+            program.validate_op(&op, next_measurement)?;
+            if matches!(
+                op,
+                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. }
+            ) {
+                next_measurement += 1;
+            }
+            program.ops.push(op);
+        }
+        Ok(program)
+    }
+
+    /// Parse a native measurement-record QEC program.
+    pub fn from_text(input: &str) -> Result<Self> {
+        parse_qec_program(input)
+    }
+
+    /// Number of qubits in the program.
+    pub fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    /// Runner options.
+    pub fn options(&self) -> QecOptions {
+        self.options
+    }
+
+    /// Set runner options.
+    pub fn set_options(&mut self, options: QecOptions) {
+        self.options = options;
+    }
+
+    /// Operation stream.
+    pub fn ops(&self) -> &[QecOp] {
+        &self.ops
+    }
+
+    /// Number of measurement records produced by the operation stream.
+    pub fn num_measurements(&self) -> usize {
+        self.ops
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. }
+                )
+            })
+            .count()
+    }
+
+    /// Number of detector rows.
+    pub fn num_detectors(&self) -> usize {
+        self.ops
+            .iter()
+            .filter(|op| matches!(op, QecOp::Detector { .. }))
+            .count()
+    }
+
+    /// Number of logical observable slots.
+    pub fn num_observables(&self) -> usize {
+        self.ops
+            .iter()
+            .filter_map(|op| match op {
+                QecOp::ObservableInclude { observable, .. } => Some(*observable),
+                _ => None,
+            })
+            .max()
+            .map_or(0, |max_idx| max_idx + 1)
+    }
+
+    /// Append a validated operation.
+    pub fn push_op(&mut self, op: QecOp) -> Result<()> {
+        self.validate_op(&op, self.num_measurements())?;
+        self.ops.push(op);
+        Ok(())
+    }
+
+    /// Append a gate operation.
+    pub fn push_gate(&mut self, gate: Gate, targets: &[usize]) -> Result<()> {
+        self.push_op(QecOp::Gate {
+            gate,
+            targets: targets.to_vec(),
+        })
+    }
+
+    /// Append a reset operation.
+    pub fn reset(&mut self, basis: QecBasis, qubit: usize) -> Result<()> {
+        self.push_op(QecOp::Reset { basis, qubit })
+    }
+
+    /// Append a single-qubit measurement and return its record index.
+    pub fn measure(&mut self, basis: QecBasis, qubit: usize) -> Result<usize> {
+        let record = self.num_measurements();
+        self.push_op(QecOp::Measure { basis, qubit })?;
+        Ok(record)
+    }
+
+    /// Append a Z-basis measurement and return its record index.
+    pub fn measure_z(&mut self, qubit: usize) -> Result<usize> {
+        self.measure(QecBasis::Z, qubit)
+    }
+
+    /// Append an X-basis measurement and return its record index.
+    pub fn measure_x(&mut self, qubit: usize) -> Result<usize> {
+        self.measure(QecBasis::X, qubit)
+    }
+
+    /// Append a Pauli-product measurement and return its record index.
+    pub fn measure_pauli_product(&mut self, terms: &[QecPauli]) -> Result<usize> {
+        let record = self.num_measurements();
+        self.push_op(QecOp::MeasurePauliProduct {
+            terms: terms.to_vec(),
+        })?;
+        Ok(record)
+    }
+
+    /// Append a detector and return its detector index.
+    pub fn detector(&mut self, records: &[QecRecordRef]) -> Result<usize> {
+        self.detector_with_coords(records, &[])
+    }
+
+    /// Append a detector with coordinates and return its detector index.
+    pub fn detector_with_coords(
+        &mut self,
+        records: &[QecRecordRef],
+        coords: &[f64],
+    ) -> Result<usize> {
+        let detector = self.num_detectors();
+        self.push_op(QecOp::Detector {
+            records: records.to_vec(),
+            coords: coords.to_vec(),
+        })?;
+        Ok(detector)
+    }
+
+    /// Append a logical observable parity contribution.
+    pub fn observable_include(
+        &mut self,
+        observable: usize,
+        records: &[QecRecordRef],
+    ) -> Result<()> {
+        self.push_op(QecOp::ObservableInclude {
+            observable,
+            records: records.to_vec(),
+        })
+    }
+
+    /// Append expectation-value metadata.
+    pub fn expectation_value(&mut self, terms: &[QecPauli], coefficient: f64) -> Result<()> {
+        self.push_op(QecOp::ExpectationValue {
+            terms: terms.to_vec(),
+            coefficient,
+        })
+    }
+
+    /// Append a postselection predicate.
+    pub fn postselect(&mut self, records: &[QecRecordRef], expected: bool) -> Result<()> {
+        self.push_op(QecOp::Postselect {
+            records: records.to_vec(),
+            expected,
+        })
+    }
+
+    /// Append a Pauli-noise annotation.
+    pub fn noise(&mut self, channel: QecNoise, targets: &[usize]) -> Result<()> {
+        self.push_op(QecOp::Noise {
+            channel,
+            targets: targets.to_vec(),
+        })
+    }
+
+    /// Resolve detector rows to absolute measurement record indices.
+    pub fn detector_rows(&self) -> Result<Vec<Vec<usize>>> {
+        let mut rows = Vec::new();
+        let mut next_measurement = 0;
+        for op in &self.ops {
+            match op {
+                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
+                    next_measurement += 1;
+                }
+                QecOp::Detector { records, .. } => {
+                    rows.push(resolve_records(records, next_measurement)?);
+                }
+                _ => {}
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Resolve observable rows to absolute measurement record indices.
+    pub fn observable_rows(&self) -> Result<Vec<Vec<usize>>> {
+        let mut rows = Vec::new();
+        let mut next_measurement = 0;
+        for op in &self.ops {
+            match op {
+                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
+                    next_measurement += 1;
+                }
+                QecOp::ObservableInclude {
+                    observable,
+                    records,
+                } => {
+                    if rows.len() <= *observable {
+                        rows.resize_with(*observable + 1, Vec::new);
+                    }
+                    rows[*observable].extend(resolve_records(records, next_measurement)?);
+                }
+                _ => {}
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Resolve postselection rows to absolute measurement record indices.
+    pub fn postselection_rows(&self) -> Result<Vec<(Vec<usize>, bool)>> {
+        let mut rows = Vec::new();
+        let mut next_measurement = 0;
+        for op in &self.ops {
+            match op {
+                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
+                    next_measurement += 1;
+                }
+                QecOp::Postselect { records, expected } => {
+                    rows.push((resolve_records(records, next_measurement)?, *expected));
+                }
+                _ => {}
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Create an empty result with the program's current record shape.
+    pub fn empty_result(&self) -> QecSampleResult {
+        QecSampleResult::empty(
+            self.num_measurements(),
+            self.num_detectors(),
+            self.num_observables(),
+        )
+    }
+
+    fn validate_op(&self, op: &QecOp, next_measurement: usize) -> Result<()> {
+        match op {
+            QecOp::Gate { gate, targets } => {
+                if gate.num_qubits() != targets.len() {
+                    return Err(PrismError::GateArity {
+                        gate: gate.name().to_string(),
+                        expected: gate.num_qubits(),
+                        got: targets.len(),
+                    });
+                }
+                validate_qubits(targets.iter().copied(), self.num_qubits)?;
+            }
+            QecOp::Measure { qubit, .. } | QecOp::Reset { qubit, .. } => {
+                validate_qubit(*qubit, self.num_qubits)?;
+            }
+            QecOp::MeasurePauliProduct { terms } => {
+                if terms.is_empty() {
+                    return Err(PrismError::InvalidParameter {
+                        message: "Pauli-product measurement requires at least one term".to_string(),
+                    });
+                }
+                validate_pauli_terms(terms, self.num_qubits)?;
+            }
+            QecOp::Detector { records, coords } => {
+                resolve_records(records, next_measurement)?;
+                validate_finite_values(coords, "detector coordinate")?;
+            }
+            QecOp::ObservableInclude { records, .. } | QecOp::Postselect { records, .. } => {
+                resolve_records(records, next_measurement)?;
+            }
+            QecOp::ExpectationValue { terms, coefficient } => {
+                if terms.is_empty() {
+                    return Err(PrismError::InvalidParameter {
+                        message: "expectation value requires at least one Pauli term".to_string(),
+                    });
+                }
+                validate_pauli_terms(terms, self.num_qubits)?;
+                if !coefficient.is_finite() {
+                    return Err(PrismError::InvalidParameter {
+                        message: "expectation-value coefficient must be finite".to_string(),
+                    });
+                }
+            }
+            QecOp::Noise { channel, targets } => {
+                validate_noise(*channel, targets, self.num_qubits)?;
+            }
+            QecOp::Tick => {}
+        }
+        Ok(())
+    }
+}
+
+/// Compile measurement-record operations into packed QEC row metadata.
+///
+/// Lowers `Measure` and `MeasurePauliProduct` ops into the same packed X/Z
+/// Pauli row representation used by the compiled sampler internals, and
+/// resolves detector, observable, and postselection record references to
+/// absolute indices. Useful when consumers want the row-level representation
+/// for custom sampler integration.
+///
+/// This is a sampler-row primitive, not an execution path: it rejects
+/// programs containing gates, resets, active Pauli noise, or `EXP_VAL`.
+/// Zero-probability noise annotations are skipped. To execute a full program
+/// (including gates, resets, and noise) use [`run_qec_program`].
+pub fn compile_qec_program_rows(program: &QecProgram) -> Result<QecCompiledRows> {
+    let mut measurement_rows = Vec::with_capacity(program.num_measurements());
+
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { gate, .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC row compiler".to_string(),
+                    reason: format!(
+                        "QEC row compilation does not lower gates yet, got `{}`",
+                        gate.name()
+                    ),
+                });
+            }
+            QecOp::Measure { basis, qubit } => {
+                measurement_rows.push(QecMeasurementRow::single(
+                    program.num_qubits(),
+                    *basis,
+                    *qubit,
+                )?);
+            }
+            QecOp::MeasurePauliProduct { terms } => {
+                measurement_rows.push(QecMeasurementRow::from_terms(program.num_qubits(), terms)?);
+            }
+            QecOp::Reset { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC row compiler".to_string(),
+                    reason: "QEC row compilation does not lower resets yet".to_string(),
+                });
+            }
+            QecOp::ExpectationValue { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC row compiler".to_string(),
+                    reason: "QEC row compilation does not evaluate EXP_VAL yet".to_string(),
+                });
+            }
+            QecOp::Detector { .. }
+            | QecOp::ObservableInclude { .. }
+            | QecOp::Postselect { .. }
+            | QecOp::Tick => {}
+            QecOp::Noise { channel, .. } if channel.probability() == 0.0 => {}
+            QecOp::Noise { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC row compiler".to_string(),
+                    reason: "QEC row compilation does not support active noise annotations yet"
+                        .to_string(),
+                });
+            }
+        }
+    }
+
+    let postselection_predicates = program.postselection_rows()?;
+    let mut postselection_rows = Vec::with_capacity(postselection_predicates.len());
+    let mut postselection_expected = Vec::with_capacity(postselection_predicates.len());
+    for (row, expected) in postselection_predicates {
+        postselection_rows.push(row);
+        postselection_expected.push(expected);
+    }
+
+    Ok(QecCompiledRows {
+        num_qubits: program.num_qubits(),
+        measurement_rows,
+        detector_rows: program.detector_rows()?,
+        observable_rows: program.observable_rows()?,
+        postselection_rows,
+        postselection_expected,
+    })
+}
+
+pub(super) fn append_basis_to_z_rotation(circuit: &mut Circuit, basis: QecBasis, qubit: usize) {
+    match basis {
+        QecBasis::X => circuit.add_gate(Gate::H, &[qubit]),
+        QecBasis::Y => {
+            circuit.add_gate(Gate::Sdg, &[qubit]);
+            circuit.add_gate(Gate::H, &[qubit]);
+        }
+        QecBasis::Z => {}
+    }
+}
+
+pub(super) fn append_z_to_basis_rotation(circuit: &mut Circuit, basis: QecBasis, qubit: usize) {
+    match basis {
+        QecBasis::X => circuit.add_gate(Gate::H, &[qubit]),
+        QecBasis::Y => {
+            circuit.add_gate(Gate::H, &[qubit]);
+            circuit.add_gate(Gate::S, &[qubit]);
+        }
+        QecBasis::Z => {}
+    }
+}
+
+fn resolve_records(records: &[QecRecordRef], next_measurement: usize) -> Result<Vec<usize>> {
+    records
+        .iter()
+        .map(|record| record.resolve(next_measurement))
+        .collect()
+}
+
+fn validate_qubit(qubit: usize, num_qubits: usize) -> Result<()> {
+    if qubit >= num_qubits {
+        return Err(PrismError::InvalidQubit {
+            index: qubit,
+            register_size: num_qubits,
+        });
+    }
+    Ok(())
+}
+
+fn validate_qubits<I>(qubits: I, num_qubits: usize) -> Result<()>
+where
+    I: IntoIterator<Item = usize>,
+{
+    for qubit in qubits {
+        validate_qubit(qubit, num_qubits)?;
+    }
+    Ok(())
+}
+
+fn validate_pauli_terms(terms: &[QecPauli], num_qubits: usize) -> Result<()> {
+    for (idx, term) in terms.iter().enumerate() {
+        validate_qubit(term.qubit, num_qubits)?;
+        if terms[..idx].iter().any(|prior| prior.qubit == term.qubit) {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "Pauli-product measurement contains duplicate qubit {}",
+                    term.qubit
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_finite_values(values: &[f64], label: &str) -> Result<()> {
+    for value in values {
+        if !value.is_finite() {
+            return Err(PrismError::InvalidParameter {
+                message: format!("{label} must be finite"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_noise(channel: QecNoise, targets: &[usize], num_qubits: usize) -> Result<()> {
+    let p = channel.probability();
+    if !(0.0..=1.0).contains(&p) || !p.is_finite() {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "{} probability must be finite and in [0, 1]",
+                channel.name()
+            ),
+        });
+    }
+
+    if targets.is_empty() {
+        return Err(PrismError::InvalidParameter {
+            message: format!("{} requires at least one target", channel.name()),
+        });
+    }
+
+    if matches!(channel, QecNoise::Depolarize2(_)) && targets.len() % 2 != 0 {
+        return Err(PrismError::InvalidParameter {
+            message: "DEPOLARIZE2 requires an even number of targets".to_string(),
+        });
+    }
+
+    if matches!(channel, QecNoise::Depolarize2(_)) {
+        for pair in targets.chunks_exact(2) {
+            if pair[0] == pair[1] {
+                return Err(PrismError::InvalidParameter {
+                    message: "DEPOLARIZE2 target pairs must use distinct qubits".to_string(),
+                });
+            }
+        }
+    }
+
+    validate_qubits(targets.iter().copied(), num_qubits)
+}

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -1,0 +1,686 @@
+use super::{
+    append_basis_to_z_rotation, append_z_to_basis_rotation, QecNoise, QecOp, QecPauli, QecProgram,
+};
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::compiled::{
+    batch_propagate_backward, compile_measurements, rng::Xoshiro256PlusPlus, xor_words,
+    CompiledSampler, PackedShots,
+};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+#[derive(Clone)]
+struct QecDeferredNoiseEvent {
+    channel: QecNoise,
+    targets: Vec<usize>,
+    position: usize,
+}
+
+struct QecDeferredProgram {
+    circuit: Circuit,
+    noise_events: Vec<QecDeferredNoiseEvent>,
+    measurement_qubits: Vec<usize>,
+}
+
+pub(super) struct QecCompiledNoiseSampler {
+    noiseless: CompiledSampler,
+    events: QecNoiseSensitivity,
+    num_measurements: usize,
+    rng: Xoshiro256PlusPlus,
+}
+
+impl QecCompiledNoiseSampler {
+    pub(super) fn sample_measurements_packed(&mut self, num_shots: usize) -> Result<PackedShots> {
+        let measurements = self.noiseless.try_sample_bulk_packed(num_shots)?;
+        if self.events.is_empty() || num_shots == 0 || self.num_measurements == 0 {
+            return Ok(measurements);
+        }
+
+        let m_words = self.num_measurements.div_ceil(64);
+        let mut data = measurements.into_shot_major_data();
+        self.events
+            .apply(&mut data, num_shots, m_words, &mut self.rng);
+        Ok(PackedShots::from_shot_major(
+            data,
+            num_shots,
+            self.num_measurements,
+        ))
+    }
+}
+
+struct QecNoiseSensitivity {
+    events: Vec<QecNoiseSensitivityEvent>,
+}
+
+impl QecNoiseSensitivity {
+    fn new() -> Self {
+        Self { events: Vec::new() }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    fn push_single(&mut self, x_flip: &[u64], z_flip: &[u64], px: f64, py: f64, pz: f64) {
+        let x_is_zero = x_flip.iter().all(|&w| w == 0);
+        let z_is_zero = z_flip.iter().all(|&w| w == 0);
+        if px + py + pz == 0.0 || (x_is_zero && z_is_zero) {
+            return;
+        }
+
+        let (px, py, pz) = if x_is_zero {
+            (px + py, 0.0, 0.0)
+        } else if z_is_zero {
+            (0.0, 0.0, py + pz)
+        } else if x_flip == z_flip {
+            (px + pz, 0.0, 0.0)
+        } else {
+            (px, py, pz)
+        };
+        if px + py + pz == 0.0 {
+            return;
+        }
+
+        self.events.push(QecNoiseSensitivityEvent::Single {
+            x_flip: x_flip.to_vec(),
+            z_flip: z_flip.to_vec(),
+            px,
+            py,
+            pz,
+        });
+    }
+
+    fn push_pair(
+        &mut self,
+        q0_x_flip: &[u64],
+        q0_z_flip: &[u64],
+        q1_x_flip: &[u64],
+        q1_z_flip: &[u64],
+        p: f64,
+    ) {
+        if p == 0.0 {
+            return;
+        }
+
+        let m_words = q0_x_flip.len();
+        let mut branch_flips = Vec::with_capacity(15 * m_words);
+        let mut branch = vec![0u64; m_words];
+        let mut any = false;
+        for sample in 1..=15 {
+            let first = sample / 4;
+            let second = sample % 4;
+            branch.fill(0);
+            append_qec_pauli_noise_effect(&mut branch, first, q0_x_flip, q0_z_flip);
+            append_qec_pauli_noise_effect(&mut branch, second, q1_x_flip, q1_z_flip);
+            any |= branch.iter().any(|&w| w != 0);
+            branch_flips.extend_from_slice(&branch);
+        }
+
+        if any {
+            self.events
+                .push(QecNoiseSensitivityEvent::Pair { branch_flips, p });
+        }
+    }
+
+    fn apply(
+        &self,
+        data: &mut [u64],
+        num_shots: usize,
+        m_words: usize,
+        rng: &mut Xoshiro256PlusPlus,
+    ) {
+        for event in &self.events {
+            match event {
+                QecNoiseSensitivityEvent::Single {
+                    x_flip,
+                    z_flip,
+                    px,
+                    py,
+                    pz,
+                } => apply_qec_single_noise_event(
+                    data,
+                    num_shots,
+                    m_words,
+                    QecSingleNoiseView {
+                        x_flip,
+                        z_flip,
+                        px: *px,
+                        py: *py,
+                        p_event: *px + *py + *pz,
+                    },
+                    rng,
+                ),
+                QecNoiseSensitivityEvent::Pair { branch_flips, p } => {
+                    apply_qec_pair_noise_event(data, num_shots, m_words, branch_flips, *p, rng)
+                }
+            }
+        }
+    }
+}
+
+enum QecNoiseSensitivityEvent {
+    Single {
+        x_flip: Vec<u64>,
+        z_flip: Vec<u64>,
+        px: f64,
+        py: f64,
+        pz: f64,
+    },
+    Pair {
+        branch_flips: Vec<u64>,
+        p: f64,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct QecSingleNoiseView<'a> {
+    x_flip: &'a [u64],
+    z_flip: &'a [u64],
+    px: f64,
+    py: f64,
+    p_event: f64,
+}
+
+pub(super) fn compile_qec_noisy_sampler(program: &QecProgram) -> Result<QecCompiledNoiseSampler> {
+    let deferred = lower_qec_program_to_deferred_circuit(program)?;
+    let events = compile_qec_noise_sensitivity(&deferred)?;
+    let noiseless = compile_measurements(&deferred.circuit, program.options().seed)?;
+    Ok(QecCompiledNoiseSampler {
+        noiseless,
+        events,
+        num_measurements: deferred.measurement_qubits.len(),
+        rng: qec_noise_rng(program.options().seed),
+    })
+}
+
+fn qec_noise_rng(seed: u64) -> Xoshiro256PlusPlus {
+    let mut seed_rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(0x51A7_EC01));
+    Xoshiro256PlusPlus::from_chacha(&mut seed_rng)
+}
+
+fn lower_qec_program_to_deferred_circuit(program: &QecProgram) -> Result<QecDeferredProgram> {
+    let has_mpp = program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::MeasurePauliProduct { .. }));
+    let base_qubits = program.num_qubits() + usize::from(has_mpp);
+    let scratch_qubit = program.num_qubits();
+    let mut circuit = Circuit::new(base_qubits, program.num_measurements());
+    let mut aliases: Vec<usize> = (0..base_qubits).collect();
+    let mut measured_aliases = vec![false; base_qubits];
+    let mut next_qubit = base_qubits;
+    let mut next_record = 0usize;
+    let mut deferred_measurements = Vec::with_capacity(program.num_measurements());
+    let mut noise_events = Vec::new();
+
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { gate, targets } => {
+                if !gate.is_clifford() {
+                    return Err(PrismError::IncompatibleBackend {
+                        backend: "QEC compiled runner".to_string(),
+                        reason: format!(
+                            "compiled QEC runner requires Clifford gates, got `{}`",
+                            gate.name()
+                        ),
+                    });
+                }
+                let mapped = map_qec_deferred_targets(targets, &aliases, &measured_aliases)?;
+                circuit.add_gate(gate.clone(), mapped.as_slice());
+            }
+            QecOp::Measure { basis, qubit } => {
+                let alias = qec_deferred_target(*qubit, &aliases, &measured_aliases)?;
+                append_basis_to_z_rotation(&mut circuit, *basis, alias);
+                deferred_measurements.push((alias, next_record));
+                measured_aliases[alias] = true;
+                next_record += 1;
+            }
+            QecOp::MeasurePauliProduct { terms } => {
+                if !has_mpp {
+                    return Err(PrismError::InvalidParameter {
+                        message: "internal QEC MPP scratch qubit was not allocated".to_string(),
+                    });
+                }
+                let scratch_alias = if measured_aliases[aliases[scratch_qubit]] {
+                    qec_assign_fresh_alias(
+                        &mut circuit,
+                        &mut aliases,
+                        &mut measured_aliases,
+                        &mut next_qubit,
+                        scratch_qubit,
+                    )
+                } else {
+                    aliases[scratch_qubit]
+                };
+
+                let mut mapped_terms = Vec::with_capacity(terms.len());
+                for term in terms {
+                    let alias = qec_deferred_target(term.qubit, &aliases, &measured_aliases)?;
+                    mapped_terms.push(QecPauli::new(term.basis, alias));
+                }
+
+                for term in &mapped_terms {
+                    append_basis_to_z_rotation(&mut circuit, term.basis, term.qubit);
+                }
+                for term in &mapped_terms {
+                    circuit.add_gate(Gate::Cx, &[term.qubit, scratch_alias]);
+                }
+                for term in mapped_terms.iter().rev() {
+                    append_z_to_basis_rotation(&mut circuit, term.basis, term.qubit);
+                }
+
+                deferred_measurements.push((scratch_alias, next_record));
+                measured_aliases[scratch_alias] = true;
+                next_record += 1;
+            }
+            QecOp::Reset { basis, qubit } => {
+                let alias = qec_assign_fresh_alias(
+                    &mut circuit,
+                    &mut aliases,
+                    &mut measured_aliases,
+                    &mut next_qubit,
+                    *qubit,
+                );
+                append_z_to_basis_rotation(&mut circuit, *basis, alias);
+            }
+            QecOp::Noise { channel, targets } => {
+                if channel.probability() > 0.0 {
+                    push_qec_deferred_noise_events(
+                        *channel,
+                        targets,
+                        &aliases,
+                        &measured_aliases,
+                        circuit.instructions.len(),
+                        &mut noise_events,
+                    )?;
+                }
+            }
+            QecOp::ExpectationValue { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC compiled runner".to_string(),
+                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
+                });
+            }
+            QecOp::Detector { .. }
+            | QecOp::ObservableInclude { .. }
+            | QecOp::Postselect { .. }
+            | QecOp::Tick => {}
+        }
+    }
+
+    if next_record != program.num_measurements() {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC deferred lowering produced {next_record} records, expected {}",
+                program.num_measurements()
+            ),
+        });
+    }
+
+    let mut measurement_qubits = Vec::with_capacity(deferred_measurements.len());
+    for (qubit, classical_bit) in deferred_measurements {
+        measurement_qubits.push(qubit);
+        circuit.add_measure(qubit, classical_bit);
+    }
+
+    Ok(QecDeferredProgram {
+        circuit,
+        noise_events,
+        measurement_qubits,
+    })
+}
+
+fn qec_assign_fresh_alias(
+    circuit: &mut Circuit,
+    aliases: &mut [usize],
+    measured_aliases: &mut Vec<bool>,
+    next_qubit: &mut usize,
+    logical_qubit: usize,
+) -> usize {
+    let alias = *next_qubit;
+    aliases[logical_qubit] = alias;
+    *next_qubit += 1;
+    measured_aliases.push(false);
+    circuit.num_qubits = *next_qubit;
+    alias
+}
+
+fn map_qec_deferred_targets(
+    targets: &[usize],
+    aliases: &[usize],
+    measured_aliases: &[bool],
+) -> Result<SmallVec<[usize; 4]>> {
+    let mut mapped = SmallVec::<[usize; 4]>::with_capacity(targets.len());
+    for &target in targets {
+        mapped.push(qec_deferred_target(target, aliases, measured_aliases)?);
+    }
+    Ok(mapped)
+}
+
+fn qec_deferred_target(
+    target: usize,
+    aliases: &[usize],
+    measured_aliases: &[bool],
+) -> Result<usize> {
+    if target >= aliases.len() {
+        return Err(PrismError::InvalidQubit {
+            index: target,
+            register_size: aliases.len(),
+        });
+    }
+    let alias = aliases[target];
+    if measured_aliases[alias] {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC compiled runner".to_string(),
+            reason: "compiled QEC runner requires reset before reusing a measured qubit"
+                .to_string(),
+        });
+    }
+    Ok(alias)
+}
+
+fn push_qec_deferred_noise_events(
+    channel: QecNoise,
+    targets: &[usize],
+    aliases: &[usize],
+    measured_aliases: &[bool],
+    position: usize,
+    noise_events: &mut Vec<QecDeferredNoiseEvent>,
+) -> Result<()> {
+    match channel {
+        QecNoise::XError(_) | QecNoise::ZError(_) | QecNoise::Depolarize1(_) => {
+            let mut live_targets = Vec::with_capacity(targets.len());
+            for &target in targets {
+                if let Some(alias) = qec_deferred_noise_target(target, aliases, measured_aliases)? {
+                    live_targets.push(alias);
+                }
+            }
+            if !live_targets.is_empty() {
+                noise_events.push(QecDeferredNoiseEvent {
+                    channel,
+                    targets: live_targets,
+                    position,
+                });
+            }
+        }
+        QecNoise::Depolarize2(p) => {
+            for pair in targets.chunks_exact(2) {
+                let first = qec_deferred_noise_target(pair[0], aliases, measured_aliases)?;
+                let second = qec_deferred_noise_target(pair[1], aliases, measured_aliases)?;
+                match (first, second) {
+                    (Some(q0), Some(q1)) => noise_events.push(QecDeferredNoiseEvent {
+                        channel,
+                        targets: vec![q0, q1],
+                        position,
+                    }),
+                    (Some(q), None) | (None, Some(q)) => {
+                        noise_events.push(QecDeferredNoiseEvent {
+                            channel: QecNoise::Depolarize1(p * 0.8),
+                            targets: vec![q],
+                            position,
+                        });
+                    }
+                    (None, None) => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn qec_deferred_noise_target(
+    target: usize,
+    aliases: &[usize],
+    measured_aliases: &[bool],
+) -> Result<Option<usize>> {
+    if target >= aliases.len() {
+        return Err(PrismError::InvalidQubit {
+            index: target,
+            register_size: aliases.len(),
+        });
+    }
+    let alias = aliases[target];
+    if measured_aliases[alias] {
+        return Ok(None);
+    }
+    Ok(Some(alias))
+}
+
+fn compile_qec_noise_sensitivity(deferred: &QecDeferredProgram) -> Result<QecNoiseSensitivity> {
+    let num_measurements = deferred.measurement_qubits.len();
+    let m_words = num_measurements.div_ceil(64);
+    let mut x_packed = vec![vec![0u64; m_words]; deferred.circuit.num_qubits];
+    let mut z_packed = vec![vec![0u64; m_words]; deferred.circuit.num_qubits];
+    let mut sign_packed = vec![0u64; m_words];
+
+    for (record, &qubit) in deferred.measurement_qubits.iter().enumerate() {
+        z_packed[qubit][record / 64] |= 1u64 << (record % 64);
+    }
+
+    let gate_count = deferred
+        .circuit
+        .instructions
+        .iter()
+        .filter(|inst| matches!(inst, Instruction::Gate { .. }))
+        .count();
+    let mut noise_by_position = vec![Vec::new(); gate_count + 1];
+    for event in &deferred.noise_events {
+        if event.position > gate_count {
+            return Err(PrismError::InvalidParameter {
+                message: "QEC noise event position exceeds deferred gate count".to_string(),
+            });
+        }
+        noise_by_position[event.position].push(event.clone());
+    }
+
+    let mut events = QecNoiseSensitivity::new();
+    for gate_position in (0..gate_count).rev() {
+        for event in &noise_by_position[gate_position + 1] {
+            push_qec_noise_sensitivity_event(event, &x_packed, &z_packed, &mut events);
+        }
+        let (gate, targets) = match &deferred.circuit.instructions[gate_position] {
+            Instruction::Gate { gate, targets } => (gate, targets.as_slice()),
+            _ => {
+                return Err(PrismError::InvalidParameter {
+                    message: "QEC deferred circuit expected gate before terminal measurements"
+                        .to_string(),
+                });
+            }
+        };
+        batch_propagate_backward(
+            &mut x_packed,
+            &mut z_packed,
+            &mut sign_packed,
+            gate,
+            targets,
+            m_words,
+        );
+    }
+
+    for event in &noise_by_position[0] {
+        push_qec_noise_sensitivity_event(event, &x_packed, &z_packed, &mut events);
+    }
+
+    Ok(events)
+}
+
+fn push_qec_noise_sensitivity_event(
+    event: &QecDeferredNoiseEvent,
+    x_packed: &[Vec<u64>],
+    z_packed: &[Vec<u64>],
+    events: &mut QecNoiseSensitivity,
+) {
+    match event.channel {
+        QecNoise::XError(p) => {
+            for &target in &event.targets {
+                events.push_single(&x_packed[target], &z_packed[target], p, 0.0, 0.0);
+            }
+        }
+        QecNoise::ZError(p) => {
+            for &target in &event.targets {
+                events.push_single(&x_packed[target], &z_packed[target], 0.0, 0.0, p);
+            }
+        }
+        QecNoise::Depolarize1(p) => {
+            let branch_p = p / 3.0;
+            for &target in &event.targets {
+                events.push_single(
+                    &x_packed[target],
+                    &z_packed[target],
+                    branch_p,
+                    branch_p,
+                    branch_p,
+                );
+            }
+        }
+        QecNoise::Depolarize2(p) => {
+            for pair in event.targets.chunks_exact(2) {
+                events.push_pair(
+                    &x_packed[pair[0]],
+                    &z_packed[pair[0]],
+                    &x_packed[pair[1]],
+                    &z_packed[pair[1]],
+                    p,
+                );
+            }
+        }
+    }
+}
+
+fn apply_qec_single_noise_event(
+    data: &mut [u64],
+    num_shots: usize,
+    m_words: usize,
+    event: QecSingleNoiseView<'_>,
+    rng: &mut Xoshiro256PlusPlus,
+) {
+    if event.p_event == 0.0 {
+        return;
+    }
+
+    if event.p_event >= 0.5 || num_shots < 32 {
+        for shot in 0..num_shots {
+            let r = rng.next_f64();
+            let base = shot * m_words;
+            apply_qec_single_noise_branch(&mut data[base..base + m_words], event, r);
+        }
+        return;
+    }
+
+    let ln_1mp = (1.0 - event.p_event).ln();
+    let px_frac = event.px / event.p_event;
+    let pxy_frac = (event.px + event.py) / event.p_event;
+    let conditional_event = QecSingleNoiseView {
+        x_flip: event.x_flip,
+        z_flip: event.z_flip,
+        px: px_frac,
+        py: pxy_frac - px_frac,
+        p_event: 1.0,
+    };
+    let mut shot = qec_geometric_sample(rng, ln_1mp);
+    while shot < num_shots {
+        let r = rng.next_f64();
+        let base = shot * m_words;
+        apply_qec_single_noise_branch(&mut data[base..base + m_words], conditional_event, r);
+        shot += 1 + qec_geometric_sample(rng, ln_1mp);
+    }
+}
+
+fn apply_qec_single_noise_branch(shot_words: &mut [u64], event: QecSingleNoiseView<'_>, r: f64) {
+    // x_flip / z_flip are the X / Z components of the propagated measurement
+    // Pauli at this point in the circuit. A Pauli error flips a measurement
+    // record iff it anti-commutes with the propagated Pauli on this qubit:
+    // X anti-commutes with Z, Z anti-commutes with X, Y anti-commutes with both.
+    if r < event.px {
+        xor_words(shot_words, event.z_flip);
+    } else if r < event.px + event.py {
+        xor_words(shot_words, event.x_flip);
+        xor_words(shot_words, event.z_flip);
+    } else if r < event.p_event {
+        xor_words(shot_words, event.x_flip);
+    }
+}
+
+fn apply_qec_pair_noise_event(
+    data: &mut [u64],
+    num_shots: usize,
+    m_words: usize,
+    branch_flips: &[u64],
+    p: f64,
+    rng: &mut Xoshiro256PlusPlus,
+) {
+    if p == 0.0 {
+        return;
+    }
+
+    if p >= 0.5 || num_shots < 32 {
+        for shot in 0..num_shots {
+            if rng.next_f64() < p {
+                apply_qec_pair_noise_branch(data, shot, m_words, branch_flips, rng);
+            }
+        }
+        return;
+    }
+
+    let ln_1mp = (1.0 - p).ln();
+    let mut shot = qec_geometric_sample(rng, ln_1mp);
+    while shot < num_shots {
+        apply_qec_pair_noise_branch(data, shot, m_words, branch_flips, rng);
+        shot += 1 + qec_geometric_sample(rng, ln_1mp);
+    }
+}
+
+fn apply_qec_pair_noise_branch(
+    data: &mut [u64],
+    shot: usize,
+    m_words: usize,
+    branch_flips: &[u64],
+    rng: &mut Xoshiro256PlusPlus,
+) {
+    // branch_flips packs the 15 non-identity 2-qubit Pauli effects in fixed
+    // order (see push_pair). Picking a uniform branch reproduces the
+    // depolarize-2 distribution conditional on an event firing.
+    let branch = qec_uniform_15(rng);
+    let flip_base = branch * m_words;
+    let shot_base = shot * m_words;
+    xor_words(
+        &mut data[shot_base..shot_base + m_words],
+        &branch_flips[flip_base..flip_base + m_words],
+    );
+}
+
+fn append_qec_pauli_noise_effect(branch: &mut [u64], pauli: usize, x_flip: &[u64], z_flip: &[u64]) {
+    match pauli {
+        0 => {}
+        1 => xor_words(branch, z_flip),
+        2 => {
+            xor_words(branch, x_flip);
+            xor_words(branch, z_flip);
+        }
+        _ => xor_words(branch, x_flip),
+    }
+}
+
+/// Inverse-CDF sample from `Geometric(p)` (number of failures before the
+/// first success). `ln_1mp` is `(1 - p).ln()` precomputed by the caller so
+/// hot-path loops avoid recomputing it. Used to skip ahead to the next shot
+/// where a Pauli-noise event fires when `p` is small.
+#[inline(always)]
+fn qec_geometric_sample(rng: &mut Xoshiro256PlusPlus, ln_1mp: f64) -> usize {
+    let u: f64 = 1.0 - rng.next_f64();
+    (u.ln() / ln_1mp) as usize
+}
+
+#[inline(always)]
+fn qec_uniform_15(rng: &mut Xoshiro256PlusPlus) -> usize {
+    const BRANCHES: u64 = 15;
+    const ZONE: u64 = u64::MAX - (u64::MAX % BRANCHES);
+    loop {
+        let value = rng.next_u64();
+        if value < ZONE {
+            return (value % BRANCHES) as usize;
+        }
+    }
+}

--- a/src/qec/parse.rs
+++ b/src/qec/parse.rs
@@ -1,0 +1,708 @@
+use super::{QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram, QecRecordRef};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+
+const MAX_QEC_EXPANDED_LINES: usize = 1_000_000;
+
+/// Parse a native measurement-record QEC program from text.
+///
+/// Recognized instructions: `H`, `S`, `S_DAG`, `T`, `T_DAG`, `CX`, `CZ`,
+/// `R`/`RX`/`RY`, `M`/`MX`/`MY`, `MR`/`MRX`/`MRY`, `MPP`, `DETECTOR`,
+/// `OBSERVABLE_INCLUDE`, `POSTSELECT`, `EXP_VAL`, `X_ERROR`, `Z_ERROR`,
+/// `DEPOLARIZE1`, `DEPOLARIZE2`, `TICK`, `QUBIT_COORDS`, `SHIFT_COORDS`, and
+/// flattened `REPEAT` blocks. `rec[-k]` measurement record references are
+/// resolved against records emitted up to that point. Comments use `#`.
+///
+/// `M(p)` and `MR(p)` lower the optional measurement-error probability into a
+/// pre-measurement Pauli flip annotation; `MPP` does not currently accept a
+/// measurement-error argument.
+pub fn parse_qec_program(input: &str) -> Result<QecProgram> {
+    let lines = expand_repeats(input)?;
+    let mut parser = QecTextParser::default();
+    for (line_num, line) in lines {
+        parser.parse_line(line_num, &line)?;
+    }
+    let num_qubits = parser.max_qubit.map_or(0, |qubit| qubit + 1);
+    QecProgram::from_ops(num_qubits, QecOptions::default(), parser.ops)
+}
+
+#[derive(Default)]
+struct QecTextParser {
+    ops: Vec<QecOp>,
+    measurement_count: usize,
+    max_qubit: Option<usize>,
+}
+
+impl QecTextParser {
+    fn parse_line(&mut self, line_num: usize, line: &str) -> Result<()> {
+        let (name, args, targets) = split_instruction(line, line_num)?;
+        match name.as_str() {
+            "I" | "X" | "Y" | "Z" | "H" | "S" | "S_DAG" | "SDAG" | "T" | "T_DAG" | "TDG" => {
+                self.parse_single_qubit_gate(&name, &targets, line_num)
+            }
+            "CX" | "CNOT" | "CZ" => self.parse_two_qubit_gate(&name, &targets, line_num),
+            "R" | "RZ" | "RX" | "RY" => {
+                self.parse_reset(measurement_basis(&name), &targets, line_num)
+            }
+            "M" | "MZ" | "MX" | "MY" => self.parse_measurement(
+                measurement_basis(&name),
+                args.as_deref(),
+                &targets,
+                line_num,
+            ),
+            "MR" | "MRZ" | "MRX" | "MRY" => self.parse_measure_reset(
+                measurement_basis(&name),
+                args.as_deref(),
+                &targets,
+                line_num,
+            ),
+            "MPP" => self.parse_mpp(args.as_deref(), &targets, line_num),
+            "DETECTOR" => self.parse_detector(args.as_deref(), &targets, line_num),
+            "OBSERVABLE_INCLUDE" => {
+                self.parse_observable_include(args.as_deref(), &targets, line_num)
+            }
+            "POSTSELECT" => self.parse_postselect(args.as_deref(), &targets, line_num),
+            "EXP_VAL" => self.parse_exp_val(args.as_deref(), &targets, line_num),
+            "X_ERROR" | "Z_ERROR" | "DEPOLARIZE1" | "DEPOLARIZE2" => {
+                self.parse_noise(&name, args.as_deref(), &targets, line_num)
+            }
+            "QUBIT_COORDS" => self.parse_qubit_coords(&targets, line_num),
+            "SHIFT_COORDS" => Ok(()),
+            "TICK" => {
+                self.ops.push(QecOp::Tick);
+                Ok(())
+            }
+            _ => Err(qec_parse_error(
+                line_num,
+                format!("unsupported QEC instruction `{name}`"),
+            )),
+        }
+    }
+
+    fn parse_single_qubit_gate(
+        &mut self,
+        name: &str,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let gate = match name {
+            "I" => Gate::Id,
+            "X" => Gate::X,
+            "Y" => Gate::Y,
+            "Z" => Gate::Z,
+            "H" => Gate::H,
+            "S" => Gate::S,
+            "S_DAG" | "SDAG" => Gate::Sdg,
+            "T" => Gate::T,
+            "T_DAG" | "TDG" => Gate::Tdg,
+            _ => unreachable!(),
+        };
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, name, line_num)?;
+        for qubit in qubits {
+            self.note_qubit(qubit);
+            self.ops.push(QecOp::Gate {
+                gate: gate.clone(),
+                targets: vec![qubit],
+            });
+        }
+        Ok(())
+    }
+
+    fn parse_two_qubit_gate(
+        &mut self,
+        name: &str,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, name, line_num)?;
+        if qubits.len() % 2 != 0 {
+            return Err(qec_parse_error(
+                line_num,
+                format!("`{name}` requires an even number of qubit targets"),
+            ));
+        }
+        let gate = if name == "CZ" { Gate::Cz } else { Gate::Cx };
+        for pair in qubits.chunks_exact(2) {
+            self.note_qubit(pair[0]);
+            self.note_qubit(pair[1]);
+            self.ops.push(QecOp::Gate {
+                gate: gate.clone(),
+                targets: pair.to_vec(),
+            });
+        }
+        Ok(())
+    }
+
+    fn parse_reset(&mut self, basis: QecBasis, targets: &[String], line_num: usize) -> Result<()> {
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, "reset", line_num)?;
+        for qubit in qubits {
+            self.note_qubit(qubit);
+            self.ops.push(QecOp::Reset { basis, qubit });
+        }
+        Ok(())
+    }
+
+    fn parse_measurement(
+        &mut self,
+        basis: QecBasis,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let measurement_error = parse_optional_probability_arg(args, "measurement", line_num)?;
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, "measurement", line_num)?;
+        for qubit in qubits {
+            self.note_qubit(qubit);
+            if let Some(p) = measurement_error.filter(|&p| p > 0.0) {
+                self.ops.push(QecOp::Noise {
+                    channel: measurement_error_channel(basis, p),
+                    targets: vec![qubit],
+                });
+            }
+            self.ops.push(QecOp::Measure { basis, qubit });
+            self.measurement_count += 1;
+        }
+        Ok(())
+    }
+
+    fn parse_measure_reset(
+        &mut self,
+        basis: QecBasis,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let measurement_error = parse_optional_probability_arg(args, "measure-reset", line_num)?;
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, "measure-reset", line_num)?;
+        for qubit in qubits {
+            self.note_qubit(qubit);
+            if let Some(p) = measurement_error.filter(|&p| p > 0.0) {
+                self.ops.push(QecOp::Noise {
+                    channel: measurement_error_channel(basis, p),
+                    targets: vec![qubit],
+                });
+            }
+            self.ops.push(QecOp::Measure { basis, qubit });
+            self.measurement_count += 1;
+            self.ops.push(QecOp::Reset { basis, qubit });
+        }
+        Ok(())
+    }
+
+    fn parse_mpp(&mut self, args: Option<&str>, targets: &[String], line_num: usize) -> Result<()> {
+        if !parse_f64_args(args, line_num)?.is_empty() {
+            return Err(qec_parse_error(
+                line_num,
+                "`MPP` does not support measurement-error arguments yet",
+            ));
+        }
+        if targets.is_empty() {
+            return Err(qec_parse_error(
+                line_num,
+                "`MPP` requires at least one Pauli product",
+            ));
+        }
+        for target in targets {
+            let terms = parse_pauli_product(target, line_num)?;
+            for term in &terms {
+                self.note_qubit(term.qubit);
+            }
+            self.ops.push(QecOp::MeasurePauliProduct { terms });
+            self.measurement_count += 1;
+        }
+        Ok(())
+    }
+
+    fn parse_detector(
+        &mut self,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let coords = parse_f64_args(args, line_num)?;
+        let records = self.parse_record_targets(targets, line_num)?;
+        self.ops.push(QecOp::Detector { records, coords });
+        Ok(())
+    }
+
+    fn parse_observable_include(
+        &mut self,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let observable = parse_single_usize_arg(args, "OBSERVABLE_INCLUDE", line_num)?;
+        let records = self.parse_record_targets(targets, line_num)?;
+        self.ops.push(QecOp::ObservableInclude {
+            observable,
+            records,
+        });
+        Ok(())
+    }
+
+    fn parse_postselect(
+        &mut self,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let expected = parse_optional_bool_arg(args, "POSTSELECT", line_num)?;
+        let records = self.parse_record_targets(targets, line_num)?;
+        self.ops.push(QecOp::Postselect { records, expected });
+        Ok(())
+    }
+
+    fn parse_exp_val(
+        &mut self,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let coefficient = parse_optional_coefficient(args, line_num)?;
+        if targets.is_empty() {
+            return Err(qec_parse_error(
+                line_num,
+                "`EXP_VAL` requires at least one Pauli target",
+            ));
+        }
+        let mut terms = Vec::new();
+        for target in targets {
+            let mut product = parse_pauli_product(target, line_num)?;
+            terms.append(&mut product);
+        }
+        for term in &terms {
+            self.note_qubit(term.qubit);
+        }
+        self.ops
+            .push(QecOp::ExpectationValue { terms, coefficient });
+        Ok(())
+    }
+
+    fn parse_noise(
+        &mut self,
+        name: &str,
+        args: Option<&str>,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<()> {
+        let p = parse_single_f64_arg(args, name, line_num)?;
+        if !p.is_finite() || !(0.0..=1.0).contains(&p) {
+            return Err(qec_parse_error(
+                line_num,
+                format!("`{name}` probability must be finite and in [0, 1]"),
+            ));
+        }
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        require_non_empty_targets(&qubits, name, line_num)?;
+        for &qubit in &qubits {
+            self.note_qubit(qubit);
+        }
+        let channel = match name {
+            "X_ERROR" => QecNoise::XError(p),
+            "Z_ERROR" => QecNoise::ZError(p),
+            "DEPOLARIZE1" => QecNoise::Depolarize1(p),
+            "DEPOLARIZE2" => QecNoise::Depolarize2(p),
+            _ => unreachable!(),
+        };
+        if p > 0.0 {
+            self.ops.push(QecOp::Noise {
+                channel,
+                targets: qubits,
+            });
+        }
+        Ok(())
+    }
+
+    fn parse_qubit_coords(&mut self, targets: &[String], line_num: usize) -> Result<()> {
+        let qubits = parse_qubit_targets(targets, line_num)?;
+        for qubit in qubits {
+            self.note_qubit(qubit);
+        }
+        Ok(())
+    }
+
+    fn parse_record_targets(
+        &self,
+        targets: &[String],
+        line_num: usize,
+    ) -> Result<Vec<QecRecordRef>> {
+        targets
+            .iter()
+            .map(|target| parse_record_ref(target, self.measurement_count, line_num))
+            .collect()
+    }
+
+    fn note_qubit(&mut self, qubit: usize) {
+        self.max_qubit = Some(self.max_qubit.map_or(qubit, |max| max.max(qubit)));
+    }
+}
+
+fn measurement_basis(name: &str) -> QecBasis {
+    if name.ends_with('X') {
+        QecBasis::X
+    } else if name.ends_with('Y') {
+        QecBasis::Y
+    } else {
+        QecBasis::Z
+    }
+}
+
+fn expand_repeats(input: &str) -> Result<Vec<(usize, String)>> {
+    let mut lines = Vec::new();
+    for (idx, raw) in input.lines().enumerate() {
+        let line = strip_qec_comment(raw).trim();
+        if !line.is_empty() {
+            lines.push((idx + 1, line.to_string()));
+        }
+    }
+
+    let mut index = 0;
+    let expanded = expand_repeat_block(&lines, &mut index, false)?;
+    if index != lines.len() {
+        let (line_num, _) = &lines[index];
+        return Err(qec_parse_error(
+            *line_num,
+            "unexpected trailing repeat block",
+        ));
+    }
+    Ok(expanded)
+}
+
+fn expand_repeat_block(
+    lines: &[(usize, String)],
+    index: &mut usize,
+    in_repeat: bool,
+) -> Result<Vec<(usize, String)>> {
+    let mut expanded = Vec::new();
+    while *index < lines.len() {
+        let (line_num, line) = &lines[*index];
+        if line == "}" {
+            if !in_repeat {
+                return Err(qec_parse_error(*line_num, "unmatched `}`"));
+            }
+            *index += 1;
+            return Ok(expanded);
+        }
+
+        if line.to_ascii_uppercase().starts_with("REPEAT ") {
+            let count = parse_repeat_header(line, *line_num)?;
+            *index += 1;
+            let body = expand_repeat_block(lines, index, true)?;
+            let repeated_len = body.len().checked_mul(count).ok_or_else(|| {
+                qec_parse_error(
+                    *line_num,
+                    format!("`REPEAT` expansion exceeds {MAX_QEC_EXPANDED_LINES} instructions"),
+                )
+            })?;
+            if expanded.len().saturating_add(repeated_len) > MAX_QEC_EXPANDED_LINES {
+                return Err(qec_parse_error(
+                    *line_num,
+                    format!("`REPEAT` expansion exceeds {MAX_QEC_EXPANDED_LINES} instructions"),
+                ));
+            }
+            for _ in 0..count {
+                expanded.extend(body.iter().cloned());
+            }
+            continue;
+        }
+
+        if line == "{" || line.contains('{') {
+            return Err(qec_parse_error(*line_num, "unexpected `{`"));
+        }
+
+        if expanded.len() == MAX_QEC_EXPANDED_LINES {
+            return Err(qec_parse_error(
+                *line_num,
+                format!("QEC text exceeds {MAX_QEC_EXPANDED_LINES} instructions"),
+            ));
+        }
+        expanded.push((*line_num, line.clone()));
+        *index += 1;
+    }
+
+    if in_repeat {
+        return Err(PrismError::Parse {
+            line: lines.last().map_or(1, |(line_num, _)| *line_num),
+            message: "unterminated `REPEAT` block".to_string(),
+        });
+    }
+    Ok(expanded)
+}
+
+fn parse_repeat_header(line: &str, line_num: usize) -> Result<usize> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() != 3 || !parts[0].eq_ignore_ascii_case("REPEAT") || parts[2] != "{" {
+        return Err(qec_parse_error(
+            line_num,
+            "`REPEAT` must have form `REPEAT count {`",
+        ));
+    }
+    parts[1]
+        .parse::<usize>()
+        .map_err(|_| qec_parse_error(line_num, "`REPEAT` count must be an unsigned integer"))
+}
+
+fn strip_qec_comment(line: &str) -> &str {
+    line.split_once('#').map_or(line, |(before, _)| before)
+}
+
+fn split_instruction(line: &str, line_num: usize) -> Result<(String, Option<String>, Vec<String>)> {
+    let line = line.trim();
+    let (head, rest) = if let Some(open) = line.find('(') {
+        let first_ws = line.find(char::is_whitespace);
+        if first_ws.map_or(true, |ws| open < ws) {
+            let close = line[open..]
+                .find(')')
+                .map(|offset| open + offset)
+                .ok_or_else(|| qec_parse_error(line_num, "unterminated instruction arguments"))?;
+            (&line[..=close], line[close + 1..].trim())
+        } else {
+            split_head_word(line)
+        }
+    } else {
+        split_head_word(line)
+    };
+
+    let (name, args) = if let Some(open) = head.find('(') {
+        if !head.ends_with(')') {
+            return Err(qec_parse_error(line_num, "malformed instruction arguments"));
+        }
+        (
+            head[..open].to_ascii_uppercase(),
+            Some(head[open + 1..head.len() - 1].trim().to_string()),
+        )
+    } else {
+        (head.to_ascii_uppercase(), None)
+    };
+    let targets = rest.split_whitespace().map(ToString::to_string).collect();
+    Ok((name, args, targets))
+}
+
+fn split_head_word(line: &str) -> (&str, &str) {
+    match line.find(char::is_whitespace) {
+        Some(idx) => (&line[..idx], line[idx..].trim()),
+        None => (line, ""),
+    }
+}
+
+fn parse_f64_args(args: Option<&str>, line_num: usize) -> Result<Vec<f64>> {
+    let Some(args) = args else {
+        return Ok(Vec::new());
+    };
+    if args.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    args.split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<f64>()
+                .map_err(|_| qec_parse_error(line_num, "expected numeric argument"))
+        })
+        .collect()
+}
+
+fn parse_single_f64_arg(args: Option<&str>, name: &str, line_num: usize) -> Result<f64> {
+    let values = parse_f64_args(args, line_num)?;
+    if values.len() != 1 {
+        return Err(qec_parse_error(
+            line_num,
+            format!("`{name}` requires one numeric argument"),
+        ));
+    }
+    Ok(values[0])
+}
+
+fn parse_optional_coefficient(args: Option<&str>, line_num: usize) -> Result<f64> {
+    let values = parse_f64_args(args, line_num)?;
+    match values.as_slice() {
+        [] => Ok(1.0),
+        [coefficient] => Ok(*coefficient),
+        _ => Err(qec_parse_error(
+            line_num,
+            "`EXP_VAL` accepts zero or one numeric argument",
+        )),
+    }
+}
+
+fn parse_optional_probability_arg(
+    args: Option<&str>,
+    name: &str,
+    line_num: usize,
+) -> Result<Option<f64>> {
+    let values = parse_f64_args(args, line_num)?;
+    match values.as_slice() {
+        [] => Ok(None),
+        [p] if p.is_finite() && (0.0..=1.0).contains(p) => Ok(Some(*p)),
+        [_] => Err(qec_parse_error(
+            line_num,
+            format!("`{name}` probability must be finite and in [0, 1]"),
+        )),
+        _ => Err(qec_parse_error(
+            line_num,
+            format!("`{name}` accepts zero or one numeric argument"),
+        )),
+    }
+}
+
+fn measurement_error_channel(basis: QecBasis, p: f64) -> QecNoise {
+    match basis {
+        QecBasis::X | QecBasis::Y => QecNoise::ZError(p),
+        QecBasis::Z => QecNoise::XError(p),
+    }
+}
+
+fn parse_optional_bool_arg(args: Option<&str>, name: &str, line_num: usize) -> Result<bool> {
+    let values = parse_f64_args(args, line_num)?;
+    match values.as_slice() {
+        [] => Ok(false),
+        [v] if *v == 0.0 => Ok(false),
+        [v] if *v == 1.0 => Ok(true),
+        [_] => Err(qec_parse_error(
+            line_num,
+            format!("`{name}` expected value must be 0 or 1"),
+        )),
+        _ => Err(qec_parse_error(
+            line_num,
+            format!("`{name}` accepts zero or one expected-value argument"),
+        )),
+    }
+}
+
+fn parse_single_usize_arg(args: Option<&str>, name: &str, line_num: usize) -> Result<usize> {
+    let Some(args) = args else {
+        return Err(qec_parse_error(
+            line_num,
+            format!("`{name}` requires one integer argument"),
+        ));
+    };
+    if args.split(',').count() != 1 {
+        return Err(qec_parse_error(
+            line_num,
+            format!("`{name}` requires one integer argument"),
+        ));
+    }
+    args.trim()
+        .parse::<usize>()
+        .map_err(|_| qec_parse_error(line_num, format!("`{name}` argument must be an integer")))
+}
+
+fn parse_qubit_targets(targets: &[String], line_num: usize) -> Result<Vec<usize>> {
+    targets
+        .iter()
+        .map(|target| parse_qubit_target(target, line_num))
+        .collect()
+}
+
+fn parse_qubit_target(target: &str, line_num: usize) -> Result<usize> {
+    reject_inverted_target(target, line_num)?;
+    target
+        .parse::<usize>()
+        .map_err(|_| qec_parse_error(line_num, format!("expected qubit target, got `{target}`")))
+}
+
+fn parse_pauli_product(target: &str, line_num: usize) -> Result<Vec<QecPauli>> {
+    reject_inverted_target(target, line_num)?;
+    if target.is_empty() {
+        return Err(qec_parse_error(line_num, "empty Pauli product"));
+    }
+    target
+        .split('*')
+        .map(|term| parse_pauli_term(term, line_num))
+        .collect()
+}
+
+fn parse_pauli_term(term: &str, line_num: usize) -> Result<QecPauli> {
+    reject_inverted_target(term, line_num)?;
+    let mut chars = term.chars();
+    let basis = match chars.next() {
+        Some('X') | Some('x') => QecBasis::X,
+        Some('Y') | Some('y') => QecBasis::Y,
+        Some('Z') | Some('z') => QecBasis::Z,
+        _ => {
+            return Err(qec_parse_error(
+                line_num,
+                format!("expected Pauli target, got `{term}`"),
+            ))
+        }
+    };
+    let qubit_text = chars.as_str();
+    if qubit_text.is_empty() {
+        return Err(qec_parse_error(
+            line_num,
+            format!("Pauli target `{term}` is missing a qubit index"),
+        ));
+    }
+    let qubit = qubit_text.parse::<usize>().map_err(|_| {
+        qec_parse_error(
+            line_num,
+            format!("Pauli target `{term}` has an invalid qubit index"),
+        )
+    })?;
+    Ok(QecPauli::new(basis, qubit))
+}
+
+fn parse_record_ref(
+    target: &str,
+    measurement_count: usize,
+    line_num: usize,
+) -> Result<QecRecordRef> {
+    reject_inverted_target(target, line_num)?;
+    if !target.starts_with("rec[") || !target.ends_with(']') {
+        return Err(qec_parse_error(
+            line_num,
+            format!("expected measurement record target, got `{target}`"),
+        ));
+    }
+    let offset = target[4..target.len() - 1].parse::<isize>().map_err(|_| {
+        qec_parse_error(
+            line_num,
+            format!("measurement record target `{target}` has invalid offset"),
+        )
+    })?;
+    if offset >= 0 {
+        return Err(qec_parse_error(
+            line_num,
+            "measurement record offsets must be negative",
+        ));
+    }
+    let distance = offset.unsigned_abs();
+    if distance == 0 || distance > measurement_count {
+        return Err(qec_parse_error(
+            line_num,
+            format!("measurement record `{target}` out of bounds for {measurement_count} records"),
+        ));
+    }
+    Ok(QecRecordRef::Absolute(measurement_count - distance))
+}
+
+fn reject_inverted_target(target: &str, line_num: usize) -> Result<()> {
+    if target.starts_with('!') {
+        return Err(qec_parse_error(
+            line_num,
+            format!("inverted target `{target}` is not supported in native QEC text"),
+        ));
+    }
+    Ok(())
+}
+
+fn require_non_empty_targets(targets: &[usize], name: &str, line_num: usize) -> Result<()> {
+    if targets.is_empty() {
+        return Err(qec_parse_error(
+            line_num,
+            format!("`{name}` requires at least one target"),
+        ));
+    }
+    Ok(())
+}
+
+fn qec_parse_error(line: usize, message: impl Into<String>) -> PrismError {
+    PrismError::Parse {
+        line,
+        message: message.into(),
+    }
+}

--- a/src/qec/result.rs
+++ b/src/qec/result.rs
@@ -5,15 +5,15 @@ use crate::sim::compiled::PackedShots;
 ///
 /// `accepted_shots + discarded_shots == total_shots`. `logical_errors[i]` is
 /// the number of accepted shots whose `i`-th observable parity is 1. When
-/// [`QecOptions::keep_measurements`] is `false`, [`Self::measurements`] is
-/// returned with zero shots; detector and observable shots are always
+/// [`super::QecOptions::keep_measurements`] is `false`, [`Self::measurements`]
+/// is returned with zero shots; detector and observable shots are always
 /// populated.
 #[derive(Debug, Clone)]
 pub struct QecSampleResult {
     /// Number of shots requested from the sampler.
     pub total_shots: usize,
     /// Raw measurement records, or a zero-shot buffer when
-    /// [`QecOptions::keep_measurements`] is `false`.
+    /// [`super::QecOptions::keep_measurements`] is `false`.
     pub measurements: PackedShots,
     /// Detector records: one bit per detector per shot.
     pub detectors: PackedShots,

--- a/src/qec/result.rs
+++ b/src/qec/result.rs
@@ -1,0 +1,151 @@
+use crate::error::{PrismError, Result};
+use crate::sim::compiled::PackedShots;
+
+/// Packed result shell for native QEC sampling.
+///
+/// `accepted_shots + discarded_shots == total_shots`. `logical_errors[i]` is
+/// the number of accepted shots whose `i`-th observable parity is 1. When
+/// [`QecOptions::keep_measurements`] is `false`, [`Self::measurements`] is
+/// returned with zero shots; detector and observable shots are always
+/// populated.
+#[derive(Debug, Clone)]
+pub struct QecSampleResult {
+    /// Number of shots requested from the sampler.
+    pub total_shots: usize,
+    /// Raw measurement records, or a zero-shot buffer when
+    /// [`QecOptions::keep_measurements`] is `false`.
+    pub measurements: PackedShots,
+    /// Detector records: one bit per detector per shot.
+    pub detectors: PackedShots,
+    /// Logical observable records: one bit per observable per shot.
+    pub observables: PackedShots,
+    /// Number of shots accepted after postselection (or `total_shots` when no
+    /// postselection predicate is present).
+    pub accepted_shots: usize,
+    /// Number of shots rejected by postselection.
+    pub discarded_shots: usize,
+    /// For each observable, count of accepted shots where the observable
+    /// parity equals 1. Length equals the number of observables.
+    pub logical_errors: Vec<u64>,
+}
+
+impl QecSampleResult {
+    /// Create an empty result with zero shots.
+    pub fn empty(num_measurements: usize, num_detectors: usize, num_observables: usize) -> Self {
+        Self {
+            total_shots: 0,
+            measurements: PackedShots::from_meas_major(Vec::new(), 0, num_measurements),
+            detectors: PackedShots::from_meas_major(Vec::new(), 0, num_detectors),
+            observables: PackedShots::from_meas_major(Vec::new(), 0, num_observables),
+            accepted_shots: 0,
+            discarded_shots: 0,
+            logical_errors: vec![0; num_observables],
+        }
+    }
+
+    /// Create a result and validate packed-shot dimensions.
+    pub fn new(
+        measurements: PackedShots,
+        detectors: PackedShots,
+        observables: PackedShots,
+        accepted_shots: usize,
+        discarded_shots: usize,
+        logical_errors: Vec<u64>,
+    ) -> Result<Self> {
+        let total_shots = infer_qec_result_total_shots(&measurements, &detectors, &observables);
+        Self::new_with_total_shots(
+            total_shots,
+            measurements,
+            detectors,
+            observables,
+            accepted_shots,
+            discarded_shots,
+            logical_errors,
+        )
+    }
+
+    /// Create a result with an explicit total shot count.
+    ///
+    /// Raw measurement records may be a zero-shot shape buffer when
+    /// `QecOptions::keep_measurements` is false. Detector and observable
+    /// buffers must carry the explicit shot count.
+    pub fn new_with_total_shots(
+        total_shots: usize,
+        measurements: PackedShots,
+        detectors: PackedShots,
+        observables: PackedShots,
+        accepted_shots: usize,
+        discarded_shots: usize,
+        logical_errors: Vec<u64>,
+    ) -> Result<Self> {
+        validate_qec_result_shots("measurement", &measurements, total_shots, true)?;
+        validate_qec_result_shots("detector", &detectors, total_shots, false)?;
+        validate_qec_result_shots("observable", &observables, total_shots, false)?;
+
+        let accounted = accepted_shots.checked_add(discarded_shots).ok_or_else(|| {
+            PrismError::InvalidParameter {
+                message: "accepted and discarded shot counts overflow".to_string(),
+            }
+        })?;
+        if accounted != total_shots {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "accepted plus discarded shots must equal {total_shots}, got {accounted}"
+                ),
+            });
+        }
+        if logical_errors.len() != observables.num_measurements() {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "logical error count length {} does not match {} observables",
+                    logical_errors.len(),
+                    observables.num_measurements()
+                ),
+            });
+        }
+        Ok(Self {
+            total_shots,
+            measurements,
+            detectors,
+            observables,
+            accepted_shots,
+            discarded_shots,
+            logical_errors,
+        })
+    }
+}
+
+fn infer_qec_result_total_shots(
+    measurements: &PackedShots,
+    detectors: &PackedShots,
+    observables: &PackedShots,
+) -> usize {
+    [
+        measurements.num_shots(),
+        detectors.num_shots(),
+        observables.num_shots(),
+    ]
+    .into_iter()
+    .find(|shots| *shots != 0)
+    .unwrap_or(0)
+}
+
+fn validate_qec_result_shots(
+    label: &str,
+    shots: &PackedShots,
+    total_shots: usize,
+    allow_omitted: bool,
+) -> Result<()> {
+    if shots.num_shots() == total_shots {
+        return Ok(());
+    }
+    if allow_omitted && shots.num_shots() == 0 && shots.raw_data().is_empty() {
+        return Ok(());
+    }
+    Err(PrismError::InvalidParameter {
+        message: format!(
+            "QEC {label} shot count {} does not match total shots {total_shots}",
+            shots.num_shots()
+        ),
+    })
+}

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -1,0 +1,778 @@
+use super::noise::compile_qec_noisy_sampler;
+use super::{
+    append_basis_to_z_rotation, append_z_to_basis_rotation, QecBasis, QecNoise, QecOp, QecOptions,
+    QecPauli, QecProgram, QecSampleResult,
+};
+use crate::backend::{statevector::StatevectorBackend, Backend};
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::compiled::{compile_detector_sampler, PackedShots, ShotLayout};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+/// Run a native QEC program through the scalable compiled Clifford path.
+///
+/// Lowers supported QEC operations into the packed compiled sampler rather
+/// than dense state-vector simulation, so sampling cost grows with the number
+/// of measurement records, not with `2^n`. Supports Clifford gates, basis
+/// resets and measurements, `MPP`, detectors, observables, and postselection.
+/// Active Pauli-noise annotations (`X_ERROR`, `Z_ERROR`, `DEPOLARIZE1`,
+/// `DEPOLARIZE2`) are compiled into packed sensitivity rows that are XORed
+/// into the noiseless measurement records.
+///
+/// V1 limitations:
+/// - Non-Clifford gates and `EXP_VAL` are rejected.
+/// - A measured qubit must be `Reset` before any later gate reuses it; the
+///   compiled lowering defers measurements to the terminal records of an
+///   internal circuit.
+/// - [`QecOptions::chunk_size`] bounds the per-batch shot count. Setting
+///   `chunk_size` together with `keep_measurements: false` keeps peak memory
+///   at one chunk worth of measurement records.
+pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
+    let has_noise = validate_qec_compiled_program(program)?;
+    let chunk_size = qec_runner_chunk_size(program.options())?;
+    if program.num_measurements() == 0 {
+        let measurements = PackedShots::from_shot_major(
+            Vec::new(),
+            program.options().shots,
+            program.num_measurements(),
+        );
+        return qec_result_from_measurements(program, measurements);
+    }
+
+    if has_noise {
+        let mut sampler = compile_qec_noisy_sampler(program)?;
+        if chunk_size >= program.options().shots {
+            let measurements = sampler.sample_measurements_packed(program.options().shots)?;
+            return qec_result_from_measurements(program, measurements);
+        }
+        return qec_result_from_measurement_chunks(program, |chunk| {
+            sampler.sample_measurements_packed(chunk)
+        });
+    }
+
+    let circuit = lower_qec_program_to_clifford_circuit(program)?;
+    let mut sampler = compile_detector_sampler(
+        &circuit,
+        program.detector_rows()?,
+        program.observable_rows()?,
+        program.options().seed,
+    )?;
+    if chunk_size >= program.options().shots {
+        let measurements = sampler.sample_measurements_packed(program.options().shots)?;
+        return qec_result_from_measurements(program, measurements);
+    }
+    qec_result_from_measurement_chunks(program, |chunk| sampler.sample_measurements_packed(chunk))
+}
+
+/// Run a native QEC program through the correctness-first reference path.
+///
+/// Executes one state-vector simulation per shot. Supports any gate the
+/// statevector backend handles (including non-Clifford), `MPP`, all four
+/// Pauli-noise channels, and postselection. Use this as a semantic oracle
+/// for small programs or to cross-check the compiled runner; cost is
+/// `O(shots * 2^n)`, so it is not the production performance path.
+///
+/// `EXP_VAL` is rejected pending estimator semantics. [`QecOptions::chunk_size`]
+/// is validated for shape but not used to bound execution batches.
+pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult> {
+    qec_runner_chunk_size(program.options())?;
+    let shots = program.options().shots;
+    let num_measurements = program.num_measurements();
+    let has_mpp = program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::MeasurePauliProduct { .. }));
+    let scratch_qubit = program.num_qubits();
+    let backend_qubits = program.num_qubits() + usize::from(has_mpp);
+    let mut backend = StatevectorBackend::new(program.options().seed);
+    let mut noise_rng = ChaCha8Rng::seed_from_u64(program.options().seed ^ 0xD1B5_4A32_D192_ED03);
+    let m_words = num_measurements.div_ceil(64);
+    let mut measurement_data = vec![0u64; shots.saturating_mul(m_words)];
+
+    for shot in 0..shots {
+        backend.init(backend_qubits, num_measurements)?;
+        let mut next_record = 0;
+
+        for op in program.ops() {
+            match op {
+                QecOp::Gate { gate, targets } => {
+                    apply_reference_gate(&mut backend, gate.clone(), targets)?;
+                }
+                QecOp::Measure { basis, qubit } => {
+                    let bit = measure_reference_basis(&mut backend, *basis, *qubit, next_record)?;
+                    set_shot_record(&mut measurement_data, m_words, shot, next_record, bit);
+                    next_record += 1;
+                }
+                QecOp::MeasurePauliProduct { terms } => {
+                    if !has_mpp {
+                        return Err(PrismError::InvalidParameter {
+                            message: "internal QEC MPP scratch qubit was not allocated".to_string(),
+                        });
+                    }
+                    let bit =
+                        measure_reference_mpp(&mut backend, terms, scratch_qubit, next_record)?;
+                    set_shot_record(&mut measurement_data, m_words, shot, next_record, bit);
+                    next_record += 1;
+                }
+                QecOp::Reset { basis, qubit } => {
+                    reset_reference_basis(&mut backend, *basis, *qubit)?;
+                }
+                QecOp::Noise { channel, targets } => {
+                    apply_reference_noise(&mut backend, &mut noise_rng, *channel, targets)?;
+                }
+                QecOp::ExpectationValue { .. } => {
+                    return Err(PrismError::IncompatibleBackend {
+                        backend: "QEC reference runner".to_string(),
+                        reason: "QEC reference runner does not evaluate EXP_VAL yet".to_string(),
+                    });
+                }
+                QecOp::Detector { .. }
+                | QecOp::ObservableInclude { .. }
+                | QecOp::Postselect { .. }
+                | QecOp::Tick => {}
+            }
+        }
+
+        if next_record != num_measurements {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "QEC reference runner produced {next_record} records, expected {num_measurements}"
+                ),
+            });
+        }
+    }
+
+    let measurements = PackedShots::from_shot_major(measurement_data, shots, num_measurements);
+    qec_result_from_measurements(program, measurements)
+}
+
+fn qec_result_from_measurements(
+    program: &QecProgram,
+    all_measurements: PackedShots,
+) -> Result<QecSampleResult> {
+    let shots = program.options().shots;
+    let num_measurements = program.num_measurements();
+    if all_measurements.num_shots() != shots
+        || all_measurements.num_measurements() != num_measurements
+    {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC measurement sample shape must be {shots} shots by {num_measurements} records, got {} by {}",
+                all_measurements.num_shots(),
+                all_measurements.num_measurements()
+            ),
+        });
+    }
+    let detector_rows = program.detector_rows()?;
+    let observable_rows = program.observable_rows()?;
+    let postselection_rows = program.postselection_rows()?;
+    let detectors = parity_rows_or_empty(&all_measurements, &detector_rows)?;
+    let observables = parity_rows_or_empty(&all_measurements, &observable_rows)?;
+    let mut accepted_shots = shots;
+    let mut logical_errors = vec![0u64; observables.num_measurements()];
+
+    if postselection_rows.is_empty() {
+        add_qec_logical_error_counts(&observables, &mut logical_errors);
+    } else {
+        accepted_shots = 0;
+        let postselection_only: Vec<Vec<usize>> = postselection_rows
+            .iter()
+            .map(|(row, _)| row.clone())
+            .collect();
+        let postselection = all_measurements.parity_rows(&postselection_only)?;
+
+        for shot in 0..shots {
+            let accepted = postselection_rows
+                .iter()
+                .enumerate()
+                .all(|(row_idx, (_, expected))| postselection.get_bit(shot, row_idx) == *expected);
+            if accepted {
+                accepted_shots += 1;
+                for (observable, count) in logical_errors.iter_mut().enumerate() {
+                    if observables.get_bit(shot, observable) {
+                        *count += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    let discarded_shots = shots - accepted_shots;
+    let measurements = if program.options().keep_measurements {
+        all_measurements
+    } else {
+        PackedShots::from_meas_major(Vec::new(), 0, num_measurements)
+    };
+
+    QecSampleResult::new_with_total_shots(
+        shots,
+        measurements,
+        detectors,
+        observables,
+        accepted_shots,
+        discarded_shots,
+        logical_errors,
+    )
+}
+
+fn qec_result_from_measurement_chunks<F>(
+    program: &QecProgram,
+    mut sample_chunk: F,
+) -> Result<QecSampleResult>
+where
+    F: FnMut(usize) -> Result<PackedShots>,
+{
+    let options = program.options();
+    let shots = options.shots;
+    let num_measurements = program.num_measurements();
+    let chunk_size = qec_runner_chunk_size(options)?;
+    let detector_rows = program.detector_rows()?;
+    let observable_rows = program.observable_rows()?;
+    let postselection_rows = program.postselection_rows()?;
+    let postselection_only: Vec<Vec<usize>> = postselection_rows
+        .iter()
+        .map(|(row, _)| row.clone())
+        .collect();
+
+    let mut measurement_data = if options.keep_measurements {
+        Vec::with_capacity(shots.saturating_mul(num_measurements.div_ceil(64)))
+    } else {
+        Vec::new()
+    };
+    let mut detector_data =
+        Vec::with_capacity(shots.saturating_mul(detector_rows.len().div_ceil(64)));
+    let mut observable_data =
+        Vec::with_capacity(shots.saturating_mul(observable_rows.len().div_ceil(64)));
+    let mut accepted_shots = 0usize;
+    let mut logical_errors = vec![0u64; observable_rows.len()];
+    let mut sampled_shots = 0usize;
+
+    while sampled_shots < shots {
+        let this_chunk = (shots - sampled_shots).min(chunk_size);
+        let measurements = sample_chunk(this_chunk)?;
+        if measurements.num_shots() != this_chunk
+            || measurements.num_measurements() != num_measurements
+        {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "QEC measurement chunk shape must be {this_chunk} shots by {num_measurements} records, got {} by {}",
+                    measurements.num_shots(),
+                    measurements.num_measurements()
+                ),
+            });
+        }
+
+        let detectors = parity_rows_or_empty(&measurements, &detector_rows)?;
+        let observables = parity_rows_or_empty(&measurements, &observable_rows)?;
+
+        if postselection_rows.is_empty() {
+            accepted_shots += this_chunk;
+            add_qec_logical_error_counts(&observables, &mut logical_errors);
+        } else {
+            let postselection = measurements.parity_rows(&postselection_only)?;
+            for shot in 0..this_chunk {
+                let accepted =
+                    postselection_rows
+                        .iter()
+                        .enumerate()
+                        .all(|(row_idx, (_, expected))| {
+                            postselection.get_bit(shot, row_idx) == *expected
+                        });
+                if accepted {
+                    accepted_shots += 1;
+                    for (observable, count) in logical_errors.iter_mut().enumerate() {
+                        if observables.get_bit(shot, observable) {
+                            *count += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        if options.keep_measurements {
+            measurement_data.extend(measurements.into_shot_major_data());
+        }
+        detector_data.extend(detectors.into_shot_major_data());
+        observable_data.extend(observables.into_shot_major_data());
+        sampled_shots += this_chunk;
+    }
+
+    let measurements = if options.keep_measurements {
+        PackedShots::from_shot_major(measurement_data, shots, num_measurements)
+    } else {
+        PackedShots::from_meas_major(Vec::new(), 0, num_measurements)
+    };
+    let detectors = PackedShots::from_shot_major(detector_data, shots, detector_rows.len());
+    let observables = PackedShots::from_shot_major(observable_data, shots, observable_rows.len());
+    let discarded_shots = shots - accepted_shots;
+
+    QecSampleResult::new_with_total_shots(
+        shots,
+        measurements,
+        detectors,
+        observables,
+        accepted_shots,
+        discarded_shots,
+        logical_errors,
+    )
+}
+
+fn qec_runner_chunk_size(options: QecOptions) -> Result<usize> {
+    match options.chunk_size {
+        Some(0) => Err(PrismError::InvalidParameter {
+            message: "QEC chunk_size must be at least 1".to_string(),
+        }),
+        Some(chunk_size) => Ok(chunk_size),
+        None => Ok(options.shots.max(1)),
+    }
+}
+
+fn parity_rows_or_empty(measurements: &PackedShots, rows: &[Vec<usize>]) -> Result<PackedShots> {
+    if rows.is_empty() {
+        return Ok(PackedShots::from_shot_major(
+            Vec::new(),
+            measurements.num_shots(),
+            0,
+        ));
+    }
+    if measurements.num_shots() == 0 {
+        return Ok(PackedShots::from_shot_major(Vec::new(), 0, rows.len()));
+    }
+    if matches!(measurements.layout(), ShotLayout::ShotMajor) {
+        if let Some(words) = repeated_shot_words(measurements) {
+            return Ok(parity_rows_for_repeated_shot(
+                words,
+                measurements.num_shots(),
+                rows,
+            ));
+        }
+        return Ok(parity_rows_for_shot_major(measurements, rows));
+    }
+    measurements.parity_rows(rows)
+}
+
+fn repeated_shot_words(measurements: &PackedShots) -> Option<&[u64]> {
+    debug_assert!(matches!(measurements.layout(), ShotLayout::ShotMajor));
+    let m_words = measurements.m_words();
+    let data = measurements.raw_data();
+    let first = &data[..m_words];
+    for shot in 1..measurements.num_shots() {
+        let base = shot * m_words;
+        if &data[base..base + m_words] != first {
+            return None;
+        }
+    }
+    Some(first)
+}
+
+fn parity_rows_for_repeated_shot(
+    shot_words: &[u64],
+    num_shots: usize,
+    rows: &[Vec<usize>],
+) -> PackedShots {
+    let out_words = rows.len().div_ceil(64);
+    let mut pattern = vec![0u64; out_words];
+    for (out_idx, row) in rows.iter().enumerate() {
+        pattern[out_idx / 64] |= qec_row_parity_word(shot_words, row) << (out_idx % 64);
+    }
+
+    let mut data = vec![0u64; num_shots * out_words];
+    if pattern.iter().any(|&word| word != 0) {
+        for shot_words in data.chunks_exact_mut(out_words) {
+            shot_words.copy_from_slice(&pattern);
+        }
+    }
+    PackedShots::from_shot_major(data, num_shots, rows.len())
+}
+
+fn parity_rows_for_shot_major(measurements: &PackedShots, rows: &[Vec<usize>]) -> PackedShots {
+    debug_assert!(matches!(measurements.layout(), ShotLayout::ShotMajor));
+    let out_words = rows.len().div_ceil(64);
+    let m_words = measurements.m_words();
+    let mut data = vec![0u64; measurements.num_shots() * out_words];
+    let measurement_data = measurements.raw_data();
+
+    for shot in 0..measurements.num_shots() {
+        let src_base = shot * m_words;
+        let dst_base = shot * out_words;
+        let shot_words = &measurement_data[src_base..src_base + m_words];
+        let dst = &mut data[dst_base..dst_base + out_words];
+        for (out_idx, row) in rows.iter().enumerate() {
+            dst[out_idx / 64] |= qec_row_parity_word(shot_words, row) << (out_idx % 64);
+        }
+    }
+
+    PackedShots::from_shot_major(data, measurements.num_shots(), rows.len())
+}
+
+#[inline(always)]
+fn qec_row_parity_word(shot_words: &[u64], row: &[usize]) -> u64 {
+    match row {
+        [] => 0,
+        [a] => qec_measurement_word(shot_words, *a),
+        [a, b] => qec_measurement_word(shot_words, *a) ^ qec_measurement_word(shot_words, *b),
+        [a, b, c] => {
+            qec_measurement_word(shot_words, *a)
+                ^ qec_measurement_word(shot_words, *b)
+                ^ qec_measurement_word(shot_words, *c)
+        }
+        _ => {
+            let mut parity = 0u64;
+            for &measurement in row {
+                parity ^= qec_measurement_word(shot_words, measurement);
+            }
+            parity
+        }
+    }
+}
+
+#[inline(always)]
+fn qec_measurement_word(shot_words: &[u64], measurement: usize) -> u64 {
+    (shot_words[measurement / 64] >> (measurement % 64)) & 1
+}
+
+fn add_qec_logical_error_counts(observables: &PackedShots, counts: &mut [u64]) {
+    debug_assert_eq!(observables.num_measurements(), counts.len());
+    if counts.is_empty() || observables.num_shots() == 0 {
+        return;
+    }
+
+    match observables.layout() {
+        ShotLayout::MeasMajor => {
+            let full_words = observables.num_shots() / 64;
+            let tail_bits = observables.num_shots() % 64;
+            let tail_mask = if tail_bits == 0 {
+                u64::MAX
+            } else {
+                (1u64 << tail_bits) - 1
+            };
+
+            for (observable, count) in counts.iter_mut().enumerate() {
+                let words = observables.meas_words(observable);
+                let mut total = 0u64;
+                for &word in &words[..full_words] {
+                    total += word.count_ones() as u64;
+                }
+                if tail_bits != 0 {
+                    total += (words[full_words] & tail_mask).count_ones() as u64;
+                }
+                *count += total;
+            }
+        }
+        ShotLayout::ShotMajor => {
+            let n_obs = observables.num_measurements();
+            let tail_bits = n_obs % 64;
+            let tail_mask = if tail_bits == 0 {
+                u64::MAX
+            } else {
+                (1u64 << tail_bits) - 1
+            };
+
+            for shot in 0..observables.num_shots() {
+                let words = observables.shot_words(shot);
+                for (word_idx, &word) in words.iter().enumerate() {
+                    let valid_word = if word_idx + 1 == words.len() {
+                        word & tail_mask
+                    } else {
+                        word
+                    };
+                    let mut bits = valid_word;
+                    while bits != 0 {
+                        let bit = bits.trailing_zeros() as usize;
+                        counts[word_idx * 64 + bit] += 1;
+                        bits &= bits - 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn validate_qec_compiled_program(program: &QecProgram) -> Result<bool> {
+    let mut has_noise = false;
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { gate, .. } if !gate.is_clifford() => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC compiled runner".to_string(),
+                    reason: format!(
+                        "compiled QEC runner requires Clifford gates, got `{}`",
+                        gate.name()
+                    ),
+                });
+            }
+            QecOp::ExpectationValue { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC compiled runner".to_string(),
+                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
+                });
+            }
+            QecOp::Noise { channel, .. } => {
+                has_noise |= channel.probability() > 0.0;
+            }
+            _ => {}
+        }
+    }
+    Ok(has_noise)
+}
+
+fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit> {
+    let has_mpp = program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::MeasurePauliProduct { .. }));
+    let scratch_qubit = program.num_qubits();
+    let mut circuit = Circuit::new(
+        program.num_qubits() + usize::from(has_mpp),
+        program.num_measurements(),
+    );
+    let mut next_record = 0usize;
+    let mut scratch_needs_reset = false;
+
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { gate, targets } => {
+                if !gate.is_clifford() {
+                    return Err(PrismError::IncompatibleBackend {
+                        backend: "QEC compiled runner".to_string(),
+                        reason: format!(
+                            "compiled QEC runner requires Clifford gates, got `{}`",
+                            gate.name()
+                        ),
+                    });
+                }
+                circuit.add_gate(gate.clone(), targets);
+            }
+            QecOp::Measure { basis, qubit } => {
+                append_basis_to_z_rotation(&mut circuit, *basis, *qubit);
+                circuit.add_measure(*qubit, next_record);
+                next_record += 1;
+            }
+            QecOp::MeasurePauliProduct { terms } => {
+                if !has_mpp {
+                    return Err(PrismError::InvalidParameter {
+                        message: "internal QEC MPP scratch qubit was not allocated".to_string(),
+                    });
+                }
+                if scratch_needs_reset {
+                    circuit.add_reset(scratch_qubit);
+                }
+                for term in terms {
+                    append_basis_to_z_rotation(&mut circuit, term.basis, term.qubit);
+                }
+                for term in terms {
+                    circuit.add_gate(Gate::Cx, &[term.qubit, scratch_qubit]);
+                }
+                for term in terms.iter().rev() {
+                    append_z_to_basis_rotation(&mut circuit, term.basis, term.qubit);
+                }
+                circuit.add_measure(scratch_qubit, next_record);
+                next_record += 1;
+                scratch_needs_reset = true;
+            }
+            QecOp::Reset { basis, qubit } => {
+                circuit.add_reset(*qubit);
+                append_z_to_basis_rotation(&mut circuit, *basis, *qubit);
+            }
+            QecOp::Noise { channel, .. } => {
+                let probability = channel.probability();
+                debug_assert!(
+                    probability == 0.0,
+                    "active QEC noise should use deferred lowering"
+                );
+                if probability > 0.0 {
+                    return Err(PrismError::IncompatibleBackend {
+                        backend: "QEC compiled runner".to_string(),
+                        reason: "compiled QEC runner does not support active noise annotations in the clean path".to_string(),
+                    });
+                }
+            }
+            QecOp::ExpectationValue { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC compiled runner".to_string(),
+                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
+                });
+            }
+            QecOp::Detector { .. }
+            | QecOp::ObservableInclude { .. }
+            | QecOp::Postselect { .. }
+            | QecOp::Tick => {}
+        }
+    }
+
+    if next_record != program.num_measurements() {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC compiled lowering produced {next_record} records, expected {}",
+                program.num_measurements()
+            ),
+        });
+    }
+    Ok(circuit)
+}
+
+fn apply_reference_gate(
+    backend: &mut StatevectorBackend,
+    gate: Gate,
+    targets: &[usize],
+) -> Result<()> {
+    backend.apply(&Instruction::Gate {
+        gate,
+        targets: qec_targets(targets),
+    })
+}
+
+fn reset_reference_basis(
+    backend: &mut StatevectorBackend,
+    basis: QecBasis,
+    qubit: usize,
+) -> Result<()> {
+    backend.reset(qubit)?;
+    rotate_reference_z_to_basis(backend, basis, qubit)
+}
+
+fn measure_reference_basis(
+    backend: &mut StatevectorBackend,
+    basis: QecBasis,
+    qubit: usize,
+    record: usize,
+) -> Result<bool> {
+    rotate_reference_basis_to_z(backend, basis, qubit)?;
+    backend.apply(&Instruction::Measure {
+        qubit,
+        classical_bit: record,
+    })?;
+    let outcome = backend.classical_results()[record];
+    rotate_reference_z_to_basis(backend, basis, qubit)?;
+    Ok(outcome)
+}
+
+fn measure_reference_mpp(
+    backend: &mut StatevectorBackend,
+    terms: &[QecPauli],
+    scratch_qubit: usize,
+    record: usize,
+) -> Result<bool> {
+    backend.reset(scratch_qubit)?;
+    for term in terms {
+        rotate_reference_basis_to_z(backend, term.basis, term.qubit)?;
+        apply_reference_gate(backend, Gate::Cx, &[term.qubit, scratch_qubit])?;
+    }
+    for term in terms.iter().rev() {
+        rotate_reference_z_to_basis(backend, term.basis, term.qubit)?;
+    }
+    backend.apply(&Instruction::Measure {
+        qubit: scratch_qubit,
+        classical_bit: record,
+    })?;
+    Ok(backend.classical_results()[record])
+}
+
+fn rotate_reference_basis_to_z(
+    backend: &mut StatevectorBackend,
+    basis: QecBasis,
+    qubit: usize,
+) -> Result<()> {
+    match basis {
+        QecBasis::X => apply_reference_gate(backend, Gate::H, &[qubit]),
+        QecBasis::Y => {
+            apply_reference_gate(backend, Gate::Sdg, &[qubit])?;
+            apply_reference_gate(backend, Gate::H, &[qubit])
+        }
+        QecBasis::Z => Ok(()),
+    }
+}
+
+fn rotate_reference_z_to_basis(
+    backend: &mut StatevectorBackend,
+    basis: QecBasis,
+    qubit: usize,
+) -> Result<()> {
+    match basis {
+        QecBasis::X => apply_reference_gate(backend, Gate::H, &[qubit]),
+        QecBasis::Y => {
+            apply_reference_gate(backend, Gate::H, &[qubit])?;
+            apply_reference_gate(backend, Gate::S, &[qubit])
+        }
+        QecBasis::Z => Ok(()),
+    }
+}
+
+fn apply_reference_noise(
+    backend: &mut StatevectorBackend,
+    rng: &mut ChaCha8Rng,
+    channel: QecNoise,
+    targets: &[usize],
+) -> Result<()> {
+    if channel.probability() == 0.0 {
+        return Ok(());
+    }
+
+    match channel {
+        QecNoise::XError(p) => {
+            for &target in targets {
+                if rng.random::<f64>() < p {
+                    apply_reference_gate(backend, Gate::X, &[target])?;
+                }
+            }
+        }
+        QecNoise::ZError(p) => {
+            for &target in targets {
+                if rng.random::<f64>() < p {
+                    apply_reference_gate(backend, Gate::Z, &[target])?;
+                }
+            }
+        }
+        QecNoise::Depolarize1(p) => {
+            for &target in targets {
+                if rng.random::<f64>() < p {
+                    let gate = match rng.random_range(0..3) {
+                        0 => Gate::X,
+                        1 => Gate::Y,
+                        _ => Gate::Z,
+                    };
+                    apply_reference_gate(backend, gate, &[target])?;
+                }
+            }
+        }
+        QecNoise::Depolarize2(p) => {
+            for pair in targets.chunks_exact(2) {
+                if rng.random::<f64>() < p {
+                    let sample = rng.random_range(1..16);
+                    let first = (sample / 4) as usize;
+                    let second = (sample % 4) as usize;
+                    apply_reference_pauli_index(backend, first, pair[0])?;
+                    apply_reference_pauli_index(backend, second, pair[1])?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_reference_pauli_index(
+    backend: &mut StatevectorBackend,
+    pauli: usize,
+    target: usize,
+) -> Result<()> {
+    match pauli {
+        0 => Ok(()),
+        1 => apply_reference_gate(backend, Gate::X, &[target]),
+        2 => apply_reference_gate(backend, Gate::Y, &[target]),
+        _ => apply_reference_gate(backend, Gate::Z, &[target]),
+    }
+}
+
+fn qec_targets(targets: &[usize]) -> SmallVec<[usize; 4]> {
+    let mut small = SmallVec::new();
+    small.extend_from_slice(targets);
+    small
+}
+
+fn set_shot_record(data: &mut [u64], m_words: usize, shot: usize, record: usize, value: bool) {
+    if value {
+        data[shot * m_words + record / 64] |= 1u64 << (record % 64);
+    }
+}

--- a/src/sim/compiled/mod.rs
+++ b/src/sim/compiled/mod.rs
@@ -73,12 +73,12 @@ impl Hash for PauliVec {
 }
 
 #[inline(always)]
-pub(super) fn get_bit(words: &[u64], qubit: usize) -> bool {
+pub(crate) fn get_bit(words: &[u64], qubit: usize) -> bool {
     (words[qubit / 64] >> (qubit % 64)) & 1 != 0
 }
 
 #[inline(always)]
-pub(super) fn set_bit(words: &mut [u64], qubit: usize, val: bool) {
+pub(crate) fn set_bit(words: &mut [u64], qubit: usize, val: bool) {
     let word = qubit / 64;
     let bit = qubit % 64;
     if val {

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -1,0 +1,869 @@
+use prism_q::circuit::openqasm;
+use prism_q::{
+    compile_qec_program_rows, parse_qec_program, run_qec_program, run_qec_program_reference, Gate,
+    PackedShots, QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram, QecRecordRef,
+    QecSampleResult,
+};
+
+#[test]
+fn qec_program_builds_measurement_record_rows() {
+    let mut program = QecProgram::new(2);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    let m1 = program.measure_x(1).unwrap();
+    let m2 = program
+        .measure_pauli_product(&[QecPauli::x(0), QecPauli::z(1)])
+        .unwrap();
+
+    assert_eq!(m0, 0);
+    assert_eq!(m1, 1);
+    assert_eq!(m2, 2);
+
+    program
+        .detector_with_coords(
+            &[
+                QecRecordRef::absolute(m0),
+                QecRecordRef::lookback(1).unwrap(),
+            ],
+            &[1.0, 2.0, 3.0],
+        )
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m1)])
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::x(1)], -0.5)
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::lookback(1).unwrap()], false)
+        .unwrap();
+
+    assert_eq!(program.num_qubits(), 2);
+    assert_eq!(program.num_measurements(), 3);
+    assert_eq!(program.num_detectors(), 1);
+    assert_eq!(program.num_observables(), 1);
+    assert_eq!(program.detector_rows().unwrap(), vec![vec![0, 2]]);
+    assert_eq!(program.observable_rows().unwrap(), vec![vec![1]]);
+    assert_eq!(
+        program.postselection_rows().unwrap(),
+        vec![(vec![2], false)]
+    );
+
+    let result = program.empty_result();
+    assert_eq!(result.measurements.num_measurements(), 3);
+    assert_eq!(result.detectors.num_measurements(), 1);
+    assert_eq!(result.observables.num_measurements(), 1);
+    assert_eq!(result.logical_errors, vec![0]);
+}
+
+#[test]
+fn qec_program_from_ops_validates_records_and_qubits() {
+    let bad_record = QecProgram::from_ops(
+        1,
+        QecOptions::default(),
+        vec![prism_q::QecOp::Detector {
+            records: vec![QecRecordRef::absolute(0)],
+            coords: Vec::new(),
+        }],
+    );
+    assert!(bad_record.is_err());
+
+    let mut program = QecProgram::new(1);
+    assert!(program.measure_z(1).is_err());
+    assert!(program
+        .measure_pauli_product(&[QecPauli::x(0), QecPauli::z(0)])
+        .is_err());
+    assert!(program.noise(QecNoise::XError(1.5), &[0]).is_err());
+    assert!(program.noise(QecNoise::Depolarize2(0.001), &[0]).is_err());
+    assert!(program
+        .noise(QecNoise::Depolarize2(0.001), &[0, 0])
+        .is_err());
+}
+
+#[test]
+fn qec_options_are_configurable() {
+    let options = QecOptions {
+        shots: 4096,
+        seed: 7,
+        chunk_size: Some(512),
+        keep_measurements: false,
+    };
+    let mut program = QecProgram::with_options(3, options);
+    assert_eq!(program.options(), options);
+
+    let updated = QecOptions {
+        seed: 11,
+        ..options
+    };
+    program.set_options(updated);
+    assert_eq!(program.options(), updated);
+}
+
+#[test]
+fn qec_sample_result_validates_packed_dimensions() {
+    let measurements = PackedShots::from_shot_major(vec![0, 1], 2, 1);
+    let detectors = PackedShots::from_shot_major(vec![1, 0], 2, 1);
+    let observables = PackedShots::from_shot_major(vec![1, 1], 2, 1);
+    let result = QecSampleResult::new(measurements, detectors, observables, 2, 0, vec![1]);
+    let result = result.unwrap();
+    assert_eq!(result.total_shots, 2);
+
+    let measurements = PackedShots::from_shot_major(vec![0, 1], 2, 1);
+    let detectors = PackedShots::from_shot_major(vec![1], 1, 1);
+    let observables = PackedShots::from_shot_major(vec![1, 1], 2, 1);
+    let result = QecSampleResult::new(measurements, detectors, observables, 2, 0, vec![1]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn qec_sample_result_allows_omitted_raw_measurements() {
+    let measurements = PackedShots::from_meas_major(Vec::new(), 0, 2);
+    let detectors = PackedShots::from_meas_major(vec![0b01], 2, 1);
+    let observables = PackedShots::from_meas_major(vec![0b10], 2, 1);
+
+    let result = QecSampleResult::new_with_total_shots(
+        2,
+        measurements,
+        detectors,
+        observables,
+        1,
+        1,
+        vec![1],
+    )
+    .unwrap();
+
+    assert_eq!(result.total_shots, 2);
+    assert_eq!(result.measurements.num_shots(), 0);
+    assert_eq!(result.measurements.num_measurements(), 2);
+}
+
+#[test]
+fn qec_reference_runner_executes_gates_and_postselection() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::X, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], true)
+        .unwrap();
+
+    let result = run_qec_program_reference(&program).unwrap();
+    assert_eq!(result.total_shots, 4);
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.discarded_shots, 0);
+    assert_eq!(result.logical_errors, vec![4]);
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.observables.to_shots(), vec![vec![true]; 4]);
+}
+
+#[test]
+fn qec_compiled_runner_executes_clifford_programs_without_statevector_fallback() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::X, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], true)
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.total_shots, 4);
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.discarded_shots, 0);
+    assert_eq!(result.logical_errors, vec![4]);
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.observables.to_shots(), vec![vec![true]; 4]);
+}
+
+#[test]
+fn qec_compiled_runner_handles_mpp_and_reset_reuse() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(2, options);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    let m0 = program
+        .measure_pauli_product(&[QecPauli::z(0), QecPauli::z(1)])
+        .unwrap();
+    program.reset(QecBasis::Z, 1).unwrap();
+    let m1 = program.measure_z(1).unwrap();
+    program
+        .detector(&[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.measurements.to_shots(), vec![vec![false, false]; 4]);
+    assert_eq!(result.detectors.to_shots(), vec![vec![false]; 4]);
+    assert_eq!(result.logical_errors, vec![0]);
+}
+
+#[test]
+fn qec_compiled_runner_can_omit_raw_measurements() {
+    let options = QecOptions {
+        shots: 3,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::X, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.total_shots, 3);
+    assert_eq!(result.measurements.num_shots(), 0);
+    assert_eq!(result.measurements.num_measurements(), 1);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 3]);
+    assert_eq!(result.observables.to_shots(), vec![vec![true]; 3]);
+    assert_eq!(result.logical_errors, vec![3]);
+}
+
+#[test]
+fn qec_compiled_runner_honors_chunk_size() {
+    let options = QecOptions {
+        shots: 5,
+        seed: 42,
+        chunk_size: Some(2),
+        keep_measurements: false,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::X, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.total_shots, 5);
+    assert_eq!(result.measurements.num_shots(), 0);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 5]);
+    assert_eq!(result.observables.to_shots(), vec![vec![true]; 5]);
+    assert_eq!(result.accepted_shots, 5);
+    assert_eq!(result.logical_errors, vec![5]);
+}
+
+#[test]
+fn qec_compiled_runner_rejects_zero_chunk_size() {
+    let options = QecOptions {
+        shots: 1,
+        seed: 42,
+        chunk_size: Some(0),
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.measure_z(0).unwrap();
+
+    let err = run_qec_program(&program).unwrap_err();
+    assert!(format!("{err}").contains("chunk_size"));
+}
+
+#[test]
+fn qec_compiled_runner_rejects_zero_chunk_size_without_measurements() {
+    let options = QecOptions {
+        shots: 1,
+        seed: 42,
+        chunk_size: Some(0),
+        keep_measurements: true,
+    };
+    let program = QecProgram::with_options(1, options);
+
+    let err = run_qec_program(&program).unwrap_err();
+    assert!(format!("{err}").contains("chunk_size"));
+}
+
+#[test]
+fn qec_compiled_runner_rejects_non_clifford_without_reference_fallback() {
+    let mut program = QecProgram::new(1);
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.measure_z(0).unwrap();
+
+    let err = run_qec_program(&program).unwrap_err();
+    assert!(format!("{err}").contains("requires Clifford gates"));
+}
+
+#[test]
+fn qec_compiled_runner_applies_deterministic_x_noise() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.noise(QecNoise::XError(1.0), &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], true)
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 4]);
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.logical_errors, vec![4]);
+}
+
+#[test]
+fn qec_compiled_runner_applies_basis_sensitive_z_noise() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.noise(QecNoise::ZError(1.0), &[0]).unwrap();
+    program.measure_x(0).unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 4]);
+}
+
+#[test]
+fn qec_compiled_runner_accepts_depolarizing_noise_channels() {
+    let options = QecOptions {
+        shots: 100,
+        seed: 42,
+        chunk_size: Some(17),
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(2, options);
+    program.noise(QecNoise::Depolarize1(0.0), &[0]).unwrap();
+    program.noise(QecNoise::Depolarize2(1.0), &[0, 1]).unwrap();
+    program.measure_z(0).unwrap();
+    program.measure_z(1).unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    let shots = result.measurements.to_shots();
+    assert_eq!(result.total_shots, 100);
+    assert_eq!(shots.len(), 100);
+    assert!(shots.iter().any(|shot| shot[0] || shot[1]));
+}
+
+#[test]
+fn qec_compiled_runner_treats_zero_probability_noise_as_clean() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.noise(QecNoise::XError(0.0), &[0]).unwrap();
+    program.measure_z(0).unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![false]; 4]);
+}
+
+#[test]
+fn qec_row_compiler_treats_zero_probability_noise_as_noop() {
+    let mut program = QecProgram::new(1);
+    program.noise(QecNoise::XError(0.0), &[0]).unwrap();
+    let record = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(record)]).unwrap();
+
+    let compiled = compile_qec_program_rows(&program).unwrap();
+    assert_eq!(compiled.num_measurements(), 1);
+    assert_eq!(compiled.detector_rows(), [vec![0]].as_slice());
+}
+
+#[test]
+fn qec_reference_runner_does_not_consume_rng_for_zero_noise() {
+    let options = QecOptions {
+        shots: 64,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut baseline = QecProgram::with_options(1, options);
+    baseline.noise(QecNoise::XError(0.5), &[0]).unwrap();
+    baseline.measure_z(0).unwrap();
+
+    let mut with_zero = QecProgram::with_options(1, options);
+    with_zero.noise(QecNoise::XError(0.0), &[0]).unwrap();
+    with_zero.noise(QecNoise::XError(0.5), &[0]).unwrap();
+    with_zero.measure_z(0).unwrap();
+
+    let baseline_result = run_qec_program_reference(&baseline).unwrap();
+    let with_zero_result = run_qec_program_reference(&with_zero).unwrap();
+    assert_eq!(
+        baseline_result.measurements.to_shots(),
+        with_zero_result.measurements.to_shots()
+    );
+}
+
+#[test]
+fn qec_compiled_runner_ignores_single_qubit_noise_after_measurement() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.measure_z(0).unwrap();
+    program.noise(QecNoise::XError(1.0), &[0]).unwrap();
+    program.reset(QecBasis::Z, 0).unwrap();
+    program.measure_z(0).unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![false, false]; 4]);
+}
+
+#[test]
+fn qec_compiled_runner_rejects_exp_val_without_reference_fallback() {
+    let mut exp_val_program = QecProgram::new(1);
+    exp_val_program
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    let err = run_qec_program(&exp_val_program).unwrap_err();
+    assert!(format!("{err}").contains("EXP_VAL"));
+}
+
+#[test]
+fn qec_compiled_runner_rejects_measurement_reuse_without_reset() {
+    let mut program = QecProgram::new(1);
+    program.measure_z(0).unwrap();
+    program.push_gate(Gate::X, &[0]).unwrap();
+    program.measure_z(0).unwrap();
+
+    let err = run_qec_program(&program).unwrap_err();
+    assert!(format!("{err}").contains("reset before reusing"));
+}
+
+#[test]
+fn qec_reference_runner_measures_mpp_products() {
+    let options = QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(2, options);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    let m0 = program
+        .measure_pauli_product(&[QecPauli::z(0), QecPauli::z(1)])
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let result = run_qec_program_reference(&program).unwrap();
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.measurements.to_shots(), vec![vec![false]; 4]);
+    assert_eq!(result.logical_errors, vec![0]);
+}
+
+#[test]
+fn qec_reference_runner_can_omit_raw_measurements() {
+    let options = QecOptions {
+        shots: 3,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::X, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let result = run_qec_program_reference(&program).unwrap();
+    assert_eq!(result.total_shots, 3);
+    assert_eq!(result.measurements.num_shots(), 0);
+    assert_eq!(result.measurements.num_measurements(), 1);
+    assert_eq!(result.detectors.to_shots(), vec![vec![true]; 3]);
+    assert_eq!(result.observables.to_shots(), vec![vec![true]; 3]);
+    assert_eq!(result.logical_errors, vec![3]);
+}
+
+#[test]
+fn qec_reference_runner_applies_pauli_noise() {
+    let options = QecOptions {
+        shots: 3,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.noise(QecNoise::XError(1.0), &[0]).unwrap();
+    program.measure_z(0).unwrap();
+
+    let result = run_qec_program_reference(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 3]);
+}
+
+#[test]
+fn qec_reference_runner_rejects_exp_val_until_result_schema_lands() {
+    let mut program = QecProgram::new(1);
+    program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
+
+    let err = run_qec_program_reference(&program).unwrap_err();
+    assert!(format!("{err}").contains("does not evaluate EXP_VAL yet"));
+}
+
+#[test]
+fn qec_reference_runner_rejects_zero_chunk_size() {
+    let options = QecOptions {
+        shots: 1,
+        seed: 42,
+        chunk_size: Some(0),
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.measure_z(0).unwrap();
+
+    let err = run_qec_program_reference(&program).unwrap_err();
+    assert!(format!("{err}").contains("chunk_size"));
+}
+
+#[test]
+fn qec_module_does_not_change_openqasm_parsing() {
+    let qasm = r#"
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[2] q;
+        bit[2] c;
+        h q[0];
+        cx q[0], q[1];
+        measure q[0] -> c[0];
+        measure q[1] -> c[1];
+    "#;
+
+    let circuit = openqasm::parse(qasm).unwrap();
+    assert_eq!(circuit.num_qubits, 2);
+    assert_eq!(circuit.num_classical_bits, 2);
+    assert_eq!(circuit.gate_count(), 2);
+}
+
+#[test]
+fn qec_reset_and_measurement_basis_are_stored() {
+    let mut program = QecProgram::new(1);
+    program.reset(QecBasis::X, 0).unwrap();
+    program.measure(QecBasis::Y, 0).unwrap();
+
+    assert_eq!(program.ops().len(), 2);
+}
+
+#[test]
+fn qec_text_parser_ingests_detector_mpp_and_exp_val_program() {
+    let text = r#"
+        # Representative measurement-record program.
+        QUBIT_COORDS(0, 0) 0
+        QUBIT_COORDS(1, 0) 1
+        H 0
+        CX 0 1
+        M 0
+        MX 1
+        MPP X0*Z1
+        DETECTOR(1, 2, 3) rec[-1] rec[-3]
+        OBSERVABLE_INCLUDE(0) rec[-2]
+        EXP_VAL(0.5) X0*Z1
+        TICK
+    "#;
+
+    let program = parse_qec_program(text).unwrap();
+    assert_eq!(program.num_qubits(), 2);
+    assert_eq!(program.num_measurements(), 3);
+    assert_eq!(program.num_detectors(), 1);
+    assert_eq!(program.num_observables(), 1);
+    assert_eq!(program.detector_rows().unwrap(), vec![vec![2, 0]]);
+    assert_eq!(program.observable_rows().unwrap(), vec![vec![1]]);
+    assert!(program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::ExpectationValue { coefficient, .. } if (*coefficient - 0.5).abs() < 1e-12)));
+    assert!(program.ops().iter().any(|op| matches!(op, QecOp::Tick)));
+}
+
+#[test]
+fn qec_text_parser_flattens_repeat_blocks() {
+    let text = r#"
+        REPEAT 2 {
+            M 0
+            DETECTOR rec[-1]
+        }
+    "#;
+
+    let program = QecProgram::from_text(text).unwrap();
+    assert_eq!(program.num_measurements(), 2);
+    assert_eq!(program.num_detectors(), 2);
+    assert_eq!(program.detector_rows().unwrap(), vec![vec![0], vec![1]]);
+}
+
+#[test]
+fn qec_text_parser_ingests_noise_and_measure_reset() {
+    let text = r#"
+        R 0
+        MRX 1
+        X_ERROR(0.001) 0
+        Z_ERROR(0.002) 1
+        DEPOLARIZE1(0.003) 0 1
+        DEPOLARIZE2(0.004) 0 1
+    "#;
+
+    let program = parse_qec_program(text).unwrap();
+    assert_eq!(program.num_qubits(), 2);
+    assert_eq!(program.num_measurements(), 1);
+    assert_eq!(program.num_detectors(), 0);
+    assert!(program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::Noise { channel: QecNoise::Depolarize2(p), .. } if (*p - 0.004).abs() < 1e-12)));
+}
+
+#[test]
+fn qec_text_parser_lowers_basis_measurement_error_args() {
+    let mut program = parse_qec_program("M(1.0) 0").unwrap();
+    program.set_options(QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    });
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.measurements.to_shots(), vec![vec![true]; 4]);
+
+    let err = parse_qec_program("MPP(0.1) X0").unwrap_err();
+    assert!(format!("{err}").contains("MPP"));
+}
+
+#[test]
+fn qec_text_parser_ingests_postselection() {
+    let mut accepted_program =
+        parse_qec_program("X_ERROR(1) 0\nM 0\nPOSTSELECT(1) rec[-1]").unwrap();
+    accepted_program.set_options(QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    });
+    assert_eq!(accepted_program.postselection_rows().unwrap().len(), 1);
+    let accepted = run_qec_program(&accepted_program).unwrap();
+    assert_eq!(accepted.accepted_shots, 4);
+    assert_eq!(accepted.discarded_shots, 0);
+
+    let mut rejected_program = parse_qec_program("M 0\nPOSTSELECT(1) rec[-1]").unwrap();
+    rejected_program.set_options(QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    });
+    let rejected = run_qec_program(&rejected_program).unwrap();
+    assert_eq!(rejected.accepted_shots, 0);
+    assert_eq!(rejected.discarded_shots, 4);
+
+    let err = parse_qec_program("M 0\nPOSTSELECT(2) rec[-1]").unwrap_err();
+    assert!(format!("{err}").contains("POSTSELECT"));
+}
+
+#[test]
+fn qec_text_parser_ingests_empty_and_multi_record_postselection() {
+    let mut program =
+        parse_qec_program("M 0\nM 1\nPOSTSELECT(0) rec[-1] rec[-2]\nPOSTSELECT").unwrap();
+    program.set_options(QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    });
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.accepted_shots, 4);
+    assert_eq!(result.discarded_shots, 0);
+
+    let mut rejected_program = parse_qec_program("M 0\nPOSTSELECT(1)").unwrap();
+    rejected_program.set_options(QecOptions {
+        shots: 4,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: false,
+    });
+    let rejected = run_qec_program(&rejected_program).unwrap();
+    assert_eq!(rejected.accepted_shots, 0);
+    assert_eq!(rejected.discarded_shots, 4);
+}
+
+#[test]
+fn qec_text_parser_skips_zero_probability_noise_annotations() {
+    let program = parse_qec_program(
+        r#"
+        X_ERROR(0) 0
+        M(0) 0
+        MR(0) 0
+        "#,
+    )
+    .unwrap();
+    assert!(!program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::Noise { .. })));
+}
+
+#[test]
+fn qec_text_parser_rejects_invalid_noise_probability() {
+    for text in ["X_ERROR(-0.1) 0", "X_ERROR(NaN) 0", "DEPOLARIZE1(1.1) 0"] {
+        let err = parse_qec_program(text).unwrap_err();
+        assert!(format!("{err}").contains("probability"));
+    }
+}
+
+#[test]
+fn qec_text_parser_rejects_out_of_scope_record_refs() {
+    let err = parse_qec_program("DETECTOR rec[-1]").unwrap_err();
+    assert!(format!("{err}").contains("out of bounds"));
+}
+
+#[test]
+fn qec_text_parser_rejects_inverted_targets() {
+    let err = parse_qec_program("M !0").unwrap_err();
+    assert!(format!("{err}").contains("inverted target"));
+
+    let err = parse_qec_program("MPP !X0").unwrap_err();
+    assert!(format!("{err}").contains("inverted target"));
+
+    let err = parse_qec_program(
+        r#"
+        M 0
+        DETECTOR !rec[-1]
+        "#,
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("inverted target"));
+}
+
+#[test]
+fn qec_text_parser_caps_repeat_expansion() {
+    let err = parse_qec_program(
+        r#"
+        REPEAT 1000001 {
+            M 0
+        }
+        "#,
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("expansion exceeds"));
+}
+
+#[test]
+fn qec_compiles_measurement_records_into_pauli_rows() {
+    let mut program = QecProgram::new(3);
+    let m0 = program.measure_z(0).unwrap();
+    let m1 = program.measure(QecBasis::Y, 1).unwrap();
+    let m2 = program
+        .measure_pauli_product(&[QecPauli::x(0), QecPauli::z(2)])
+        .unwrap();
+    program
+        .detector(&[QecRecordRef::absolute(m0), QecRecordRef::absolute(m2)])
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m1)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m2)], true)
+        .unwrap();
+
+    let compiled = compile_qec_program_rows(&program).unwrap();
+    assert_eq!(compiled.num_qubits(), 3);
+    assert_eq!(compiled.num_measurements(), 3);
+    assert_eq!(compiled.num_detectors(), 1);
+    assert_eq!(compiled.num_observables(), 1);
+    assert_eq!(compiled.num_postselections(), 1);
+    assert_eq!(compiled.packed_row_words(), 1);
+    assert_eq!(compiled.measurement_mask_bytes(), 3 * 2 * 8);
+
+    let rows = compiled.measurement_rows();
+    assert_eq!(rows[0].terms(), vec![QecPauli::z(0)]);
+    assert_eq!(rows[1].pauli_at(1), Some(QecBasis::Y));
+    assert_eq!(rows[1].weight(), 1);
+    assert_eq!(rows[2].terms(), vec![QecPauli::x(0), QecPauli::z(2)]);
+    assert_eq!(rows[2].x_mask(), &[0b001]);
+    assert_eq!(rows[2].z_mask(), &[0b100]);
+    assert_eq!(compiled.detector_rows(), [vec![0, 2]].as_slice());
+    assert_eq!(compiled.observable_rows(), [vec![1]].as_slice());
+    assert_eq!(compiled.postselection_rows(), [vec![2]].as_slice());
+    assert_eq!(compiled.postselection_expected(), &[true]);
+    assert_eq!(
+        compiled.postselection_predicates().collect::<Vec<_>>(),
+        vec![(vec![2].as_slice(), true)]
+    );
+
+    let measurements = PackedShots::from_meas_major(vec![0b101, 0b010, 0b111], 3, 3);
+    let detectors = compiled.detector_parities(&measurements).unwrap();
+    let observables = compiled.observable_parities(&measurements).unwrap();
+    let postselection = compiled.postselection_parities(&measurements).unwrap();
+    assert_eq!(detectors.raw_data(), &[0b010]);
+    assert_eq!(observables.raw_data(), &[0b010]);
+    assert_eq!(postselection.raw_data(), &[0b111]);
+}
+
+#[test]
+fn qec_row_compiler_rejects_later_stage_features() {
+    let mut gate_program = QecProgram::new(1);
+    gate_program.push_gate(Gate::H, &[0]).unwrap();
+    gate_program.measure_z(0).unwrap();
+    let err = compile_qec_program_rows(&gate_program).unwrap_err();
+    assert!(format!("{err}").contains("does not lower gates yet"));
+
+    let mut reset_program = QecProgram::new(1);
+    reset_program.reset(QecBasis::Z, 0).unwrap();
+    reset_program.measure_z(0).unwrap();
+    let err = compile_qec_program_rows(&reset_program).unwrap_err();
+    assert!(format!("{err}").contains("does not lower resets yet"));
+
+    let mut noisy_program = QecProgram::new(1);
+    noisy_program.noise(QecNoise::XError(0.001), &[0]).unwrap();
+    noisy_program.measure_z(0).unwrap();
+    let err = compile_qec_program_rows(&noisy_program).unwrap_err();
+    assert!(format!("{err}").contains("active noise annotations"));
+
+    let mut exp_val_program = QecProgram::new(1);
+    exp_val_program
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    let err = compile_qec_program_rows(&exp_val_program).unwrap_err();
+    assert!(format!("{err}").contains("EXP_VAL"));
+}


### PR DESCRIPTION
## Summary

Adds a native QEC program IR with text parsing, packed Clifford execution, detector and observable records, postselection, and Pauli noise support. The feature gives QEC workloads a measurement-record runner instead of forcing circuit-only final-measurement semantics or dense state-vector reference execution.

## Scope

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Command:

```text
cargo bench --bench bench_shots_perf --features parallel,bench-fast -- qec_ --sample-size 10 --warm-up-time 0.2 --measurement-time 1
```

Environment:

```text
CPU: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
OS: Microsoft Windows NT 10.0.19045.0
Rust: rustc 1.93.0 (254b59607 2026-01-19)
Seed: 0xDEAD_BEEF
Compiler flags: Criterion bench profile via Cargo defaults
```

Native QEC benchmark entries are new relative to the main branch. The "Before" column below uses the local Criterion saved baseline for the focused QEC benchmark run.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| qec_clifford_runner/25q_r5/10000 | 0.49169 ms | 0.46983 ms | -4.45% | Yes |
| qec_clifford_runner/25q_r5/100000 | 3.0978 ms | 2.8697 ms | -7.36% | Yes |
| qec_clifford_runner/100q_r3/100000 | 4.2912 ms | 4.3213 ms | +0.70% | Yes |
| qec_clifford_runner/25q_r5_p0/100000 | 3.0919 ms | 2.8752 ms | -7.01% | Yes |
| qec_noisy_runner/25q_r5_p001/10000 | 3.5966 ms | 3.2472 ms | -9.71% | Yes |
| qec_noisy_runner/25q_r5_p001/100000 | 30.006 ms | 30.100 ms | +0.31% | Yes |

Regression verdict: PASS

## Correctness

- [x] `cargo test --all-features` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] N/A, no new gate, backend, or fusion pass requiring statevector golden tests
- [x] N/A, no GPU-affecting change

## Hotspot notes

Affected hot paths:

- `run_qec_program`
- `qec_result_from_measurement_chunks`
- `parity_rows_or_empty`
- `QecCompiledNoiseSampler::sample_measurements_packed`
- `QecNoiseSensitivity::apply`
- `apply_qec_single_noise_event`
- `apply_qec_pair_noise_event`

Performance-sensitive details:

- Clean QEC sampling uses packed Clifford measurement sampling and avoids dense state-vector execution.
- Detector and observable extraction has a QEC shot-major fast path for repeated deterministic shot words.
- Pauli noise sampling uses packed sensitivity rows and the compiled sampler's fast Xoshiro RNG in the hot loop.
- Single-qubit Pauli noise branches with no observable measurement effect are collapsed before sampling.

Profiler output: not attached in this draft. Focused Criterion results above cover the changed QEC runner and Pauli noise paths.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems

## Breaking changes

None. The QEC API is additive and does not change existing `Circuit` or OpenQASM behavior.

## Risks and rollback

Risk is concentrated in the new QEC module, especially deferred measurement lowering, detector and observable parity extraction, and stochastic Pauli noise application. Existing circuit execution remains on the existing code paths unless callers opt into the QEC API.

Rollback path: revert the QEC module exports, QEC tests, QEC benchmark entries, and architecture documentation from this PR.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
