### PR TITLE
feat(qec): add noisy validation and staged profiling benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ parallel = ["rayon", "num_cpus", "faer"]
 serialization = ["serde", "serde_json"]
 gpu = ["dep:cudarc"]
 bench-fast = []
+bench-internal = []
 
 [profile.release]
 opt-level = 3

--- a/benches/README.md
+++ b/benches/README.md
@@ -29,6 +29,14 @@ Criterion.rs with HTML reports. Two benchmark binaries:
 | `depth_sweep/12q_random` | 12-qubit random circuits, depth 5–100 |
 | `entanglement_structure` | Sparse vs dense entanglement, 16 qubits |
 
+### Shot and QEC benchmarks (bench_shots_perf)
+
+| Group | What it measures |
+|-------|-----------------|
+| `qec_clifford_runner` | Packed native Clifford QEC execution |
+| `qec_noisy_runner` | Packed native QEC execution with Pauli-noise rows |
+| `qec_noisy_runner_split` | Parse, compile, sample, noise, detector, postselection, logical count, and total QEC timings |
+
 ## Circuit families
 
 All seeded with `0xDEAD_BEEF` for reproducibility.

--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -6,15 +6,21 @@
 //! 3. `PackedShots::counts()`: histogram from packed u64 representation
 //! 4. `run_shots_compiled` round-trip: compile + sample + to_shots
 
+#[cfg(feature = "bench-internal")]
+use criterion::BatchSize;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
 use prism_q::sim;
 use prism_q::sim::noise::NoiseModel;
 use prism_q::BackendKind;
+#[cfg(feature = "bench-internal")]
+use prism_q::{compile_qec_profiled_sampler, parse_qec_program};
 use prism_q::{
     run_qec_program, HomologicalSampler, QecNoise, QecOptions, QecPauli, QecProgram, QecRecordRef,
 };
+#[cfg(feature = "bench-internal")]
+use std::hint::black_box;
 use std::time::Duration;
 
 const SEED: u64 = 0xDEAD_BEEF;
