### PR TITLE
perf(backend): block-based CX kernels and NT-store rowmul for stabilizer

### DIFF
--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -3,11 +3,12 @@
 //! Use `--features bench-fast` for a quick run that reduces warmup and
 //! measurement time. Omit for the full suite with default Criterion timing.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use prism_q::backend::Backend;
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
 use prism_q::sim;
-use prism_q::BackendKind;
+use prism_q::{BackendKind, StatevectorBackend};
 use std::time::Duration;
 
 fn is_fast() -> bool {
@@ -72,9 +73,53 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
             });
         });
 
+        group.bench_with_input(
+            BenchmarkId::new("cx_ctrl_gt_adjacent", n_qubits),
+            &n_qubits,
+            |b, &n| {
+                let mut circuit = Circuit::new(n, 0);
+                circuit.add_gate(Gate::Cx, &[1, 0]);
+                b.iter(|| {
+                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("cx_ctrl_lt_high", n_qubits),
+            &n_qubits,
+            |b, &n| {
+                let mut circuit = Circuit::new(n, 0);
+                circuit.add_gate(Gate::Cx, &[0, n - 1]);
+                b.iter(|| {
+                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("cx_ctrl_gt_high", n_qubits),
+            &n_qubits,
+            |b, &n| {
+                let mut circuit = Circuit::new(n, 0);
+                circuit.add_gate(Gate::Cx, &[n - 1, 0]);
+                b.iter(|| {
+                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                });
+            },
+        );
+
         group.bench_with_input(BenchmarkId::new("cz_gate", n_qubits), &n_qubits, |b, &n| {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Cz, &[0, 1]);
+            b.iter(|| {
+                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("cz_high", n_qubits), &n_qubits, |b, &n| {
+            let mut circuit = Circuit::new(n, 0);
+            circuit.add_gate(Gate::Cz, &[0, n - 1]);
             b.iter(|| {
                 sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
@@ -91,6 +136,141 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 });
             },
         );
+
+        group.bench_with_input(
+            BenchmarkId::new("fused2q_adjacent", n_qubits),
+            &n_qubits,
+            |b, &n| {
+                let mut circuit = Circuit::new(n, 0);
+                circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, 1]);
+                b.iter(|| {
+                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("fused2q_high", n_qubits),
+            &n_qubits,
+            |b, &n| {
+                let mut circuit = Circuit::new(n, 0);
+                circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, n - 1]);
+                b.iter(|| {
+                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_two_qubit_gate_kernels(c: &mut Criterion) {
+    let mut group = c.benchmark_group("two_qubit_gate_kernels");
+    configure_group(&mut group);
+
+    for &n_qubits in &[12, 16, 20, 22] {
+        let mut cx_lt_adj = Circuit::new(n_qubits, 0);
+        cx_lt_adj.add_gate(Gate::Cx, &[0, 1]);
+        group.bench_function(BenchmarkId::new("cx_ctrl_lt_adjacent", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cx_lt_adj.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let mut cx_gt_adj = Circuit::new(n_qubits, 0);
+        cx_gt_adj.add_gate(Gate::Cx, &[1, 0]);
+        group.bench_function(BenchmarkId::new("cx_ctrl_gt_adjacent", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cx_gt_adj.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let mut cx_lt_high = Circuit::new(n_qubits, 0);
+        cx_lt_high.add_gate(Gate::Cx, &[0, n_qubits - 1]);
+        group.bench_function(BenchmarkId::new("cx_ctrl_lt_high", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cx_lt_high.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let mut cx_gt_high = Circuit::new(n_qubits, 0);
+        cx_gt_high.add_gate(Gate::Cx, &[n_qubits - 1, 0]);
+        group.bench_function(BenchmarkId::new("cx_ctrl_gt_high", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cx_gt_high.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let mut cz_adj = Circuit::new(n_qubits, 0);
+        cz_adj.add_gate(Gate::Cz, &[0, 1]);
+        group.bench_function(BenchmarkId::new("cz_adjacent", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cz_adj.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        let mut cz_high = Circuit::new(n_qubits, 0);
+        cz_high.add_gate(Gate::Cz, &[0, n_qubits - 1]);
+        group.bench_function(BenchmarkId::new("cz_high", n_qubits), |b| {
+            b.iter_batched(
+                || {
+                    let mut backend = StatevectorBackend::new(42);
+                    backend.init(n_qubits, 0).unwrap();
+                    backend
+                },
+                |mut backend| {
+                    backend.apply(&cz_high.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::SmallInput,
+            );
+        });
     }
 
     group.finish();
@@ -358,6 +538,7 @@ criterion_group!(
     benches,
     bench_single_qubit_gates,
     bench_two_qubit_gates,
+    bench_two_qubit_gate_kernels,
     bench_measurement,
     bench_qasm_parse_and_simulate,
     bench_high_target_qubit,

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -919,7 +919,7 @@ unsafe fn negate_slice_avx2(slice: &mut [Complex64]) {
 
 const MIN_SIMD_SLICE: usize = 4;
 
-#[cfg(any(feature = "parallel", test))]
+#[inline(always)]
 pub(crate) fn negate_slice(slice: &mut [Complex64]) {
     #[cfg(target_arch = "x86_64")]
     if slice.len() >= MIN_SIMD_SLICE && has_avx2_fma() {
@@ -968,6 +968,7 @@ unsafe fn swap_slices_avx2(a: &mut [Complex64], b: &mut [Complex64]) {
     }
 }
 
+#[inline(always)]
 pub(crate) fn swap_slices(a: &mut [Complex64], b: &mut [Complex64]) {
     debug_assert_eq!(a.len(), b.len());
     #[cfg(target_arch = "x86_64")]

--- a/src/backend/stabilizer/kernels/simd.rs
+++ b/src/backend/stabilizer/kernels/simd.rs
@@ -74,6 +74,13 @@ pub(crate) fn rowmul_words(
     let nw = dst_x.len();
 
     #[cfg(target_arch = "x86_64")]
+    if nw >= 16 && has_avx2() {
+        // SAFETY: AVX2 detected at runtime; slices have equal lengths (debug_assert above).
+        // The NT helper performs its own alignment check and falls back to
+        // non-NT stores if alignment is insufficient.
+        return unsafe { rowmul_words_avx2_nt(dst_x, dst_z, src_x, src_z, initial_sum) };
+    }
+    #[cfg(target_arch = "x86_64")]
     if nw >= 4 && has_avx2() {
         // SAFETY: AVX2 detected at runtime; slices have equal lengths (debug_assert above).
         return unsafe { rowmul_words_avx2(dst_x, dst_z, src_x, src_z, initial_sum) };
@@ -193,6 +200,123 @@ unsafe fn rowmul_words_avx2(
         );
         vsum_nz = _mm256_add_epi64(vsum_nz, _mm256_sad_epu8(cnt_n, vzero));
     }
+
+    let pos_lo = _mm256_castsi256_si128(vsum_pos);
+    let pos_hi = _mm256_extracti128_si256(vsum_pos, 1);
+    let pos_sum = _mm_add_epi64(pos_lo, pos_hi);
+    let total_pos =
+        (_mm_cvtsi128_si64(pos_sum) as u64).wrapping_add(_mm_extract_epi64(pos_sum, 1) as u64);
+
+    let nz_lo = _mm256_castsi256_si128(vsum_nz);
+    let nz_hi = _mm256_extracti128_si256(vsum_nz, 1);
+    let nz_sum = _mm_add_epi64(nz_lo, nz_hi);
+    let total_nz =
+        (_mm_cvtsi128_si64(nz_sum) as u64).wrapping_add(_mm_extract_epi64(nz_sum, 1) as u64);
+
+    let mut sum = initial_sum
+        .wrapping_add(2u64.wrapping_mul(total_pos))
+        .wrapping_sub(total_nz);
+
+    let tail = chunks * 4;
+    for w in tail..nw {
+        let x1 = src_x[w];
+        let z1 = src_z[w];
+        let x2 = dst_x[w];
+        let z2 = dst_z[w];
+        let new_x = x1 ^ x2;
+        let new_z = z1 ^ z2;
+        dst_x[w] = new_x;
+        dst_z[w] = new_z;
+        if (x1 | z1 | x2 | z2) == 0 {
+            continue;
+        }
+        let nonzero = (new_x | new_z) & (x1 | z1) & (x2 | z2);
+        let pos = (x1 & z1 & !x2 & z2) | (x1 & !z1 & x2 & z2) | (!x1 & z1 & x2 & !z2);
+        sum = sum.wrapping_add(2 * pos.count_ones() as u64);
+        sum = sum.wrapping_sub(nonzero.count_ones() as u64);
+    }
+
+    sum
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn rowmul_words_avx2_nt(
+    dst_x: &mut [u64],
+    dst_z: &mut [u64],
+    src_x: &[u64],
+    src_z: &[u64],
+    initial_sum: u64,
+) -> u64 {
+    use std::arch::x86_64::*;
+
+    if (dst_x.as_ptr() as usize) & 31 != 0 || (dst_z.as_ptr() as usize) & 31 != 0 {
+        return rowmul_words_avx2(dst_x, dst_z, src_x, src_z, initial_sum);
+    }
+
+    let nw = dst_x.len();
+    let chunks = nw / 4;
+
+    let lookup = _mm256_setr_epi8(
+        0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3,
+        3, 4,
+    );
+    let low_mask = _mm256_set1_epi8(0x0f);
+    let vzero = _mm256_setzero_si256();
+
+    let mut vsum_pos = _mm256_setzero_si256();
+    let mut vsum_nz = _mm256_setzero_si256();
+
+    for i in 0..chunks {
+        let off = i * 4;
+        let vx1 = _mm256_loadu_si256(src_x.as_ptr().add(off) as *const __m256i);
+        let vz1 = _mm256_loadu_si256(src_z.as_ptr().add(off) as *const __m256i);
+        let vx2 = _mm256_loadu_si256(dst_x.as_ptr().add(off) as *const __m256i);
+        let vz2 = _mm256_loadu_si256(dst_z.as_ptr().add(off) as *const __m256i);
+
+        let vnew_x = _mm256_xor_si256(vx1, vx2);
+        let vnew_z = _mm256_xor_si256(vz1, vz2);
+        // SAFETY: dst_x and dst_z verified 32-byte aligned at function entry;
+        // chunk offsets advance by 32 bytes, preserving alignment.
+        _mm256_stream_si256(dst_x.as_mut_ptr().add(off) as *mut __m256i, vnew_x);
+        _mm256_stream_si256(dst_z.as_mut_ptr().add(off) as *mut __m256i, vnew_z);
+
+        let vor = _mm256_or_si256(_mm256_or_si256(vx1, vz1), _mm256_or_si256(vx2, vz2));
+        if _mm256_testz_si256(vor, vor) != 0 {
+            continue;
+        }
+
+        let vnonzero = _mm256_and_si256(
+            _mm256_and_si256(_mm256_or_si256(vnew_x, vnew_z), _mm256_or_si256(vx1, vz1)),
+            _mm256_or_si256(vx2, vz2),
+        );
+
+        let vpos = _mm256_or_si256(
+            _mm256_or_si256(
+                _mm256_and_si256(_mm256_and_si256(vx1, vz1), _mm256_andnot_si256(vx2, vz2)),
+                _mm256_and_si256(_mm256_andnot_si256(vz1, vx1), _mm256_and_si256(vx2, vz2)),
+            ),
+            _mm256_and_si256(_mm256_andnot_si256(vx1, vz1), _mm256_andnot_si256(vz2, vx2)),
+        );
+
+        let lo_p = _mm256_and_si256(vpos, low_mask);
+        let hi_p = _mm256_and_si256(_mm256_srli_epi16(vpos, 4), low_mask);
+        let cnt_p = _mm256_add_epi8(
+            _mm256_shuffle_epi8(lookup, lo_p),
+            _mm256_shuffle_epi8(lookup, hi_p),
+        );
+        vsum_pos = _mm256_add_epi64(vsum_pos, _mm256_sad_epu8(cnt_p, vzero));
+
+        let lo_n = _mm256_and_si256(vnonzero, low_mask);
+        let hi_n = _mm256_and_si256(_mm256_srli_epi16(vnonzero, 4), low_mask);
+        let cnt_n = _mm256_add_epi8(
+            _mm256_shuffle_epi8(lookup, lo_n),
+            _mm256_shuffle_epi8(lookup, hi_n),
+        );
+        vsum_nz = _mm256_add_epi64(vsum_nz, _mm256_sad_epu8(cnt_n, vzero));
+    }
+
+    _mm_sfence();
 
     let pos_lo = _mm256_castsi256_si128(vsum_pos);
     let pos_hi = _mm256_extracti128_si256(vsum_pos, 1);

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -56,6 +56,29 @@ fn adjacent_2q_indices(offset: usize, stride: usize, q0_is_lo: bool) -> [usize; 
     }
 }
 
+#[inline(always)]
+fn swap_slices_kernel(a: &mut [Complex64], b: &mut [Complex64]) {
+    debug_assert_eq!(a.len(), b.len());
+    if a.len() < 4 {
+        for (x, y) in a.iter_mut().zip(b.iter_mut()) {
+            std::mem::swap(x, y);
+        }
+    } else {
+        simd::swap_slices(a, b);
+    }
+}
+
+#[inline(always)]
+fn negate_slice_kernel(slice: &mut [Complex64]) {
+    if slice.len() < 4 {
+        for amp in slice {
+            *amp = -*amp;
+        }
+    } else {
+        simd::negate_slice(slice);
+    }
+}
+
 pub(crate) const BATCH_PHASE_GROUP_SIZE: usize = 10;
 pub(crate) const BATCH_PHASE_TABLE_SIZE: usize = 1024;
 pub(crate) const MAX_BATCH_PHASE_GROUPS: usize = 4;
@@ -566,14 +589,32 @@ impl StatevectorBackend {
             return;
         }
 
-        let ctrl_mask = 1usize << control;
-        let tgt_mask = 1usize << target;
-        let n = 1usize << self.num_qubits;
+        if control > target {
+            let ctrl_half = 1usize << control;
+            let block_size = ctrl_half << 1;
+            let tgt_half = 1usize << target;
+            let tgt_block = tgt_half << 1;
 
-        for i in 0..n {
-            if (i & ctrl_mask) != 0 && (i & tgt_mask) == 0 {
-                let j = i | tgt_mask;
-                self.state.swap(i, j);
+            for chunk in self.state.chunks_mut(block_size) {
+                let (_, hi) = chunk.split_at_mut(ctrl_half);
+                for sub in hi.chunks_mut(tgt_block) {
+                    let (sub_lo, sub_hi) = sub.split_at_mut(tgt_half);
+                    swap_slices_kernel(sub_lo, sub_hi);
+                }
+            }
+        } else {
+            let ctrl_half = 1usize << control;
+            let ctrl_block = ctrl_half << 1;
+            let tgt_half = 1usize << target;
+            let block_size = tgt_half << 1;
+
+            for chunk in self.state.chunks_mut(block_size) {
+                let (lo, hi) = chunk.split_at_mut(tgt_half);
+                for (lo_sub, hi_sub) in lo.chunks_mut(ctrl_block).zip(hi.chunks_mut(ctrl_block)) {
+                    let (_, lo_active) = lo_sub.split_at_mut(ctrl_half);
+                    let (_, hi_active) = hi_sub.split_at_mut(ctrl_half);
+                    swap_slices_kernel(lo_active, hi_active);
+                }
             }
         }
     }
@@ -596,7 +637,7 @@ impl StatevectorBackend {
                         let (_, hi) = chunk.split_at_mut(ctrl_half);
                         for sub in hi.chunks_mut(tgt_block) {
                             let (sub_lo, sub_hi) = sub.split_at_mut(tgt_half);
-                            simd::swap_slices(sub_lo, sub_hi);
+                            swap_slices_kernel(sub_lo, sub_hi);
                         }
                     });
             } else {
@@ -606,15 +647,16 @@ impl StatevectorBackend {
                     hi.par_chunks_mut(inner_tile).for_each(|tile| {
                         for sub in tile.chunks_mut(tgt_block) {
                             let (sub_lo, sub_hi) = sub.split_at_mut(tgt_half);
-                            simd::swap_slices(sub_lo, sub_hi);
+                            swap_slices_kernel(sub_lo, sub_hi);
                         }
                     });
                 }
             }
         } else {
+            let ctrl_half = 1usize << control;
+            let ctrl_block = ctrl_half << 1;
             let tgt_half = 1usize << target;
             let block_size = tgt_half << 1;
-            let ctrl_mask = 1usize << control;
             let num_blocks = self.state.len() / block_size;
 
             if num_blocks >= 4 {
@@ -623,24 +665,28 @@ impl StatevectorBackend {
                     .with_min_len(chunk_min_len(block_size))
                     .for_each(|chunk| {
                         let (lo, hi) = chunk.split_at_mut(tgt_half);
-                        for k in 0..tgt_half {
-                            if k & ctrl_mask != 0 {
-                                std::mem::swap(&mut lo[k], &mut hi[k]);
-                            }
+                        for (lo_sub, hi_sub) in
+                            lo.chunks_mut(ctrl_block).zip(hi.chunks_mut(ctrl_block))
+                        {
+                            let (_, lo_active) = lo_sub.split_at_mut(ctrl_half);
+                            let (_, hi_active) = hi_sub.split_at_mut(ctrl_half);
+                            swap_slices_kernel(lo_active, hi_active);
                         }
                     });
             } else {
+                let inner_tile = MIN_PAR_ELEMS.max(ctrl_block);
                 for chunk in self.state.chunks_mut(block_size) {
                     let (lo, hi) = chunk.split_at_mut(tgt_half);
-                    lo.par_chunks_mut(MIN_PAR_ELEMS)
-                        .zip(hi.par_chunks_mut(MIN_PAR_ELEMS))
-                        .enumerate()
-                        .for_each(|(tile_idx, (lo_tile, hi_tile))| {
-                            let offset = tile_idx * MIN_PAR_ELEMS;
-                            for k in 0..lo_tile.len() {
-                                if (offset + k) & ctrl_mask != 0 {
-                                    std::mem::swap(&mut lo_tile[k], &mut hi_tile[k]);
-                                }
+                    lo.par_chunks_mut(inner_tile)
+                        .zip(hi.par_chunks_mut(inner_tile))
+                        .for_each(|(lo_tile, hi_tile)| {
+                            for (lo_sub, hi_sub) in lo_tile
+                                .chunks_mut(ctrl_block)
+                                .zip(hi_tile.chunks_mut(ctrl_block))
+                            {
+                                let (_, lo_active) = lo_sub.split_at_mut(ctrl_half);
+                                let (_, hi_active) = hi_sub.split_at_mut(ctrl_half);
+                                swap_slices_kernel(lo_active, hi_active);
                             }
                         });
                 }
@@ -656,13 +702,17 @@ impl StatevectorBackend {
             return;
         }
 
-        let mask0 = 1usize << q0;
-        let mask1 = 1usize << q1;
-        let n = 1usize << self.num_qubits;
+        let (lo_q, hi_q) = if q0 < q1 { (q0, q1) } else { (q1, q0) };
+        let lo_half = 1usize << lo_q;
+        let lo_block = lo_half << 1;
+        let hi_half = 1usize << hi_q;
+        let block_size = hi_half << 1;
 
-        for i in 0..n {
-            if (i & mask0) != 0 && (i & mask1) != 0 {
-                self.state[i] = -self.state[i];
+        for chunk in self.state.chunks_mut(block_size) {
+            let (_, hi_group) = chunk.split_at_mut(hi_half);
+            for sub in hi_group.chunks_mut(lo_block) {
+                let (_, sub_hi) = sub.split_at_mut(lo_half);
+                negate_slice_kernel(sub_hi);
             }
         }
     }
@@ -685,7 +735,7 @@ impl StatevectorBackend {
                     let (_, hi_group) = chunk.split_at_mut(hi_half);
                     for sub in hi_group.chunks_mut(lo_block) {
                         let (_, sub_hi) = sub.split_at_mut(lo_half);
-                        simd::negate_slice(sub_hi);
+                        negate_slice_kernel(sub_hi);
                     }
                 });
         } else {
@@ -695,7 +745,7 @@ impl StatevectorBackend {
                 hi_group.par_chunks_mut(inner_tile).for_each(|tile| {
                     for sub in tile.chunks_mut(lo_block) {
                         let (_, sub_hi) = sub.split_at_mut(lo_half);
-                        simd::negate_slice(sub_hi);
+                        negate_slice_kernel(sub_hi);
                     }
                 });
             }

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -93,6 +93,36 @@ fn test_cz() {
 }
 
 #[test]
+fn test_cx_high_target_both_orders() {
+    let n = 6;
+    for &(control, target) in &[(0, n - 1), (n - 1, 0)] {
+        let mut c = Circuit::new(n, 0);
+        c.add_gate(Gate::X, &[control]);
+        c.add_gate(Gate::Cx, &[control, target]);
+        let mut b = StatevectorBackend::new(42);
+        sim::run_on(&mut b, &c).unwrap();
+        let probs = b.probabilities().unwrap();
+        let expected = (1usize << control) | (1usize << target);
+        assert!((probs[expected] - 1.0).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn test_cz_high_pair() {
+    let n = 6;
+    let hi = n - 1;
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[hi]);
+    c.add_gate(Gate::Cz, &[0, hi]);
+    let mut b = StatevectorBackend::new(42);
+    sim::run_on(&mut b, &c).unwrap();
+    let sv = b.state_vector();
+    let idx = (1usize << hi) | 1;
+    assert!((sv[idx].re - (-0.5)).abs() < 1e-12);
+}
+
+#[test]
 fn test_measurement_deterministic() {
     let mut c = Circuit::new(1, 1);
     c.add_gate(Gate::X, &[0]);


### PR DESCRIPTION
## Summary

Optimize CPU backend hot paths for statevector CX/CZ and stabilizer row multiplication. Statevector CX/CZ now use block-based slice kernels for common target/control layouts, and stabilizer rowmul uses an AVX2 non-temporal store path for large rows to reduce cache pressure.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Run from saved baseline `tier_s_before` with `--features parallel`.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| `statevector/qft_textbook/22` | 194.36 ms | 193.89 ms | -0.2% | Yes, unchanged, p=0.75 |
| `statevector/qpe_t_gate/22q` | 387.07 ms | 388.39 ms | +0.3% | Yes, unchanged, p=0.58 |
| `stabilizer/scaling/1000` | 4.42 ms | 4.30 ms | -4.0% | Yes, borderline improvement, p=0.08 |
| `factored_stabilizer/scaling/1000` | 4.11 ms | 3.63 ms | -8.6% | Yes, improved, p=0.03 |

Regression verdict: PASS

## Correctness

- [x] `cargo test --all-features` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings, N/A, no new public API
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend, N/A
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`, N/A, CPU backend changes only

## Hotspot notes

Affected hot paths:

- `src/backend/statevector/kernels.rs`: CX and CZ statevector kernels now use block-based slice traversal for control < target, control > target, adjacent, and high-target layouts.
- `src/backend/simd.rs`: shared slice swap and negate helpers remain available to sequential and parallel statevector kernels.
- `src/backend/stabilizer/kernels/simd.rs`: `rowmul_words` dispatches to the AVX2 non-temporal store variant for large rows.
- `src/backend/stabilizer/mod.rs` and `src/backend/factored_stabilizer/mod.rs`: row multiplication callers benefit through the shared rowmul kernel.

Focused Criterion subset is attached above. No flamegraph attached.

## Architecture or design changes

- [ ] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems, N/A, no new subsystem

## Breaking changes

None.

## Risks and rollback

Blast radius is limited to CPU statevector CX/CZ execution and CPU stabilizer row multiplication. Correctness risk is primarily index traversal mistakes in high-target or reversed-control layouts, plus AVX2 alignment or store behavior in the NT rowmul path.

Rollback is straightforward by reverting the specialized CX/CZ block traversal and disabling the NT-store rowmul dispatch while keeping the existing scalar and regular SIMD paths.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
