### PR TITLE
refactor(sim): consolidate simulator hot path helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Formatting
         run: cargo fmt --all -- --check
@@ -68,6 +70,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-bin: false
           workspaces: |
             base -> target
             head -> target
@@ -141,6 +144,8 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
         run: cargo llvm-cov --features "$CI_FEATURES" --lcov --output-path lcov.info
@@ -174,6 +179,8 @@ jobs:
         with:
           targets: aarch64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Install cross-compilation toolchain
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Check (no features)
@@ -194,6 +201,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
       - name: Clippy
         run: cargo clippy --all-targets --features "$CI_FEATURES" -- -D warnings -D clippy::undocumented_unsafe_blocks
       - name: Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Install tools
         run: cargo install git-cliff cargo-release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 documentation = "https://docs.rs/prism-q"
 repository = "https://github.com/AbeCoull/prism-q"
 homepage = "https://github.com/AbeCoull/prism-q"
-keywords = ["quantum", "simulator", "openqasm", "circuit", "statevector"]
-categories = ["science", "simulation"]
+keywords = ["quantum", "quantum-computing", "simulator", "stabilizer", "qec"]
+categories = ["science", "simulation", "mathematics"]
 
 [dependencies]
 num-complex = "0.4"

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -12,7 +12,7 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
 use crate::backend::stabilizer::kernels::rowmul_words;
-use crate::backend::Backend;
+use crate::backend::{max_qubits_unsupported, Backend};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
@@ -591,14 +591,12 @@ impl SubTableau {
     fn compute_probabilities(&self) -> Result<Vec<f64>> {
         let n = self.n;
         if n > crate::backend::MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: "factored-stabilizer".to_string(),
-                operation: format!(
-                    "probabilities for {} qubits (max {})",
-                    n,
-                    crate::backend::MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                "factored-stabilizer",
+                "probabilities",
+                n,
+                crate::backend::MAX_PROB_QUBITS,
+            ));
         }
 
         let mut work_xz = self.xz.clone();

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -12,7 +12,7 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
 use crate::backend::stabilizer::kernels::rowmul_words;
-use crate::backend::{max_qubits_unsupported, Backend};
+use crate::backend::{dense_probability_len, dense_statevector_len, reserve_dense_output, Backend};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
@@ -590,14 +590,7 @@ impl SubTableau {
 
     fn compute_probabilities(&self) -> Result<Vec<f64>> {
         let n = self.n;
-        if n > crate::backend::MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                "factored-stabilizer",
-                "probabilities",
-                n,
-                crate::backend::MAX_PROB_QUBITS,
-            ));
-        }
+        let dim = dense_probability_len("factored-stabilizer", n)?;
 
         let mut work_xz = self.xz.clone();
         let mut work_phase = self.phase.clone();
@@ -608,8 +601,9 @@ impl SubTableau {
 
         let seed = solve_diagonal_seed(&work_xz, &work_phase, n, nw, stride, &col_map, k);
 
-        let dim = 1usize << n;
-        let mut probs = vec![0.0f64; dim];
+        let mut probs = Vec::new();
+        reserve_dense_output(&mut probs, dim, "factored-stabilizer", "probabilities")?;
+        probs.resize(dim, 0.0f64);
         let num_coset = 1usize << k;
         let amp_sq = 1.0 / num_coset as f64;
 
@@ -640,12 +634,7 @@ impl SubTableau {
 
     fn compute_statevector(&self) -> Result<Vec<Complex64>> {
         let n = self.n;
-        if n > crate::backend::MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: "factored-stabilizer".to_string(),
-                operation: format!("statevector for {} qubits", n),
-            });
-        }
+        let dim = dense_statevector_len("factored-stabilizer", "statevector", n)?;
 
         let mut work_xz = self.xz.clone();
         let mut work_phase = self.phase.clone();