@@ -207,6 +213,16 @@ fn qec_repetition_program(
     shots: usize,
     noise_rate: Option<f64>,
 ) -> QecProgram {
+    qec_repetition_program_with_postselection(n_data, rounds, shots, noise_rate, false)
+}
+
+fn qec_repetition_program_with_postselection(
+    n_data: usize,
+    rounds: usize,
+    shots: usize,
+    noise_rate: Option<f64>,
+    include_postselection: bool,
+) -> QecProgram {
     assert!(n_data > 0);
     let options = QecOptions {
         shots,
@@ -217,6 +233,7 @@ fn qec_repetition_program(
     let mut program = QecProgram::with_options(n_data, options);
     let checks = n_data.saturating_sub(1);
     let mut previous_round = Vec::with_capacity(checks);
+    let mut first_check = None;
 
     for _ in 0..rounds {
         let mut current_round = Vec::with_capacity(checks);
@@ -229,6 +246,7 @@ fn qec_repetition_program(
             let record = program
                 .measure_pauli_product(&[QecPauli::z(q), QecPauli::z(q + 1)])
                 .unwrap();
+            first_check.get_or_insert(record);
             if let Some(previous) = previous_round.get(q) {
                 program
                     .detector(&[
@@ -246,7 +264,59 @@ fn qec_repetition_program(
     program
         .observable_include(0, &[QecRecordRef::absolute(logical)])
         .unwrap();
+    if include_postselection {
+        if let Some(first_check) = first_check {
+            program
+                .postselect(&[QecRecordRef::absolute(first_check)], false)
+                .unwrap();
+        }
+    }
     program
+}
+
+#[cfg(feature = "bench-internal")]
+fn qec_repetition_program_text(
+    n_data: usize,
+    rounds: usize,
+    noise_rate: Option<f64>,
+    include_postselection: bool,
+) -> String {
+    assert!(n_data > 0);
+    let checks = n_data.saturating_sub(1);
+    let mut text = String::new();
+    let mut previous_round = Vec::with_capacity(checks);
+    let mut first_check = None;
+    let mut records = 0usize;
+
+    for _ in 0..rounds {
+        let mut current_round = Vec::with_capacity(checks);
+        for q in 0..checks {
+            if let Some(p) = noise_rate {
+                text.push_str(&format!("DEPOLARIZE1({p}) {q} {}\n", q + 1));
+            }
+            text.push_str(&format!("MPP Z{q}*Z{}\n", q + 1));
+            let record = records;
+            records += 1;
+            first_check.get_or_insert(record);
+            if let Some(previous) = previous_round.get(q) {
+                let previous_distance = records - previous;
+                text.push_str(&format!("DETECTOR rec[-{previous_distance}] rec[-1]\n"));
+            }
+            current_round.push(record);
+        }
+        previous_round = current_round;
+    }
+
+    text.push_str("M 0\n");
+    records += 1;
+    text.push_str("OBSERVABLE_INCLUDE(0) rec[-1]\n");
+    if include_postselection {
+        if let Some(first_check) = first_check {
+            let first_distance = records - first_check;
+            text.push_str(&format!("POSTSELECT rec[-{first_distance}]\n"));
+        }
+    }
+    text
 }
 
 fn bench_qec_clifford_runner(c: &mut Criterion) {
@@ -288,6 +358,112 @@ fn bench_qec_noisy_runner(c: &mut Criterion) {
             b.iter(|| run_qec_program(program).unwrap());
         });
     }
+
+    group.finish();
+}
+
+#[cfg(not(feature = "bench-internal"))]
+fn bench_qec_noisy_runner_split(_c: &mut Criterion) {}
+
+#[cfg(feature = "bench-internal")]
+fn bench_qec_noisy_runner_split(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_noisy_runner_split");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_secs(3));
+
+    let n_data = 25;
+    let rounds = 5;
+    let shots = 100_000;
+    let noise_rate = 0.001;
+    let label = format!("{n_data}q_r{rounds}_p001_post");
+    let text = qec_repetition_program_text(n_data, rounds, Some(noise_rate), true);
+    let program =
+        qec_repetition_program_with_postselection(n_data, rounds, shots, Some(noise_rate), true);
+
+    group.bench_with_input(BenchmarkId::new("parse", &label), &text, |b, text| {
+        b.iter(|| {
+            let mut program = parse_qec_program(black_box(text)).unwrap();
+            let mut options = program.options();
+            options.shots = shots;
+            options.seed = SEED;
+            options.chunk_size = Some(10_000);
+            options.keep_measurements = false;
+            program.set_options(options);
+            black_box(program.num_measurements());
+        });
+    });
+
+    group.bench_with_input(
+        BenchmarkId::new("compile", &label),
+        &program,
+        |b, program| {
+            b.iter(|| compile_qec_profiled_sampler(black_box(program)).unwrap());
+        },
+    );
+
+    let mut sample_sampler = compile_qec_profiled_sampler(&program).unwrap();
+    group.bench_with_input(BenchmarkId::new("sample", &label), &shots, |b, &shots| {
+        b.iter(|| {
+            sample_sampler
+                .sample_noiseless_measurements_packed(black_box(shots))
+                .unwrap()
+        });
+    });
+
+    let mut noise_sampler = compile_qec_profiled_sampler(&program).unwrap();
+    let noiseless = noise_sampler
+        .sample_noiseless_measurements_packed(shots)
+        .unwrap();
+    group.bench_with_input(
+        BenchmarkId::new("noise_generation", &label),
+        &noiseless,
+        |b, measurements| {
+            b.iter_batched(
+                || measurements.clone(),
+                |measurements| {
+                    noise_sampler
+                        .apply_noise_to_measurements(measurements)
+                        .unwrap()
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    let mut staged_sampler = compile_qec_profiled_sampler(&program).unwrap();
+    let noisy_measurements = staged_sampler.sample_measurements_packed(shots).unwrap();
+    let observables = staged_sampler
+        .observable_records(&noisy_measurements)
+        .unwrap();
+
+    group.bench_with_input(
+        BenchmarkId::new("detector_projection", &label),
+        &noisy_measurements,
+        |b, measurements| {
+            b.iter(|| {
+                staged_sampler
+                    .detector_records(black_box(measurements))
+                    .unwrap()
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("postselection_logical_count", &label),
+        &noisy_measurements,
+        |b, measurements| {
+            b.iter(|| {
+                staged_sampler
+                    .postselection_and_logical_counts(black_box(measurements), &observables)
+                    .unwrap()
+            });
+        },
+    );
+
+    group.bench_with_input(BenchmarkId::new("total", &label), &program, |b, program| {
+        b.iter(|| run_qec_program(black_box(program)).unwrap());
+    });
 
     group.finish();
 }
@@ -448,6 +624,7 @@ criterion_group!(
     bench_sparse_deterministic,
     bench_qec_clifford_runner,
     bench_qec_noisy_runner,
+    bench_qec_noisy_runner_split,
     bench_homological_compile,
     bench_homological_sample,
     bench_analytical_marginals,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub use circuit::builder::CircuitBuilder;
 pub use circuit::{Circuit, ClassicalCondition, Instruction, SvgOptions, TextOptions};
 pub use error::{PrismError, Result};
 pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
+#[cfg(feature = "bench-internal")]
+pub use qec::{compile_qec_profiled_sampler, QecProfiledCounts, QecProfiledSampler};
 pub use qec::{
     compile_qec_program_rows, parse_qec_program, run_qec_program, run_qec_program_reference,
     QecBasis, QecCompiledRows, QecMeasurementRow, QecNoise, QecOp, QecOptions, QecPauli,

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -31,6 +31,8 @@ mod runner;
 
 pub use parse::parse_qec_program;
 pub use result::QecSampleResult;
+#[cfg(feature = "bench-internal")]
+pub use runner::{compile_qec_profiled_sampler, QecProfiledCounts, QecProfiledSampler};
 pub use runner::{run_qec_program, run_qec_program_reference};
 
 use crate::circuit::Circuit;

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -33,7 +33,31 @@ pub(super) struct QecCompiledNoiseSampler {
 
 impl QecCompiledNoiseSampler {
     pub(super) fn sample_measurements_packed(&mut self, num_shots: usize) -> Result<PackedShots> {
-        let measurements = self.noiseless.try_sample_bulk_packed(num_shots)?;
+        let measurements = self.sample_noiseless_measurements_packed(num_shots)?;
+        self.apply_noise_to_measurements(measurements)
+    }
+
+    pub(super) fn sample_noiseless_measurements_packed(
+        &mut self,
+        num_shots: usize,
+    ) -> Result<PackedShots> {
+        self.noiseless.try_sample_bulk_packed(num_shots)
+    }
+
+    pub(super) fn apply_noise_to_measurements(
+        &mut self,
+        measurements: PackedShots,
+    ) -> Result<PackedShots> {
+        let num_shots = measurements.num_shots();
+        if measurements.num_measurements() != self.num_measurements {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "QEC noisy sampler expected {} measurement records, got {}",
+                    self.num_measurements,
+                    measurements.num_measurements()
+                ),
+            });
+        }
         if self.events.is_empty() || num_shots == 0 || self.num_measurements == 0 {
             return Ok(measurements);
         }

--- a/src/qec/result.rs
+++ b/src/qec/result.rs
@@ -103,6 +103,17 @@ impl QecSampleResult {
                 ),
             });
         }
+        if let Some((observable, count)) = logical_errors
+            .iter()
+            .enumerate()
+            .find(|(_, count)| **count > accepted_shots as u64)
+        {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "logical error count {count} for observable {observable} exceeds {accepted_shots} accepted shots"
+                ),
+            });
+        }
         Ok(Self {
             total_shots,
             measurements,
@@ -113,6 +124,60 @@ impl QecSampleResult {
             logical_errors,
         })
     }
+
+    /// Fraction of requested shots accepted after postselection.
+    pub fn survivor_rate(&self) -> f64 {
+        qec_binomial_rate(self.accepted_shots as u64, self.total_shots)
+    }
+
+    /// Per-observable logical-error rates among accepted shots.
+    pub fn logical_error_rates(&self) -> Vec<f64> {
+        self.logical_errors
+            .iter()
+            .map(|&count| qec_binomial_rate(count, self.accepted_shots))
+            .collect()
+    }
+
+    /// Wilson score interval for the survivor rate.
+    ///
+    /// `z_score` controls the confidence level. For example, use
+    /// `1.959963984540054` for a two-sided 95 percent interval.
+    pub fn survivor_rate_wilson_interval(&self, z_score: f64) -> (f64, f64) {
+        qec_wilson_interval(self.accepted_shots as u64, self.total_shots, z_score)
+    }
+
+    /// Wilson score intervals for logical-error rates among accepted shots.
+    ///
+    /// `z_score` controls the confidence level. For example, use
+    /// `1.959963984540054` for a two-sided 95 percent interval.
+    pub fn logical_error_rate_wilson_intervals(&self, z_score: f64) -> Vec<(f64, f64)> {
+        self.logical_errors
+            .iter()
+            .map(|&count| qec_wilson_interval(count, self.accepted_shots, z_score))
+            .collect()
+    }
+}
+
+fn qec_binomial_rate(successes: u64, trials: usize) -> f64 {
+    if trials == 0 {
+        return 0.0;
+    }
+    successes as f64 / trials as f64
+}
+
+fn qec_wilson_interval(successes: u64, trials: usize, z_score: f64) -> (f64, f64) {
+    if trials == 0 {
+        return (0.0, 0.0);
+    }
+
+    let n = trials as f64;
+    let p = successes as f64 / n;
+    let z = z_score.abs();
+    let z2 = z * z;
+    let denom = 1.0 + z2 / n;
+    let center = (p + z2 / (2.0 * n)) / denom;
+    let spread = z * ((p * (1.0 - p) + z2 / (4.0 * n)) / n).sqrt() / denom;
+    ((center - spread).max(0.0), (center + spread).min(1.0))
 }
 
 fn infer_qec_result_total_shots(

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -1,4 +1,6 @@
 use super::noise::compile_qec_noisy_sampler;
+#[cfg(feature = "bench-internal")]
+use super::noise::QecCompiledNoiseSampler;
 use super::{
     append_basis_to_z_rotation, append_z_to_basis_rotation, QecBasis, QecNoise, QecOp, QecOptions,
     QecPauli, QecProgram, QecSampleResult,
@@ -7,6 +9,8 @@ use crate::backend::{statevector::StatevectorBackend, Backend};
 use crate::circuit::{Circuit, Instruction, SmallVec};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
+#[cfg(feature = "bench-internal")]
+use crate::sim::compiled::CompiledDetectorSampler;
 use crate::sim::compiled::{compile_detector_sampler, PackedShots, ShotLayout};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -64,6 +68,211 @@ pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
         return qec_result_from_measurements(program, measurements);
     }
     qec_result_from_measurement_chunks(program, |chunk| sampler.sample_measurements_packed(chunk))
+}
+
+/// Internal staged QEC sampler used by benchmark harnesses.
+///
+/// The ordinary public execution API is [`run_qec_program`]. This type exposes
+/// the same packed Clifford path in smaller pieces so benchmarks can measure
+/// compile, noiseless sampling, noise application, detector projection,
+/// postselection, logical counting, and total execution separately. Gated
+/// behind the `bench-internal` feature; not part of the stable API.
+#[cfg(feature = "bench-internal")]
+pub struct QecProfiledSampler {
+    sampler: QecProfiledMeasurementSampler,
+    num_measurements: usize,
+    detector_rows: Vec<Vec<usize>>,
+    observable_rows: Vec<Vec<usize>>,
+    postselection_rows: Vec<(Vec<usize>, bool)>,
+    keep_measurements: bool,
+}
+
+#[cfg(feature = "bench-internal")]
+enum QecProfiledMeasurementSampler {
+    Empty,
+    Clean(CompiledDetectorSampler),
+    Noisy(QecCompiledNoiseSampler),
+}
+
+/// Internal postselection and logical count summary.
+///
+/// Used internally by the QEC runner and exposed publicly only under the
+/// `bench-internal` feature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QecProfiledCounts {
+    /// Shots accepted after postselection.
+    pub accepted_shots: usize,
+    /// Shots discarded by postselection.
+    pub discarded_shots: usize,
+    /// Per-observable logical error counts among accepted shots.
+    pub logical_errors: Vec<u64>,
+}
+
+/// Compile a native QEC program into a staged sampler for benchmarks.
+///
+/// Prefer [`run_qec_program`] for application code. Gated behind the
+/// `bench-internal` feature; not part of the stable API.
+#[cfg(feature = "bench-internal")]
+pub fn compile_qec_profiled_sampler(program: &QecProgram) -> Result<QecProfiledSampler> {
+    let has_noise = validate_qec_compiled_program(program)?;
+    qec_runner_chunk_size(program.options())?;
+
+    let detector_rows = program.detector_rows()?;
+    let observable_rows = program.observable_rows()?;
+    let postselection_rows = program.postselection_rows()?;
+    let num_measurements = program.num_measurements();
+    let sampler = if num_measurements == 0 {
+        QecProfiledMeasurementSampler::Empty
+    } else if has_noise {
+        QecProfiledMeasurementSampler::Noisy(compile_qec_noisy_sampler(program)?)
+    } else {
+        let circuit = lower_qec_program_to_clifford_circuit(program)?;
+        QecProfiledMeasurementSampler::Clean(compile_detector_sampler(
+            &circuit,
+            detector_rows.clone(),
+            observable_rows.clone(),
+            program.options().seed,
+        )?)
+    };
+
+    Ok(QecProfiledSampler {
+        sampler,
+        num_measurements,
+        detector_rows,
+        observable_rows,
+        postselection_rows,
+        keep_measurements: program.options().keep_measurements,
+    })
+}
+
+#[cfg(feature = "bench-internal")]
+impl QecProfiledSampler {
+    /// Number of measurement records produced per shot.
+    pub fn num_measurements(&self) -> usize {
+        self.num_measurements
+    }
+
+    /// Number of detector records produced per shot.
+    pub fn num_detectors(&self) -> usize {
+        self.detector_rows.len()
+    }
+
+    /// Number of observable records produced per shot.
+    pub fn num_observables(&self) -> usize {
+        self.observable_rows.len()
+    }
+
+    /// Number of postselection predicates.
+    pub fn num_postselections(&self) -> usize {
+        self.postselection_rows.len()
+    }
+
+    /// Whether active Pauli-noise rows were compiled.
+    pub fn has_noise(&self) -> bool {
+        matches!(self.sampler, QecProfiledMeasurementSampler::Noisy(_))
+    }
+
+    /// Sample noiseless measurement records.
+    pub fn sample_noiseless_measurements_packed(
+        &mut self,
+        num_shots: usize,
+    ) -> Result<PackedShots> {
+        match &mut self.sampler {
+            QecProfiledMeasurementSampler::Empty => Ok(PackedShots::from_shot_major(
+                Vec::new(),
+                num_shots,
+                self.num_measurements,
+            )),
+            QecProfiledMeasurementSampler::Clean(sampler) => {
+                sampler.sample_measurements_packed(num_shots)
+            }
+            QecProfiledMeasurementSampler::Noisy(sampler) => {
+                sampler.sample_noiseless_measurements_packed(num_shots)
+            }
+        }
+    }
+
+    /// Apply compiled Pauli-noise rows to measurement records.
+    pub fn apply_noise_to_measurements(
+        &mut self,
+        measurements: PackedShots,
+    ) -> Result<PackedShots> {
+        match &mut self.sampler {
+            QecProfiledMeasurementSampler::Noisy(sampler) => {
+                sampler.apply_noise_to_measurements(measurements)
+            }
+            QecProfiledMeasurementSampler::Empty | QecProfiledMeasurementSampler::Clean(_) => {
+                Ok(measurements)
+            }
+        }
+    }
+
+    /// Sample measurement records with compiled noise applied.
+    pub fn sample_measurements_packed(&mut self, num_shots: usize) -> Result<PackedShots> {
+        let measurements = self.sample_noiseless_measurements_packed(num_shots)?;
+        self.apply_noise_to_measurements(measurements)
+    }
+
+    /// Project detector parity rows from measurement records.
+    pub fn detector_records(&self, measurements: &PackedShots) -> Result<PackedShots> {
+        validate_qec_measurement_shape(
+            "QEC detector projection input",
+            measurements,
+            measurements.num_shots(),
+            self.num_measurements,
+        )?;
+        parity_rows_or_empty(measurements, &self.detector_rows)
+    }
+
+    /// Project observable parity rows from measurement records.
+    pub fn observable_records(&self, measurements: &PackedShots) -> Result<PackedShots> {
+        validate_qec_measurement_shape(
+            "QEC observable projection input",
+            measurements,
+            measurements.num_shots(),
+            self.num_measurements,
+        )?;
+        parity_rows_or_empty(measurements, &self.observable_rows)
+    }
+
+    /// Count postselection survivors and logical errors from packed records.
+    pub fn postselection_and_logical_counts(
+        &self,
+        measurements: &PackedShots,
+        observables: &PackedShots,
+    ) -> Result<QecProfiledCounts> {
+        validate_qec_measurement_shape(
+            "QEC postselection input",
+            measurements,
+            observables.num_shots(),
+            self.num_measurements,
+        )?;
+        validate_qec_measurement_shape(
+            "QEC logical count observable input",
+            observables,
+            measurements.num_shots(),
+            self.observable_rows.len(),
+        )?;
+        qec_count_postselection_and_logical(
+            observables.num_shots(),
+            &self.postselection_rows,
+            measurements,
+            observables,
+        )
+    }
+
+    /// Build the regular QEC result from staged measurement records.
+    pub fn result_from_measurements(&self, measurements: PackedShots) -> Result<QecSampleResult> {
+        qec_result_from_measurement_rows(
+            measurements.num_shots(),
+            self.num_measurements,
+            self.keep_measurements,
+            &self.detector_rows,
+            &self.observable_rows,
+            &self.postselection_rows,
+            measurements,
+        )
+    }
 }
 
 /// Run a native QEC program through the correctness-first reference path.
@@ -152,29 +361,99 @@ fn qec_result_from_measurements(
     program: &QecProgram,
     all_measurements: PackedShots,
 ) -> Result<QecSampleResult> {
-    let shots = program.options().shots;
-    let num_measurements = program.num_measurements();
-    if all_measurements.num_shots() != shots
-        || all_measurements.num_measurements() != num_measurements
-    {
-        return Err(PrismError::InvalidParameter {
-            message: format!(
-                "QEC measurement sample shape must be {shots} shots by {num_measurements} records, got {} by {}",
-                all_measurements.num_shots(),
-                all_measurements.num_measurements()
-            ),
-        });
-    }
     let detector_rows = program.detector_rows()?;
     let observable_rows = program.observable_rows()?;
     let postselection_rows = program.postselection_rows()?;
-    let detectors = parity_rows_or_empty(&all_measurements, &detector_rows)?;
-    let observables = parity_rows_or_empty(&all_measurements, &observable_rows)?;
+    qec_result_from_measurement_rows(
+        program.options().shots,
+        program.num_measurements(),
+        program.options().keep_measurements,
+        &detector_rows,
+        &observable_rows,
+        &postselection_rows,
+        all_measurements,
+    )
+}
+
+fn qec_result_from_measurement_rows(
+    shots: usize,
+    num_measurements: usize,
+    keep_measurements: bool,
+    detector_rows: &[Vec<usize>],
+    observable_rows: &[Vec<usize>],
+    postselection_rows: &[(Vec<usize>, bool)],
+    all_measurements: PackedShots,
+) -> Result<QecSampleResult> {
+    validate_qec_measurement_shape(
+        "QEC measurement sample",
+        &all_measurements,
+        shots,
+        num_measurements,
+    )?;
+    let detectors = parity_rows_or_empty(&all_measurements, detector_rows)?;
+    let observables = parity_rows_or_empty(&all_measurements, observable_rows)?;
+    let counts = qec_count_postselection_and_logical(
+        shots,
+        postselection_rows,
+        &all_measurements,
+        &observables,
+    )?;
+    let measurements = if keep_measurements {
+        all_measurements
+    } else {
+        PackedShots::from_meas_major(Vec::new(), 0, num_measurements)
+    };
+
+    QecSampleResult::new_with_total_shots(
+        shots,
+        measurements,
+        detectors,
+        observables,
+        counts.accepted_shots,
+        counts.discarded_shots,
+        counts.logical_errors,
+    )
+}
+
+fn validate_qec_measurement_shape(
+    label: &str,
+    measurements: &PackedShots,
+    expected_shots: usize,
+    expected_measurements: usize,
+) -> Result<()> {
+    if measurements.num_shots() == expected_shots
+        && measurements.num_measurements() == expected_measurements
+    {
+        return Ok(());
+    }
+    Err(PrismError::InvalidParameter {
+        message: format!(
+            "{label} shape must be {expected_shots} shots by {expected_measurements} records, got {} by {}",
+            measurements.num_shots(),
+            measurements.num_measurements()
+        ),
+    })
+}
+
+fn qec_count_postselection_and_logical(
+    shots: usize,
+    postselection_rows: &[(Vec<usize>, bool)],
+    all_measurements: &PackedShots,
+    observables: &PackedShots,
+) -> Result<QecProfiledCounts> {
+    if observables.num_shots() != shots {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC observable shot count {} does not match {shots}",
+                observables.num_shots()
+            ),
+        });
+    }
+
     let mut accepted_shots = shots;
     let mut logical_errors = vec![0u64; observables.num_measurements()];
-
     if postselection_rows.is_empty() {
-        add_qec_logical_error_counts(&observables, &mut logical_errors);
+        add_qec_logical_error_counts(observables, &mut logical_errors);
     } else {
         accepted_shots = 0;
         let postselection_only: Vec<Vec<usize>> = postselection_rows
@@ -199,22 +478,11 @@ fn qec_result_from_measurements(
         }
     }
 
-    let discarded_shots = shots - accepted_shots;
-    let measurements = if program.options().keep_measurements {
-        all_measurements
-    } else {
-        PackedShots::from_meas_major(Vec::new(), 0, num_measurements)
-    };
-
-    QecSampleResult::new_with_total_shots(
-        shots,
-        measurements,
-        detectors,
-        observables,
+    Ok(QecProfiledCounts {
         accepted_shots,
-        discarded_shots,
+        discarded_shots: shots - accepted_shots,
         logical_errors,
-    )
+    })
 }
 
 fn qec_result_from_measurement_chunks<F>(
@@ -374,8 +642,9 @@ fn parity_rows_for_repeated_shot(
 ) -> PackedShots {
     let out_words = rows.len().div_ceil(64);
     let mut pattern = vec![0u64; out_words];
-    for (out_idx, row) in rows.iter().enumerate() {
-        pattern[out_idx / 64] |= qec_row_parity_word(shot_words, row) << (out_idx % 64);
+    let prepared_rows = prepare_qec_parity_rows(rows);
+    for (out_idx, row) in prepared_rows.iter().enumerate() {
+        pattern[out_idx / 64] |= row.parity(shot_words) << (out_idx % 64);
     }
 
     let mut data = vec![0u64; num_shots * out_words];
@@ -393,44 +662,90 @@ fn parity_rows_for_shot_major(measurements: &PackedShots, rows: &[Vec<usize>]) -
     let m_words = measurements.m_words();
     let mut data = vec![0u64; measurements.num_shots() * out_words];
     let measurement_data = measurements.raw_data();
+    let prepared_rows = prepare_qec_parity_rows(rows);
 
     for shot in 0..measurements.num_shots() {
         let src_base = shot * m_words;
         let dst_base = shot * out_words;
         let shot_words = &measurement_data[src_base..src_base + m_words];
         let dst = &mut data[dst_base..dst_base + out_words];
-        for (out_idx, row) in rows.iter().enumerate() {
-            dst[out_idx / 64] |= qec_row_parity_word(shot_words, row) << (out_idx % 64);
+        for (out_idx, row) in prepared_rows.iter().enumerate() {
+            dst[out_idx / 64] |= row.parity(shot_words) << (out_idx % 64);
         }
     }
 
     PackedShots::from_shot_major(data, measurements.num_shots(), rows.len())
 }
 
-#[inline(always)]
-fn qec_row_parity_word(shot_words: &[u64], row: &[usize]) -> u64 {
-    match row {
-        [] => 0,
-        [a] => qec_measurement_word(shot_words, *a),
-        [a, b] => qec_measurement_word(shot_words, *a) ^ qec_measurement_word(shot_words, *b),
-        [a, b, c] => {
-            qec_measurement_word(shot_words, *a)
-                ^ qec_measurement_word(shot_words, *b)
-                ^ qec_measurement_word(shot_words, *c)
-        }
-        _ => {
-            let mut parity = 0u64;
-            for &measurement in row {
-                parity ^= qec_measurement_word(shot_words, measurement);
+enum QecPreparedParityRow {
+    Empty,
+    Single(QecPreparedMeasurement),
+    Pair(QecPreparedMeasurement, QecPreparedMeasurement),
+    Triple(
+        QecPreparedMeasurement,
+        QecPreparedMeasurement,
+        QecPreparedMeasurement,
+    ),
+    Many(Vec<QecPreparedMeasurement>),
+}
+
+#[derive(Clone, Copy)]
+struct QecPreparedMeasurement {
+    word: usize,
+    bit: u32,
+}
+
+fn prepare_qec_parity_rows(rows: &[Vec<usize>]) -> Vec<QecPreparedParityRow> {
+    rows.iter()
+        .map(|row| {
+            let prepared: Vec<_> = row
+                .iter()
+                .copied()
+                .map(QecPreparedMeasurement::new)
+                .collect();
+            match prepared.as_slice() {
+                [] => QecPreparedParityRow::Empty,
+                [a] => QecPreparedParityRow::Single(*a),
+                [a, b] => QecPreparedParityRow::Pair(*a, *b),
+                [a, b, c] => QecPreparedParityRow::Triple(*a, *b, *c),
+                _ => QecPreparedParityRow::Many(prepared),
             }
-            parity
+        })
+        .collect()
+}
+
+impl QecPreparedMeasurement {
+    #[inline(always)]
+    fn new(measurement: usize) -> Self {
+        Self {
+            word: measurement / 64,
+            bit: (measurement % 64) as u32,
         }
+    }
+
+    #[inline(always)]
+    fn read(self, shot_words: &[u64]) -> u64 {
+        (shot_words[self.word] >> self.bit) & 1
     }
 }
 
-#[inline(always)]
-fn qec_measurement_word(shot_words: &[u64], measurement: usize) -> u64 {
-    (shot_words[measurement / 64] >> (measurement % 64)) & 1
+impl QecPreparedParityRow {
+    #[inline(always)]
+    fn parity(&self, shot_words: &[u64]) -> u64 {
+        match self {
+            Self::Empty => 0,
+            Self::Single(a) => a.read(shot_words),
+            Self::Pair(a, b) => a.read(shot_words) ^ b.read(shot_words),
+            Self::Triple(a, b, c) => a.read(shot_words) ^ b.read(shot_words) ^ c.read(shot_words),
+            Self::Many(row) => {
+                let mut parity = 0u64;
+                for measurement in row {
+                    parity ^= measurement.read(shot_words);
+                }
+                parity
+            }
+        }
+    }
 }
 
 fn add_qec_logical_error_counts(observables: &PackedShots, counts: &mut [u64]) {

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -5,6 +5,18 @@ use prism_q::{
     QecSampleResult,
 };
 
+fn assert_f64_close(actual: f64, expected: f64, tolerance: f64) {
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "expected {actual} to be within {tolerance} of {expected}"
+    );
+}
+
+fn assert_interval_close(actual: (f64, f64), expected: (f64, f64), tolerance: f64) {
+    assert_f64_close(actual.0, expected.0, tolerance);
+    assert_f64_close(actual.1, expected.1, tolerance);
+}
+
 #[test]
 fn qec_program_builds_measurement_record_rows() {
     let mut program = QecProgram::new(2);
@@ -135,6 +147,70 @@ fn qec_sample_result_allows_omitted_raw_measurements() {
     assert_eq!(result.total_shots, 2);
     assert_eq!(result.measurements.num_shots(), 0);
     assert_eq!(result.measurements.num_measurements(), 2);
+}
+
+#[test]
+fn qec_sample_result_rejects_impossible_logical_error_counts() {
+    let measurements = PackedShots::from_shot_major(vec![0, 1], 2, 1);
+    let detectors = PackedShots::from_shot_major(vec![1, 0], 2, 1);
+    let observables = PackedShots::from_shot_major(vec![1, 1], 2, 1);
+
+    let result = QecSampleResult::new(measurements, detectors, observables, 1, 1, vec![2]);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn qec_sample_result_reports_rates_and_wilson_intervals() {
+    let measurements = PackedShots::from_shot_major(vec![0; 100], 100, 1);
+    let detectors = PackedShots::from_shot_major(vec![0; 100], 100, 1);
+    let observables = PackedShots::from_shot_major(vec![0; 100], 100, 2);
+
+    let result = QecSampleResult::new_with_total_shots(
+        100,
+        measurements,
+        detectors,
+        observables,
+        40,
+        60,
+        vec![5, 20],
+    )
+    .unwrap();
+    let z_95 = 1.959_963_984_540_054;
+
+    assert_f64_close(result.survivor_rate(), 0.4, 1e-12);
+    assert_eq!(result.logical_error_rates().len(), 2);
+    assert_f64_close(result.logical_error_rates()[0], 0.125, 1e-12);
+    assert_f64_close(result.logical_error_rates()[1], 0.5, 1e-12);
+    assert_interval_close(
+        result.survivor_rate_wilson_interval(z_95),
+        (0.309_401_286_432_459, 0.497_997_413_208_938),
+        1e-12,
+    );
+    assert_eq!(result.logical_error_rate_wilson_intervals(z_95).len(), 2);
+    assert_interval_close(
+        result.logical_error_rate_wilson_intervals(z_95)[0],
+        (0.054_595_002_509_454, 0.261_121_198_388_511),
+        1e-12,
+    );
+    assert_interval_close(
+        result.logical_error_rate_wilson_intervals(z_95)[1],
+        (0.351_995_269_334_654, 0.648_004_730_665_346),
+        1e-12,
+    );
+}
+
+#[test]
+fn qec_sample_result_reports_zero_rates_for_empty_results() {
+    let result = QecSampleResult::empty(2, 1, 2);
+
+    assert_eq!(result.survivor_rate(), 0.0);
+    assert_eq!(result.logical_error_rates(), vec![0.0, 0.0]);
+    assert_eq!(result.survivor_rate_wilson_interval(1.96), (0.0, 0.0));
+    assert_eq!(
+        result.logical_error_rate_wilson_intervals(1.96),
+        vec![(0.0, 0.0), (0.0, 0.0)]
+    );
 }
 
 #[test]

--- a/tests/qec_noisy_validation.rs
+++ b/tests/qec_noisy_validation.rs
@@ -1,0 +1,235 @@
+#[cfg(feature = "bench-internal")]
+use prism_q::compile_qec_profiled_sampler;
+use prism_q::{
+    parse_qec_program, run_qec_program, run_qec_program_reference, Gate, PackedShots, QecNoise,
+    QecOptions, QecProgram, QecRecordRef,
+};
+
+const SEED: u64 = 0xDEAD_BEEF;
+const STAT_SHOTS: usize = 20_000;
+
+fn qec_options(shots: usize, keep_measurements: bool) -> QecOptions {
+    QecOptions {
+        shots,
+        seed: SEED,
+        chunk_size: Some(4096),
+        keep_measurements,
+    }
+}
+
+fn bit_rate(shots: &PackedShots, column: usize) -> f64 {
+    let mut count = 0usize;
+    for shot in 0..shots.num_shots() {
+        count += usize::from(shots.get_bit(shot, column));
+    }
+    count as f64 / shots.num_shots() as f64
+}
+
+#[track_caller]
+fn assert_rate_close(label: &str, actual: f64, expected: f64, tolerance: f64) {
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= tolerance,
+        "{label}: actual {actual:.4}, expected {expected:.4}, diff {diff:.4}, tolerance {tolerance:.4}"
+    );
+}
+
+#[test]
+fn qec_noisy_single_qubit_channels_match_expected_rates() {
+    let p = 0.25;
+
+    let mut x_program = QecProgram::with_options(1, qec_options(STAT_SHOTS, true));
+    x_program.noise(QecNoise::XError(p), &[0]).unwrap();
+    x_program.measure_z(0).unwrap();
+    let x_result = run_qec_program(&x_program).unwrap();
+    assert_rate_close(
+        "X_ERROR before MZ",
+        bit_rate(&x_result.measurements, 0),
+        p,
+        0.025,
+    );
+
+    let mut z_program = QecProgram::with_options(1, qec_options(STAT_SHOTS, true));
+    z_program.push_gate(Gate::H, &[0]).unwrap();
+    z_program.noise(QecNoise::ZError(p), &[0]).unwrap();
+    z_program.measure_x(0).unwrap();
+    let z_result = run_qec_program(&z_program).unwrap();
+    assert_rate_close(
+        "Z_ERROR before MX",
+        bit_rate(&z_result.measurements, 0),
+        p,
+        0.025,
+    );
+
+    let mut depol_program = QecProgram::with_options(1, qec_options(STAT_SHOTS, true));
+    depol_program.noise(QecNoise::Depolarize1(p), &[0]).unwrap();
+    depol_program.measure_z(0).unwrap();
+    let depol_result = run_qec_program(&depol_program).unwrap();
+    assert_rate_close(
+        "DEPOLARIZE1 before MZ",
+        bit_rate(&depol_result.measurements, 0),
+        2.0 * p / 3.0,
+        0.025,
+    );
+}
+
+#[test]
+fn qec_noisy_depolarize2_matches_marginal_and_detector_rates() {
+    let p = 0.30;
+    let expected = p * 8.0 / 15.0;
+    let mut program = QecProgram::with_options(2, qec_options(STAT_SHOTS, true));
+    program.noise(QecNoise::Depolarize2(p), &[0, 1]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    let m1 = program.measure_z(1).unwrap();
+    program
+        .detector(&[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    assert_rate_close(
+        "DEPOLARIZE2 first target MZ",
+        bit_rate(&result.measurements, 0),
+        expected,
+        0.025,
+    );
+    assert_rate_close(
+        "DEPOLARIZE2 second target MZ",
+        bit_rate(&result.measurements, 1),
+        expected,
+        0.025,
+    );
+    assert_rate_close(
+        "DEPOLARIZE2 detector parity",
+        bit_rate(&result.detectors, 0),
+        expected,
+        0.025,
+    );
+}
+
+#[test]
+fn qec_noisy_postselection_counts_use_noisy_measurement_records() {
+    let p = 0.25;
+    let mut program = QecProgram::with_options(1, qec_options(STAT_SHOTS, false));
+    program.noise(QecNoise::XError(p), &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], true)
+        .unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    let accepted_rate = result.accepted_shots as f64 / result.total_shots as f64;
+    assert_rate_close("noisy postselection acceptance", accepted_rate, p, 0.025);
+    assert_eq!(
+        result.discarded_shots,
+        result.total_shots - result.accepted_shots
+    );
+    assert_eq!(result.logical_errors, vec![result.accepted_shots as u64]);
+    assert_eq!(result.measurements.num_shots(), 0);
+}
+
+#[test]
+fn qec_text_measurement_error_arguments_match_expected_rates() {
+    let mut z_program = parse_qec_program("M(0.2) 0").unwrap();
+    z_program.set_options(qec_options(STAT_SHOTS, true));
+    let z_result = run_qec_program(&z_program).unwrap();
+    assert_rate_close(
+        "M measurement error",
+        bit_rate(&z_result.measurements, 0),
+        0.2,
+        0.025,
+    );
+
+    let mut x_program = parse_qec_program("H 0\nMX(0.2) 0").unwrap();
+    x_program.set_options(qec_options(STAT_SHOTS, true));
+    let x_result = run_qec_program(&x_program).unwrap();
+    assert_rate_close(
+        "MX measurement error",
+        bit_rate(&x_result.measurements, 0),
+        0.2,
+        0.025,
+    );
+}
+
+#[test]
+fn qec_noisy_compiled_runner_matches_reference_statistics() {
+    let mut program = QecProgram::with_options(2, qec_options(8_000, true));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.noise(QecNoise::XError(0.17), &[0]).unwrap();
+    program.noise(QecNoise::ZError(0.11), &[1]).unwrap();
+    program.noise(QecNoise::Depolarize2(0.13), &[0, 1]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    let m1 = program.measure_z(1).unwrap();
+    program
+        .detector(&[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let compiled = run_qec_program(&program).unwrap();
+    let reference = run_qec_program_reference(&program).unwrap();
+    assert_rate_close(
+        "compiled versus reference detector rate",
+        bit_rate(&compiled.detectors, 0),
+        bit_rate(&reference.detectors, 0),
+        0.05,
+    );
+    assert_rate_close(
+        "compiled versus reference observable rate",
+        bit_rate(&compiled.observables, 0),
+        bit_rate(&reference.observables, 0),
+        0.05,
+    );
+}
+
+#[cfg(feature = "bench-internal")]
+#[test]
+fn qec_profiled_sampler_stages_match_public_runner_result() {
+    let mut program = QecProgram::with_options(1, qec_options(16, false));
+    program.noise(QecNoise::XError(1.0), &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], true)
+        .unwrap();
+
+    let public_result = run_qec_program(&program).unwrap();
+    let mut sampler = compile_qec_profiled_sampler(&program).unwrap();
+    assert!(sampler.has_noise());
+    assert_eq!(sampler.num_measurements(), 1);
+    assert_eq!(sampler.num_detectors(), 1);
+    assert_eq!(sampler.num_observables(), 1);
+    assert_eq!(sampler.num_postselections(), 1);
+
+    let measurements = sampler
+        .sample_noiseless_measurements_packed(program.options().shots)
+        .unwrap();
+    assert_eq!(measurements.to_shots(), vec![vec![false]; 16]);
+    let measurements = sampler.apply_noise_to_measurements(measurements).unwrap();
+    let observables = sampler.observable_records(&measurements).unwrap();
+    let counts = sampler
+        .postselection_and_logical_counts(&measurements, &observables)
+        .unwrap();
+    let staged_result = sampler.result_from_measurements(measurements).unwrap();
+
+    assert_eq!(counts.accepted_shots, public_result.accepted_shots);
+    assert_eq!(counts.discarded_shots, public_result.discarded_shots);
+    assert_eq!(counts.logical_errors, public_result.logical_errors);
+    assert_eq!(staged_result.measurements.num_shots(), 0);
+    assert_eq!(
+        staged_result.detectors.to_shots(),
+        public_result.detectors.to_shots()
+    );
+    assert_eq!(
+        staged_result.observables.to_shots(),
+        public_result.observables.to_shots()
+    );
+    assert_eq!(staged_result.logical_errors, public_result.logical_errors);
+}


### PR DESCRIPTION
## Summary

Adds validation coverage for noisy native QEC execution, including Pauli noise channels, noisy postselection, measurement error arguments, and compiled versus reference statistics. Adds a `bench-internal` staged QEC sampler so Criterion can measure parse, compile, sampling, noise application, detector projection, postselection, logical counting, and total execution separately.

## Scope

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Command: `cargo bench --features parallel --bench bench_shots_perf -- qec`

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- |
| `qec_clifford_runner/25q_r5/10000` | 467.45 us | 418.02 us | -10.57% | Yes |
| `qec_clifford_runner/25q_r5/100000` | 2.711 ms | 2.518 ms | -7.11% | Yes |
| `qec_clifford_runner/100q_r3/100000` | 3.890 ms | 3.797 ms | -2.37% | Yes |
| `qec_clifford_runner/25q_r5_p0/100000` | 2.745 ms | 2.440 ms | -11.11% | Yes |
| `qec_noisy_runner/25q_r5_p001/10000` | 3.538 ms | 3.103 ms | -12.29% | Yes |
| `qec_noisy_runner/25q_r5_p001/100000` | 28.388 ms | 28.422 ms | +0.12% | Yes |


## Correctness

- [ ] `cargo test --all-features` passes locally, command timed out after visible suites passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo fmt --check` passes, currently fails import ordering and trailing whitespace
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Targeted QEC validation passed with `cargo test --all-features qec --quiet`, covering 45 existing QEC tests and 6 noisy validation tests.

## Hotspot notes

Touches packed native QEC execution paths in `src/qec/runner.rs` and `src/qec/noise.rs`, including noisy measurement sampling, Pauli-noise application, detector and observable projection, postselection, logical counting, and prepared parity row evaluation.

No profiler or Criterion output is attached yet. Benchmark output is required before merge.

## Architecture or design changes

- [ ] `docs/architecture.md` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No architecture update included. The staged sampler is gated behind `bench-internal` and intended for benchmark harnesses.

## Breaking changes

No API removal.

`QecSampleResult::new` and `new_with_total_shots` now reject logical error counts greater than accepted shots, which tightens validation for invalid result construction.

## Risks and rollback

Risk is concentrated in native QEC packed execution and result aggregation. Incorrect behavior could affect noisy measurement records, detector projection, postselection counts, or logical error rates.

The staged profiling API is guarded by the `bench-internal` feature. Runtime behavior changes can be rolled back by reverting the QEC runner, noise sampler, and result validation changes.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
