### PR TITLE
perf(qft): Add native statevector QFT block kernel

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -288,7 +288,7 @@ fn bench_statevector_qft_textbook(c: &mut Criterion) {
     let mut group = c.benchmark_group("statevector/qft_textbook");
     configure_group(&mut group);
 
-    for &n in &[4, 8, 12, 16, 20, 22] {
+    for &n in &[4, 8, 12, 16, 20, 22, 24, 26] {
         let circuit = circuits::qft_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -169,6 +169,14 @@ pub trait Backend {
         true
     }
 
+    /// Whether this backend has a native kernel for `Gate::QftBlock`.
+    ///
+    /// Native support is currently limited to whole-state CPU statevector QFT.
+    /// Other backends expand the block to textbook gates before dispatch.
+    fn supports_qft_block(&self) -> bool {
+        false
+    }
+
     /// Export the current quantum state as a dense statevector.
     ///
     /// Returns a `Vec<Complex64>` of length 2^n containing the full amplitude

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -121,7 +121,11 @@ impl MatBroadcast {
 
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
-unsafe fn complex_mul_neon(c_rr: float64x2_t, c_ii_as: float64x2_t, z: float64x2_t) -> float64x2_t {
+pub(crate) unsafe fn complex_mul_neon(
+    c_rr: float64x2_t,
+    c_ii_as: float64x2_t,
+    z: float64x2_t,
+) -> float64x2_t {
     let z_swap = vextq_f64(z, z, 1);
     let prod = vmulq_f64(c_rr, z);
     vfmaq_f64(prod, c_ii_as, z_swap)
@@ -174,7 +178,7 @@ unsafe fn apply_slices_sse2(lo: &mut [Complex64], hi: &mut [Complex64], mat: &Ma
 #[cfg(target_arch = "x86_64")]
 #[inline]
 #[target_feature(enable = "fma")]
-unsafe fn complex_mul_fma(c_rr: __m128d, c_ii: __m128d, z: __m128d) -> __m128d {
+pub(crate) unsafe fn complex_mul_fma(c_rr: __m128d, c_ii: __m128d, z: __m128d) -> __m128d {
     let z_swap = _mm_shuffle_pd(z, z, 0b01);
     let t = _mm_mul_pd(c_ii, z_swap);
     _mm_fmaddsub_pd(c_rr, z, t)
@@ -239,7 +243,7 @@ unsafe fn apply_slices_neon(lo: &mut [Complex64], hi: &mut [Complex64], mat: &Ma
 #[cfg(target_arch = "x86_64")]
 #[inline]
 #[target_feature(enable = "avx2,fma")]
-unsafe fn complex_mul_avx2fma(c_rr: __m256d, c_ii: __m256d, z: __m256d) -> __m256d {
+pub(crate) unsafe fn complex_mul_avx2fma(c_rr: __m256d, c_ii: __m256d, z: __m256d) -> __m256d {
     let z_swap = _mm256_permute_pd(z, 0b0101);
     let t = _mm256_mul_pd(c_ii, z_swap);
     _mm256_fmaddsub_pd(c_rr, z, t)
@@ -900,7 +904,7 @@ pub(crate) fn has_bmi2() -> bool {
     *CACHED.get_or_init(|| is_x86_feature_detected!("bmi2"))
 }
 
-#[cfg(all(target_arch = "x86_64", any(feature = "parallel", test)))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn negate_slice_avx2(slice: &mut [Complex64]) {
     let sign = _mm256_set1_pd(-0.0_f64);

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -7,6 +7,7 @@
 use num_complex::Complex64;
 use rand::Rng;
 use smallvec::SmallVec;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use super::insert_zero_bit;
 use super::StatevectorBackend;
@@ -14,7 +15,8 @@ use super::StatevectorBackend;
 use super::{SendPtr, MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS};
 use crate::backend::simd;
 use crate::backend::{is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
-use crate::gates::DiagEntry;
+use crate::circuit::{qft_textbook_steps, QftTextbookStep};
+use crate::gates::{DiagEntry, Gate};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -94,6 +96,169 @@ const BATCH_RZZ_BMI2_TABLE_SIZE: usize = 1024;
 pub(crate) const DIAG_BATCH_MAX_QUBITS_PER_GROUP: usize = 10;
 pub(crate) const DIAG_BATCH_TABLE_SIZE: usize = 1024; // 2^10
 pub(crate) const MAX_DIAG_BATCH_GROUPS: usize = 4;
+
+type QftTwiddleTable = Arc<[Complex64]>;
+
+struct CachedQftTwiddles {
+    table: QftTwiddleTable,
+    last_used: u64,
+}
+
+struct QftTwiddleCache {
+    entries: Vec<Option<CachedQftTwiddles>>,
+    bytes: usize,
+    tick: u64,
+}
+
+impl QftTwiddleCache {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            bytes: 0,
+            tick: 0,
+        }
+    }
+
+    #[inline]
+    fn next_tick(&mut self) -> u64 {
+        self.tick = self.tick.wrapping_add(1);
+        self.tick
+    }
+}
+
+const QFT_TWIDDLE_CACHE_DEFAULT_LIMIT_BYTES: usize = 256 * 1024 * 1024;
+
+// Soft LRU cap for QFT twiddles. One oversized table may occupy the cache
+// alone, which keeps large repeated QFT runs from rebuilding twiddles every
+// sample. Set the environment value to 0 to disable caching.
+#[inline]
+fn qft_twiddle_cache_limit_bytes() -> usize {
+    static LIMIT: OnceLock<usize> = OnceLock::new();
+    *LIMIT.get_or_init(|| {
+        std::env::var("PRISM_QFT_TWIDDLE_CACHE_LIMIT_MB")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .map(|mb| mb.saturating_mul(1024 * 1024))
+            .unwrap_or(QFT_TWIDDLE_CACHE_DEFAULT_LIMIT_BYTES)
+    })
+}
+
+#[inline(always)]
+fn qft_twiddle_table_bytes(table_len: usize) -> usize {
+    table_len.saturating_mul(std::mem::size_of::<Complex64>())
+}
+
+fn qft_twiddles_scaled(n: usize) -> QftTwiddleTable {
+    static CACHE: OnceLock<Mutex<QftTwiddleCache>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(QftTwiddleCache::new()));
+
+    {
+        let mut guard = cache.lock().unwrap();
+        let tick = guard.next_tick();
+        if let Some(Some(entry)) = guard.entries.get_mut(n) {
+            entry.last_used = tick;
+            return Arc::clone(&entry.table);
+        }
+    }
+
+    let inv_sqrt2 = std::f64::consts::FRAC_1_SQRT_2;
+    let qft_size = 1usize << n;
+    let mut twiddles = Vec::with_capacity(qft_size / 2);
+    for k in 0..qft_size / 2 {
+        let angle = std::f64::consts::TAU * k as f64 / qft_size as f64;
+        twiddles.push(Complex64::from_polar(inv_sqrt2, angle));
+    }
+    let twiddles: Arc<[Complex64]> = twiddles.into();
+    let table_bytes = qft_twiddle_table_bytes(twiddles.len());
+    let cache_limit = qft_twiddle_cache_limit_bytes();
+    if cache_limit == 0 {
+        return twiddles;
+    }
+
+    let mut guard = cache.lock().unwrap();
+    let tick = guard.next_tick();
+    if guard.entries.len() <= n {
+        guard.entries.resize_with(n + 1, || None);
+    }
+    if let Some(existing) = &mut guard.entries[n] {
+        existing.last_used = tick;
+        return Arc::clone(&existing.table);
+    }
+
+    while guard.bytes.saturating_add(table_bytes) > cache_limit {
+        let Some((idx, _)) = guard
+            .entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| entry.as_ref().map(|entry| (idx, entry.last_used)))
+            .min_by_key(|&(_, last_used)| last_used)
+        else {
+            break;
+        };
+        if let Some(evicted) = guard.entries[idx].take() {
+            guard.bytes = guard
+                .bytes
+                .saturating_sub(qft_twiddle_table_bytes(evicted.table.len()));
+        }
+    }
+
+    guard.entries[n] = Some(CachedQftTwiddles {
+        table: Arc::clone(&twiddles),
+        last_used: tick,
+    });
+    guard.bytes = guard.bytes.saturating_add(table_bytes);
+    twiddles
+}
+
+#[inline(always)]
+fn reverse_low_bits(x: usize, bits: usize) -> usize {
+    if bits == 0 {
+        return 0;
+    }
+    x.reverse_bits() >> (usize::BITS as usize - bits)
+}
+
+#[inline]
+fn apply_bit_reverse_permutation(state: &mut [Complex64], bits: usize) {
+    let len = state.len();
+    debug_assert_eq!(len, 1usize << bits);
+    if len <= 2 {
+        return;
+    }
+
+    #[cfg(feature = "parallel")]
+    if bits >= PARALLEL_THRESHOLD_QUBITS {
+        let ptr = SendPtr(state.as_mut_ptr());
+        (0..len)
+            .into_par_iter()
+            .with_min_len(MIN_PAR_ITERS)
+            .for_each(move |i| {
+                let j = reverse_low_bits(i, bits);
+                if j > i {
+                    // SAFETY: bit reversal is an involution. The `j > i`
+                    // guard assigns each pair to exactly one iteration, and
+                    // fixed points are skipped. The safe alternative is the
+                    // serial `state.swap` fallback below; above the parallel
+                    // threshold this O(N) final pass is part of the measured
+                    // whole-state QFT hot path.
+                    unsafe {
+                        let a = ptr.load(i);
+                        let b = ptr.load(j);
+                        ptr.store(i, b);
+                        ptr.store(j, a);
+                    }
+                }
+            });
+        return;
+    }
+
+    for i in 0..len {
+        let j = reverse_low_bits(i, bits);
+        if j > i {
+            state.swap(i, j);
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 pub(crate) struct BatchRzzGroup {
@@ -504,6 +669,799 @@ unsafe fn batch_phase_tile_bmi2(
             *tile.get_unchecked_mut(j) *= combined;
         }
     }
+}
+
+/// Run a single FFT stage in parallel.
+///
+/// Run one FFT stage in parallel.
+///
+/// Large group counts split by group. High-stride stages split inside each
+/// group so all cores still get work.
+#[cfg(feature = "parallel")]
+#[inline]
+fn fft_stage_par(
+    state: &mut [Complex64],
+    stride: usize,
+    block_size: usize,
+    twiddle_step: usize,
+    twiddles_scaled: &[Complex64],
+    inv_sqrt2: f64,
+) {
+    let total = state.len();
+    let num_groups = total / block_size;
+
+    let apply_pairs = |lo: &mut [Complex64], hi: &mut [Complex64], k_base: usize| {
+        debug_assert_eq!(lo.len(), hi.len());
+        for j in 0..lo.len() {
+            let k = k_base + j;
+            let w = twiddles_scaled[k * twiddle_step];
+            let (out_lo, out_hi) = radix2_butterfly_values(lo[j], hi[j], w, inv_sqrt2);
+            lo[j] = out_lo;
+            hi[j] = out_hi;
+        }
+    };
+
+    if num_groups >= 4 && block_size >= MIN_PAR_ELEMS {
+        // Many large groups: split state by group.
+        state.par_chunks_mut(block_size).for_each(|group| {
+            let (lo, hi) = group.split_at_mut(stride);
+            apply_pairs(lo, hi, 0);
+        });
+    } else if block_size < MIN_PAR_ELEMS {
+        // Small groups: bundle work so each Rayon job has enough elements.
+        let task_size = MIN_PAR_ELEMS;
+        state.par_chunks_mut(task_size).for_each(|task_chunk| {
+            let mut g = 0;
+            while g + block_size <= task_chunk.len() {
+                let group = &mut task_chunk[g..g + block_size];
+                let (lo, hi) = group.split_at_mut(stride);
+                apply_pairs(lo, hi, 0);
+                g += block_size;
+            }
+        });
+    } else {
+        // Few groups: split each large group into zipped chunks.
+        const MIN_PAR_PAIRS: usize = MIN_PAR_ELEMS / 2;
+        for group_start in (0..total).step_by(block_size) {
+            let group = &mut state[group_start..group_start + block_size];
+            let (lo, hi) = group.split_at_mut(stride);
+            let sub = MIN_PAR_PAIRS.min(stride).max(1);
+            lo.par_chunks_mut(sub)
+                .zip(hi.par_chunks_mut(sub))
+                .enumerate()
+                .for_each(|(chunk_idx, (lo_c, hi_c))| {
+                    let k_base = chunk_idx * sub;
+                    apply_pairs(lo_c, hi_c, k_base);
+                });
+        }
+    }
+}
+
+/// Scalar radix-2 DIF butterfly. `w` includes the `1/sqrt(2)` factor.
+#[inline(always)]
+fn radix2_butterfly_values(
+    a: Complex64,
+    b: Complex64,
+    w: Complex64,
+    inv_sqrt2: f64,
+) -> (Complex64, Complex64) {
+    let lo = Complex64::new((a.re + b.re) * inv_sqrt2, (a.im + b.im) * inv_sqrt2);
+    let hi = (a - b) * w;
+    (lo, hi)
+}
+
+/// Apply one full radix-2 DIF stage in place to `state` at the given stride.
+/// `twiddle_step = total_state_len / (2 * stride)` selects the right
+/// subsample of the twiddle table.
+#[inline]
+fn run_radix2_stage_seq(
+    state: &mut [Complex64],
+    stride: usize,
+    twiddles_scaled: &[Complex64],
+    twiddle_step: usize,
+    inv_sqrt2: f64,
+) {
+    let block_size = stride << 1;
+    let total = state.len();
+    let mut group_start = 0;
+    while group_start < total {
+        for k in 0..stride {
+            let i0 = group_start + k;
+            let i1 = i0 + stride;
+            let w = twiddles_scaled[k * twiddle_step];
+            let (lo, hi) = radix2_butterfly_values(state[i0], state[i1], w, inv_sqrt2);
+            state[i0] = lo;
+            state[i1] = hi;
+        }
+        group_start += block_size;
+    }
+}
+
+/// Scalar radix-4 butterfly math. Twiddles include the `1/sqrt(2)` factor.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn radix4_butterfly_values(
+    a: Complex64,
+    b: Complex64,
+    c: Complex64,
+    d: Complex64,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+    inv_sqrt2: f64,
+) -> (Complex64, Complex64, Complex64, Complex64) {
+    let t_ac_sum = Complex64::new((a.re + c.re) * inv_sqrt2, (a.im + c.im) * inv_sqrt2);
+    let t_ac_diff = (a - c) * w_2s_k;
+    let t_bd_sum = Complex64::new((b.re + d.re) * inv_sqrt2, (b.im + d.im) * inv_sqrt2);
+    let t_bd_diff = (b - d) * w_2s_kps;
+
+    let oa = Complex64::new(
+        (t_ac_sum.re + t_bd_sum.re) * inv_sqrt2,
+        (t_ac_sum.im + t_bd_sum.im) * inv_sqrt2,
+    );
+    let ob = (t_ac_sum - t_bd_sum) * w_s_k;
+    let oc = Complex64::new(
+        (t_ac_diff.re + t_bd_diff.re) * inv_sqrt2,
+        (t_ac_diff.im + t_bd_diff.im) * inv_sqrt2,
+    );
+    let od = (t_ac_diff - t_bd_diff) * w_s_k;
+    (oa, ob, oc, od)
+}
+
+/// Apply one fused radix-4 butterfly at state index `i`.
+#[inline(always)]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+fn radix4_butterfly_scalar(
+    state: &mut [Complex64],
+    i: usize,
+    inner_stride: usize,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+    inv_sqrt2: f64,
+) {
+    let s = inner_stride;
+    let (oa, ob, oc, od) = radix4_butterfly_values(
+        state[i],
+        state[i + s],
+        state[i + 2 * s],
+        state[i + 3 * s],
+        w_2s_k,
+        w_2s_kps,
+        w_s_k,
+        inv_sqrt2,
+    );
+    state[i] = oa;
+    state[i + s] = ob;
+    state[i + 2 * s] = oc;
+    state[i + 3 * s] = od;
+}
+
+/// Apply one radix-4 butterfly across four disjoint quarter slices.
+#[inline(always)]
+#[cfg_attr(
+    any(target_arch = "aarch64", not(feature = "parallel")),
+    allow(dead_code)
+)]
+#[allow(clippy::too_many_arguments)]
+fn radix4_butterfly_quartet_scalar(
+    qa: &mut [Complex64],
+    qb: &mut [Complex64],
+    qc: &mut [Complex64],
+    qd: &mut [Complex64],
+    j: usize,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+    inv_sqrt2: f64,
+) {
+    let (oa, ob, oc, od) = radix4_butterfly_values(
+        qa[j], qb[j], qc[j], qd[j], w_2s_k, w_2s_kps, w_s_k, inv_sqrt2,
+    );
+    qa[j] = oa;
+    qb[j] = ob;
+    qc[j] = oc;
+    qd[j] = od;
+}
+
+/// FMA variant for one radix-4 butterfly.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "fma")]
+unsafe fn radix4_butterfly_fma(
+    base_ptr: *mut f64,
+    inner_stride: usize,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+) {
+    use std::arch::x86_64::{
+        _mm_add_pd, _mm_loadu_pd, _mm_mul_pd, _mm_set1_pd, _mm_storeu_pd, _mm_sub_pd,
+    };
+    let s = inner_stride;
+    let inv_sqrt2_v = _mm_set1_pd(std::f64::consts::FRAC_1_SQRT_2);
+
+    let a_ptr = base_ptr;
+    let b_ptr = base_ptr.add(s * 2);
+    let c_ptr = base_ptr.add(2 * s * 2);
+    let d_ptr = base_ptr.add(3 * s * 2);
+
+    let a = _mm_loadu_pd(a_ptr);
+    let b = _mm_loadu_pd(b_ptr);
+    let c = _mm_loadu_pd(c_ptr);
+    let d = _mm_loadu_pd(d_ptr);
+
+    let w_2s_k_rr = _mm_set1_pd(w_2s_k.re);
+    let w_2s_k_ii = _mm_set1_pd(w_2s_k.im);
+    let w_2s_kps_rr = _mm_set1_pd(w_2s_kps.re);
+    let w_2s_kps_ii = _mm_set1_pd(w_2s_kps.im);
+    let w_s_k_rr = _mm_set1_pd(w_s_k.re);
+    let w_s_k_ii = _mm_set1_pd(w_s_k.im);
+
+    let t_ac_sum = _mm_mul_pd(_mm_add_pd(a, c), inv_sqrt2_v);
+    let t_ac_diff = simd::complex_mul_fma(w_2s_k_rr, w_2s_k_ii, _mm_sub_pd(a, c));
+    let t_bd_sum = _mm_mul_pd(_mm_add_pd(b, d), inv_sqrt2_v);
+    let t_bd_diff = simd::complex_mul_fma(w_2s_kps_rr, w_2s_kps_ii, _mm_sub_pd(b, d));
+
+    _mm_storeu_pd(
+        a_ptr,
+        _mm_mul_pd(_mm_add_pd(t_ac_sum, t_bd_sum), inv_sqrt2_v),
+    );
+    _mm_storeu_pd(
+        b_ptr,
+        simd::complex_mul_fma(w_s_k_rr, w_s_k_ii, _mm_sub_pd(t_ac_sum, t_bd_sum)),
+    );
+    _mm_storeu_pd(
+        c_ptr,
+        _mm_mul_pd(_mm_add_pd(t_ac_diff, t_bd_diff), inv_sqrt2_v),
+    );
+    _mm_storeu_pd(
+        d_ptr,
+        simd::complex_mul_fma(w_s_k_rr, w_s_k_ii, _mm_sub_pd(t_ac_diff, t_bd_diff)),
+    );
+}
+
+/// AVX2-256 SIMD variant: processes TWO radix-4 butterflies per call (at
+/// consecutive `k` and `k+1`, four complex amplitudes each, eight elements
+/// total). Each load/store is one 256-bit op covering two adjacent complex
+/// values (which are 32 bytes contiguous in memory). Twiddles are still
+/// loaded scalar-by-scalar since the stage's `twiddle_step` is typically
+/// > 1 for high-stride pairs.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn radix4_butterfly_pair_avx2fma(
+    base_ptr: *mut f64,
+    inner_stride: usize,
+    w_2s_k0: Complex64,
+    w_2s_k1: Complex64,
+    w_2s_kps0: Complex64,
+    w_2s_kps1: Complex64,
+    w_s_k0: Complex64,
+    w_s_k1: Complex64,
+) {
+    use std::arch::x86_64::{
+        _mm256_add_pd, _mm256_loadu_pd, _mm256_mul_pd, _mm256_set1_pd, _mm256_set_pd,
+        _mm256_storeu_pd, _mm256_sub_pd,
+    };
+    let s = inner_stride;
+    let inv_sqrt2_v = _mm256_set1_pd(std::f64::consts::FRAC_1_SQRT_2);
+
+    let a_ptr = base_ptr;
+    let b_ptr = base_ptr.add(s * 2);
+    let c_ptr = base_ptr.add(2 * s * 2);
+    let d_ptr = base_ptr.add(3 * s * 2);
+
+    let a = _mm256_loadu_pd(a_ptr);
+    let b = _mm256_loadu_pd(b_ptr);
+    let c = _mm256_loadu_pd(c_ptr);
+    let d = _mm256_loadu_pd(d_ptr);
+
+    // c_rr layout: [w0.re, w0.re, w1.re, w1.re], broadcasts each twiddle's
+    // real part to the two lanes corresponding to that butterfly's complex.
+    let w_2s_k_rr = _mm256_set_pd(w_2s_k1.re, w_2s_k1.re, w_2s_k0.re, w_2s_k0.re);
+    let w_2s_k_ii = _mm256_set_pd(w_2s_k1.im, w_2s_k1.im, w_2s_k0.im, w_2s_k0.im);
+    let w_2s_kps_rr = _mm256_set_pd(w_2s_kps1.re, w_2s_kps1.re, w_2s_kps0.re, w_2s_kps0.re);
+    let w_2s_kps_ii = _mm256_set_pd(w_2s_kps1.im, w_2s_kps1.im, w_2s_kps0.im, w_2s_kps0.im);
+    let w_s_k_rr = _mm256_set_pd(w_s_k1.re, w_s_k1.re, w_s_k0.re, w_s_k0.re);
+    let w_s_k_ii = _mm256_set_pd(w_s_k1.im, w_s_k1.im, w_s_k0.im, w_s_k0.im);
+
+    let t_ac_sum = _mm256_mul_pd(_mm256_add_pd(a, c), inv_sqrt2_v);
+    let t_ac_diff = simd::complex_mul_avx2fma(w_2s_k_rr, w_2s_k_ii, _mm256_sub_pd(a, c));
+    let t_bd_sum = _mm256_mul_pd(_mm256_add_pd(b, d), inv_sqrt2_v);
+    let t_bd_diff = simd::complex_mul_avx2fma(w_2s_kps_rr, w_2s_kps_ii, _mm256_sub_pd(b, d));
+
+    _mm256_storeu_pd(
+        a_ptr,
+        _mm256_mul_pd(_mm256_add_pd(t_ac_sum, t_bd_sum), inv_sqrt2_v),
+    );
+    _mm256_storeu_pd(
+        b_ptr,
+        simd::complex_mul_avx2fma(w_s_k_rr, w_s_k_ii, _mm256_sub_pd(t_ac_sum, t_bd_sum)),
+    );
+    _mm256_storeu_pd(
+        c_ptr,
+        _mm256_mul_pd(_mm256_add_pd(t_ac_diff, t_bd_diff), inv_sqrt2_v),
+    );
+    _mm256_storeu_pd(
+        d_ptr,
+        simd::complex_mul_avx2fma(w_s_k_rr, w_s_k_ii, _mm256_sub_pd(t_ac_diff, t_bd_diff)),
+    );
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+#[cfg_attr(not(feature = "parallel"), allow(dead_code))]
+#[allow(clippy::too_many_arguments)]
+unsafe fn radix4_butterfly_pair_slices_avx2fma(
+    a_ptr: *mut f64,
+    b_ptr: *mut f64,
+    c_ptr: *mut f64,
+    d_ptr: *mut f64,
+    w_2s_k0: Complex64,
+    w_2s_k1: Complex64,
+    w_2s_kps0: Complex64,
+    w_2s_kps1: Complex64,
+    w_s_k0: Complex64,
+    w_s_k1: Complex64,
+) {
+    use std::arch::x86_64::{
+        _mm256_add_pd, _mm256_loadu_pd, _mm256_mul_pd, _mm256_set1_pd, _mm256_set_pd,
+        _mm256_storeu_pd, _mm256_sub_pd,
+    };
+    let inv_sqrt2_v = _mm256_set1_pd(std::f64::consts::FRAC_1_SQRT_2);
+
+    let a = _mm256_loadu_pd(a_ptr);
+    let b = _mm256_loadu_pd(b_ptr);
+    let c = _mm256_loadu_pd(c_ptr);
+    let d = _mm256_loadu_pd(d_ptr);
+
+    let w_2s_k_rr = _mm256_set_pd(w_2s_k1.re, w_2s_k1.re, w_2s_k0.re, w_2s_k0.re);
+    let w_2s_k_ii = _mm256_set_pd(w_2s_k1.im, w_2s_k1.im, w_2s_k0.im, w_2s_k0.im);
+    let w_2s_kps_rr = _mm256_set_pd(w_2s_kps1.re, w_2s_kps1.re, w_2s_kps0.re, w_2s_kps0.re);
+    let w_2s_kps_ii = _mm256_set_pd(w_2s_kps1.im, w_2s_kps1.im, w_2s_kps0.im, w_2s_kps0.im);
+    let w_s_k_rr = _mm256_set_pd(w_s_k1.re, w_s_k1.re, w_s_k0.re, w_s_k0.re);
+    let w_s_k_ii = _mm256_set_pd(w_s_k1.im, w_s_k1.im, w_s_k0.im, w_s_k0.im);
+
+    let t_ac_sum = _mm256_mul_pd(_mm256_add_pd(a, c), inv_sqrt2_v);
+    let t_ac_diff = simd::complex_mul_avx2fma(w_2s_k_rr, w_2s_k_ii, _mm256_sub_pd(a, c));
+    let t_bd_sum = _mm256_mul_pd(_mm256_add_pd(b, d), inv_sqrt2_v);
+    let t_bd_diff = simd::complex_mul_avx2fma(w_2s_kps_rr, w_2s_kps_ii, _mm256_sub_pd(b, d));
+
+    _mm256_storeu_pd(
+        a_ptr,
+        _mm256_mul_pd(_mm256_add_pd(t_ac_sum, t_bd_sum), inv_sqrt2_v),
+    );
+    _mm256_storeu_pd(
+        b_ptr,
+        simd::complex_mul_avx2fma(w_s_k_rr, w_s_k_ii, _mm256_sub_pd(t_ac_sum, t_bd_sum)),
+    );
+    _mm256_storeu_pd(
+        c_ptr,
+        _mm256_mul_pd(_mm256_add_pd(t_ac_diff, t_bd_diff), inv_sqrt2_v),
+    );
+    _mm256_storeu_pd(
+        d_ptr,
+        simd::complex_mul_avx2fma(w_s_k_rr, w_s_k_ii, _mm256_sub_pd(t_ac_diff, t_bd_diff)),
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+unsafe fn neon_twiddle_parts(
+    w: Complex64,
+) -> (
+    std::arch::aarch64::float64x2_t,
+    std::arch::aarch64::float64x2_t,
+) {
+    use std::arch::aarch64::{vcombine_f64, vdup_n_f64, vdupq_n_f64};
+    (
+        vdupq_n_f64(w.re),
+        vcombine_f64(vdup_n_f64(-w.im), vdup_n_f64(w.im)),
+    )
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn radix4_butterfly_neon(
+    base_ptr: *mut f64,
+    inner_stride: usize,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+) {
+    use std::arch::aarch64::{vaddq_f64, vdupq_n_f64, vld1q_f64, vmulq_f64, vst1q_f64, vsubq_f64};
+    let s = inner_stride;
+    let inv_sqrt2_v = vdupq_n_f64(std::f64::consts::FRAC_1_SQRT_2);
+
+    let a_ptr = base_ptr;
+    let b_ptr = base_ptr.add(s * 2);
+    let c_ptr = base_ptr.add(2 * s * 2);
+    let d_ptr = base_ptr.add(3 * s * 2);
+
+    let a = vld1q_f64(a_ptr);
+    let b = vld1q_f64(b_ptr);
+    let c = vld1q_f64(c_ptr);
+    let d = vld1q_f64(d_ptr);
+
+    let (w_2s_k_rr, w_2s_k_ii_as) = neon_twiddle_parts(w_2s_k);
+    let (w_2s_kps_rr, w_2s_kps_ii_as) = neon_twiddle_parts(w_2s_kps);
+    let (w_s_k_rr, w_s_k_ii_as) = neon_twiddle_parts(w_s_k);
+
+    let t_ac_sum = vmulq_f64(vaddq_f64(a, c), inv_sqrt2_v);
+    let t_ac_diff = simd::complex_mul_neon(w_2s_k_rr, w_2s_k_ii_as, vsubq_f64(a, c));
+    let t_bd_sum = vmulq_f64(vaddq_f64(b, d), inv_sqrt2_v);
+    let t_bd_diff = simd::complex_mul_neon(w_2s_kps_rr, w_2s_kps_ii_as, vsubq_f64(b, d));
+
+    vst1q_f64(a_ptr, vmulq_f64(vaddq_f64(t_ac_sum, t_bd_sum), inv_sqrt2_v));
+    vst1q_f64(
+        b_ptr,
+        simd::complex_mul_neon(w_s_k_rr, w_s_k_ii_as, vsubq_f64(t_ac_sum, t_bd_sum)),
+    );
+    vst1q_f64(
+        c_ptr,
+        vmulq_f64(vaddq_f64(t_ac_diff, t_bd_diff), inv_sqrt2_v),
+    );
+    vst1q_f64(
+        d_ptr,
+        simd::complex_mul_neon(w_s_k_rr, w_s_k_ii_as, vsubq_f64(t_ac_diff, t_bd_diff)),
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn radix4_butterfly_slices_neon(
+    a_ptr: *mut f64,
+    b_ptr: *mut f64,
+    c_ptr: *mut f64,
+    d_ptr: *mut f64,
+    w_2s_k: Complex64,
+    w_2s_kps: Complex64,
+    w_s_k: Complex64,
+) {
+    use std::arch::aarch64::{vaddq_f64, vdupq_n_f64, vld1q_f64, vmulq_f64, vst1q_f64, vsubq_f64};
+    let inv_sqrt2_v = vdupq_n_f64(std::f64::consts::FRAC_1_SQRT_2);
+
+    let a = vld1q_f64(a_ptr);
+    let b = vld1q_f64(b_ptr);
+    let c = vld1q_f64(c_ptr);
+    let d = vld1q_f64(d_ptr);
+
+    let (w_2s_k_rr, w_2s_k_ii_as) = neon_twiddle_parts(w_2s_k);
+    let (w_2s_kps_rr, w_2s_kps_ii_as) = neon_twiddle_parts(w_2s_kps);
+    let (w_s_k_rr, w_s_k_ii_as) = neon_twiddle_parts(w_s_k);
+
+    let t_ac_sum = vmulq_f64(vaddq_f64(a, c), inv_sqrt2_v);
+    let t_ac_diff = simd::complex_mul_neon(w_2s_k_rr, w_2s_k_ii_as, vsubq_f64(a, c));
+    let t_bd_sum = vmulq_f64(vaddq_f64(b, d), inv_sqrt2_v);
+    let t_bd_diff = simd::complex_mul_neon(w_2s_kps_rr, w_2s_kps_ii_as, vsubq_f64(b, d));
+
+    vst1q_f64(a_ptr, vmulq_f64(vaddq_f64(t_ac_sum, t_bd_sum), inv_sqrt2_v));
+    vst1q_f64(
+        b_ptr,
+        simd::complex_mul_neon(w_s_k_rr, w_s_k_ii_as, vsubq_f64(t_ac_sum, t_bd_sum)),
+    );
+    vst1q_f64(
+        c_ptr,
+        vmulq_f64(vaddq_f64(t_ac_diff, t_bd_diff), inv_sqrt2_v),
+    );
+    vst1q_f64(
+        d_ptr,
+        simd::complex_mul_neon(w_s_k_rr, w_s_k_ii_as, vsubq_f64(t_ac_diff, t_bd_diff)),
+    );
+}
+
+#[inline]
+fn apply_radix4_groups(
+    group: &mut [Complex64],
+    s: usize,
+    k_base: usize,
+    step_outer: usize,
+    step_inner: usize,
+    twiddles_scaled: &[Complex64],
+    inv_sqrt2: f64,
+) {
+    debug_assert_eq!(group.len() % (s * 4), 0);
+    let groups = group.len() / (s * 4);
+    #[cfg(target_arch = "aarch64")]
+    let _ = inv_sqrt2;
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if simd::has_avx2_fma() && s >= 2 {
+            // SAFETY: has_avx2_fma() is runtime checked. Adjacent pairs stay
+            // inside the same radix-4 group because s >= 2. The safe
+            // alternative is the scalar radix-4 loop below; this SIMD path is
+            // kept because the measured QFT speedup depends on avoiding scalar
+            // Complex64 arithmetic in the fused stage-pair hot loop.
+            unsafe {
+                let base_ptr = group.as_mut_ptr() as *mut f64;
+                for g in 0..groups {
+                    let group_off = g * s * 4;
+                    let mut k_offset = 0usize;
+                    while k_offset + 2 <= s {
+                        let k = k_base + k_offset;
+                        let w_2s_k0 = twiddles_scaled[k * step_outer];
+                        let w_2s_k1 = twiddles_scaled[(k + 1) * step_outer];
+                        let w_2s_kps0 = twiddles_scaled[(k + s) * step_outer];
+                        let w_2s_kps1 = twiddles_scaled[(k + s + 1) * step_outer];
+                        let w_s_k0 = twiddles_scaled[k * step_inner];
+                        let w_s_k1 = twiddles_scaled[(k + 1) * step_inner];
+                        let pair_base = base_ptr.add((group_off + k_offset) * 2);
+                        radix4_butterfly_pair_avx2fma(
+                            pair_base, s, w_2s_k0, w_2s_k1, w_2s_kps0, w_2s_kps1, w_s_k0, w_s_k1,
+                        );
+                        k_offset += 2;
+                    }
+                    if k_offset < s {
+                        let k = k_base + k_offset;
+                        let w_2s_k = twiddles_scaled[k * step_outer];
+                        let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                        let w_s_k = twiddles_scaled[k * step_inner];
+                        let pair_base = base_ptr.add((group_off + k_offset) * 2);
+                        radix4_butterfly_fma(pair_base, s, w_2s_k, w_2s_kps, w_s_k);
+                    }
+                }
+            }
+            return;
+        }
+        if simd::has_fma() {
+            // SAFETY: has_fma() is runtime checked. The safe alternative is
+            // the scalar radix-4 loop below; this SIMD path is kept because the
+            // measured QFT speedup depends on avoiding scalar Complex64
+            // arithmetic in the fused stage-pair hot loop.
+            unsafe {
+                let base_ptr = group.as_mut_ptr() as *mut f64;
+                for g in 0..groups {
+                    let group_off = g * s * 4;
+                    for k_offset in 0..s {
+                        let k = k_base + k_offset;
+                        let w_2s_k = twiddles_scaled[k * step_outer];
+                        let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                        let w_s_k = twiddles_scaled[k * step_inner];
+                        let pair_base = base_ptr.add((group_off + k_offset) * 2);
+                        radix4_butterfly_fma(pair_base, s, w_2s_k, w_2s_kps, w_s_k);
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: aarch64 targets provide NEON. The loop maps each radix-4
+        // butterfly to four in-bounds amplitudes inside `group`; the safe
+        // alternative is the scalar fallback below. This SIMD counterpart is
+        // required so Apple Silicon does not pay scalar Complex64 overhead in
+        // the same measured QFT hot loop as x86.
+        unsafe {
+            let base_ptr = group.as_mut_ptr() as *mut f64;
+            for g in 0..groups {
+                let group_off = g * s * 4;
+                for k_offset in 0..s {
+                    let k = k_base + k_offset;
+                    let w_2s_k = twiddles_scaled[k * step_outer];
+                    let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                    let w_s_k = twiddles_scaled[k * step_inner];
+                    let pair_base = base_ptr.add((group_off + k_offset) * 2);
+                    radix4_butterfly_neon(pair_base, s, w_2s_k, w_2s_kps, w_s_k);
+                }
+            }
+        }
+        return;
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for g in 0..groups {
+            let base = g * s * 4;
+            for k_offset in 0..s {
+                let k = k_base + k_offset;
+                let w_2s_k = twiddles_scaled[k * step_outer];
+                let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                let w_s_k = twiddles_scaled[k * step_inner];
+                radix4_butterfly_scalar(
+                    group,
+                    base + k_offset,
+                    s,
+                    w_2s_k,
+                    w_2s_kps,
+                    w_s_k,
+                    inv_sqrt2,
+                );
+            }
+        }
+    }
+}
+
+#[inline]
+fn fft_stage_pair_in_slice(
+    slice: &mut [Complex64],
+    inner_stride: usize,
+    total: usize,
+    twiddles_scaled: &[Complex64],
+    inv_sqrt2: f64,
+) {
+    let s = inner_stride;
+    let block_size = s << 2;
+    let step_outer = total / block_size;
+    let step_inner = total / (s << 1);
+    apply_radix4_groups(
+        slice,
+        s,
+        0,
+        step_outer,
+        step_inner,
+        twiddles_scaled,
+        inv_sqrt2,
+    );
+}
+
+/// Run two DIF FFT stages as one radix-4 pass.
+///
+/// `inner_stride = 2^(outer_stage - 1)`. Falls back to a sequential loop when
+/// the `parallel` feature is off.
+#[inline]
+fn fft_stage_pair_par(
+    state: &mut [Complex64],
+    inner_stride: usize,
+    twiddles_scaled: &[Complex64],
+    inv_sqrt2: f64,
+) {
+    let s = inner_stride;
+    let block_size = s << 2;
+    let total = state.len();
+    let step_outer = total / block_size;
+    let step_inner = total / (s << 1);
+
+    let apply_group = |group: &mut [Complex64], k_base: usize| {
+        apply_radix4_groups(
+            group,
+            s,
+            k_base,
+            step_outer,
+            step_inner,
+            twiddles_scaled,
+            inv_sqrt2,
+        );
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        let num_groups = total / block_size;
+        if num_groups >= 4 && block_size >= MIN_PAR_ELEMS {
+            // Case A: many independent groups, split state by block.
+            state.par_chunks_mut(block_size).for_each(|chunk| {
+                apply_group(chunk, 0);
+            });
+            return;
+        }
+        if block_size < MIN_PAR_ELEMS {
+            // Case B: small groups, bundle work per Rayon task.
+            let task_size = MIN_PAR_ELEMS;
+            state.par_chunks_mut(task_size).for_each(|task_chunk| {
+                apply_group(task_chunk, 0);
+            });
+            return;
+        }
+        // Case C: 1-3 large groups, split inside each group.
+        const MIN_PAR_PAIRS: usize = MIN_PAR_ELEMS / 4;
+        for group_start in (0..total).step_by(block_size) {
+            let group = &mut state[group_start..group_start + block_size];
+            let (q0, rest) = group.split_at_mut(s);
+            let (q1, rest) = rest.split_at_mut(s);
+            let (q2, q3) = rest.split_at_mut(s);
+            let sub = MIN_PAR_PAIRS.min(s).max(1);
+            q0.par_chunks_mut(sub)
+                .zip(q1.par_chunks_mut(sub))
+                .zip(q2.par_chunks_mut(sub))
+                .zip(q3.par_chunks_mut(sub))
+                .enumerate()
+                .for_each(|(chunk_idx, (((qa, qb), qc), qd))| {
+                    let k_base = chunk_idx * sub;
+                    let n_local = qa.len();
+                    #[cfg(target_arch = "x86_64")]
+                    if simd::has_avx2_fma() && n_local >= 2 {
+                        // SAFETY: the four slices are disjoint quarters of
+                        // one radix-4 group. Each AVX2 call handles adjacent
+                        // complex values inside the same local chunk. The
+                        // safe alternative is the scalar quartet loop below;
+                        // this SIMD path is kept because the measured QFT
+                        // speedup depends on avoiding scalar Complex64
+                        // arithmetic in the fused stage-pair hot loop.
+                        unsafe {
+                            let qa_ptr = qa.as_mut_ptr() as *mut f64;
+                            let qb_ptr = qb.as_mut_ptr() as *mut f64;
+                            let qc_ptr = qc.as_mut_ptr() as *mut f64;
+                            let qd_ptr = qd.as_mut_ptr() as *mut f64;
+                            let mut j = 0usize;
+                            while j + 2 <= n_local {
+                                let k = k_base + j;
+                                let w_2s_k0 = twiddles_scaled[k * step_outer];
+                                let w_2s_k1 = twiddles_scaled[(k + 1) * step_outer];
+                                let w_2s_kps0 = twiddles_scaled[(k + s) * step_outer];
+                                let w_2s_kps1 = twiddles_scaled[(k + s + 1) * step_outer];
+                                let w_s_k0 = twiddles_scaled[k * step_inner];
+                                let w_s_k1 = twiddles_scaled[(k + 1) * step_inner];
+                                radix4_butterfly_pair_slices_avx2fma(
+                                    qa_ptr.add(j * 2),
+                                    qb_ptr.add(j * 2),
+                                    qc_ptr.add(j * 2),
+                                    qd_ptr.add(j * 2),
+                                    w_2s_k0,
+                                    w_2s_k1,
+                                    w_2s_kps0,
+                                    w_2s_kps1,
+                                    w_s_k0,
+                                    w_s_k1,
+                                );
+                                j += 2;
+                            }
+                            if j == n_local {
+                                return;
+                            }
+                            let k = k_base + j;
+                            let w_2s_k = twiddles_scaled[k * step_outer];
+                            let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                            let w_s_k = twiddles_scaled[k * step_inner];
+                            radix4_butterfly_quartet_scalar(
+                                qa, qb, qc, qd, j, w_2s_k, w_2s_kps, w_s_k, inv_sqrt2,
+                            );
+                            return;
+                        }
+                    }
+                    #[cfg(target_arch = "aarch64")]
+                    {
+                        // SAFETY: the zipped Rayon chunks own disjoint
+                        // quarter slices. Each iteration touches the same
+                        // local offset in all four quarters, matching the
+                        // scalar fallback below without aliasing. This SIMD
+                        // counterpart is required so Apple Silicon does not
+                        // pay scalar Complex64 overhead in the same measured
+                        // QFT hot loop as x86.
+                        unsafe {
+                            let qa_ptr = qa.as_mut_ptr() as *mut f64;
+                            let qb_ptr = qb.as_mut_ptr() as *mut f64;
+                            let qc_ptr = qc.as_mut_ptr() as *mut f64;
+                            let qd_ptr = qd.as_mut_ptr() as *mut f64;
+                            for j in 0..n_local {
+                                let k = k_base + j;
+                                let w_2s_k = twiddles_scaled[k * step_outer];
+                                let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                                let w_s_k = twiddles_scaled[k * step_inner];
+                                radix4_butterfly_slices_neon(
+                                    qa_ptr.add(j * 2),
+                                    qb_ptr.add(j * 2),
+                                    qc_ptr.add(j * 2),
+                                    qd_ptr.add(j * 2),
+                                    w_2s_k,
+                                    w_2s_kps,
+                                    w_s_k,
+                                );
+                            }
+                        }
+                        return;
+                    }
+                    #[cfg(not(target_arch = "aarch64"))]
+                    {
+                        for j in 0..n_local {
+                            let k = k_base + j;
+                            let w_2s_k = twiddles_scaled[k * step_outer];
+                            let w_2s_kps = twiddles_scaled[(k + s) * step_outer];
+                            let w_s_k = twiddles_scaled[k * step_inner];
+                            radix4_butterfly_quartet_scalar(
+                                qa, qb, qc, qd, j, w_2s_k, w_2s_kps, w_s_k, inv_sqrt2,
+                            );
+                        }
+                    }
+                });
+        }
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    apply_group(state, 0);
 }
 
 impl StatevectorBackend {
@@ -1319,7 +2277,7 @@ impl StatevectorBackend {
         let ptr = SendPtr(self.state.as_mut_ptr());
         let prepared = simd::PreparedGate2q::new(mat);
 
-        // SAFETY: insert_zero_bit bijection → disjoint index groups per iteration.
+        // SAFETY: insert_zero_bit bijection gives disjoint index groups per iteration.
         (0..n_iter)
             .into_par_iter()
             .with_min_len(MIN_PAR_ITERS)
@@ -1454,6 +2412,149 @@ impl StatevectorBackend {
                     }
                 }
             });
+    }
+
+    /// Apply a whole-state QFT with a tiled DIF FFT.
+    ///
+    /// The DIF output is bit-reversed; the final pass restores textbook order.
+    pub(super) fn apply_qft_block(&mut self, start: usize, num: usize) {
+        assert!(start + num <= self.num_qubits);
+        assert!(num >= 1);
+
+        assert_eq!(
+            start, 0,
+            "QftBlock with non-zero start is not supported by the FFT kernel; \
+             sim::expand_qft_blocks should pre-expand before reaching this point"
+        );
+
+        let n = num;
+        let qft_size = 1usize << n;
+        let inv_sqrt2 = std::f64::consts::FRAC_1_SQRT_2;
+
+        let twiddles_scaled = qft_twiddles_scaled(n);
+        let twiddles_scaled = twiddles_scaled.as_ref();
+
+        let total = self.state.len();
+        assert_eq!(
+            total, qft_size,
+            "QftBlock currently requires whole-state QFT"
+        );
+
+        // Cache-tiled DIF FFT:
+        //   - High-stride stages run as full-state passes.
+        //   - Low-stride stages run together inside each L2-sized tile.
+        const TILE_BITS: usize = 13;
+
+        let tile_bits = TILE_BITS.min(n);
+
+        // Phase 1: high-stride stages.
+        //
+        // Fuse adjacent high-stride stages as radix-4 pairs to cut memory
+        // traffic. If the count is odd, run one radix-2 stage first.
+        let high_stride_count = n - tile_bits;
+        let mut stage_top = n;
+        let mut stages_left = high_stride_count;
+
+        let run_radix2_stage = |state: &mut Vec<Complex64>, stage: usize| {
+            let stride = 1usize << stage;
+            let block_size = stride << 1;
+            let twiddle_step = total / block_size;
+
+            #[cfg(feature = "parallel")]
+            if state.len() >= 1usize << PARALLEL_THRESHOLD_QUBITS {
+                fft_stage_par(
+                    state,
+                    stride,
+                    block_size,
+                    twiddle_step,
+                    twiddles_scaled,
+                    inv_sqrt2,
+                );
+                return;
+            }
+
+            run_radix2_stage_seq(state, stride, twiddles_scaled, twiddle_step, inv_sqrt2);
+        };
+
+        if stages_left % 2 == 1 {
+            stage_top -= 1;
+            run_radix2_stage(&mut self.state, stage_top);
+            stages_left -= 1;
+        }
+
+        while stages_left > 0 {
+            // Fuse pair (stage_top - 1, stage_top - 2): outer stride
+            // = 2^(stage_top - 1), inner stride = 2^(stage_top - 2).
+            let inner_stride = 1usize << (stage_top - 2);
+            fft_stage_pair_par(&mut self.state, inner_stride, twiddles_scaled, inv_sqrt2);
+            stage_top -= 2;
+            stages_left -= 2;
+        }
+
+        // Phase 2: low-stride stages on cache-resident tiles.
+        if tile_bits == 0 {
+            return;
+        }
+        let tile_size = 1usize << tile_bits;
+
+        let apply_low_stages_in_tile = |tile: &mut [Complex64], twiddles_scaled: &[Complex64]| {
+            let mut stage_top = tile_bits;
+            let mut stages_left = tile_bits;
+            if stages_left % 2 == 1 {
+                stage_top -= 1;
+                let stride = 1usize << stage_top;
+                let block_size = stride << 1;
+                let twiddle_step = total / block_size;
+                run_radix2_stage_seq(tile, stride, twiddles_scaled, twiddle_step, inv_sqrt2);
+                stages_left -= 1;
+            }
+            while stages_left > 0 {
+                let inner_stride = 1usize << (stage_top - 2);
+                fft_stage_pair_in_slice(tile, inner_stride, total, twiddles_scaled, inv_sqrt2);
+                stage_top -= 2;
+                stages_left -= 2;
+            }
+        };
+
+        #[cfg(feature = "parallel")]
+        let low_done_parallel =
+            if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS && total / tile_size >= 4 {
+                self.state.par_chunks_mut(tile_size).for_each(|tile| {
+                    apply_low_stages_in_tile(tile, twiddles_scaled);
+                });
+                true
+            } else {
+                false
+            };
+        #[cfg(not(feature = "parallel"))]
+        let low_done_parallel = false;
+
+        if !low_done_parallel {
+            for tile in self.state.chunks_mut(tile_size) {
+                apply_low_stages_in_tile(tile, twiddles_scaled);
+            }
+        }
+
+        apply_bit_reverse_permutation(&mut self.state, n);
+    }
+
+    #[inline]
+    pub(super) fn apply_qft_block_textbook(&mut self, start: usize, num: usize) {
+        assert!(start + num <= self.num_qubits);
+        assert!(num >= 1);
+
+        let h = Gate::H.matrix_2x2();
+        for step in qft_textbook_steps(start, num) {
+            match step {
+                QftTextbookStep::Hadamard(q) => self.apply_single_gate(q, h),
+                QftTextbookStep::CPhase {
+                    control,
+                    target,
+                    theta,
+                } => self.apply_cu_phase(control, target, Complex64::from_polar(1.0, theta)),
+                QftTextbookStep::Swap(a, b) => self.apply_swap(a, b),
+            }
+        }
     }
 
     #[inline(always)]

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -1250,7 +1250,6 @@ fn apply_radix4_groups(
                 }
             }
         }
-        return;
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -1442,7 +1441,6 @@ fn fft_stage_pair_par(
                                 );
                             }
                         }
-                        return;
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -15,16 +15,18 @@
 //! - CX/CZ/SWAP: specialized routines avoid materializing a 4×4 matrix.
 //! - All gate kernels are `#[inline(always)]` to enable LTO to inline across
 //!   the dispatch boundary.
-//! - No heap allocation during gate application.
+//! - No heap allocation in per-amplitude inner loops. QFT twiddle tables may
+//!   allocate once outside the loop and are bounded by cache policy.
 //!
 //! # Threading strategy
 //!
 //! The pair-iteration loops are embarrassingly parallel. When the `parallel`
 //! feature is enabled and the qubit count meets `PARALLEL_THRESHOLD_QUBITS`
 //! (default: 14), each kernel dispatches to a Rayon-parallelized variant
-//! using `par_chunks_mut` / `split_at_mut`. All parallel code is fully safe
-//! (no `unsafe`). The sequential path is unchanged when the feature is off
-//! or the circuit is below threshold.
+//! using `par_chunks_mut` / `split_at_mut`. Most partitioning uses safe
+//! slices; a few hot kernels use raw pointers after proving disjoint access.
+//! The sequential path is unchanged when the feature is off or the circuit is
+//! below threshold.
 //!
 //! # SIMD strategy
 //!
@@ -51,6 +53,8 @@ use std::sync::Arc;
 use crate::backend::simd;
 use crate::backend::Backend;
 use crate::circuit::Instruction;
+#[cfg(feature = "gpu")]
+use crate::circuit::{qft_textbook_steps, QftTextbookStep};
 use crate::error::Result;
 use crate::gates::Gate;
 
@@ -147,6 +151,16 @@ pub struct StatevectorBackend {
     gpu_context: Option<Arc<GpuContext>>,
     #[cfg(feature = "gpu")]
     gpu_state: Option<GpuState>,
+}
+
+/// Kill switch for the native whole-state `QftBlock` FFT path.
+///
+/// Set `PRISM_NO_QFT_BLOCK=1` to force textbook expansion for A/B runs.
+#[inline]
+fn qft_block_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PRISM_NO_QFT_BLOCK").is_none())
 }
 
 impl StatevectorBackend {
@@ -250,6 +264,27 @@ impl StatevectorBackend {
             }
             Gate::BatchRzz(data) => k::launch_apply_batch_rzz(&ctx, gpu, &data.edges),
             Gate::DiagonalBatch(data) => k::launch_apply_diagonal_batch(&ctx, gpu, &data.entries),
+            Gate::QftBlock { start, num } => {
+                let h = Gate::H.matrix_2x2();
+                for step in qft_textbook_steps(*start as usize, *num as usize) {
+                    match step {
+                        QftTextbookStep::Hadamard(q) => k::launch_apply_gate_1q(&ctx, gpu, q, h)?,
+                        QftTextbookStep::CPhase {
+                            control,
+                            target,
+                            theta,
+                        } => k::launch_apply_cu_phase(
+                            &ctx,
+                            gpu,
+                            control,
+                            target,
+                            Complex64::from_polar(1.0, theta),
+                        )?,
+                        QftTextbookStep::Swap(a, b) => k::launch_apply_swap(&ctx, gpu, a, b)?,
+                    }
+                }
+                Ok(())
+            }
             Gate::MultiFused(data) => {
                 if data.all_diagonal {
                     k::launch_apply_multi_fused_diagonal(&ctx, gpu, &data.gates)
@@ -406,6 +441,15 @@ impl StatevectorBackend {
             Gate::BatchPhase(data) => {
                 self.apply_batch_phase(targets[0], &data.phases);
             }
+            Gate::QftBlock { start, num } => {
+                let start = *start as usize;
+                let num = *num as usize;
+                if start == 0 && num == self.num_qubits {
+                    self.apply_qft_block(start, num);
+                } else {
+                    self.apply_qft_block_textbook(start, num);
+                }
+            }
             Gate::BatchRzz(data) => {
                 self.apply_batch_rzz(&data.edges);
             }
@@ -440,6 +484,20 @@ impl StatevectorBackend {
 impl Backend for StatevectorBackend {
     fn name(&self) -> &'static str {
         "statevector"
+    }
+
+    fn supports_qft_block(&self) -> bool {
+        if !qft_block_enabled() {
+            return false;
+        }
+        #[cfg(feature = "gpu")]
+        {
+            self.gpu_context.is_none()
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            true
+        }
     }
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -1170,11 +1170,17 @@ mod tests {
 
     #[test]
     fn qft_4q_diagram() {
+        // `qft_circuit` emits a single `Gate::QftBlock`.
+        // The block renders as a labelled box; users wanting the unrolled
+        // H + cphase diagram can call `expand_qft_blocks` first.
         let circuit = crate::circuits::qft_circuit(4);
         let text = circuit.draw(&TextOptions::default());
         assert!(text.contains("q[0]"));
         assert!(text.contains("q[3]"));
-        assert!(text.contains("H"));
+
+        let unrolled = crate::circuit::expand_qft_blocks(&circuit);
+        let unrolled_text = unrolled.draw(&TextOptions::default());
+        assert!(unrolled_text.contains("H"));
     }
 
     #[test]

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -1366,7 +1366,6 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
     let pass1c = apply_pass(pass1r, cancel_self_inverse_pairs);
     let pass1f = apply_pass(pass1c, fuse_single_qubit_gates);
 
-    // Expensive passes, gated by qubit count
     let pass_2q = if circuit.num_qubits >= MIN_QUBITS_FOR_2Q_FUSION {
         fuse_2q_gates(pass1f)
     } else {

--- a/src/circuit/fusion_phase.rs
+++ b/src/circuit/fusion_phase.rs
@@ -9,6 +9,128 @@ use super::fusion::IDENTITY_EPS;
 
 const MIN_BATCH_PHASES: usize = 2;
 
+type PhaseVec = SmallVec<[(usize, Complex64); 8]>;
+type TargetUserVec = SmallVec<[usize; 8]>;
+type PendingPhaseVec = Vec<Option<PhaseVec>>;
+
+fn is_controlled_phase_2q(inst: &Instruction) -> bool {
+    matches!(
+        inst,
+        Instruction::Gate { gate, .. }
+            if gate.controlled_phase().is_some() && gate.num_qubits() == 2
+    )
+}
+
+fn remove_target_user(target_users: &mut [TargetUserVec], target: usize, control: usize) {
+    target_users[target].retain(|c| *c != control);
+}
+
+fn emit_phase_chain(control: usize, phases: PhaseVec, output: &mut Vec<Instruction>) {
+    if phases.len() >= MIN_BATCH_PHASES {
+        output.push(Instruction::Gate {
+            gate: Gate::BatchPhase(Box::new(BatchPhaseData { phases })),
+            targets: smallvec![control],
+        });
+        return;
+    }
+
+    let one = Complex64::new(1.0, 0.0);
+    let zero = Complex64::new(0.0, 0.0);
+    for (target, phase) in phases {
+        output.push(Instruction::Gate {
+            gate: Gate::cu([[one, zero], [zero, phase]]),
+            targets: smallvec![control, target],
+        });
+    }
+}
+
+fn flush_phase_control(
+    control: usize,
+    pending: &mut [Option<PhaseVec>],
+    target_users: &mut [TargetUserVec],
+    output: &mut Vec<Instruction>,
+) {
+    let Some(phases) = pending[control].take() else {
+        return;
+    };
+    for &(target, _) in &phases {
+        remove_target_user(target_users, target, control);
+    }
+    emit_phase_chain(control, phases, output);
+}
+
+fn push_pending_phase(
+    control: usize,
+    target: usize,
+    phase: Complex64,
+    pending: &mut [Option<PhaseVec>],
+    target_users: &mut [TargetUserVec],
+) {
+    let already_indexed = pending[control]
+        .as_ref()
+        .is_some_and(|phases| phases.iter().any(|&(t, _)| t == target));
+    if !already_indexed {
+        target_users[target].push(control);
+    }
+
+    match &mut pending[control] {
+        Some(v) => v.push((target, phase)),
+        slot => *slot = Some(smallvec![(target, phase)]),
+    }
+}
+
+fn flush_phase_target_conflicts(
+    target: usize,
+    pending: &mut [Option<PhaseVec>],
+    target_users: &mut [TargetUserVec],
+    output: &mut Vec<Instruction>,
+) {
+    let controls = std::mem::take(&mut target_users[target]);
+    if controls.is_empty() {
+        return;
+    }
+
+    let mut re_rooted: PhaseVec = SmallVec::new();
+    for control in controls {
+        let Some(phases) = pending[control].take() else {
+            continue;
+        };
+        let mut kept: PhaseVec = SmallVec::new();
+        for (phase_target, phase) in phases {
+            if phase_target == target {
+                re_rooted.push((control, phase));
+            } else {
+                kept.push((phase_target, phase));
+            }
+        }
+        if !kept.is_empty() {
+            pending[control] = Some(kept);
+        }
+    }
+
+    if !re_rooted.is_empty() {
+        emit_phase_chain(target, re_rooted, output);
+    }
+}
+
+fn flush_phase_qubits_in_use(
+    qs: &[usize],
+    diagonal_only: bool,
+    pending: &mut [Option<PhaseVec>],
+    target_users: &mut [TargetUserVec],
+    output: &mut Vec<Instruction>,
+) {
+    for &q in qs {
+        flush_phase_control(q, pending, target_users, output);
+    }
+    if diagonal_only {
+        return;
+    }
+    for &q in qs {
+        flush_phase_target_conflicts(q, pending, target_users, output);
+    }
+}
+
 pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     if !has_batchable_phases(&circuit) {
         return circuit;
@@ -16,29 +138,8 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
 
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
     let n = circuit.num_qubits;
-    type PhaseVec = SmallVec<[(usize, Complex64); 8]>;
-    let mut pending: Vec<Option<PhaseVec>> = (0..n).map(|_| None).collect();
-
-    let flush_qubit =
-        |q: usize, pending: &mut [Option<PhaseVec>], output: &mut Vec<Instruction>| {
-            if let Some(phases) = pending[q].take() {
-                if phases.len() >= MIN_BATCH_PHASES {
-                    output.push(Instruction::Gate {
-                        gate: Gate::BatchPhase(Box::new(BatchPhaseData { phases })),
-                        targets: smallvec![q],
-                    });
-                } else {
-                    for (target, phase) in phases {
-                        let one = Complex64::new(1.0, 0.0);
-                        let zero = Complex64::new(0.0, 0.0);
-                        output.push(Instruction::Gate {
-                            gate: Gate::cu([[one, zero], [zero, phase]]),
-                            targets: smallvec![q, target],
-                        });
-                    }
-                }
-            }
-        };
+    let mut pending: PendingPhaseVec = (0..n).map(|_| None).collect();
+    let mut target_users: Vec<TargetUserVec> = (0..n).map(|_| SmallVec::new()).collect();
 
     for inst in &circuit.instructions {
         match inst {
@@ -47,40 +148,65 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     if gate.num_qubits() == 2 {
                         let control = targets[0];
                         let target = targets[1];
-                        flush_qubit(target, &mut pending, &mut output);
-                        match &mut pending[control] {
-                            Some(v) => v.push((target, phase)),
-                            slot => *slot = Some(smallvec![(target, phase)]),
-                        }
+                        // Incoming cphase on target, its action depends on
+                        // the current diagonal-frame phase of `target`, so
+                        // any pending control chain on `target` must flush first.
+                        flush_phase_qubits_in_use(
+                            std::slice::from_ref(&target),
+                            true,
+                            &mut pending,
+                            &mut target_users,
+                            &mut output,
+                        );
+                        push_pending_phase(control, target, phase, &mut pending, &mut target_users);
                         continue;
                     }
                 }
-                for &q in targets.iter() {
-                    flush_qubit(q, &mut pending, &mut output);
-                }
+                let diagonal_only = gate.num_qubits() == 1 && gate.is_diagonal_1q();
+                flush_phase_qubits_in_use(
+                    targets,
+                    diagonal_only,
+                    &mut pending,
+                    &mut target_users,
+                    &mut output,
+                );
                 output.push(inst.clone());
             }
             Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                flush_qubit(*qubit, &mut pending, &mut output);
+                flush_phase_qubits_in_use(
+                    std::slice::from_ref(qubit),
+                    false,
+                    &mut pending,
+                    &mut target_users,
+                    &mut output,
+                );
                 output.push(inst.clone());
             }
             Instruction::Barrier { qubits } => {
-                for &q in qubits.iter() {
-                    flush_qubit(q, &mut pending, &mut output);
-                }
+                flush_phase_qubits_in_use(
+                    qubits,
+                    false,
+                    &mut pending,
+                    &mut target_users,
+                    &mut output,
+                );
                 output.push(inst.clone());
             }
             Instruction::Conditional { targets, .. } => {
-                for &q in targets.iter() {
-                    flush_qubit(q, &mut pending, &mut output);
-                }
+                flush_phase_qubits_in_use(
+                    targets,
+                    false,
+                    &mut pending,
+                    &mut target_users,
+                    &mut output,
+                );
                 output.push(inst.clone());
             }
         }
     }
 
     for q in 0..n {
-        flush_qubit(q, &mut pending, &mut output);
+        flush_phase_control(q, &mut pending, &mut target_users, &mut output);
     }
 
     Cow::Owned(Circuit {
@@ -91,36 +217,134 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
 }
 
 fn has_batchable_phases(circuit: &Circuit) -> bool {
-    let mut has_pending = vec![false; circuit.num_qubits];
+    type PendingTargets = SmallVec<[usize; 8]>;
+
+    if !circuit.instructions.iter().any(is_controlled_phase_2q) {
+        return false;
+    }
+
+    fn push_pending_target(
+        control: usize,
+        target: usize,
+        pending: &mut [PendingTargets],
+        target_users: &mut [TargetUserVec],
+    ) {
+        if !pending[control].contains(&target) {
+            target_users[target].push(control);
+        }
+        pending[control].push(target);
+    }
+
+    fn flush_control(
+        q: usize,
+        pending: &mut [PendingTargets],
+        target_users: &mut [TargetUserVec],
+    ) -> bool {
+        let len = pending[q].len();
+        for target in pending[q].drain(..) {
+            remove_target_user(target_users, target, q);
+        }
+        len >= MIN_BATCH_PHASES
+    }
+
+    fn flush_target_conflicts(
+        target: usize,
+        pending: &mut [PendingTargets],
+        target_users: &mut [TargetUserVec],
+    ) -> bool {
+        let controls = std::mem::take(&mut target_users[target]);
+        let mut re_rooted = 0usize;
+        for control in controls {
+            let mut kept: PendingTargets = SmallVec::new();
+            for pending_target in pending[control].drain(..) {
+                if pending_target == target {
+                    re_rooted += 1;
+                } else {
+                    kept.push(pending_target);
+                }
+            }
+            pending[control] = kept;
+        }
+        re_rooted >= MIN_BATCH_PHASES
+    }
+
+    fn flush_qubits_in_use(
+        qs: &[usize],
+        diagonal_only: bool,
+        pending: &mut [PendingTargets],
+        target_users: &mut [TargetUserVec],
+    ) -> bool {
+        for &q in qs {
+            if flush_control(q, pending, target_users) {
+                return true;
+            }
+        }
+        if diagonal_only {
+            return false;
+        }
+        for &q in qs {
+            if flush_target_conflicts(q, pending, target_users) {
+                return true;
+            }
+        }
+        false
+    }
+
+    let mut pending: Vec<PendingTargets> =
+        (0..circuit.num_qubits).map(|_| SmallVec::new()).collect();
+    let mut target_users: Vec<TargetUserVec> =
+        (0..circuit.num_qubits).map(|_| SmallVec::new()).collect();
     for inst in &circuit.instructions {
         match inst {
             Instruction::Gate { gate, targets } => {
                 if gate.controlled_phase().is_some() && gate.num_qubits() == 2 {
                     let control = targets[0];
-                    if has_pending[control] {
+                    let target = targets[1];
+                    if flush_qubits_in_use(
+                        std::slice::from_ref(&target),
+                        true,
+                        &mut pending,
+                        &mut target_users,
+                    ) {
                         return true;
                     }
-                    has_pending[control] = true;
-                    has_pending[targets[1]] = false;
+                    if pending[control].len() + 1 >= MIN_BATCH_PHASES {
+                        return true;
+                    }
+                    push_pending_target(control, target, &mut pending, &mut target_users);
                 } else {
-                    for &q in targets.iter() {
-                        has_pending[q] = false;
+                    let diagonal_only = gate.num_qubits() == 1 && gate.is_diagonal_1q();
+                    if flush_qubits_in_use(targets, diagonal_only, &mut pending, &mut target_users)
+                    {
+                        return true;
                     }
                 }
             }
             Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                has_pending[*qubit] = false;
+                if flush_qubits_in_use(
+                    std::slice::from_ref(qubit),
+                    false,
+                    &mut pending,
+                    &mut target_users,
+                ) {
+                    return true;
+                }
             }
             Instruction::Barrier { qubits } => {
-                for &q in qubits {
-                    has_pending[q] = false;
+                if flush_qubits_in_use(qubits, false, &mut pending, &mut target_users) {
+                    return true;
                 }
             }
             Instruction::Conditional { targets, .. } => {
-                for &q in targets.iter() {
-                    has_pending[q] = false;
+                if flush_qubits_in_use(targets, false, &mut pending, &mut target_users) {
+                    return true;
                 }
             }
+        }
+    }
+    for q in 0..circuit.num_qubits {
+        if flush_control(q, &mut pending, &mut target_users) {
+            return true;
         }
     }
     false

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -746,6 +746,94 @@ impl Circuit {
     }
 }
 
+/// One step in the textbook QFT decomposition. Yielded by
+/// [`qft_textbook_steps`] so backends and the sim layer share a single
+/// definition of the H + controlled-phase + Swap pattern.
+#[derive(Debug, Clone, Copy)]
+pub enum QftTextbookStep {
+    Hadamard(usize),
+    CPhase {
+        control: usize,
+        target: usize,
+        theta: f64,
+    },
+    Swap(usize, usize),
+}
+
+/// Yield the textbook QFT decomposition for `num` qubits starting at `start`.
+/// Order: for each `i in 0..num`, `H q[start+i]` followed by
+/// `cphase(TAU / 2^(j-i))` for `j in i+1..num`, then bit-reversal swaps.
+pub fn qft_textbook_steps(start: usize, num: usize) -> impl Iterator<Item = QftTextbookStep> {
+    let outer = (0..num).flat_map(move |i| {
+        let head = std::iter::once(QftTextbookStep::Hadamard(start + i));
+        let phases = ((i + 1)..num).map(move |j| QftTextbookStep::CPhase {
+            control: start + i,
+            target: start + j,
+            theta: std::f64::consts::TAU / (1u64 << (j - i)) as f64,
+        });
+        head.chain(phases)
+    });
+    let swaps = (0..num / 2).map(move |i| QftTextbookStep::Swap(start + i, start + num - 1 - i));
+    outer.chain(swaps)
+}
+
+/// Expand `Gate::QftBlock` instructions to textbook QFT gates.
+///
+/// Backends without native support call this before dispatch. Returns
+/// `Cow::Borrowed` when there is nothing to expand.
+pub fn expand_qft_blocks(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
+    let has_qft = circuit.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::QftBlock { .. },
+                ..
+            }
+        )
+    });
+    if !has_qft {
+        return std::borrow::Cow::Borrowed(circuit);
+    }
+
+    let mut out: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len() * 2);
+    for inst in &circuit.instructions {
+        if let Instruction::Gate {
+            gate: Gate::QftBlock { start, num },
+            ..
+        } = inst
+        {
+            for step in qft_textbook_steps(*start as usize, *num as usize) {
+                match step {
+                    QftTextbookStep::Hadamard(q) => out.push(Instruction::Gate {
+                        gate: Gate::H,
+                        targets: smallvec![q],
+                    }),
+                    QftTextbookStep::CPhase {
+                        control,
+                        target,
+                        theta,
+                    } => out.push(Instruction::Gate {
+                        gate: Gate::cphase(theta),
+                        targets: smallvec![control, target],
+                    }),
+                    QftTextbookStep::Swap(a, b) => out.push(Instruction::Gate {
+                        gate: Gate::Swap,
+                        targets: smallvec![a, b],
+                    }),
+                }
+            }
+        } else {
+            out.push(inst.clone());
+        }
+    }
+
+    std::borrow::Cow::Owned(Circuit {
+        num_qubits: circuit.num_qubits,
+        num_classical_bits: circuit.num_classical_bits,
+        instructions: out,
+    })
+}
+
 /// Condition for classically-controlled gate execution.
 #[derive(Debug, Clone)]
 pub enum ClassicalCondition {

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -11,19 +11,21 @@ use rand_chacha::ChaCha8Rng;
 use crate::circuit::Circuit;
 use crate::gates::Gate;
 
-/// Build an n-qubit textbook QFT circuit (Hadamard + controlled-phase + SWAP).
+/// Build an n-qubit QFT circuit.
+///
+/// Emits one `Gate::QftBlock` over `0..n`. CPU statevector runs the native
+/// FFT path; other backends expand the block before execution.
 pub fn qft_circuit(n: usize) -> Circuit {
     let mut c = Circuit::new(n, 0);
-    for i in 0..n {
-        c.add_gate(Gate::H, &[i]);
-        for j in (i + 1)..n {
-            let theta = std::f64::consts::TAU / (1u64 << (j - i)) as f64;
-            c.add_gate(Gate::cphase(theta), &[i, j]);
-        }
-    }
-    for i in 0..n / 2 {
-        c.add_gate(Gate::Swap, &[i, n - 1 - i]);
-    }
+    debug_assert!(n <= u8::MAX as usize, "QFT block size must fit in u8");
+    let targets: Vec<usize> = (0..n).collect();
+    c.add_gate(
+        Gate::QftBlock {
+            start: 0,
+            num: n as u8,
+        },
+        &targets,
+    );
     c
 }
 

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -122,6 +122,14 @@ pub enum Gate {
     /// statevector. Created by the multi-2q fusion pass. Each entry stores
     /// `(q0, q1, 4×4 matrix)`. Boxed to keep `Gate` at 16 bytes.
     Multi2q(Box<Multi2qData>),
+
+    /// Quantum Fourier Transform on `start..start+num`.
+    ///
+    /// The CPU statevector backend has a fast whole-state FFT path. Subrange
+    /// blocks and non-native backends expand to textbook H, cphase, and swap
+    /// gates before execution.
+    /// Boxless: `(u8, u8)` fits within the 16-byte enum slot.
+    QftBlock { start: u8, num: u8 },
 }
 
 /// Data for a multi-controlled unitary gate.
@@ -328,6 +336,7 @@ impl Gate {
             Gate::Rzz(_) | Gate::Cx | Gate::Cz | Gate::Swap | Gate::Cu(_) | Gate::Fused2q(_) => 2,
             Gate::Mcu(data) => data.num_controls as usize + 1,
             Gate::BatchPhase(data) => 1 + data.phases.len(),
+            Gate::QftBlock { num, .. } => *num as usize,
             Gate::BatchRzz(data) => {
                 let mut count = 0;
                 let mut seen = [false; 64];
@@ -454,6 +463,7 @@ impl Gate {
             | Gate::Cu(_)
             | Gate::Mcu(_)
             | Gate::BatchPhase(_)
+            | Gate::QftBlock { .. }
             | Gate::BatchRzz(_)
             | Gate::DiagonalBatch(_)
             | Gate::MultiFused(_)
@@ -529,6 +539,7 @@ impl Gate {
             Gate::Mcu(_) => "mcu",
             Gate::Fused(_) => "fused",
             Gate::BatchPhase(_) => "batch_phase",
+            Gate::QftBlock { .. } => "qft_block",
             Gate::BatchRzz(_) => "batch_rzz",
             Gate::DiagonalBatch(_) => "diagonal_batch",
             Gate::MultiFused(_) => "multi_fused",
@@ -559,6 +570,13 @@ impl Gate {
             Gate::BatchPhase(data) => Gate::BatchPhase(Box::new(BatchPhaseData {
                 phases: data.phases.iter().map(|&(q, p)| (q, p.conj())).collect(),
             })),
+            Gate::QftBlock { .. } => {
+                panic!(
+                    "Gate::QftBlock has no in-place inverse. Run \
+                     circuit::expand_qft_blocks before applying `inv @` or any \
+                     transform that calls Gate::inverse()."
+                )
+            }
             Gate::BatchRzz(data) => Gate::BatchRzz(Box::new(BatchRzzData {
                 edges: data
                     .edges
@@ -904,6 +922,7 @@ impl fmt::Display for Gate {
             Gate::Fused2q(_) => f.write_str("U2"),
             Gate::MultiFused(data) => write!(f, "MF[{}]", data.gates.len()),
             Gate::BatchPhase(data) => write!(f, "BP[{}]", data.phases.len()),
+            Gate::QftBlock { start, num } => write!(f, "QFT[{}..{}]", start, start + num),
             Gate::BatchRzz(data) => write!(f, "BZZ[{}]", data.edges.len()),
             Gate::DiagonalBatch(data) => write!(f, "BD[{}]", data.entries.len()),
             Gate::Multi2q(data) => write!(f, "M2[{}]", data.gates.len()),

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -74,7 +74,12 @@ fn execute(
     circuit: &Circuit,
     opts: &SimOptions,
 ) -> Result<SimulationResult> {
-    let fused = crate::circuit::fusion::fuse_circuit(circuit, backend.supports_fused_gates());
+    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
+        std::borrow::Cow::Borrowed(circuit)
+    } else {
+        crate::circuit::expand_qft_blocks(circuit)
+    };
+    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     execute_circuit(backend, &fused, opts)
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -60,7 +60,12 @@ pub fn run_unfused_probs<B: Backend>(backend: &mut B, circuit: &Circuit) -> Vec<
     backend
         .init(circuit.num_qubits, circuit.num_classical_bits)
         .unwrap();
-    for instr in &circuit.instructions {
+    let expanded = if backend.supports_qft_block() {
+        std::borrow::Cow::Borrowed(circuit)
+    } else {
+        prism_q::circuit::expand_qft_blocks(circuit)
+    };
+    for instr in &expanded.instructions {
         backend.apply(instr).unwrap();
     }
     backend.probabilities().unwrap()

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -16,12 +16,18 @@ use prism_q::sim;
 const EPS: f64 = 1e-10;
 
 /// Run a circuit without any fusion (manual init + apply loop).
+///
+/// The statevector backend supports `Gate::QftBlock` natively, so this
+/// helper still tests "without fusion" rather than "without QftBlock".
+/// Expand here so the unfused reference path uses raw textbook gates and
+/// remains comparable with fused execution.
 fn run_unfused(circuit: &Circuit) -> Vec<f64> {
     let mut backend = StatevectorBackend::new(42);
     backend
         .init(circuit.num_qubits, circuit.num_classical_bits)
         .unwrap();
-    for instr in &circuit.instructions {
+    let expanded = prism_q::circuit::expand_qft_blocks(circuit);
+    for instr in &expanded.instructions {
         backend.apply(instr).unwrap();
     }
     backend.probabilities().unwrap()
@@ -39,7 +45,8 @@ fn run_unfused_state(circuit: &Circuit) -> Vec<Complex64> {
     backend
         .init(circuit.num_qubits, circuit.num_classical_bits)
         .unwrap();
-    for instr in &circuit.instructions {
+    let expanded = prism_q::circuit::expand_qft_blocks(circuit);
+    for instr in &expanded.instructions {
         backend.apply(instr).unwrap();
     }
     backend.export_statevector().unwrap()
@@ -85,6 +92,17 @@ fn assert_fusion_preserves_state(circuit: &Circuit) {
     assert_state_close(&fused, &unfused, EPS);
 }
 
+#[test]
+fn subrange_qft_block_matches_textbook_expansion() {
+    let mut c = Circuit::new(5, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::X, &[4]);
+    c.add_gate(Gate::QftBlock { start: 1, num: 3 }, &[1, 2, 3]);
+    c.add_gate(Gate::Ry(0.37), &[2]);
+
+    assert_fusion_preserves_state(&c);
+}
+
 fn has_2q_fusion(circuit: &Circuit) -> bool {
     let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
     fused.instructions.iter().any(|inst| {
@@ -128,6 +146,45 @@ fn fusion_qft_14q() {
 #[test]
 fn fusion_qft_16q() {
     assert_fusion_preserves_correctness(&circuits::qft_circuit(16));
+}
+
+// ===== QFT amplitude-level checks (locks the FP-3 fix) =====
+//
+// Probability-only goldens are sign-invariant. Until 2026-05-11, fusion's
+// `fuse_controlled_phases` pass reordered `cphase(c, t)` past non-diagonal
+// 1q gates on `t` (notably `H[t]` immediately after, in the textbook QFT
+// pattern). The result was probability-correct but amplitude-wrong on
+// QFT-style circuits at >= 16q. These tests compare the full state vector
+// element-wise so any future regression on the same shape will fail.
+
+#[test]
+fn fusion_qft_state_amplitude_8q() {
+    assert_fusion_preserves_state(&circuits::qft_circuit(8));
+}
+
+#[test]
+fn fusion_qft_state_amplitude_12q() {
+    assert_fusion_preserves_state(&circuits::qft_circuit(12));
+}
+
+#[test]
+fn fusion_qft_state_amplitude_16q() {
+    assert_fusion_preserves_state(&circuits::qft_circuit(16));
+}
+
+#[test]
+fn fusion_qft_state_amplitude_20q() {
+    assert_fusion_preserves_state(&circuits::qft_circuit(20));
+}
+
+#[test]
+fn fusion_phase_estimation_state_amplitude_12q() {
+    assert_fusion_preserves_state(&circuits::phase_estimation_circuit(12));
+}
+
+#[test]
+fn fusion_phase_estimation_state_amplitude_16q() {
+    assert_fusion_preserves_state(&circuits::phase_estimation_circuit(16));
 }
 
 // ===== Hardware-Efficient Ansatz =====
@@ -646,9 +703,27 @@ fn fusion_same_pair_keeps_diagonal_batch_paths() {
         .count();
     assert_eq!(batch_rzz, 3, "qaoa should keep BatchRzz fusion");
 
+    // QFT emits one QftBlock. Expanded QFT still exercises BatchPhase.
     let qft = circuits::qft_circuit(20);
     let qft_fused = prism_q::circuit::fusion::fuse_circuit(&qft, true);
-    let batch_phase = qft_fused
+    let qft_block = qft_fused
+        .instructions
+        .iter()
+        .filter(|inst| {
+            matches!(
+                inst,
+                prism_q::circuit::Instruction::Gate {
+                    gate: Gate::QftBlock { .. },
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(qft_block, 1, "qft should emit a single QftBlock");
+
+    let expanded = prism_q::circuit::expand_qft_blocks(&qft);
+    let expanded_fused = prism_q::circuit::fusion::fuse_circuit(&expanded, true);
+    let batch_phase_after_expand = expanded_fused
         .instructions
         .iter()
         .filter(|inst| {
@@ -661,7 +736,10 @@ fn fusion_same_pair_keeps_diagonal_batch_paths() {
             )
         })
         .count();
-    assert!(batch_phase > 0, "qft should keep BatchPhase fusion");
+    assert!(
+        batch_phase_after_expand > 0,
+        "expanded qft should still hit BatchPhase fusion"
+    );
 
     let mut diagonal = Circuit::new(20, 0);
     diagonal.add_gate(Gate::Rzz(0.1), &[0, 1]);


### PR DESCRIPTION
## Summary

Adds a native whole-state `QftBlock` path for the CPU statevector backend. The QFT builder now emits one block instruction, statevector executes it with a tiled DIF FFT plus final bit reversal, and non-native backends expand the block back to textbook gates.

Also tightens controlled-phase fusion correctness, adds bounded QFT twiddle caching, and adds an aarch64 NEON counterpart for the QFT radix helpers.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Local Windows run, `cargo bench --features "parallel bench-fast" --bench circuits`, seed `0xDEAD_BEEF`.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- |
| statevector/qft_textbook/16 | 1.920 ms | 1.048 ms | 45.4% faster | Yes |
| statevector/qft_textbook/20 | 44.748 ms | 32.169 ms | 28.1% faster | Yes |
| statevector/qft_textbook/22 | 236.17 ms | 167.24 ms | 29.2% faster | Yes |
| statevector/qft_like/16 | 1.801 ms | 1.870 ms | 3.8% slower | Yes |
| statevector/qpe_t_gate/20q | 89.225 ms | 93.582 ms | 4.9% slower | Yes |
| statevector/hea_l5/20 | 70.441 ms | 72.338 ms | 2.7% slower | Yes |
| statevector/qaoa_l3/20 | 67.701 ms | 48.759 ms | 28.0% faster | Yes |
| statevector/clifford_d10/20 | 98.279 ms | 85.992 ms | 12.5% faster | Yes |
| statevector/qv/16 | 8.513 ms | 8.073 ms | 5.2% faster | Yes |
| statevector/w_state/20 | 21.041 ms | 20.787 ms | 1.2% faster | Yes |


Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has correctness coverage against statevector or textbook expansion
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional local checks run:

- `cargo test --features parallel --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --features parallel --all-targets -- -D warnings`
- `cargo check --target aarch64-apple-darwin --features parallel`
- `git diff --check`

## Hotspot notes

Touched hot paths:

- `StatevectorBackend::apply_qft_block`
- `qft_twiddles_scaled`
- `apply_bit_reverse_permutation`
- `fft_stage_par`
- `fft_stage_pair_par`
- `apply_radix4_groups`
- `fuse_controlled_phases`

No flamegraph attached. Criterion coverage above captures the changed QFT execution path, controlled-phase-heavy circuits, and representative non-QFT circuit classes.

## Architecture or design changes

- [ ] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems

Notes:

- `Gate::QftBlock` is the new compact QFT representation.
- CPU statevector advertises native support.
- Other backends expand through `expand_qft_blocks` before dispatch.
- `PRISM_NO_QFT_BLOCK=1` forces textbook expansion for A/B runs.
- `PRISM_QFT_TWIDDLE_CACHE_LIMIT_MB=0` disables QFT twiddle caching.

## Breaking changes

`qft_circuit(n)` now emits one `Gate::QftBlock` instead of textbook H, cphase, and swap instructions. Simulation results are preserved. Code that needs the unrolled circuit can call `expand_qft_blocks`.

## Risks and rollback

Main risks are QFT numerical correctness, memory pressure from cached twiddles, and platform-specific SIMD behavior.

Rollback options:

- Set `PRISM_NO_QFT_BLOCK=1` to disable the native QFT path.
- Set `PRISM_QFT_TWIDDLE_CACHE_LIMIT_MB=0` to disable twiddle caching.
- Non-native backends already use textbook expansion.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