@@ -655,9 +644,10 @@ impl SubTableau {
         let (k, col_map) = gauss_eliminate_x(&mut work_xz, &mut work_phase, n, nw, stride);
         let seed = solve_diagonal_seed(&work_xz, &work_phase, n, nw, stride, &col_map, k);
 
-        let dim = 1usize << n;
         let zero = Complex64::new(0.0, 0.0);
-        let mut sv = vec![zero; dim];
+        let mut sv = Vec::new();
+        reserve_dense_output(&mut sv, dim, "factored-stabilizer", "statevector")?;
+        sv.resize(dim, zero);
         sv[seed] = Complex64::new(1.0, 0.0);
 
         let powers_of_i = [
@@ -667,7 +657,9 @@ impl SubTableau {
             Complex64::new(0.0, -1.0),
         ];
 
-        let mut visited_gen = vec![0u32; dim];
+        let mut visited_gen = Vec::new();
+        reserve_dense_output(&mut visited_gen, dim, "factored-stabilizer", "statevector")?;
+        visited_gen.resize(dim, 0u32);
         let mut current_gen = 0u32;
         for i in 0..n {
             let row = (i + n) * stride;
@@ -1143,6 +1135,7 @@ impl Backend for FactoredStabilizerBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
+        dense_probability_len(self.name(), self.num_qubits)?;
         let active: Vec<&SubTableau> = self.subs.iter().filter_map(|s| s.as_ref()).collect();
 
         if active.len() == 1 && active[0].n == self.num_qubits {
@@ -1152,13 +1145,11 @@ impl Backend for FactoredStabilizerBackend {
         let blocks: Vec<(Vec<f64>, Vec<usize>)> = active
             .iter()
             .map(|sub| {
-                let probs = sub
-                    .compute_probabilities()
-                    .unwrap_or_else(|_| vec![0.0; 1 << sub.n]);
+                let probs = sub.compute_probabilities()?;
                 let qubits: Vec<usize> = sub.qubits.to_vec();
-                (probs, qubits)
+                Ok((probs, qubits))
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
     }

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -1,0 +1,240 @@
+use std::mem::size_of;
+
+use num_complex::Complex64;
+
+use crate::error::{PrismError, Result};
+
+const MEMORY_BUDGET_DIVISOR: u64 = 2;
+
+pub(crate) fn max_statevector_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_SV_QUBITS",
+            size_of::<Complex64>(),
+            "statevector qubit cap",
+        )
+    })
+}
+
+pub(crate) fn max_dense_probability_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_PROB_QUBITS",
+            size_of::<f64>(),
+            "dense probability cap",
+        )
+    })
+}
+
+pub(crate) fn max_dense_statevector_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_EXPORT_QUBITS",
+            size_of::<Complex64>(),
+            "dense statevector export cap",
+        )
+    })
+}
+
+pub(crate) fn max_tensor_probability_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_PROB_QUBITS",
+            size_of::<Complex64>() + size_of::<f64>(),
+            "tensor-network dense probability cap",
+        )
+    })
+}
+
+fn configured_or_detected_dense_qubits(
+    env_var: &str,
+    bytes_per_basis_state: usize,
+    warning_label: &str,
+) -> usize {
+    if let Ok(val) = std::env::var(env_var) {
+        if let Ok(n) = val.parse::<usize>() {
+            return n;
+        }
+    }
+    match detect_physical_memory_bytes().and_then(|bytes| {
+        max_dense_qubits_for_budget(bytes / MEMORY_BUDGET_DIVISOR, bytes_per_basis_state)
+    }) {
+        Some(n) => n,
+        None => {
+            eprintln!(
+                "warning: could not detect system memory; {warning_label} is disabled. \
+                 Large outputs may abort on allocation. Set {env_var} to suppress."
+            );
+            usize::MAX
+        }
+    }
+}
+
+fn max_dense_qubits_for_budget(budget_bytes: u64, bytes_per_basis_state: usize) -> Option<usize> {
+    let bytes_per_basis_state = u64::try_from(bytes_per_basis_state).ok()?;
+    if bytes_per_basis_state == 0 {
+        return None;
+    }
+    let max_elements = budget_bytes / bytes_per_basis_state;
+    if max_elements == 0 {
+        return None;
+    }
+    let max_qubits = (u64::BITS - 1 - max_elements.leading_zeros()) as usize;
+    Some(max_qubits.min(usize::BITS as usize - 1))
+}
+
+pub(crate) fn dense_probability_len(backend: &str, num_qubits: usize) -> Result<usize> {
+    dense_output_len(
+        backend,
+        "probabilities",
+        num_qubits,
+        size_of::<f64>(),
+        max_dense_probability_qubits(),
+    )
+}
+
+pub(crate) fn dense_statevector_len(
+    backend: &str,
+    operation: &str,
+    num_qubits: usize,
+) -> Result<usize> {
+    dense_output_len(
+        backend,
+        operation,
+        num_qubits,
+        size_of::<Complex64>(),
+        max_dense_statevector_qubits(),
+    )
+}
+
+pub(crate) fn tensor_probability_len(backend: &str, num_qubits: usize) -> Result<usize> {
+    dense_output_len(
+        backend,
+        "probabilities",
+        num_qubits,
+        size_of::<Complex64>() + size_of::<f64>(),
+        max_tensor_probability_qubits(),
+    )
+}
+
+fn dense_output_len(
+    backend: &str,
+    operation: &str,
+    num_qubits: usize,
+    bytes_per_basis_state: usize,
+    max_qubits: usize,
+) -> Result<usize> {
+    if num_qubits >= usize::BITS as usize {
+        return Err(PrismError::BackendUnsupported {
+            backend: backend.to_string(),
+            operation: format!("{operation} for {num_qubits} qubits (exceeds addressable memory)"),
+        });
+    }
+    if num_qubits > max_qubits {
+        return Err(PrismError::BackendUnsupported {
+            backend: backend.to_string(),
+            operation: format!(
+                "{operation} for {num_qubits} qubits (max {max_qubits} on this machine, {} bytes required)",
+                required_dense_bytes(num_qubits, bytes_per_basis_state)
+            ),
+        });
+    }
+    Ok(1usize << num_qubits)
+}
+
+pub(crate) fn reserve_dense_output<T>(
+    out: &mut Vec<T>,
+    len: usize,
+    backend: &str,
+    operation: &str,
+) -> Result<()> {
+    out.try_reserve_exact(len)
+        .map_err(|_| PrismError::BackendUnsupported {
+            backend: backend.to_string(),
+            operation: format!(
+                "{operation} for {} elements ({} bytes required)",
+                len,
+                len.saturating_mul(size_of::<T>())
+            ),
+        })
+}
+
+fn required_dense_bytes(num_qubits: usize, bytes_per_basis_state: usize) -> usize {
+    (1usize << num_qubits).saturating_mul(bytes_per_basis_state)
+}
+
+#[cfg(windows)]
+fn detect_physical_memory_bytes() -> Option<u64> {
+    #[repr(C)]
+    struct MemoryStatusEx {
+        dw_length: u32,
+        dw_memory_load: u32,
+        ull_total_phys: u64,
+        ull_avail_phys: u64,
+        ull_total_page_file: u64,
+        ull_avail_page_file: u64,
+        ull_total_virtual: u64,
+        ull_avail_virtual: u64,
+        ull_avail_extended_virtual: u64,
+    }
+
+    extern "system" {
+        fn GlobalMemoryStatusEx(lp_buffer: *mut MemoryStatusEx) -> i32;
+    }
+
+    // SAFETY: MemoryStatusEx is a repr(C) data struct and the all-zero pattern is valid.
+    let mut status: MemoryStatusEx = unsafe { std::mem::zeroed() };
+    status.dw_length = size_of::<MemoryStatusEx>() as u32;
+    // SAFETY: status points to a valid MemoryStatusEx with dw_length set.
+    if unsafe { GlobalMemoryStatusEx(&mut status) } == 0 {
+        return None;
+    }
+
+    Some(status.ull_total_phys)
+}
+
+#[cfg(unix)]
+fn detect_physical_memory_bytes() -> Option<u64> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: u64 = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
+            return kb.checked_mul(1024);
+        }
+    }
+    None
+}
+
+#[cfg(not(any(windows, unix)))]
+fn detect_physical_memory_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_budget_counts_fit_elements() {
+        assert_eq!(max_dense_qubits_for_budget(8, 8), Some(0));
+        assert_eq!(max_dense_qubits_for_budget(16, 8), Some(1));
+        assert_eq!(max_dense_qubits_for_budget(31, 8), Some(1));
+        assert_eq!(max_dense_qubits_for_budget(32, 8), Some(2));
+    }
+
+    #[test]
+    fn dense_output_rejects_unaddressable_shift() {
+        let err = dense_output_len("test", "probabilities", usize::BITS as usize, 8, usize::MAX)
+            .unwrap_err();
+        match err {
+            PrismError::BackendUnsupported { operation, .. } => {
+                assert!(operation.contains("exceeds addressable memory"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod factored;
 pub mod factored_stabilizer;
+pub(crate) mod memory;
 pub mod mps;
 pub mod product;
 pub(crate) mod simd;
@@ -35,7 +36,7 @@ pub(crate) mod word_ops;
 use num_complex::Complex64;
 
 use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 
 #[cfg(feature = "parallel")]
 pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
@@ -65,20 +66,10 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 /// errors accumulate multiplicatively.
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
-pub(crate) const MAX_PROB_QUBITS: usize = 25;
-
-#[inline]
-pub(crate) fn max_qubits_unsupported(
-    backend: &str,
-    operation: &str,
-    num_qubits: usize,
-    max_qubits: usize,
-) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: backend.to_string(),
-        operation: format!("{operation} for {num_qubits} qubits (max {max_qubits})"),
-    }
-}
+pub(crate) use memory::{
+    dense_probability_len, dense_statevector_len, max_statevector_qubits, reserve_dense_output,
+    tensor_probability_len,
+};
 
 #[inline(always)]
 pub(crate) fn is_phase_one(phase: Complex64) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -30,11 +30,12 @@ pub mod sparse;
 pub mod stabilizer;
 pub mod statevector;
 pub mod tensornetwork;
+pub(crate) mod word_ops;
 
 use num_complex::Complex64;
 
 use crate::circuit::Instruction;
-use crate::error::Result;
+use crate::error::{PrismError, Result};
 
 #[cfg(feature = "parallel")]
 pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
@@ -65,6 +66,19 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) const MAX_PROB_QUBITS: usize = 25;
+
+#[inline]
+pub(crate) fn max_qubits_unsupported(
+    backend: &str,
+    operation: &str,
+    num_qubits: usize,
+    max_qubits: usize,
+) -> PrismError {
+    PrismError::BackendUnsupported {
+        backend: backend.to_string(),
+        operation: format!("{operation} for {num_qubits} qubits (max {max_qubits})"),
+    }
+}
 
 #[inline(always)]
 pub(crate) fn is_phase_one(phase: Complex64) -> bool {

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -34,9 +34,9 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use crate::backend::{simd, Backend, NORM_CLAMP_MIN};
+use crate::backend::{max_qubits_unsupported, simd, Backend, NORM_CLAMP_MIN};
 use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 use crate::gates::Gate;
 
 #[cfg(feature = "parallel")]
@@ -189,6 +189,52 @@ pub fn svd(a: &[Complex64], m: usize, n: usize) -> SvdResult {
         return svd_faer(a, m, n);
     }
     svd_jacobi(a, m, n)
+}
+
+fn truncated_svd_rank(singular_values: &[f64], epsilon: f64, max_bond_dim: usize) -> usize {
+    let s_max = singular_values.first().copied().unwrap_or(0.0);
+    let threshold = epsilon * s_max;
+    singular_values
+        .iter()
+        .take_while(|&&s| s > threshold)
+        .count()
+        .max(1)
+        .min(max_bond_dim)
+}
+
+fn svd_left_site_data(svd_result: &SvdResult, bond_left: usize, chi: usize) -> Vec<Complex64> {
+    let mut left_data = vec![ZERO; bond_left * 2 * chi];
+    for alpha in 0..bond_left {
+        for i in 0..2 {
+            for gamma in 0..chi {
+                let r = alpha * 2 + i;
+                left_data[alpha * (2 * chi) + i * chi + gamma] =
+                    svd_result.u[gamma * svd_result.u_rows + r];
+            }
+        }
+    }
+    left_data
+}
+
+fn fill_scaled_vt_data(
+    out: &mut Vec<Complex64>,
+    svd_result: &SvdResult,
+    chi: usize,
+    physical_dim: usize,
+    bond_right: usize,
+) {
+    out.clear();
+    out.resize(chi * physical_dim * bond_right, ZERO);
+    for gamma in 0..chi {
+        let s_val = Complex64::new(svd_result.s[gamma], 0.0);
+        for s in 0..physical_dim {
+            for beta in 0..bond_right {
+                let c = s * bond_right + beta;
+                out[gamma * (physical_dim * bond_right) + s * bond_right + beta] =
+                    s_val * svd_result.vt[gamma * svd_result.vt_cols + c];
+            }
+        }
+    }
 }
 
 /// Compute thin SVD using Jacobi one-sided rotations (column-major storage).
@@ -622,43 +668,16 @@ impl MpsBackend {
         }
 
         let svd_result = svd(&mat, rows, cols);
-
-        let s_max = svd_result.s.first().copied().unwrap_or(0.0);
-        let thresh = self.svd_epsilon * s_max;
-        let mut chi_new = svd_result
-            .s
-            .iter()
-            .take_while(|&&s| s > thresh)
-            .count()
-            .max(1);
-        chi_new = chi_new.min(self.max_bond_dim);
+        let chi_new = truncated_svd_rank(&svd_result.s, self.svd_epsilon, self.max_bond_dim);
 
         // A[k] from U: shape (bl, 2, chi_new)
         // U is column-major: U[col * rows + row]
-        let mut left_data = vec![ZERO; bl * 2 * chi_new];
-        for alpha in 0..bl {
-            for i in 0..2 {
-                for gamma in 0..chi_new {
-                    let r = alpha * 2 + i;
-                    left_data[alpha * (2 * chi_new) + i * chi_new + gamma] =
-                        svd_result.u[gamma * svd_result.u_rows + r];
-                }
-            }
-        }
+        let left_data = svd_left_site_data(&svd_result, bl, chi_new);
 
         // A[k+1] from S·V†: shape (chi_new, 2, br)
         // V† is row-major: Vt[row * cols + col]
-        let mut right_data = vec![ZERO; chi_new * 2 * br];
-        for gamma in 0..chi_new {
-            let s_val = Complex64::new(svd_result.s[gamma], 0.0);
-            for j in 0..2 {
-                for beta in 0..br {
-                    let c = j * br + beta;
-                    right_data[gamma * (2 * br) + j * br + beta] =
-                        s_val * svd_result.vt[gamma * svd_result.vt_cols + c];
-                }
-            }
-        }
+        let mut right_data = Vec::new();
+        fill_scaled_vt_data(&mut right_data, &svd_result, chi_new, 2, br);
 
         self.sites[left_site] = SiteTensor {
             bond_left: bl,
@@ -982,28 +1001,10 @@ impl MpsBackend {
             }
 
             let svd_result = svd(&mat, rows, cols);
-
-            let s_max = svd_result.s.first().copied().unwrap_or(0.0);
-            let thresh = self.svd_epsilon * s_max;
-            let mut chi_new = svd_result
-                .s
-                .iter()
-                .take_while(|&&s| s > thresh)
-                .count()
-                .max(1);
-            chi_new = chi_new.min(self.max_bond_dim);
+            let chi_new = truncated_svd_rank(&svd_result.s, self.svd_epsilon, self.max_bond_dim);
 
             // Extract left site from U: shape (cur_bl, 2, chi_new)
-            let mut left_data = vec![ZERO; cur_bl * 2 * chi_new];
-            for alpha in 0..cur_bl {
-                for i in 0..2 {
-                    for gamma in 0..chi_new {
-                        let r = alpha * 2 + i;
-                        left_data[alpha * (2 * chi_new) + i * chi_new + gamma] =
-                            svd_result.u[gamma * svd_result.u_rows + r];
-                    }
-                }
-            }
+            let left_data = svd_left_site_data(&svd_result, cur_bl, chi_new);
 
             self.sites[start + k] = SiteTensor {
                 bond_left: cur_bl,
@@ -1013,34 +1014,13 @@ impl MpsBackend {
 
             if k < n - 2 {
                 // Build remainder from S·V†: shape (chi_new, remaining_dim, br)
-                let nr_len = chi_new * remaining_dim * br;
-                new_remaining.clear();
-                new_remaining.resize(nr_len, ZERO);
-                for gamma in 0..chi_new {
-                    let s_val = Complex64::new(svd_result.s[gamma], 0.0);
-                    for s_rest in 0..remaining_dim {
-                        for beta in 0..br {
-                            let c = s_rest * br + beta;
-                            new_remaining[gamma * (remaining_dim * br) + s_rest * br + beta] =
-                                s_val * svd_result.vt[gamma * svd_result.vt_cols + c];
-                        }
-                    }
-                }
+                fill_scaled_vt_data(&mut new_remaining, &svd_result, chi_new, remaining_dim, br);
                 std::mem::swap(&mut remaining, &mut new_remaining);
                 cur_bl = chi_new;
             } else {
                 // Last site: S·V† reshaped to (chi_new, 2, br)
-                let mut right_data = vec![ZERO; chi_new * 2 * br];
-                for gamma in 0..chi_new {
-                    let s_val = Complex64::new(svd_result.s[gamma], 0.0);
-                    for j in 0..2 {
-                        for beta in 0..br {
-                            let c = j * br + beta;
-                            right_data[gamma * (2 * br) + j * br + beta] =
-                                s_val * svd_result.vt[gamma * svd_result.vt_cols + c];
-                        }
-                    }
-                }
+                let mut right_data = Vec::new();
+                fill_scaled_vt_data(&mut right_data, &svd_result, chi_new, 2, br);
                 self.sites[start + n - 1] = SiteTensor {
                     bond_left: chi_new,
                     bond_right: br,
@@ -1595,6 +1575,11 @@ impl Backend for MpsBackend {
         Ok(())
     }
 
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        self.apply_single_qubit_gate(self.site_for_logical(qubit), matrix);
+        Ok(())
+    }
+
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         Ok(self.reduced_density_site(self.site_for_logical(qubit)))
     }
@@ -1605,13 +1590,12 @@ impl Backend for MpsBackend {
 
     fn probabilities(&self) -> Result<Vec<f64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "probabilities for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "probabilities",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
 
         let dim = 1usize << self.num_qubits;
@@ -1635,13 +1619,12 @@ impl Backend for MpsBackend {
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "statevector export for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "statevector export",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
 
         let dim = 1usize << self.num_qubits;

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -34,7 +34,10 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use crate::backend::{max_qubits_unsupported, simd, Backend, NORM_CLAMP_MIN};
+use crate::backend::{
+    dense_probability_len, dense_statevector_len, reserve_dense_output, simd, Backend,
+    NORM_CLAMP_MIN,
+};
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::Gate;
@@ -47,7 +50,6 @@ const ONE: Complex64 = Complex64::new(1.0, 0.0);
 const DEFAULT_SVD_EPSILON: f64 = 1e-12;
 const MAX_SVD_SWEEPS: usize = 100;
 const SVD_CONVERGENCE: f64 = 1e-14;
-const MAX_PROB_QUBITS: usize = 20;
 #[cfg(feature = "parallel")]
 const MIN_DIM_FOR_PAR: usize = 1 << 14;
 #[cfg(feature = "parallel")]
@@ -1589,28 +1591,23 @@ impl Backend for MpsBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "probabilities",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
-
-        let dim = 1usize << self.num_qubits;
+        let dim = dense_probability_len(self.name(), self.num_qubits)?;
+        let mut probs = Vec::new();
+        reserve_dense_output(&mut probs, dim, self.name(), "probabilities")?;
+        probs.resize(dim, 0.0);
 
         #[cfg(feature = "parallel")]
         if dim >= MIN_DIM_FOR_PAR {
-            return Ok((0..dim)
-                .into_par_iter()
-                .map(|basis| self.chain_amplitude(basis).norm_sqr())
-                .collect());
+            probs.par_iter_mut().enumerate().for_each(|(basis, prob)| {
+                *prob = self.chain_amplitude(basis).norm_sqr();
+            });
+            return Ok(probs);
         }
 
-        Ok((0..dim)
-            .map(|basis| self.chain_amplitude(basis).norm_sqr())
-            .collect())
+        for (basis, prob) in probs.iter_mut().enumerate() {
+            *prob = self.chain_amplitude(basis).norm_sqr();
+        }
+        Ok(probs)
     }
 
     fn num_qubits(&self) -> usize {
@@ -1618,26 +1615,23 @@ impl Backend for MpsBackend {
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "statevector export",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
-
-        let dim = 1usize << self.num_qubits;
+        let dim = dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
+        let mut state = Vec::new();
+        reserve_dense_output(&mut state, dim, self.name(), "statevector export")?;
+        state.resize(dim, ZERO);
 
         #[cfg(feature = "parallel")]
         if dim >= MIN_DIM_FOR_PAR {
-            return Ok((0..dim)
-                .into_par_iter()
-                .map(|basis| self.chain_amplitude(basis))
-                .collect());
+            state.par_iter_mut().enumerate().for_each(|(basis, amp)| {
+                *amp = self.chain_amplitude(basis);
+            });
+            return Ok(state);
         }
 
-        Ok((0..dim).map(|basis| self.chain_amplitude(basis)).collect())
+        for (basis, amp) in state.iter_mut().enumerate() {
+            *amp = self.chain_amplitude(basis);
+        }
+        Ok(state)
     }
 }
 
@@ -1919,7 +1913,7 @@ mod tests {
     #[test]
     fn test_probabilities_cap() {
         let mut b = MpsBackend::new(42, 64);
-        b.init(21, 0).unwrap();
+        b.init(usize::BITS as usize, 0).unwrap();
         assert!(b.probabilities().is_err());
     }
 

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -25,7 +25,7 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use crate::backend::{Backend, MAX_PROB_QUBITS, NORM_CLAMP_MIN};
+use crate::backend::{max_qubits_unsupported, Backend, MAX_PROB_QUBITS, NORM_CLAMP_MIN};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
 use crate::gates::{DiagEntry, Gate};
@@ -49,6 +49,12 @@ impl ProductStateBackend {
         }
     }
 
+    #[inline(always)]
+    fn apply_single_qubit_matrix(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
+        let [a, b] = self.qubits[target];
+        self.qubits[target] = [mat[0][0] * a + mat[0][1] * b, mat[1][0] * a + mat[1][1] * b];
+    }
+
     fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         match gate {
             Gate::Rzz(_)
@@ -69,9 +75,7 @@ impl ProductStateBackend {
             }),
             Gate::MultiFused(data) => {
                 for &(target, mat) in &data.gates {
-                    let [a, b] = self.qubits[target];
-                    self.qubits[target] =
-                        [mat[0][0] * a + mat[0][1] * b, mat[1][0] * a + mat[1][1] * b];
+                    self.apply_single_qubit_matrix(target, mat);
                 }
                 Ok(())
             }
@@ -96,10 +100,7 @@ impl ProductStateBackend {
             }
             _ => {
                 let target = targets[0];
-                let mat = gate.matrix_2x2();
-                let [a, b] = self.qubits[target];
-                self.qubits[target] =
-                    [mat[0][0] * a + mat[0][1] * b, mat[1][0] * a + mat[1][1] * b];
+                self.apply_single_qubit_matrix(target, gate.matrix_2x2());
                 Ok(())
             }
         }
@@ -167,6 +168,11 @@ impl Backend for ProductStateBackend {
         Ok(())
     }
 
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        self.apply_single_qubit_matrix(qubit, *matrix);
+        Ok(())
+    }
+
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         let [alpha, beta] = self.qubits[qubit];
         let r = beta * alpha.conj();
@@ -182,13 +188,12 @@ impl Backend for ProductStateBackend {
 
     fn probabilities(&self) -> Result<Vec<f64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "probabilities for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "probabilities",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
 
         #[cfg(feature = "parallel")]
@@ -236,13 +241,12 @@ impl Backend for ProductStateBackend {
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "statevector export for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "statevector export",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
 
         #[cfg(feature = "parallel")]

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -25,7 +25,9 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use crate::backend::{max_qubits_unsupported, Backend, MAX_PROB_QUBITS, NORM_CLAMP_MIN};
+use crate::backend::{
+    dense_probability_len, dense_statevector_len, reserve_dense_output, Backend, NORM_CLAMP_MIN,
+};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
 use crate::gates::{DiagEntry, Gate};
@@ -187,44 +189,37 @@ impl Backend for ProductStateBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "probabilities",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
+        let dim = dense_probability_len(self.name(), self.num_qubits)?;
 
         #[cfg(feature = "parallel")]
         if self.num_qubits >= 14 {
             use rayon::prelude::*;
             let n = self.num_qubits;
-            let dim = 1usize << n;
             let qubit_probs: Vec<[f64; 2]> = self
                 .qubits
                 .iter()
                 .map(|q| [q[0].norm_sqr(), q[1].norm_sqr()])
                 .collect();
-            let probs: Vec<f64> = (0..dim)
-                .into_par_iter()
-                .map(|idx| {
-                    let mut p = 1.0f64;
-                    for q in 0..n {
-                        p *= qubit_probs[q][(idx >> q) & 1];
-                    }
-                    p
-                })
-                .collect();
+            let mut probs = Vec::new();
+            reserve_dense_output(&mut probs, dim, self.name(), "probabilities")?;
+            probs.resize(dim, 0.0);
+            probs.par_iter_mut().enumerate().for_each(|(idx, prob)| {
+                let mut p = 1.0f64;
+                for q in 0..n {
+                    p *= qubit_probs[q][(idx >> q) & 1];
+                }
+                *prob = p;
+            });
             return Ok(probs);
         }
 
-        let mut probs = vec![1.0f64];
+        let mut probs = Vec::new();
+        reserve_dense_output(&mut probs, dim, self.name(), "probabilities")?;
+        probs.push(1.0f64);
         for q in 0..self.num_qubits {
             let p0 = self.qubits[q][0].norm_sqr();
             let p1 = self.qubits[q][1].norm_sqr();
             let len = probs.len();
-            probs.reserve(len);
             for i in 0..len {
                 probs.push(probs[i] * p1);
             }
@@ -240,41 +235,34 @@ impl Backend for ProductStateBackend {
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "statevector export",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
+        let dim = dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
 
         #[cfg(feature = "parallel")]
         if self.num_qubits >= 14 {
             use rayon::prelude::*;
             let n = self.num_qubits;
-            let dim = 1usize << n;
             let qubits = &self.qubits;
-            let sv: Vec<Complex64> = (0..dim)
-                .into_par_iter()
-                .map(|idx| {
-                    let mut amp = Complex64::new(1.0, 0.0);
-                    for q in 0..n {
-                        amp *= qubits[q][(idx >> q) & 1];
-                    }
-                    amp
-                })
-                .collect();
+            let mut sv = Vec::new();
+            reserve_dense_output(&mut sv, dim, self.name(), "statevector export")?;
+            sv.resize(dim, Complex64::new(0.0, 0.0));
+            sv.par_iter_mut().enumerate().for_each(|(idx, amp_out)| {
+                let mut amp = Complex64::new(1.0, 0.0);
+                for q in 0..n {
+                    amp *= qubits[q][(idx >> q) & 1];
+                }
+                *amp_out = amp;
+            });
             return Ok(sv);
         }
 
         // Qubit 0 is LSB: index bit 0 selects qubit 0's state.
-        let mut sv = vec![Complex64::new(1.0, 0.0)];
+        let mut sv = Vec::new();
+        reserve_dense_output(&mut sv, dim, self.name(), "statevector export")?;
+        sv.push(Complex64::new(1.0, 0.0));
         for q in 0..self.num_qubits {
             let a = self.qubits[q][0]; // α = ⟨0|ψ_q⟩
             let b = self.qubits[q][1]; // β = ⟨1|ψ_q⟩
             let len = sv.len();
-            sv.reserve(len);
             for i in 0..len {
                 sv.push(sv[i] * b);
             }

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -528,10 +528,10 @@ impl PreparedGate1q {
         #[cfg(target_arch = "x86_64")]
         {
             let broadcast = MatBroadcast::from_matrix(mat);
-            let has_avx2_fma = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+            let has_avx2_fma = has_avx2_fma();
             let tier = if has_avx2_fma {
                 SimdTier::Avx2Fma
-            } else if is_x86_feature_detected!("fma") {
+            } else if has_fma() {
                 SimdTier::Fma
             } else {
                 SimdTier::Sse2
@@ -1831,10 +1831,10 @@ impl PreparedGate2q {
         #[cfg(target_arch = "x86_64")]
         {
             let broadcast = Mat4x4Broadcast::from_matrix(mat);
-            let has_avx2_fma = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+            let has_avx2_fma = has_avx2_fma();
             let tier = if has_avx2_fma {
                 SimdTier::Avx2Fma
-            } else if is_x86_feature_detected!("fma") {
+            } else if has_fma() {
                 SimdTier::Fma
             } else {
                 SimdTier::Sse2

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -28,9 +28,9 @@ use rayon::prelude::*;
 #[cfg(feature = "parallel")]
 const MIN_STATES_FOR_PAR: usize = 4096;
 
-use crate::backend::{is_phase_one, Backend, MAX_PROB_QUBITS};
+use crate::backend::{is_phase_one, max_qubits_unsupported, Backend, MAX_PROB_QUBITS};
 use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 use crate::gates::{DiagEntry, Gate};
 
 const DEFAULT_EPSILON: f64 = 1e-16;
@@ -197,6 +197,16 @@ impl SparseBackend {
         }
     }
 
+    #[inline(always)]
+    fn apply_rzz(&mut self, q0: usize, q1: usize, theta: f64) {
+        let phase_same = Complex64::from_polar(1.0, -theta / 2.0);
+        let phase_diff = Complex64::from_polar(1.0, theta / 2.0);
+        for (idx, amp) in self.state.iter_mut() {
+            let parity = ((*idx >> q0) ^ (*idx >> q1)) & 1;
+            *amp *= if parity == 0 { phase_same } else { phase_diff };
+        }
+    }
+
     fn apply_batch_phase(&mut self, control: usize, phases: &[(usize, Complex64)]) {
         let ctrl_mask = 1usize << control;
         let one = Complex64::new(1.0, 0.0);
@@ -330,14 +340,7 @@ impl SparseBackend {
     fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
         match gate {
             Gate::Rzz(theta) => {
-                let phase_same = Complex64::from_polar(1.0, -theta / 2.0);
-                let phase_diff = Complex64::from_polar(1.0, theta / 2.0);
-                let q0 = targets[0];
-                let q1 = targets[1];
-                for (idx, amp) in self.state.iter_mut() {
-                    let parity = ((*idx >> q0) ^ (*idx >> q1)) & 1;
-                    *amp *= if parity == 0 { phase_same } else { phase_diff };
-                }
+                self.apply_rzz(targets[0], targets[1], *theta);
             }
             Gate::Cx => {
                 self.apply_cx(targets[0], targets[1]);
@@ -368,12 +371,7 @@ impl SparseBackend {
             }
             Gate::BatchRzz(data) => {
                 for &(q0, q1, theta) in &data.edges {
-                    let phase_same = Complex64::from_polar(1.0, -theta / 2.0);
-                    let phase_diff = Complex64::from_polar(1.0, theta / 2.0);
-                    for (idx, amp) in self.state.iter_mut() {
-                        let parity = ((*idx >> q0) ^ (*idx >> q1)) & 1;
-                        *amp *= if parity == 0 { phase_same } else { phase_diff };
-                    }
+                    self.apply_rzz(q0, q1, theta);
                 }
             }
             Gate::DiagonalBatch(data) => {
@@ -476,6 +474,11 @@ impl Backend for SparseBackend {
         Ok(())
     }
 
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        self.apply_single_qubit(qubit, *matrix);
+        Ok(())
+    }
+
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         let mask = 1usize << qubit;
         let mut p0 = 0.0f64;
@@ -505,13 +508,12 @@ impl Backend for SparseBackend {
 
     fn probabilities(&self) -> Result<Vec<f64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "probabilities for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "probabilities",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
         let dim = 1usize << self.num_qubits;
         let mut probs = vec![0.0f64; dim];
@@ -527,13 +529,12 @@ impl Backend for SparseBackend {
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "statevector export for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
+            return Err(max_qubits_unsupported(
+                self.name(),
+                "statevector export",
+                self.num_qubits,
+                MAX_PROB_QUBITS,
+            ));
         }
         let dim = 1usize << self.num_qubits;
         let mut sv = vec![Complex64::new(0.0, 0.0); dim];

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -28,7 +28,9 @@ use rayon::prelude::*;
 #[cfg(feature = "parallel")]
 const MIN_STATES_FOR_PAR: usize = 4096;
 
-use crate::backend::{is_phase_one, max_qubits_unsupported, Backend, MAX_PROB_QUBITS};
+use crate::backend::{
+    dense_probability_len, dense_statevector_len, is_phase_one, reserve_dense_output, Backend,
+};
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::{DiagEntry, Gate};
@@ -507,16 +509,10 @@ impl Backend for SparseBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "probabilities",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
-        let dim = 1usize << self.num_qubits;
-        let mut probs = vec![0.0f64; dim];
+        let dim = dense_probability_len(self.name(), self.num_qubits)?;
+        let mut probs = Vec::new();
+        reserve_dense_output(&mut probs, dim, self.name(), "probabilities")?;
+        probs.resize(dim, 0.0f64);
         for (&idx, amp) in &self.state {
             probs[idx] = amp.norm_sqr();
         }
@@ -528,16 +524,10 @@ impl Backend for SparseBackend {
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(max_qubits_unsupported(
-                self.name(),
-                "statevector export",
-                self.num_qubits,
-                MAX_PROB_QUBITS,
-            ));
-        }
-        let dim = 1usize << self.num_qubits;
-        let mut sv = vec![Complex64::new(0.0, 0.0); dim];
+        let dim = dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
+        let mut sv = Vec::new();
+        reserve_dense_output(&mut sv, dim, self.name(), "statevector export")?;
+        sv.resize(dim, Complex64::new(0.0, 0.0));
         for (&idx, &amp) in &self.state {
             sv[idx] = amp;
         }

--- a/src/backend/stabilizer/kernels/simd.rs
+++ b/src/backend/stabilizer/kernels/simd.rs
@@ -1,3 +1,4 @@
+#[cfg(target_arch = "x86_64")]
 use crate::backend::word_ops::has_avx2;
 pub(crate) use crate::backend::word_ops::xor_words_ptr as xor_words;
 

--- a/src/backend/stabilizer/kernels/simd.rs
+++ b/src/backend/stabilizer/kernels/simd.rs
@@ -1,61 +1,5 @@
-#[inline(always)]
-pub(crate) unsafe fn xor_words(dst: *mut u64, src: *const u64, len: usize) {
-    #[cfg(target_arch = "x86_64")]
-    if has_avx2() {
-        // SAFETY: AVX2 support is checked above. The caller guarantees both
-        // pointers are valid for len u64 values.
-        unsafe { xor_words_avx2(dst, src, len) };
-        return;
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        // SAFETY: NEON is available on supported aarch64 targets. The caller
-        // guarantees both pointers are valid for len u64 values.
-        unsafe { xor_words_neon(dst, src, len) };
-        return;
-    }
-    #[allow(unreachable_code)]
-    for i in 0..len {
-        // SAFETY: The caller guarantees both pointers are valid for len u64 values.
-        unsafe { *dst.add(i) ^= *src.add(i) };
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2")]
-unsafe fn xor_words_avx2(dst: *mut u64, src: *const u64, len: usize) {
-    #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::*;
-
-    let chunks = len / 4;
-    for i in 0..chunks {
-        let off = i * 4;
-        let d = _mm256_loadu_si256(dst.add(off) as *const __m256i);
-        let s = _mm256_loadu_si256(src.add(off) as *const __m256i);
-        _mm256_storeu_si256(dst.add(off) as *mut __m256i, _mm256_xor_si256(d, s));
-    }
-    let tail = chunks * 4;
-    for i in tail..len {
-        *dst.add(i) ^= *src.add(i);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-#[target_feature(enable = "neon")]
-unsafe fn xor_words_neon(dst: *mut u64, src: *const u64, len: usize) {
-    use std::arch::aarch64::*;
-
-    let chunks = len / 2;
-    for i in 0..chunks {
-        let off = i * 2;
-        let d = vld1q_u64(dst.add(off));
-        let s = vld1q_u64(src.add(off));
-        vst1q_u64(dst.add(off), veorq_u64(d, s));
-    }
-    if len & 1 != 0 {
-        *dst.add(len - 1) ^= *src.add(len - 1);
-    }
-}
+use crate::backend::word_ops::has_avx2;
+pub(crate) use crate::backend::word_ops::xor_words_ptr as xor_words;
 
 /// Rowmul word loop: XOR x/z words from src into dst, returning the
 /// accumulated phase sum (caller applies `sum & 3 >= 2`).
@@ -439,16 +383,4 @@ unsafe fn rowmul_words_neon(
     }
 
     sum
-}
-
-#[cfg(target_arch = "x86_64")]
-fn has_avx2() -> bool {
-    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| is_x86_feature_detected!("avx2"))
-}
-
-#[cfg(not(target_arch = "x86_64"))]
-#[allow(dead_code)]
-fn has_avx2() -> bool {
-    false
 }

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -29,14 +29,18 @@
 //! - Gate application: O(n) per gate (iterates 2n+1 rows, constant work per row)
 //! - Measurement: O(n²) worst case (rowmul is O(n), applied to up to 2n rows)
 //! - Memory: n=1000 → ~500 KB, n=10000 → ~50 MB
-//! - Probability extraction: O(2^n * n), only available for n <= 20
+//! - Probability extraction: O(2^n * n), limited by dense output memory budget
 
 use num_complex::Complex64;
 use smallvec::SmallVec;
 
-use crate::backend::{Backend, NORM_CLAMP_MIN};
+use crate::backend::{
+    dense_probability_len, dense_statevector_len, reserve_dense_output, Backend, NORM_CLAMP_MIN,
+};
 use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+#[cfg(feature = "gpu")]
+use crate::error::PrismError;
+use crate::error::Result;
 use crate::gates::Gate;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -323,27 +327,9 @@ impl StabilizerBackend {
 
     #[inline]
     fn validate_probability_capacity(&self) -> Result<()> {
-        if self.n >= usize::BITS as usize {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "probability extraction for {} qubits (exceeds addressable memory)",
-                    self.n
-                ),
-            });
-        }
-        let dim = 1usize << self.n;
+        let dim = dense_probability_len(self.name(), self.n)?;
         let mut check = Vec::<f64>::new();
-        if check.try_reserve_exact(dim).is_err() {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "probability extraction for {} qubits ({} bytes required)",
-                    self.n,
-                    dim * std::mem::size_of::<f64>()
-                ),
-            });
-        }
+        reserve_dense_output(&mut check, dim, self.name(), "probabilities")?;
         drop(check);
         Ok(())
     }
@@ -990,27 +976,9 @@ impl StabilizerBackend {
             cpu.classical_bits = self.classical_bits.clone();
             return cpu.export_statevector();
         }
-        if self.n >= usize::BITS as usize {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "statevector export for {} qubits (exceeds addressable memory)",
-                    self.n
-                ),
-            });
-        }
-        let dim = 1usize << self.n;
+        let dim = dense_statevector_len(self.name(), "statevector export", self.n)?;
         let mut check = Vec::<Complex64>::new();
-        if check.try_reserve_exact(dim).is_err() {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "statevector export for {} qubits ({} bytes required)",
-                    self.n,
-                    dim * std::mem::size_of::<Complex64>()
-                ),
-            });
-        }
+        reserve_dense_output(&mut check, dim, self.name(), "statevector export")?;
         drop(check);
         Ok(self.compute_statevector())
     }
@@ -1846,12 +1814,7 @@ impl Backend for FilteredStabilizerBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
-        if self.num_qubits >= crate::backend::MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!("probability extraction for {} qubits", self.num_qubits),
-            });
-        }
+        dense_probability_len(self.name(), self.num_qubits)?;
 
         let mut blocks: Vec<(Vec<f64>, Vec<usize>)> = Vec::new();
         for cluster in self.clusters.iter().flatten() {

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -39,6 +39,11 @@ const fn max_target_for_tile(tile_size: usize) -> usize {
     t - 1
 }
 
+const MULTI_GATE_L2_TILE: usize = 16_384;
+const MULTI_GATE_L3_TILE: usize = 131_072;
+const MULTI_GATE_MAX_L2_TARGET: usize = max_target_for_tile(MULTI_GATE_L2_TILE);
+const MULTI_GATE_MAX_L3_TARGET: usize = max_target_for_tile(MULTI_GATE_L3_TILE);
+
 #[inline(always)]
 fn adjacent_2q_indices(offset: usize, stride: usize, q0_is_lo: bool) -> [usize; 4] {
     if q0_is_lo {
@@ -2758,20 +2763,14 @@ impl StatevectorBackend {
             return;
         }
 
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, simd::PreparedGate1q); 16]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, simd::PreparedGate1q); 4]> = SmallVec::new();
         let mut large_gates: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = SmallVec::new();
 
         for &(target, mat) in gates {
-            if target <= max_l2_target {
+            if target <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((target, simd::PreparedGate1q::new(&mat)));
-            } else if target <= max_l3_target {
+            } else if target <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((target, simd::PreparedGate1q::new(&mat)));
             } else {
                 large_gates.push((target, mat));
@@ -2779,8 +2778,8 @@ impl StatevectorBackend {
         }
 
         if !small_gates.is_empty() {
-            let outer_block = 1usize << (max_l2_target + 1);
-            let tile_size = MULTI_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
+            let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
             for tile in self.state.chunks_mut(tile_size) {
                 for &(target, ref prepared) in &small_gates {
                     prepared.apply_tiled(tile, target);
@@ -2789,8 +2788,8 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let outer_block = 1usize << (max_l3_target + 1);
-            let tile_size = L3_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
+            let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
             for tile in self.state.chunks_mut(tile_size) {
                 for &(target, ref prepared) in &medium_gates {
                     prepared.apply_tiled(tile, target);
@@ -2806,20 +2805,14 @@ impl StatevectorBackend {
     #[cfg(feature = "parallel")]
     #[inline(always)]
     fn apply_multi_1q_par(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, simd::PreparedGate1q); 16]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, simd::PreparedGate1q); 4]> = SmallVec::new();
         let mut large_gates: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = SmallVec::new();
 
         for &(target, mat) in gates {
-            if target <= max_l2_target {
+            if target <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((target, simd::PreparedGate1q::new(&mat)));
-            } else if target <= max_l3_target {
+            } else if target <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((target, simd::PreparedGate1q::new(&mat)));
             } else {
                 large_gates.push((target, mat));
@@ -2827,8 +2820,8 @@ impl StatevectorBackend {
         }
 
         if !small_gates.is_empty() {
-            let outer_block = 1usize << (max_l2_target + 1);
-            let tile_size = MULTI_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
+            let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
             self.state
                 .par_chunks_mut(tile_size)
                 .with_min_len(chunk_min_len(tile_size))
@@ -2840,8 +2833,8 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let outer_block = 1usize << (max_l3_target + 1);
-            let tile_size = L3_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
+            let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
             self.state
                 .par_chunks_mut(tile_size)
                 .with_min_len(chunk_min_len(tile_size))
@@ -2872,12 +2865,6 @@ impl StatevectorBackend {
             return;
         }
 
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, Complex64, Complex64, bool); 16]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, Complex64, Complex64, bool); 4]> = SmallVec::new();
         let mut large_gates: SmallVec<[(usize, Complex64, Complex64); 4]> = SmallVec::new();
@@ -2886,9 +2873,9 @@ impl StatevectorBackend {
             let d0 = mat[0][0];
             let d1 = mat[1][1];
             let skip_lo = is_phase_one(d0);
-            if target <= max_l2_target {
+            if target <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((target, d0, d1, skip_lo));
-            } else if target <= max_l3_target {
+            } else if target <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((target, d0, d1, skip_lo));
             } else {
                 large_gates.push((target, d0, d1));
@@ -2896,8 +2883,8 @@ impl StatevectorBackend {
         }
 
         if !small_gates.is_empty() {
-            let outer_block = 1usize << (max_l2_target + 1);
-            let tile_size = MULTI_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
+            let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
             for tile in self.state.chunks_mut(tile_size) {
                 for &(target, d0, d1, skip_lo) in &small_gates {
                     simd::apply_diagonal_sequential(tile, target, d0, d1, skip_lo);
@@ -2906,8 +2893,8 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let outer_block = 1usize << (max_l3_target + 1);
-            let tile_size = L3_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
+            let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
             for tile in self.state.chunks_mut(tile_size) {
                 for &(target, d0, d1, skip_lo) in &medium_gates {
                     simd::apply_diagonal_sequential(tile, target, d0, d1, skip_lo);
@@ -2924,12 +2911,6 @@ impl StatevectorBackend {
     #[cfg(feature = "parallel")]
     #[inline(always)]
     fn apply_multi_1q_diagonal_par(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, Complex64, Complex64, bool); 16]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, Complex64, Complex64, bool); 4]> = SmallVec::new();
         let mut large_gates: SmallVec<[(usize, Complex64, Complex64); 4]> = SmallVec::new();
@@ -2938,9 +2919,9 @@ impl StatevectorBackend {
             let d0 = mat[0][0];
             let d1 = mat[1][1];
             let skip_lo = is_phase_one(d0);
-            if target <= max_l2_target {
+            if target <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((target, d0, d1, skip_lo));
-            } else if target <= max_l3_target {
+            } else if target <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((target, d0, d1, skip_lo));
             } else {
                 large_gates.push((target, d0, d1));
@@ -2948,8 +2929,8 @@ impl StatevectorBackend {
         }
 
         if !small_gates.is_empty() {
-            let outer_block = 1usize << (max_l2_target + 1);
-            let tile_size = MULTI_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
+            let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
             self.state
                 .par_chunks_mut(tile_size)
                 .with_min_len(chunk_min_len(tile_size))
@@ -2961,8 +2942,8 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let outer_block = 1usize << (max_l3_target + 1);
-            let tile_size = L3_TILE.max(outer_block);
+            let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
+            let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
             self.state
                 .par_chunks_mut(tile_size)
                 .with_min_len(chunk_min_len(tile_size))
@@ -3009,26 +2990,20 @@ impl StatevectorBackend {
             return;
         }
 
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, usize, simd::PreparedGate2q); 2]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, usize, simd::PreparedGate2q); 2]> = SmallVec::new();
 
         for &(q0, q1, ref mat) in gates {
             let max_q = q0.max(q1);
-            if max_q <= max_l2_target {
+            if max_q <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((q0, q1, simd::PreparedGate2q::new(mat)));
-            } else if max_q <= max_l3_target {
+            } else if max_q <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((q0, q1, simd::PreparedGate2q::new(mat)));
             }
         }
 
         if !small_gates.is_empty() {
-            let tile_size = MULTI_TILE;
+            let tile_size = MULTI_GATE_L2_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             for tile in self.state.chunks_mut(tile_size) {
                 let n = tile.len().trailing_zeros() as usize;
@@ -3039,7 +3014,7 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let tile_size = L3_TILE;
+            let tile_size = MULTI_GATE_L3_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             for tile in self.state.chunks_mut(tile_size) {
                 let n = tile.len().trailing_zeros() as usize;
@@ -3050,7 +3025,7 @@ impl StatevectorBackend {
         }
 
         for &(q0, q1, ref mat) in gates {
-            if q0.max(q1) > max_l3_target {
+            if q0.max(q1) > MULTI_GATE_MAX_L3_TARGET {
                 self.apply_fused_2q(q0, q1, mat);
             }
         }
@@ -3059,26 +3034,20 @@ impl StatevectorBackend {
     #[cfg(feature = "parallel")]
     #[inline(always)]
     fn apply_multi_2q_par(&mut self, gates: &[(usize, usize, [[Complex64; 4]; 4])]) {
-        const MULTI_TILE: usize = 16384;
-        const L3_TILE: usize = 131072;
-
-        let max_l2_target = max_target_for_tile(MULTI_TILE);
-        let max_l3_target = max_target_for_tile(L3_TILE);
-
         let mut small_gates: SmallVec<[(usize, usize, simd::PreparedGate2q); 2]> = SmallVec::new();
         let mut medium_gates: SmallVec<[(usize, usize, simd::PreparedGate2q); 2]> = SmallVec::new();
 
         for &(q0, q1, ref mat) in gates {
             let max_q = q0.max(q1);
-            if max_q <= max_l2_target {
+            if max_q <= MULTI_GATE_MAX_L2_TARGET {
                 small_gates.push((q0, q1, simd::PreparedGate2q::new(mat)));
-            } else if max_q <= max_l3_target {
+            } else if max_q <= MULTI_GATE_MAX_L3_TARGET {
                 medium_gates.push((q0, q1, simd::PreparedGate2q::new(mat)));
             }
         }
 
         if !small_gates.is_empty() {
-            let tile_size = MULTI_TILE;
+            let tile_size = MULTI_GATE_L2_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             self.state
                 .par_chunks_mut(tile_size)
@@ -3092,7 +3061,7 @@ impl StatevectorBackend {
         }
 
         if !medium_gates.is_empty() {
-            let tile_size = L3_TILE;
+            let tile_size = MULTI_GATE_L3_TILE;
             let tile_qubits = tile_size.trailing_zeros() as usize;
             self.state
                 .par_chunks_mut(tile_size)
@@ -3106,7 +3075,7 @@ impl StatevectorBackend {
         }
 
         for &(q0, q1, ref mat) in gates {
-            if q0.max(q1) > max_l3_target {
+            if q0.max(q1) > MULTI_GATE_MAX_L3_TARGET {
                 self.apply_fused_2q(q0, q1, mat);
             }
         }

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -51,7 +51,7 @@ use rand_chacha::ChaCha8Rng;
 use std::sync::Arc;
 
 use crate::backend::simd;
-use crate::backend::Backend;
+use crate::backend::{dense_probability_len, dense_statevector_len, Backend};
 use crate::circuit::Instruction;
 #[cfg(feature = "gpu")]
 use crate::circuit::{qft_textbook_steps, QftTextbookStep};
@@ -564,8 +564,8 @@ impl Backend for StatevectorBackend {
         if let Some(gpu) = self.gpu_state.as_ref() {
             return gpu.probabilities();
         }
+        let dim = dense_probability_len(self.name(), self.num_qubits)?;
         let norm_sq = self.pending_norm * self.pending_norm;
-        let dim = self.state.len();
         let mut probs = vec![0.0_f64; dim];
 
         #[cfg(feature = "parallel")]
@@ -601,6 +601,7 @@ impl Backend for StatevectorBackend {
         if let Some(gpu) = self.gpu_state.as_ref() {
             return gpu.export_statevector();
         }
+        dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
         if self.pending_norm == 1.0 {
             return Ok(self.state.clone());
         }

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -20,9 +20,9 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
-use crate::backend::{Backend, MAX_PROB_QUBITS, NORM_CLAMP_MIN};
+use crate::backend::{dense_statevector_len, tensor_probability_len, Backend, NORM_CLAMP_MIN};
 use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 use crate::gates::Gate;
 
 #[cfg(feature = "parallel")]
@@ -553,15 +553,7 @@ impl TensorNetworkBackend {
     /// Contract the full network and return the amplitude vector in
     /// computational basis order.
     fn contract_to_statevector(&self) -> Result<Vec<Complex64>> {
-        if self.num_qubits > MAX_PROB_QUBITS {
-            return Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: format!(
-                    "contraction for {} qubits (max {})",
-                    self.num_qubits, MAX_PROB_QUBITS
-                ),
-            });
-        }
+        dense_statevector_len(self.name(), "contraction", self.num_qubits)?;
 
         let mut tensors = self.tensors.clone();
         let result = greedy_contract(&mut tensors);
@@ -773,6 +765,7 @@ impl Backend for TensorNetworkBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
+        tensor_probability_len(self.name(), self.num_qubits)?;
         let amplitudes = self.contract_to_statevector()?;
         #[cfg(feature = "parallel")]
         if amplitudes.len() >= MIN_PAR_ELEMS {

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -399,7 +399,7 @@ impl TensorNetworkBackend {
         id
     }
 
-    fn apply_1q_matrix(&mut self, target: usize, mat: &[[Complex64; 2]; 2]) {
+    fn append_1q_matrix(&mut self, target: usize, mat: &[[Complex64; 2]; 2]) {
         let in_leg = self.output_legs[target];
         let out_leg = self.fresh_leg();
 
@@ -639,7 +639,7 @@ impl TensorNetworkBackend {
             Gate::DiagonalBatch(data) => {
                 for entry in &data.entries {
                     if let Some((q, mat)) = entry.as_1q_matrix() {
-                        self.apply_1q_matrix(q, &mat);
+                        self.append_1q_matrix(q, &mat);
                     } else if let Some((q0, q1, mat)) = entry.as_2q_matrix() {
                         self.apply_2q_matrix(q0, q1, &mat);
                     }
@@ -647,7 +647,7 @@ impl TensorNetworkBackend {
             }
             Gate::MultiFused(data) => {
                 for &(target, ref mat) in &data.gates {
-                    self.apply_1q_matrix(target, mat);
+                    self.append_1q_matrix(target, mat);
                 }
             }
             Gate::Multi2q(data) => {
@@ -657,7 +657,7 @@ impl TensorNetworkBackend {
             }
             _ => {
                 let mat = gate.matrix_2x2();
-                self.apply_1q_matrix(targets[0], &mat);
+                self.append_1q_matrix(targets[0], &mat);
             }
         }
     }
@@ -761,6 +761,11 @@ impl Backend for TensorNetworkBackend {
 
     fn reset(&mut self, qubit: usize) -> Result<()> {
         self.apply_reset(qubit)
+    }
+
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        self.append_1q_matrix(qubit, matrix);
+        Ok(())
     }
 
     fn classical_results(&self) -> &[bool] {

--- a/src/backend/word_ops.rs
+++ b/src/backend/word_ops.rs
@@ -1,0 +1,105 @@
+#[inline(always)]
+pub(crate) fn xor_words(dst: &mut [u64], src: &[u64]) {
+    let len = dst.len().min(src.len());
+
+    #[cfg(target_arch = "x86_64")]
+    if len >= 4 && has_avx2() {
+        // SAFETY: AVX2 support is checked above. Slices provide valid pointers
+        // for len u64 values.
+        unsafe { xor_words_ptr(dst.as_mut_ptr(), src.as_ptr(), len) };
+        return;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if len >= 2 {
+        // SAFETY: NEON is available on supported aarch64 targets. Slices
+        // provide valid pointers for len u64 values.
+        unsafe { xor_words_ptr(dst.as_mut_ptr(), src.as_ptr(), len) };
+        return;
+    }
+
+    for (d, &s) in dst.iter_mut().zip(src) {
+        *d ^= s;
+    }
+}
+
+#[inline(always)]
+pub(crate) unsafe fn xor_words_ptr(dst: *mut u64, src: *const u64, len: usize) {
+    #[cfg(target_arch = "x86_64")]
+    if has_avx2() {
+        // SAFETY: AVX2 support is checked above. The caller guarantees both
+        // pointers are valid for len u64 values.
+        unsafe { xor_words_avx2(dst, src, len) };
+        return;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: NEON is available on supported aarch64 targets. The caller
+        // guarantees both pointers are valid for len u64 values.
+        unsafe { xor_words_neon(dst, src, len) };
+        return;
+    }
+
+    #[allow(unreachable_code)]
+    for i in 0..len {
+        // SAFETY: The caller guarantees both pointers are valid for len u64 values.
+        unsafe { *dst.add(i) ^= *src.add(i) };
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn xor_words_avx2(dst: *mut u64, src: *const u64, len: usize) {
+    use std::arch::x86_64::*;
+
+    let chunks = len / 4;
+    for i in 0..chunks {
+        let off = i * 4;
+        // SAFETY: The caller guarantees pointers are valid for len u64 values.
+        // Unaligned loads and stores are used for arbitrary slice alignment.
+        unsafe {
+            let d = _mm256_loadu_si256(dst.add(off) as *const __m256i);
+            let s = _mm256_loadu_si256(src.add(off) as *const __m256i);
+            _mm256_storeu_si256(dst.add(off) as *mut __m256i, _mm256_xor_si256(d, s));
+        }
+    }
+    let tail = chunks * 4;
+    for i in tail..len {
+        // SAFETY: The caller guarantees both pointers are valid for len u64 values.
+        unsafe { *dst.add(i) ^= *src.add(i) };
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn xor_words_neon(dst: *mut u64, src: *const u64, len: usize) {
+    use std::arch::aarch64::*;
+
+    let chunks = len / 2;
+    for i in 0..chunks {
+        let off = i * 2;
+        // SAFETY: The caller guarantees pointers are valid for len u64 values.
+        unsafe {
+            let d = vld1q_u64(dst.add(off));
+            let s = vld1q_u64(src.add(off));
+            vst1q_u64(dst.add(off), veorq_u64(d, s));
+        }
+    }
+    if len & 1 != 0 {
+        // SAFETY: The caller guarantees both pointers are valid for len u64 values.
+        unsafe { *dst.add(len - 1) ^= *src.add(len - 1) };
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn has_avx2() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| is_x86_feature_detected!("avx2"))
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
+pub(crate) fn has_avx2() -> bool {
+    false
+}

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -31,6 +31,7 @@ pub(super) struct PlacedOp {
     pub(super) label: String,
     pub(super) qubits: SmallVec<[usize; 4]>,
     pub(super) kind: OpKind,
+    pub(super) gate: Option<Gate>,
 }
 
 pub(super) enum OpKind {
@@ -97,6 +98,7 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                     label,
                     qubits: SmallVec::from_slice(targets),
                     kind,
+                    gate: Some(gate.clone()),
                 };
                 if max_d >= moments.len() {
                     moments.resize_with(max_d + 1, Vec::new);
@@ -117,6 +119,7 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                     kind: OpKind::Measure {
                         cbit: *classical_bit,
                     },
+                    gate: None,
                 };
                 if d >= moments.len() {
                     moments.resize_with(d + 1, Vec::new);
@@ -130,6 +133,7 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                     label: "|0⟩".into(),
                     qubits: smallvec::smallvec![*qubit],
                     kind: OpKind::Reset,
+                    gate: None,
                 };
                 if d >= moments.len() {
                     moments.resize_with(d + 1, Vec::new);
@@ -143,6 +147,7 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                     label: String::new(),
                     qubits: SmallVec::from_slice(qubits),
                     kind: OpKind::Barrier,
+                    gate: None,
                 };
                 if max_d >= moments.len() {
                     moments.resize_with(max_d + 1, Vec::new);
@@ -180,6 +185,7 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                     label: gate.to_string(),
                     qubits: SmallVec::from_slice(targets),
                     kind: OpKind::Conditional { cbit_label },
+                    gate: Some(gate.clone()),
                 };
                 if max_d >= moments.len() {
                     moments.resize_with(max_d + 1, Vec::new);

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -225,6 +225,36 @@ fn is_identity(mat: &[[Complex64; 2]; 2]) -> bool {
         && mat[1][1].im.abs() < IDENTITY_EPS
 }
 
+#[inline]
+fn gate_1q_matrix(gate: &Gate) -> [[Complex64; 2]; 2] {
+    match gate {
+        Gate::Fused(m) => **m,
+        _ => gate.matrix_2x2(),
+    }
+}
+
+#[inline]
+fn accumulate_1q(slot: &mut Option<[[Complex64; 2]; 2]>, mat: [[Complex64; 2]; 2]) -> bool {
+    match slot {
+        Some(existing) => {
+            *existing = mat_mul_2x2(&mat, existing);
+            false
+        }
+        empty => {
+            *empty = Some(mat);
+            true
+        }
+    }
+}
+
+#[inline]
+fn push_fused_1q(output: &mut Vec<Instruction>, q: usize, mat: [[Complex64; 2]; 2]) {
+    output.push(Instruction::Gate {
+        gate: Gate::Fused(Box::new(mat)),
+        targets: smallvec![q],
+    });
+}
+
 struct PendingFusion {
     matrix: [[Complex64; 2]; 2],
     target: usize,
@@ -556,16 +586,9 @@ pub fn fuse_multi_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
         match inst {
             Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
                 let q = targets[0];
-                let mat = match gate {
-                    Gate::Fused(m) => **m,
-                    _ => gate.matrix_2x2(),
-                };
-                match &mut pending[q] {
-                    Some(existing) => *existing = mat_mul_2x2(&mat, existing),
-                    slot => {
-                        *slot = Some(mat);
-                        pending_count += 1;
-                    }
+                let mat = gate_1q_matrix(gate);
+                if accumulate_1q(&mut pending[q], mat) {
+                    pending_count += 1;
                 }
             }
             _ => {
@@ -585,18 +608,26 @@ pub fn fuse_multi_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     })
 }
 
+#[inline]
+fn flush_indexed_1q(
+    q: usize,
+    pending: &mut [Option<[[Complex64; 2]; 2]>],
+    output: &mut Vec<Instruction>,
+) {
+    if let Some(mat) = pending[q].take() {
+        push_fused_1q(output, q, mat);
+    }
+}
+
 fn flush_1q_pending(
     q: usize,
     pending: &mut [Option<[[Complex64; 2]; 2]>],
     pending_count: &mut usize,
     output: &mut Vec<Instruction>,
 ) {
-    if let Some(mat) = pending[q].take() {
+    if pending[q].is_some() {
         *pending_count -= 1;
-        output.push(Instruction::Gate {
-            gate: Gate::Fused(Box::new(mat)),
-            targets: smallvec![q],
-        });
+        flush_indexed_1q(q, pending, output);
     }
 }
 
@@ -626,10 +657,7 @@ fn flush_all_pending(
     } else {
         for (q, slot) in pending.iter_mut().enumerate() {
             if let Some(mat) = slot.take() {
-                output.push(Instruction::Gate {
-                    gate: Gate::Fused(Box::new(mat)),
-                    targets: smallvec![q],
-                });
+                push_fused_1q(output, q, mat);
             }
         }
     }
@@ -674,28 +702,12 @@ pub fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     let mut pending_1q: Vec<Option<[[Complex64; 2]; 2]>> = vec![None; n];
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
 
-    let flush_1q =
-        |q: usize, pending: &mut [Option<[[Complex64; 2]; 2]>], output: &mut Vec<Instruction>| {
-            if let Some(mat) = pending[q].take() {
-                output.push(Instruction::Gate {
-                    gate: Gate::Fused(Box::new(mat)),
-                    targets: smallvec![q],
-                });
-            }
-        };
-
     for inst in &circuit.instructions {
         match inst {
             Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
                 let q = targets[0];
-                let mat = match gate {
-                    Gate::Fused(m) => **m,
-                    _ => gate.matrix_2x2(),
-                };
-                match &mut pending_1q[q] {
-                    Some(p) => *p = mat_mul_2x2(&mat, p),
-                    slot => *slot = Some(mat),
-                }
+                let mat = gate_1q_matrix(gate);
+                accumulate_1q(&mut pending_1q[q], mat);
             }
             Instruction::Gate {
                 gate: gate @ (Gate::Cx | Gate::Cz),
@@ -722,23 +734,23 @@ pub fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
             }
             Instruction::Gate { targets, .. } => {
                 for &q in targets.iter() {
-                    flush_1q(q, &mut pending_1q, &mut output);
+                    flush_indexed_1q(q, &mut pending_1q, &mut output);
                 }
                 output.push(inst.clone());
             }
             Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                flush_1q(*qubit, &mut pending_1q, &mut output);
+                flush_indexed_1q(*qubit, &mut pending_1q, &mut output);
                 output.push(inst.clone());
             }
             Instruction::Barrier { qubits } => {
                 for &q in qubits.iter() {
-                    flush_1q(q, &mut pending_1q, &mut output);
+                    flush_indexed_1q(q, &mut pending_1q, &mut output);
                 }
                 output.push(inst.clone());
             }
             Instruction::Conditional { targets, .. } => {
                 for &q in targets.iter() {
-                    flush_1q(q, &mut pending_1q, &mut output);
+                    flush_indexed_1q(q, &mut pending_1q, &mut output);
                 }
                 output.push(inst.clone());
             }
@@ -746,7 +758,7 @@ pub fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     }
 
     for q in 0..n {
-        flush_1q(q, &mut pending_1q, &mut output);
+        flush_indexed_1q(q, &mut pending_1q, &mut output);
     }
 
     Cow::Owned(Circuit {
@@ -964,10 +976,7 @@ fn fuse_same_pair_2q_blocks(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
             Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
                 if let Some(active) = &mut run {
                     if active.can_accept_1q(targets[0]) {
-                        let mat = match gate {
-                            Gate::Fused(m) => **m,
-                            _ => gate.matrix_2x2(),
-                        };
+                        let mat = gate_1q_matrix(gate);
                         active.push_1q(mat, targets[0], inst.clone());
                     } else {
                         flush_pair_run(&mut run, &mut output, &mut changed);
@@ -1341,6 +1350,23 @@ where
     }
 }
 
+#[inline]
+fn gated<'a, F>(
+    input: Cow<'a, Circuit>,
+    num_qubits: usize,
+    threshold: usize,
+    pass: F,
+) -> Cow<'a, Circuit>
+where
+    F: FnOnce(Cow<'a, Circuit>) -> Cow<'a, Circuit>,
+{
+    if num_qubits >= threshold {
+        pass(input)
+    } else {
+        input
+    }
+}
+
 /// Returns `Cow::Borrowed` when no fusion is profitable (zero overhead).
 /// Set `supports_fused` to `false` for backends that cannot handle fused gates
 /// (e.g., stabilizer).
@@ -1349,15 +1375,14 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
         return Cow::Borrowed(circuit);
     }
 
+    let n = circuit.num_qubits;
     let pass0 = cancel_self_inverse_pairs(circuit);
     let pass0r = apply_pass(pass0, fuse_rzz);
-    let pass0b = if circuit.num_qubits >= MIN_QUBITS_FOR_DIAG_BATCH {
-        apply_pass(pass0r, fuse_batch_rzz)
-    } else {
-        pass0r
-    };
+    let pass0b = gated(pass0r, n, MIN_QUBITS_FOR_DIAG_BATCH, |c| {
+        apply_pass(c, fuse_batch_rzz)
+    });
 
-    if circuit.num_qubits < MIN_QUBITS_FOR_FUSION {
+    if n < MIN_QUBITS_FOR_FUSION {
         return pass0b;
     }
 
@@ -1366,46 +1391,43 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
     let pass1c = apply_pass(pass1r, cancel_self_inverse_pairs);
     let pass1f = apply_pass(pass1c, fuse_single_qubit_gates);
 
-    let pass_2q = if circuit.num_qubits >= MIN_QUBITS_FOR_2Q_FUSION {
-        fuse_2q_gates(pass1f)
-    } else {
-        pass1f
-    };
-    let pass_2qb = if circuit.num_qubits >= MIN_QUBITS_FOR_2Q_FUSION {
-        fuse_same_pair_2q_blocks(pass_2q)
-    } else {
-        pass_2q
-    };
-    let pass2 = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_FUSION {
-        fuse_multi_1q_gates(pass_2qb)
-    } else {
-        pass_2qb
-    };
-    let pass_2qr = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION && reorder_2q_enabled() {
+    let pass_2q = gated(pass1f, n, MIN_QUBITS_FOR_2Q_FUSION, fuse_2q_gates);
+    let pass_2qb = gated(
+        pass_2q,
+        n,
+        MIN_QUBITS_FOR_2Q_FUSION,
+        fuse_same_pair_2q_blocks,
+    );
+    let pass2 = gated(
+        pass_2qb,
+        n,
+        MIN_QUBITS_FOR_MULTI_FUSION,
+        fuse_multi_1q_gates,
+    );
+    let pass_2qr = if n >= MIN_QUBITS_FOR_MULTI_2Q_FUSION && reorder_2q_enabled() {
         reorder_disjoint_fused2q(pass2)
     } else {
         pass2
     };
-    let pass_m2q = if circuit.num_qubits >= MIN_QUBITS_FOR_MULTI_2Q_FUSION {
-        fuse_multi_2q_gates(pass_2qr)
-    } else {
-        pass_2qr
-    };
-    let pass_cp = if circuit.num_qubits >= MIN_QUBITS_FOR_DIAG_BATCH {
-        fuse_controlled_phases(pass_m2q)
-    } else {
-        pass_m2q
-    };
-    let pass_db = if circuit.num_qubits >= MIN_QUBITS_FOR_DIAG_BATCH {
-        fuse_diagonal_batch(pass_cp)
-    } else {
-        pass_cp
-    };
-    if circuit.num_qubits >= MIN_QUBITS_FOR_POST_PHASE_BATCH {
-        batch_post_phase_1q(pass_db)
-    } else {
-        pass_db
-    }
+    let pass_m2q = gated(
+        pass_2qr,
+        n,
+        MIN_QUBITS_FOR_MULTI_2Q_FUSION,
+        fuse_multi_2q_gates,
+    );
+    let pass_cp = gated(
+        pass_m2q,
+        n,
+        MIN_QUBITS_FOR_DIAG_BATCH,
+        fuse_controlled_phases,
+    );
+    let pass_db = gated(pass_cp, n, MIN_QUBITS_FOR_DIAG_BATCH, fuse_diagonal_batch);
+    gated(
+        pass_db,
+        n,
+        MIN_QUBITS_FOR_POST_PHASE_BATCH,
+        batch_post_phase_1q,
+    )
 }
 
 #[cfg(test)]

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -106,6 +106,34 @@ enum BlockKind {
     For,
 }
 
+#[derive(Clone, Copy)]
+enum RegisterKind {
+    Qubit,
+    Classical,
+}
+
+impl RegisterKind {
+    fn name(self) -> &'static str {
+        match self {
+            RegisterKind::Qubit => "qubit",
+            RegisterKind::Classical => "bit",
+        }
+    }
+
+    fn invalid_index(self, index: usize, register_size: usize) -> PrismError {
+        match self {
+            RegisterKind::Qubit => PrismError::InvalidQubit {
+                index,
+                register_size,
+            },
+            RegisterKind::Classical => PrismError::InvalidClassicalBit {
+                index,
+                register_size,
+            },
+        }
+    }
+}
+
 struct BlockState {
     kind: BlockKind,
     buf: String,
@@ -599,94 +627,67 @@ impl<'a> Parser<'a> {
 
     /// OQ3 syntax: `qubit[4] q` or `qubit q` (single qubit).
     fn parse_qubit_decl(&mut self, line: &str, line_num: usize) -> Result<()> {
-        let rest = line.strip_prefix("qubit").unwrap();
-
-        if rest.trim_start().starts_with('[') {
-            let bracket_content = Self::extract_bracket(rest).ok_or(PrismError::Parse {
-                line: line_num,
-                message: "missing `]` in qubit declaration".to_string(),
-            })?;
-            let size: usize = bracket_content.parse().map_err(|_| PrismError::Parse {
-                line: line_num,
-                message: format!("invalid qubit count: `{bracket_content}`"),
-            })?;
-            if size == 0 {
-                return Err(PrismError::Parse {
-                    line: line_num,
-                    message: "qubit count must be > 0".to_string(),
-                });
-            }
-            let end = rest.find(']').unwrap(); // safe: extract_bracket succeeded
-            let after_bracket = rest[end + 1..].trim();
-            let name = after_bracket.to_string();
-            if name.is_empty() {
-                return Err(PrismError::Parse {
-                    line: line_num,
-                    message: "qubit declaration missing name".to_string(),
-                });
-            }
-            let offset = self.total_qubits;
-            self.total_qubits += size;
-            self.qregs.insert(name, Register { offset, size });
-        } else {
-            let name = rest.trim().to_string();
-            if name.is_empty() {
-                return Err(PrismError::Parse {
-                    line: line_num,
-                    message: "qubit declaration missing name".to_string(),
-                });
-            }
-            let offset = self.total_qubits;
-            self.total_qubits += 1;
-            self.qregs.insert(name, Register { offset, size: 1 });
-        }
+        let (name, size) =
+            Self::parse_oq3_register_decl(line, "qubit", RegisterKind::Qubit, line_num)?;
+        let offset = self.total_qubits;
+        self.total_qubits += size;
+        self.qregs.insert(name, Register { offset, size });
         Ok(())
     }
 
     /// OQ3 syntax: `bit[4] c` or `bit c` (single bit).
     fn parse_bit_decl(&mut self, line: &str, line_num: usize) -> Result<()> {
-        let rest = line.strip_prefix("bit").unwrap();
+        let (name, size) =
+            Self::parse_oq3_register_decl(line, "bit", RegisterKind::Classical, line_num)?;
+        let offset = self.total_cbits;
+        self.total_cbits += size;
+        self.cregs.insert(name, Register { offset, size });
+        Ok(())
+    }
+
+    fn parse_oq3_register_decl(
+        line: &str,
+        keyword: &str,
+        kind: RegisterKind,
+        line_num: usize,
+    ) -> Result<(String, usize)> {
+        let rest = line.strip_prefix(keyword).unwrap();
+        let kind_name = kind.name();
 
         if rest.trim_start().starts_with('[') {
             let bracket_content = Self::extract_bracket(rest).ok_or(PrismError::Parse {
                 line: line_num,
-                message: "missing `]` in bit declaration".to_string(),
+                message: format!("missing `]` in {kind_name} declaration"),
             })?;
             let size: usize = bracket_content.parse().map_err(|_| PrismError::Parse {
                 line: line_num,
-                message: format!("invalid bit count: `{bracket_content}`"),
+                message: format!("invalid {kind_name} count: `{bracket_content}`"),
             })?;
             if size == 0 {
                 return Err(PrismError::Parse {
                     line: line_num,
-                    message: "bit count must be > 0".to_string(),
+                    message: format!("{kind_name} count must be > 0"),
                 });
             }
             let end = rest.find(']').unwrap(); // safe: extract_bracket succeeded
-            let after_bracket = rest[end + 1..].trim();
-            let name = after_bracket.to_string();
+            let name = rest[end + 1..].trim().to_string();
             if name.is_empty() {
                 return Err(PrismError::Parse {
                     line: line_num,
-                    message: "bit declaration missing name".to_string(),
+                    message: format!("{kind_name} declaration missing name"),
                 });
             }
-            let offset = self.total_cbits;
-            self.total_cbits += size;
-            self.cregs.insert(name, Register { offset, size });
-        } else {
-            let name = rest.trim().to_string();
-            if name.is_empty() {
-                return Err(PrismError::Parse {
-                    line: line_num,
-                    message: "bit declaration missing name".to_string(),
-                });
-            }
-            let offset = self.total_cbits;
-            self.total_cbits += 1;
-            self.cregs.insert(name, Register { offset, size: 1 });
+            return Ok((name, size));
         }
-        Ok(())
+
+        let name = rest.trim().to_string();
+        if name.is_empty() {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("{kind_name} declaration missing name"),
+            });
+        }
+        Ok((name, 1))
     }
 
     /// Extract content between first `[` and `]`, if present.
@@ -746,48 +747,34 @@ impl<'a> Parser<'a> {
         Ok((name, size))
     }
 
-    fn resolve_qubit(&self, token: &str, line_num: usize) -> Result<usize> {
-        let (name, idx) = self.parse_indexed_ref(token, line_num)?;
-        let reg = self
-            .qregs
-            .get(name)
-            .ok_or_else(|| PrismError::UndefinedRegister {
-                name: name.to_string(),
-                line: line_num,
-            })?;
-        if idx >= reg.size {
-            return Err(PrismError::InvalidQubit {
-                index: idx,
-                register_size: reg.size,
-            });
-        }
-        Ok(reg.offset + idx)
-    }
-
     /// Resolve a qubit argument that may be indexed (`q[0]`) or a bare register (`q`).
     /// Returns all matching qubit indices.
     fn resolve_qubit_arg(&self, token: &str, line_num: usize) -> Result<SmallVec<[usize; 4]>> {
-        if token.contains('[') {
-            Ok(smallvec![self.resolve_qubit(token, line_num)?])
-        } else {
-            let reg = self
-                .qregs
-                .get(token)
-                .ok_or_else(|| PrismError::UndefinedRegister {
-                    name: token.to_string(),
-                    line: line_num,
-                })?;
-            Ok((0..reg.size).map(|i| reg.offset + i).collect())
-        }
+        self.resolve_register_arg(&self.qregs, RegisterKind::Qubit, token, line_num)
     }
 
     /// Resolve a classical bit argument that may be indexed (`c[0]`) or a bare register (`c`).
     fn resolve_cbit_arg(&self, token: &str, line_num: usize) -> Result<SmallVec<[usize; 4]>> {
+        self.resolve_register_arg(&self.cregs, RegisterKind::Classical, token, line_num)
+    }
+
+    fn resolve_cbit(&self, token: &str, line_num: usize) -> Result<usize> {
+        self.resolve_register_index(&self.cregs, RegisterKind::Classical, token, line_num)
+    }
+
+    fn resolve_register_arg(
+        &self,
+        registers: &HashMap<String, Register>,
+        kind: RegisterKind,
+        token: &str,
+        line_num: usize,
+    ) -> Result<SmallVec<[usize; 4]>> {
         if token.contains('[') {
-            Ok(smallvec![self.resolve_cbit(token, line_num)?])
+            Ok(smallvec![self.resolve_register_index(
+                registers, kind, token, line_num
+            )?])
         } else {
-            let reg = self
-                .cregs
+            let reg = registers
                 .get(token)
                 .ok_or_else(|| PrismError::UndefinedRegister {
                     name: token.to_string(),
@@ -797,20 +784,22 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn resolve_cbit(&self, token: &str, line_num: usize) -> Result<usize> {
+    fn resolve_register_index(
+        &self,
+        registers: &HashMap<String, Register>,
+        kind: RegisterKind,
+        token: &str,
+        line_num: usize,
+    ) -> Result<usize> {
         let (name, idx) = self.parse_indexed_ref(token, line_num)?;
-        let reg = self
-            .cregs
+        let reg = registers
             .get(name)
             .ok_or_else(|| PrismError::UndefinedRegister {
                 name: name.to_string(),
                 line: line_num,
             })?;
         if idx >= reg.size {
-            return Err(PrismError::InvalidClassicalBit {
-                index: idx,
-                register_size: reg.size,
-            });
+            return Err(kind.invalid_index(idx, reg.size));
         }
         Ok(reg.offset + idx)
     }
@@ -853,24 +842,7 @@ impl<'a> Parser<'a> {
         }
         let qubits = self.resolve_qubit_arg(parts[0].trim(), line_num)?;
         let cbits = self.resolve_cbit_arg(parts[1].trim(), line_num)?;
-        if qubits.len() != cbits.len() {
-            return Err(PrismError::Parse {
-                line: line_num,
-                message: format!(
-                    "register size mismatch in measure: {} qubits vs {} classical bits",
-                    qubits.len(),
-                    cbits.len()
-                ),
-            });
-        }
-        Ok(qubits
-            .iter()
-            .zip(cbits.iter())
-            .map(|(&qubit, &classical_bit)| Instruction::Measure {
-                qubit,
-                classical_bit,
-            })
-            .collect())
+        Self::build_measurements(qubits, cbits, line_num)
     }
 
     /// OQ3: `c[0] = measure q[0]` or `c = measure q` (broadcast)
@@ -894,6 +866,14 @@ impl<'a> Parser<'a> {
 
         let cbits = self.resolve_cbit_arg(cbit_token, line_num)?;
         let qubits = self.resolve_qubit_arg(qubit_token, line_num)?;
+        Self::build_measurements(qubits, cbits, line_num)
+    }
+
+    fn build_measurements(
+        qubits: SmallVec<[usize; 4]>,
+        cbits: SmallVec<[usize; 4]>,
+        line_num: usize,
+    ) -> Result<Vec<Instruction>> {
         if qubits.len() != cbits.len() {
             return Err(PrismError::Parse {
                 line: line_num,
@@ -905,9 +885,9 @@ impl<'a> Parser<'a> {
             });
         }
         Ok(qubits
-            .iter()
-            .zip(cbits.iter())
-            .map(|(&qubit, &classical_bit)| Instruction::Measure {
+            .into_iter()
+            .zip(cbits)
+            .map(|(qubit, classical_bit)| Instruction::Measure {
                 qubit,
                 classical_bit,
             })
@@ -1406,39 +1386,8 @@ impl<'a> Parser<'a> {
 
         if broadcast_len <= 1 {
             let qubits: SmallVec<[usize; 4]> = resolved.iter().map(|v| v[0]).collect();
-
-            if let Some(instrs) =
-                Self::resolve_decomposed_gate(&gate_name, &params, &qubits, line_num)?
-            {
-                if !modifiers.is_empty() {
-                    return Err(PrismError::UnsupportedConstruct {
-                        construct: format!("modifier on decomposed gate `{gate_name}`"),
-                        line: line_num,
-                    });
-                }
-                return Ok(instrs);
-            }
-
-            if let Some(instrs) = self.expand_user_gate(&gate_name, &params, &qubits, line_num)? {
-                return Ok(instrs);
-            }
-
-            let mut gate = Self::resolve_gate(&gate_name, &params, line_num)?;
-            for modifier in modifiers.iter().rev() {
-                gate = Self::apply_modifier(gate, modifier, line_num)?;
-            }
-            let expected = gate.num_qubits();
-            if qubits.len() != expected {
-                return Err(PrismError::GateArity {
-                    gate: gate_name,
-                    expected,
-                    got: qubits.len(),
-                });
-            }
-            return Ok(vec![Instruction::Gate {
-                gate,
-                targets: qubits,
-            }]);
+            return self
+                .resolve_gate_application_once(&gate_name, &params, &modifiers, &qubits, line_num);
         }
 
         let mut all_instrs = Vec::with_capacity(broadcast_len);
@@ -1448,36 +1397,51 @@ impl<'a> Parser<'a> {
                 .map(|v| if v.len() == 1 { v[0] } else { v[i] })
                 .collect();
 
-            if let Some(mut instrs) =
-                Self::resolve_decomposed_gate(&gate_name, &params, &qubits, line_num)?
-            {
-                if !modifiers.is_empty() {
-                    return Err(PrismError::UnsupportedConstruct {
-                        construct: format!("modifier on decomposed gate `{gate_name}`"),
-                        line: line_num,
-                    });
-                }
-                all_instrs.append(&mut instrs);
-                continue;
-            }
-
-            if let Some(mut instrs) =
-                self.expand_user_gate(&gate_name, &params, &qubits, line_num)?
-            {
-                all_instrs.append(&mut instrs);
-                continue;
-            }
-
-            let mut gate = Self::resolve_gate(&gate_name, &params, line_num)?;
-            for modifier in modifiers.iter().rev() {
-                gate = Self::apply_modifier(gate, modifier, line_num)?;
-            }
-            all_instrs.push(Instruction::Gate {
-                gate,
-                targets: qubits,
-            });
+            all_instrs.append(&mut self.resolve_gate_application_once(
+                &gate_name, &params, &modifiers, &qubits, line_num,
+            )?);
         }
         Ok(all_instrs)
+    }
+
+    fn resolve_gate_application_once(
+        &self,
+        gate_name: &str,
+        params: &[f64],
+        modifiers: &[Modifier],
+        qubits: &SmallVec<[usize; 4]>,
+        line_num: usize,
+    ) -> Result<Vec<Instruction>> {
+        if let Some(instrs) = Self::resolve_decomposed_gate(gate_name, params, qubits, line_num)? {
+            if !modifiers.is_empty() {
+                return Err(PrismError::UnsupportedConstruct {
+                    construct: format!("modifier on decomposed gate `{gate_name}`"),
+                    line: line_num,
+                });
+            }
+            return Ok(instrs);
+        }
+
+        if let Some(instrs) = self.expand_user_gate(gate_name, params, qubits, line_num)? {
+            return Ok(instrs);
+        }
+
+        let mut gate = Self::resolve_gate(gate_name, params, line_num)?;
+        for modifier in modifiers.iter().rev() {
+            gate = Self::apply_modifier(gate, modifier, line_num)?;
+        }
+        let expected = gate.num_qubits();
+        if qubits.len() != expected {
+            return Err(PrismError::GateArity {
+                gate: gate_name.to_string(),
+                expected,
+                got: qubits.len(),
+            });
+        }
+        Ok(vec![Instruction::Gate {
+            gate,
+            targets: qubits.clone(),
+        }])
     }
 
     /// Determine the broadcast length from resolved qubit arguments.

--- a/src/circuit/svg.rs
+++ b/src/circuit/svg.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 
 use super::draw::{assign_moments, OpKind, PlacedOp};
 use super::Circuit;
+use crate::gates::Gate;
 
 const GATE_CORNER_RADIUS: f64 = 1.0;
 const JUNCTION_DOT_RADIUS: f64 = 1.5;
@@ -265,16 +266,10 @@ impl Theme {
     }
 }
 
-fn classify_gate(label: &str) -> GateCategory {
-    match label {
-        "S" | "T" | "Sdg" | "Tdg" => GateCategory::Phase,
-        "H" | "X" | "Y" | "Z" | "Id" | "SX" | "SXdg" => GateCategory::Standard,
-        _ if label.starts_with("Rx(")
-            || label.starts_with("Ry(")
-            || label.starts_with("Rz(")
-            || label.starts_with("P(")
-            || label.starts_with("Rzz(") =>
-        {
+fn classify_gate(gate: Option<&Gate>) -> GateCategory {
+    match gate {
+        Some(Gate::S | Gate::T | Gate::Sdg | Gate::Tdg) => GateCategory::Phase,
+        Some(Gate::Rx(_) | Gate::Ry(_) | Gate::Rz(_) | Gate::P(_) | Gate::Rzz(_)) => {
             GateCategory::Parametric
         }
         _ => GateCategory::Standard,
@@ -770,7 +765,7 @@ fn render_svg(
 
             match &op.kind {
                 OpKind::Single => {
-                    let cat = classify_gate(&op.label);
+                    let cat = classify_gate(op.gate.as_ref());
                     present_cats.insert(cat);
                     let cls = cat.css_class();
                     for &q in &op.qubits {
@@ -859,7 +854,7 @@ fn render_svg(
 
                 OpKind::TwoQubit => {
                     let rows: Vec<usize> = op.qubits.iter().filter_map(|&q| row_of(q)).collect();
-                    let cat = classify_gate(&op.label);
+                    let cat = classify_gate(op.gate.as_ref());
                     present_cats.insert(cat);
 
                     if rows.len() >= 2 {
@@ -983,7 +978,7 @@ fn render_svg(
                 }
 
                 OpKind::Conditional { cbit_label } => {
-                    let cat = classify_gate(&op.label);
+                    let cat = classify_gate(op.gate.as_ref());
                     present_cats.insert(cat);
                     for &q in &op.qubits {
                         if let Some(row) = row_of(q) {

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -313,6 +313,19 @@ fn adjoint_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
     ]
 }
 
+#[inline]
+fn count_unique_qubits<I: IntoIterator<Item = usize>>(iter: I) -> usize {
+    let mut seen = [false; 64];
+    let mut count = 0;
+    for q in iter {
+        if q < 64 && !seen[q] {
+            seen[q] = true;
+            count += 1;
+        }
+    }
+    count
+}
+
 /// Product of two 2×2 matrices: A · B.
 #[inline]
 pub(crate) fn mat_mul_2x2(a: &[[Complex64; 2]; 2], b: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
@@ -338,54 +351,19 @@ impl Gate {
             Gate::BatchPhase(data) => 1 + data.phases.len(),
             Gate::QftBlock { num, .. } => *num as usize,
             Gate::BatchRzz(data) => {
-                let mut count = 0;
-                let mut seen = [false; 64];
-                for &(q0, q1, _) in &data.edges {
-                    if !seen[q0] {
-                        seen[q0] = true;
-                        count += 1;
-                    }
-                    if !seen[q1] {
-                        seen[q1] = true;
-                        count += 1;
-                    }
-                }
-                count
+                count_unique_qubits(data.edges.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
             }
             Gate::DiagonalBatch(data) => {
-                let mut count = 0;
-                let mut seen = [false; 64];
-                for e in &data.entries {
-                    let qs = match e {
-                        DiagEntry::Phase1q { qubit, .. } => [*qubit, usize::MAX],
-                        DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
-                            [*q0, *q1]
-                        }
-                    };
-                    for &q in &qs {
-                        if q < 64 && !seen[q] {
-                            seen[q] = true;
-                            count += 1;
-                        }
+                count_unique_qubits(data.entries.iter().flat_map(|e| match e {
+                    DiagEntry::Phase1q { qubit, .. } => [*qubit, usize::MAX],
+                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                        [*q0, *q1]
                     }
-                }
-                count
+                }))
             }
             Gate::MultiFused(data) => data.gates.len(),
             Gate::Multi2q(data) => {
-                let mut count = 0;
-                let mut seen = [false; 64];
-                for &(q0, q1, _) in &data.gates {
-                    if !seen[q0] {
-                        seen[q0] = true;
-                        count += 1;
-                    }
-                    if !seen[q1] {
-                        seen[q1] = true;
-                        count += 1;
-                    }
-                }
-                count
+                count_unique_qubits(data.gates.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
             }
             _ => 1,
         }

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -315,15 +315,35 @@ fn adjoint_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
 
 #[inline]
 fn count_unique_qubits<I: IntoIterator<Item = usize>>(iter: I) -> usize {
-    let mut seen = [false; 64];
-    let mut count = 0;
+    let mut seen: SmallVec<[usize; 8]> = SmallVec::new();
     for q in iter {
-        if q < 64 && !seen[q] {
-            seen[q] = true;
-            count += 1;
+        if !seen.contains(&q) {
+            seen.push(q);
         }
     }
-    count
+    seen.len()
+}
+
+#[inline]
+fn push_unique_qubit(seen: &mut SmallVec<[usize; 8]>, qubit: usize) {
+    if !seen.contains(&qubit) {
+        seen.push(qubit);
+    }
+}
+
+#[inline]
+fn count_unique_diag_qubits(entries: &[DiagEntry]) -> usize {
+    let mut seen: SmallVec<[usize; 8]> = SmallVec::new();
+    for entry in entries {
+        match entry {
+            DiagEntry::Phase1q { qubit, .. } => push_unique_qubit(&mut seen, *qubit),
+            DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                push_unique_qubit(&mut seen, *q0);
+                push_unique_qubit(&mut seen, *q1);
+            }
+        }
+    }
+    seen.len()
 }
 
 /// Product of two 2×2 matrices: A · B.
@@ -353,14 +373,7 @@ impl Gate {
             Gate::BatchRzz(data) => {
                 count_unique_qubits(data.edges.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
             }
-            Gate::DiagonalBatch(data) => {
-                count_unique_qubits(data.entries.iter().flat_map(|e| match e {
-                    DiagEntry::Phase1q { qubit, .. } => [*qubit, usize::MAX],
-                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
-                        [*q0, *q1]
-                    }
-                }))
-            }
+            Gate::DiagonalBatch(data) => count_unique_diag_qubits(&data.entries),
             Gate::MultiFused(data) => data.gates.len(),
             Gate::Multi2q(data) => {
                 count_unique_qubits(data.gates.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
@@ -938,6 +951,39 @@ mod tests {
         assert_eq!(Gate::Rx(0.5).num_qubits(), 1);
         assert_eq!(Gate::Cx.num_qubits(), 2);
         assert_eq!(Gate::Swap.num_qubits(), 2);
+    }
+
+    #[test]
+    fn batch_gate_arity_counts_qubits_above_word_boundary() {
+        let one = Complex64::new(1.0, 0.0);
+        let batch_rzz = Gate::BatchRzz(Box::new(BatchRzzData {
+            edges: vec![(0, 64, 0.25), (64, 129, 0.5)],
+        }));
+        assert_eq!(batch_rzz.num_qubits(), 3);
+
+        let diagonal_batch = Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+            entries: vec![
+                DiagEntry::Phase1q {
+                    qubit: 64,
+                    d0: one,
+                    d1: -one,
+                },
+                DiagEntry::Phase2q {
+                    q0: 64,
+                    q1: 130,
+                    phase: -one,
+                },
+            ],
+        }));
+        assert_eq!(diagonal_batch.num_qubits(), 2);
+
+        let multi_2q = Gate::Multi2q(Box::new(Multi2qData {
+            gates: vec![
+                (63, 64, Gate::Cx.matrix_4x4()),
+                (64, 130, Gate::Cz.matrix_4x4()),
+            ],
+        }));
+        assert_eq!(multi_2q.num_qubits(), 3);
     }
 
     #[test]

--- a/src/gpu/kernels/bts.rs
+++ b/src/gpu/kernels/bts.rs
@@ -13,12 +13,13 @@
 
 use cudarc::driver::{LaunchConfig, PushKernelArg};
 
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 use crate::gpu::GpuBuffer;
 use crate::sim::compiled::parity::SparseParity;
 use crate::sim::compiled::rng::Xoshiro256PlusPlus;
 
 use super::super::GpuContext;
+use super::{div_ceil_grid, launch_err, require_i32, require_u32};
 
 const SAMPLE_BLOCK_SIZE: u32 = 128;
 const NOISE_BLOCK_SIZE: u32 = 128;
@@ -581,32 +582,6 @@ extern "C" __global__ void bts_apply_noise_masks_meas_major(
 
 pub(crate) fn kernel_source() -> String {
     KERNEL_SOURCE.to_string()
-}
-
-fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: "gpu".to_string(),
-        operation: format!("{op}: {err}"),
-    }
-}
-
-fn launch_limit_err(op: &str, name: &str, value: usize, limit: &str) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: "gpu".to_string(),
-        operation: format!("{op}: {name}={value} exceeds {limit} kernel limit"),
-    }
-}
-
-fn require_i32(op: &str, name: &str, value: usize) -> Result<i32> {
-    i32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "i32"))
-}
-
-fn require_u32(op: &str, name: &str, value: usize) -> Result<u32> {
-    u32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "u32"))
-}
-
-fn div_ceil_grid(op: &str, name: &str, value: usize, block: u32) -> Result<u32> {
-    Ok(require_u32(op, name, value)?.div_ceil(block).max(1))
 }
 
 /// Pick a block size for the noise kernels that doesn't leave the back half

--- a/src/gpu/kernels/dense.rs
+++ b/src/gpu/kernels/dense.rs
@@ -24,6 +24,7 @@ use num_complex::Complex64;
 use crate::error::{PrismError, Result};
 
 use super::super::{GpuContext, GpuState};
+use super::launch_err;
 
 const BLOCK_SIZE: u32 = 256;
 
@@ -676,13 +677,6 @@ pub(crate) fn kernel_source() -> String {
 // ============================================================================
 // Rust-side launchers
 // ============================================================================
-
-fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: "gpu".to_string(),
-        operation: format!("{op}: {err}"),
-    }
-}
 
 fn grid_for(count: u64) -> u32 {
     count.div_ceil(BLOCK_SIZE as u64).max(1) as u32

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -12,9 +12,35 @@ pub(crate) mod stabilizer;
 
 use cudarc::driver::{DeviceRepr, ValidAsZeroBits};
 
-use crate::error::Result;
+use crate::error::{PrismError, Result};
 use crate::gpu::device::GpuDevice;
 use crate::gpu::memory::GpuBuffer;
+
+pub(super) fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
+    PrismError::BackendUnsupported {
+        backend: "gpu".to_string(),
+        operation: format!("{op}: {err}"),
+    }
+}
+
+pub(super) fn launch_limit_err(op: &str, name: &str, value: usize, limit: &str) -> PrismError {
+    PrismError::BackendUnsupported {
+        backend: "gpu".to_string(),
+        operation: format!("{op}: {name}={value} exceeds {limit} kernel limit"),
+    }
+}
+
+pub(super) fn require_i32(op: &str, name: &str, value: usize) -> Result<i32> {
+    i32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "i32"))
+}
+
+pub(super) fn require_u32(op: &str, name: &str, value: usize) -> Result<u32> {
+    u32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "u32"))
+}
+
+pub(super) fn div_ceil_grid(op: &str, name: &str, value: usize, block: u32) -> Result<u32> {
+    Ok(require_u32(op, name, value)?.div_ceil(block).max(1))
+}
 
 /// Scratch buffers reused across launches that need to upload small per-call
 /// metadata (sorted-qubit lists, packed lookup tables, fused gate matrices).

--- a/src/gpu/kernels/stabilizer.rs
+++ b/src/gpu/kernels/stabilizer.rs
@@ -47,9 +47,10 @@
 
 use cudarc::driver::{CudaSlice, LaunchConfig, PushKernelArg};
 
-use crate::error::{PrismError, Result};
+use crate::error::Result;
 
 use super::super::{GpuContext, GpuTableau};
+use super::{div_ceil_grid, launch_err, require_i32, require_u32};
 
 const BLOCK_SIZE: u32 = 128;
 
@@ -609,32 +610,6 @@ extern "C" __global__ void stab_measure_deterministic(
 /// Return the stabilizer CUDA C source for concatenation into the shared PTX module.
 pub(crate) fn kernel_source() -> String {
     KERNEL_SOURCE.to_string()
-}
-
-fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: "gpu".to_string(),
-        operation: format!("{op}: {err}"),
-    }
-}
-
-fn launch_limit_err(op: &str, name: &str, value: usize, limit: &str) -> PrismError {
-    PrismError::BackendUnsupported {
-        backend: "gpu".to_string(),
-        operation: format!("{op}: {name}={value} exceeds {limit} kernel limit"),
-    }
-}
-
-fn require_i32(op: &str, name: &str, value: usize) -> Result<i32> {
-    i32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "i32"))
-}
-
-fn require_u32(op: &str, name: &str, value: usize) -> Result<u32> {
-    u32::try_from(value).map_err(|_| launch_limit_err(op, name, value, "u32"))
-}
-
-fn div_ceil_grid(op: &str, name: &str, value: usize, block: u32) -> Result<u32> {
-    Ok(require_u32(op, name, value)?.div_ceil(block).max(1))
 }
 
 /// Initialise a freshly-allocated `GpuTableau` to the identity tableau: destabilizer

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -50,18 +50,20 @@ pub fn is_available() -> bool {
     GpuContext::is_available()
 }
 
+#[inline]
+fn env_usize_or(var: &str, default: usize, min: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|n| n.max(min))
+        .unwrap_or(default)
+}
+
 /// Effective GPU crossover threshold. Reads `PRISM_GPU_MIN_QUBITS` once per
 /// process and caches the result.
 pub fn min_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_GPU_MIN_QUBITS") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n;
-            }
-        }
-        MIN_QUBITS_DEFAULT
-    })
+    *CACHED.get_or_init(|| env_usize_or("PRISM_GPU_MIN_QUBITS", MIN_QUBITS_DEFAULT, 0))
 }
 
 /// Default minimum shot count for routing compiled BTS sampling to the GPU.
@@ -92,28 +94,14 @@ pub const BTS_MIN_WEIGHT_FACTOR_DEFAULT: usize = 2;
 /// process and caches the result.
 pub(crate) fn bts_min_shots() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_GPU_BTS_MIN_SHOTS") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n;
-            }
-        }
-        BTS_MIN_SHOTS_DEFAULT
-    })
+    *CACHED.get_or_init(|| env_usize_or("PRISM_GPU_BTS_MIN_SHOTS", BTS_MIN_SHOTS_DEFAULT, 0))
 }
 
 /// Effective GPU BTS rank threshold. Reads `PRISM_GPU_BTS_MIN_RANK` once per
 /// process and caches the result.
 pub(crate) fn bts_min_rank() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_GPU_BTS_MIN_RANK") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n.max(1);
-            }
-        }
-        BTS_MIN_RANK_DEFAULT
-    })
+    *CACHED.get_or_init(|| env_usize_or("PRISM_GPU_BTS_MIN_RANK", BTS_MIN_RANK_DEFAULT, 1))
 }
 
 /// Effective GPU BTS parity-weight threshold factor. Reads
@@ -121,12 +109,11 @@ pub(crate) fn bts_min_rank() -> usize {
 pub(crate) fn bts_min_weight_factor() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_GPU_BTS_MIN_WEIGHT_FACTOR") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n.max(1);
-            }
-        }
-        BTS_MIN_WEIGHT_FACTOR_DEFAULT
+        env_usize_or(
+            "PRISM_GPU_BTS_MIN_WEIGHT_FACTOR",
+            BTS_MIN_WEIGHT_FACTOR_DEFAULT,
+            1,
+        )
     })
 }
 
@@ -148,12 +135,11 @@ pub const STABILIZER_MIN_QUBITS_DEFAULT: usize = 100_000;
 pub fn stabilizer_min_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_STABILIZER_GPU_MIN_QUBITS") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n;
-            }
-        }
-        STABILIZER_MIN_QUBITS_DEFAULT
+        env_usize_or(
+            "PRISM_STABILIZER_GPU_MIN_QUBITS",
+            STABILIZER_MIN_QUBITS_DEFAULT,
+            0,
+        )
     })
 }
 

--- a/src/sim/compiled/mod.rs
+++ b/src/sim/compiled/mod.rs
@@ -27,6 +27,7 @@ pub use parity::ParityStats;
 use parity::{build_parity_blocks_if_useful, build_xor_dag_if_useful, minimize_flip_row_weight};
 pub(crate) use parity::{ParityBlock, ParityBlocks, SparseParity, XorDag};
 
+pub(crate) use crate::backend::word_ops::xor_words;
 pub(crate) use propagation::batch_propagate_backward;
 pub(crate) use propagation::propagate_backward;
 use propagation::{
@@ -528,6 +529,20 @@ impl CompiledSampler {
                 num_shots
             };
 
+            let apply_seq = |dst: &mut [u64]| {
+                for tile_start in (0..num_shots).step_by(max_batch) {
+                    let tile_end = (tile_start + max_batch).min(num_shots);
+                    for g in 0..total_groups {
+                        for s in tile_start..tile_end {
+                            let byte = rand_buf[s * bytes_per_shot + g] as usize;
+                            let entry = lut.lookup(g, byte);
+                            let shot_base = s * m_words;
+                            xor_words(&mut dst[shot_base..shot_base + m_words], entry);
+                        }
+                    }
+                }
+            };
+
             #[cfg(feature = "parallel")]
             const PAR_SHOT_THRESHOLD: usize = 256;
 
@@ -557,33 +572,11 @@ impl CompiledSampler {
                         }
                     });
             } else {
-                for tile_start in (0..num_shots).step_by(max_batch) {
-                    let tile_end = (tile_start + max_batch).min(num_shots);
-                    for g in 0..total_groups {
-                        for s in tile_start..tile_end {
-                            let byte = rand_buf[s * bytes_per_shot + g] as usize;
-                            let entry = lut.lookup(g, byte);
-                            let shot_base = s * m_words;
-                            xor_words(&mut accum[shot_base..shot_base + m_words], entry);
-                        }
-                    }
-                }
+                apply_seq(accum);
             }
 
             #[cfg(not(feature = "parallel"))]
-            {
-                for tile_start in (0..num_shots).step_by(max_batch) {
-                    let tile_end = (tile_start + max_batch).min(num_shots);
-                    for g in 0..total_groups {
-                        for s in tile_start..tile_end {
-                            let byte = rand_buf[s * bytes_per_shot + g] as usize;
-                            let entry = lut.lookup(g, byte);
-                            let shot_base = s * m_words;
-                            xor_words(&mut accum[shot_base..shot_base + m_words], entry);
-                        }
-                    }
-                }
-            }
+            apply_seq(accum);
 
             m_words
         } else {
@@ -1634,7 +1627,6 @@ impl PackedShots {
         self.data
     }
 
-    #[allow(dead_code)]
     pub(crate) fn into_shot_major_data(self) -> Vec<u64> {
         if self.layout == ShotLayout::ShotMajor {
             return self.data;
@@ -2110,72 +2102,6 @@ impl DevicePackedShots {
             }
         }
         Ok(self.to_host()?.counts())
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2")]
-unsafe fn xor_words_avx2(dst: &mut [u64], src: &[u64]) {
-    use std::arch::x86_64::*;
-    let len = dst.len().min(src.len());
-    let chunks = len / 4;
-    let dp = dst.as_mut_ptr() as *mut __m256i;
-    let sp = src.as_ptr() as *const __m256i;
-    for i in 0..chunks {
-        let d = _mm256_loadu_si256(dp.add(i));
-        let s = _mm256_loadu_si256(sp.add(i));
-        _mm256_storeu_si256(dp.add(i), _mm256_xor_si256(d, s));
-    }
-    let tail = chunks * 4;
-    for i in tail..len {
-        *dst.get_unchecked_mut(i) ^= *src.get_unchecked(i);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-#[allow(dead_code)]
-unsafe fn xor_words_neon(dst: &mut [u64], src: &[u64]) {
-    use std::arch::aarch64::*;
-    let len = dst.len().min(src.len());
-    let chunks = len / 2;
-    let dp = dst.as_mut_ptr();
-    let sp = src.as_ptr();
-    for i in 0..chunks {
-        let off = i * 2;
-        let d = vld1q_u64(dp.add(off));
-        let s = vld1q_u64(sp.add(off));
-        vst1q_u64(dp.add(off), veorq_u64(d, s));
-    }
-    let tail = chunks * 2;
-    for i in tail..len {
-        *dst.get_unchecked_mut(i) ^= *src.get_unchecked(i);
-    }
-}
-
-#[inline(always)]
-pub(crate) fn xor_words(dst: &mut [u64], src: &[u64]) {
-    #[cfg(target_arch = "x86_64")]
-    {
-        if is_x86_feature_detected!("avx2") && dst.len() >= 4 {
-            // SAFETY: AVX2 detected, pointers are valid u64 slices
-            unsafe {
-                xor_words_avx2(dst, src);
-            }
-            return;
-        }
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        if dst.len() >= 2 {
-            // SAFETY: NEON is baseline on aarch64, pointers are valid u64 slices
-            unsafe {
-                xor_words_neon(dst, src);
-            }
-            return;
-        }
-    }
-    for (d, &s) in dst.iter_mut().zip(src) {
-        *d ^= s;
     }
 }
 

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -123,6 +123,16 @@ pub(super) const MIN_FACTORED_STABILIZER_QUBITS: usize = 128;
 
 pub(super) const MIN_BLOCK_FOR_FACTORED_STAB: usize = 16;
 
+#[inline]
+pub(super) fn stabilizer_rank_budget(num_qubits: usize) -> usize {
+    let log2n = if num_qubits >= 2 {
+        (num_qubits as f64).log2().ceil() as usize * 2
+    } else {
+        0
+    };
+    num_qubits.saturating_sub(log2n)
+}
+
 // GPU crossover threshold and its env override live in `crate::gpu` so users
 // can introspect them without depending on internal dispatch plumbing. The
 // dispatch layer calls `crate::gpu::min_qubits()` directly; there is no
@@ -252,24 +262,13 @@ impl BackendKind {
 }
 
 pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
+    if kind.is_stabilizer_family() && !circuit.is_clifford_only() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "stabilizer".into(),
+            reason: "circuit contains non-Clifford gates".into(),
+        });
+    }
     match kind {
-        BackendKind::Stabilizer
-        | BackendKind::FilteredStabilizer
-        | BackendKind::FactoredStabilizer
-            if !circuit.is_clifford_only() =>
-        {
-            return Err(PrismError::IncompatibleBackend {
-                backend: "stabilizer".into(),
-                reason: "circuit contains non-Clifford gates".into(),
-            });
-        }
-        #[cfg(feature = "gpu")]
-        BackendKind::StabilizerGpu { .. } if !circuit.is_clifford_only() => {
-            return Err(PrismError::IncompatibleBackend {
-                backend: "stabilizer".into(),
-                reason: "circuit contains non-Clifford gates".into(),
-            });
-        }
         BackendKind::ProductState if circuit.has_entangling_gates() => {
             return Err(PrismError::IncompatibleBackend {
                 backend: "productstate".into(),

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -4,7 +4,7 @@ use crate::backend::sparse::SparseBackend;
 use crate::backend::stabilizer::StabilizerBackend;
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::tensornetwork::TensorNetworkBackend;
-use crate::backend::Backend;
+use crate::backend::{max_statevector_qubits, Backend};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
@@ -21,86 +21,6 @@ pub(super) enum DispatchAction {
     StabilizerRank,
     StochasticPauli { num_samples: usize },
     DeterministicPauli { epsilon: f64, max_terms: usize },
-}
-
-pub(super) fn max_statevector_qubits() -> usize {
-    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_MAX_SV_QUBITS") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n;
-            }
-        }
-        match detect_max_sv_qubits() {
-            Some(n) => n,
-            None => {
-                eprintln!(
-                    "warning: could not detect system memory; statevector qubit cap is disabled. \
-                     Large circuits may abort on allocation. Set PRISM_MAX_SV_QUBITS to suppress."
-                );
-                usize::MAX
-            }
-        }
-    })
-}
-
-#[cfg(windows)]
-fn detect_max_sv_qubits() -> Option<usize> {
-    #[repr(C)]
-    struct MemoryStatusEx {
-        dw_length: u32,
-        dw_memory_load: u32,
-        ull_total_phys: u64,
-        ull_avail_phys: u64,
-        ull_total_page_file: u64,
-        ull_avail_page_file: u64,
-        ull_total_virtual: u64,
-        ull_avail_virtual: u64,
-        ull_avail_extended_virtual: u64,
-    }
-
-    extern "system" {
-        fn GlobalMemoryStatusEx(lp_buffer: *mut MemoryStatusEx) -> i32;
-    }
-
-    // SAFETY: zeroed MemoryStatusEx is valid (all-zero bit pattern is a valid repr(C) struct)
-    let mut status: MemoryStatusEx = unsafe { std::mem::zeroed() };
-    status.dw_length = std::mem::size_of::<MemoryStatusEx>() as u32;
-    // SAFETY: status is a valid MemoryStatusEx with dw_length set; FFI call reads/writes only within the struct
-    if unsafe { GlobalMemoryStatusEx(&mut status) } == 0 {
-        return None;
-    }
-
-    let budget = status.ull_total_phys / 2;
-    let max_elements = budget / 16;
-    if max_elements == 0 {
-        return None;
-    }
-    let n = 63 - max_elements.leading_zeros() as usize;
-    Some(n.min(33))
-}
-
-#[cfg(unix)]
-fn detect_max_sv_qubits() -> Option<usize> {
-    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
-    for line in meminfo.lines() {
-        if let Some(rest) = line.strip_prefix("MemTotal:") {
-            let kb: u64 = rest.trim().trim_end_matches(" kB").trim().parse().ok()?;
-            let budget = (kb * 1024) / 2;
-            let max_elements = budget / 16;
-            if max_elements == 0 {
-                return None;
-            }
-            let n = 63 - max_elements.leading_zeros() as usize;
-            return Some(n.min(33));
-        }
-    }
-    None
-}
-
-#[cfg(not(any(windows, unix)))]
-fn detect_max_sv_qubits() -> Option<usize> {
-    None
 }
 
 pub(super) const AUTO_MPS_BOND_DIM: usize = 256;

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -21,10 +21,11 @@ use decomposed::{
 pub use dispatch::BackendKind;
 use dispatch::{
     has_temporal_clifford_opportunity, max_statevector_qubits, select_backend, select_dispatch,
-    supports_fused_for_kind, try_temporal_clifford, validate_explicit_backend, DispatchAction,
-    AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM, AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX,
-    MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS, MAX_STABILIZER_RANK_QUBITS,
-    MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS, MIN_QUBITS_FOR_SPD_AUTO,
+    stabilizer_rank_budget, supports_fused_for_kind, try_temporal_clifford,
+    validate_explicit_backend, DispatchAction, AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM,
+    AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
+    MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
+    MIN_QUBITS_FOR_SPD_AUTO,
 };
 pub use probability::{FactoredBlock, Probabilities, ProbabilitiesIter};
 pub use shots::{bitstring, ShotsResult};
@@ -66,6 +67,14 @@ pub struct SimulationResult {
     /// Probability of each computational basis state (length 2^n).
     /// `None` if the backend does not support probability extraction.
     pub probabilities: Option<Probabilities>,
+}
+
+#[inline]
+fn probs_only_result(probs: Vec<f64>) -> SimulationResult {
+    SimulationResult {
+        probabilities: Some(Probabilities::Dense(probs)),
+        classical_bits: vec![],
+    }
 }
 
 /// Core execution: fuse, init, apply, extract.
@@ -216,27 +225,15 @@ fn run_with_internal(
         && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
     {
         let t = circuit.t_count();
-        let n = circuit.num_qubits;
-        let log2n = if n >= 2 {
-            (n as f64).log2().ceil() as usize * 2
-        } else {
-            0
-        };
-        let sr_budget = n.saturating_sub(log2n);
+        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
         if t <= MAX_AUTO_T_COUNT_EXACT && t <= sr_budget {
             let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
-            return Ok(SimulationResult {
-                probabilities: Some(Probabilities::Dense(sr.probabilities)),
-                classical_bits: vec![],
-            });
+            return Ok(probs_only_result(sr.probabilities));
         }
         if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
             let sr =
                 stabilizer_rank::run_stabilizer_rank_approx(circuit, AUTO_APPROX_MAX_TERMS, seed)?;
-            return Ok(SimulationResult {
-                probabilities: Some(Probabilities::Dense(sr.probabilities)),
-                classical_bits: vec![],
-            });
+            return Ok(probs_only_result(sr.probabilities));
         }
     }
     if let Some(result) = try_temporal_clifford(&kind, circuit, seed) {
@@ -246,26 +243,15 @@ fn run_with_internal(
         DispatchAction::Backend(mut backend) => execute(&mut *backend, circuit, &opts),
         DispatchAction::StabilizerRank => {
             let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
-            Ok(SimulationResult {
-                probabilities: Some(Probabilities::Dense(sr.probabilities)),
-                classical_bits: vec![],
-            })
+            Ok(probs_only_result(sr.probabilities))
         }
         DispatchAction::StochasticPauli { num_samples } => {
             let spp = unified_pauli::run_spp(circuit, num_samples, seed)?;
-            let probs = unified_pauli::spp_to_probabilities(&spp);
-            Ok(SimulationResult {
-                probabilities: Some(Probabilities::Dense(probs)),
-                classical_bits: vec![],
-            })
+            Ok(probs_only_result(unified_pauli::spp_to_probabilities(&spp)))
         }
         DispatchAction::DeterministicPauli { epsilon, max_terms } => {
             let spd = unified_pauli::run_spd(circuit, epsilon, max_terms)?;
-            let probs = unified_pauli::spd_to_probabilities(&spd);
-            Ok(SimulationResult {
-                probabilities: Some(Probabilities::Dense(probs)),
-                classical_bits: vec![],
-            })
+            Ok(probs_only_result(unified_pauli::spd_to_probabilities(&spd)))
         }
     }
 }
@@ -312,15 +298,7 @@ fn supports_deferred_measurement_sampling(circuit: &Circuit) -> bool {
             .any(|inst| matches!(inst, Instruction::Conditional { .. }))
 }
 
-fn should_use_compiled_clifford_sampling(
-    kind: &BackendKind,
-    circuit: &Circuit,
-    num_shots: usize,
-) -> bool {
-    if num_shots < 2 || !supports_compiled_measurement_sampling(circuit) {
-        return false;
-    }
-
+fn is_clifford_sampler_kind(kind: &BackendKind) -> bool {
     match kind {
         BackendKind::Auto | BackendKind::Stabilizer | BackendKind::FilteredStabilizer => true,
         #[cfg(feature = "gpu")]
@@ -329,21 +307,24 @@ fn should_use_compiled_clifford_sampling(
     }
 }
 
+fn should_use_compiled_clifford_sampling(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+) -> bool {
+    num_shots >= 2
+        && supports_compiled_measurement_sampling(circuit)
+        && is_clifford_sampler_kind(kind)
+}
+
 fn should_use_deferred_clifford_sampling(
     kind: &BackendKind,
     circuit: &Circuit,
     num_shots: usize,
 ) -> bool {
-    if num_shots < 2 || !supports_deferred_measurement_sampling(circuit) {
-        return false;
-    }
-
-    match kind {
-        BackendKind::Auto | BackendKind::Stabilizer | BackendKind::FilteredStabilizer => true,
-        #[cfg(feature = "gpu")]
-        BackendKind::StabilizerGpu { .. } => true,
-        _ => false,
-    }
+    num_shots >= 2
+        && supports_deferred_measurement_sampling(circuit)
+        && is_clifford_sampler_kind(kind)
 }
 
 fn compile_measurements_for_kind(
@@ -384,18 +365,7 @@ pub fn run_counts(
     }
 
     let result = run_shots_with(kind, circuit, num_shots, seed)?;
-    let m_words = circuit.num_classical_bits.div_ceil(64).max(1);
-    let mut counts: HashMap<Vec<u64>, u64> = HashMap::new();
-    for shot in &result.shots {
-        let mut key = vec![0u64; m_words];
-        for (i, &b) in shot.iter().enumerate() {
-            if b {
-                key[i / 64] |= 1u64 << (i % 64);
-            }
-        }
-        *counts.entry(key).or_insert(0) += 1;
-    }
-    Ok(counts)
+    Ok(result.counts())
 }
 
 /// Compute per-qubit marginal probabilities: P(q_i = 0) and P(q_i = 1) for each qubit.
@@ -548,13 +518,7 @@ pub fn run_shots_with(
     }
     if matches!(kind, BackendKind::Auto) && circuit.is_clifford_plus_t() && circuit.has_t_gates() {
         let t = circuit.t_count();
-        let n = circuit.num_qubits;
-        let log2n = if n >= 2 {
-            (n as f64).log2().ceil() as usize * 2
-        } else {
-            0
-        };
-        let sr_budget = n.saturating_sub(log2n);
+        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
         if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
             return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
         }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -20,19 +20,18 @@ use decomposed::{
 };
 pub use dispatch::BackendKind;
 use dispatch::{
-    has_temporal_clifford_opportunity, max_statevector_qubits, select_backend, select_dispatch,
-    stabilizer_rank_budget, supports_fused_for_kind, try_temporal_clifford,
-    validate_explicit_backend, DispatchAction, AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM,
-    AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
-    MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
-    MIN_QUBITS_FOR_SPD_AUTO,
+    has_temporal_clifford_opportunity, select_backend, select_dispatch, stabilizer_rank_budget,
+    supports_fused_for_kind, try_temporal_clifford, validate_explicit_backend, DispatchAction,
+    AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM, AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX,
+    MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS, MAX_STABILIZER_RANK_QUBITS,
+    MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS, MIN_QUBITS_FOR_SPD_AUTO,
 };
 pub use probability::{FactoredBlock, Probabilities, ProbabilitiesIter};
 pub use shots::{bitstring, ShotsResult};
 
 use std::collections::HashMap;
 
-use crate::backend::Backend;
+use crate::backend::{max_statevector_qubits, Backend};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::Result;
 use shots::{packed_shots_to_classical_bits, sample_shots};


### PR DESCRIPTION
## Summary

This is ultimately just a tech debt and code clean up process. I have been just trying to get things to work and implement the ideas but now it is time to move this into cleaner, easier to read code as the complexity has expanded.

Consolidates repeated simulator helpers while preserving the existing dispatch behavior. Adds direct backend matrix hooks for product, sparse, MPS, and tensor network backends, shares word wise XOR kernels across compiled sampling and stabilizer operations, and adds focused Criterion coverage for the refactor-sensitive paths.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Run from local machine using focused before/after trees based on `origin/main` and this branch, with `--features parallel,bench-fast`.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- |
| `refactor/apply_1q_matrix/product/128` | 857.41 ns | 644.55 ns | -24.83% | Yes |
| `refactor/apply_1q_matrix/sparse/16` | 400.44 ns | 300.80 ns | -24.88% | Yes |
| `refactor/apply_1q_matrix/mps/32` | 1.574 us | 1.354 us | -14.02% | Yes |
| `refactor/apply_1q_matrix/tensor_network/16` | 1.085 us | 1.017 us | -6.27% | Yes |
| `refactor/sparse_rzz/single/16q_10active` | 8.438 us | 7.492 us | -11.21% | Yes |
| `refactor/sparse_rzz/batch4/16q_10active` | 17.978 us | 16.546 us | -7.97% | Yes |
| `refactor/sparse_rzz/single/20q_12active` | 28.647 us | 26.069 us | -9.00% | Yes |
| `refactor/sparse_rzz/batch4/20q_12active` | 65.606 us | 65.273 us | -0.51% | Yes |

Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally
  - `cargo test --all-features --lib` passed locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
  - `cargo clippy --all-targets --all-features -- -D warnings` passed locally
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
  - N/A, no new public API
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
  - N/A, no new gate, backend, or fusion pass
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
  - Not run locally

Additional checks:
- `cargo bench --features bench-fast --bench refactor_hotspots --no-run` passed
- `git diff --check` passed

## Hotspot notes

Touched hot-path-adjacent code:

- `Backend::apply_1q_matrix` implementations for product, sparse, MPS, and tensor-network backends
- shared `backend::word_ops::xor_words` and pointer-based stabilizer XOR path
- compiled sampler XOR accumulation
- sparse `Rzz` and `BatchRzz` application
- statevector multi-gate tiling constants
- fusion pass helper paths used before backend execution

Criterion coverage was added in `benches/refactor_hotspots.rs` for direct matrix dispatch and sparse Rzz paths. No flamegraph was captured.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
  - N/A, this is helper consolidation and benchmark coverage, not a new subsystem
- [x] Design or research notes added where required for new subsystems
  - N/A

## Breaking changes

None.

## Risks and rollback

Main risk is behavioral drift from helper extraction in parser, fusion, simulation dispatch, GPU launch validation, or backend matrix application. The direct backend hooks are local overrides of existing behavior, and rollback can be done by reverting the commit or by removing the direct `apply_1q_matrix` overrides to fall back to generic instruction dispatch.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
