### PR TITLE
perf(sim): streamline query APIs with terminal sampling fast paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ All notable changes to PRISM-Q will be documented in this file.
 
 ### Refactor
 
+- **sim:** Replace public free-function simulation aliases with the query-aware builder API.
 - **sim:** Consolidate simulator hot path helpers (#65)([5ebb2b8](https://github.com/AbeCoull/prism-q/commit/5ebb2b885035a0ad185a78fbe9d77b318d8cbab9))
+
+### Performance
+
+- **sim:** Add terminal statevector shot and count fast paths with high-shot Criterion coverage.
 
 ### Testing
 
@@ -316,4 +321,3 @@ All notable changes to PRISM-Q will be documented in this file.
 ### `fix
 
 - Fusion pass fixes with temporal blocking (#8)([eb9fc76](https://github.com/AbeCoull/prism-q/commit/eb9fc762a122e66903defb793a1345b3b3e2a5ad))
-

--- a/README.md
+++ b/README.md
@@ -82,29 +82,49 @@ println!("{:?}", result.probabilities);
 ### Shot-based sampling
 
 ```rust
-use prism_q::{circuit::openqasm, run_shots};
+use prism_q::{bitstring, circuit::openqasm, simulate};
 
 let circuit = openqasm::parse(qasm).unwrap();
-let result = run_shots(&circuit, 1024, 42).unwrap();
+let result = simulate(&circuit).seed(42).shots(1024).unwrap();
 println!("{result}");
 // 00: 512
 // 11: 512
+
+let counts = simulate(&circuit)
+    .seed(42)
+    .sample_counts(1024)
+    .unwrap();
+for (bits, count) in counts.into_counts() {
+    println!("{}: {count}", bitstring(&bits, circuit.num_classical_bits));
+}
 ```
 
 ### Backend dispatch
 
 ```rust
-use prism_q::{circuit::openqasm, run_with, BackendKind};
+use prism_q::{circuit::openqasm, simulate, BackendKind};
 
 let circuit = openqasm::parse(qasm).unwrap();
 
 // Auto picks the optimal backend based on circuit properties.
-let auto   = run_with(BackendKind::Auto, &circuit, 42).unwrap();
+let auto = simulate(&circuit).seed(42).run().unwrap();
 
 // Or choose explicitly.
-let stab   = run_with(BackendKind::Stabilizer, &circuit, 42).unwrap();
-let mps    = run_with(BackendKind::Mps { max_bond_dim: 64 }, &circuit, 42).unwrap();
-let sparse = run_with(BackendKind::Sparse, &circuit, 42).unwrap();
+let stab = simulate(&circuit)
+    .backend(BackendKind::Stabilizer)
+    .seed(42)
+    .run()
+    .unwrap();
+let mps = simulate(&circuit)
+    .backend(BackendKind::Mps { max_bond_dim: 64 })
+    .seed(42)
+    .run()
+    .unwrap();
+let sparse = simulate(&circuit)
+    .backend(BackendKind::Sparse)
+    .seed(42)
+    .run()
+    .unwrap();
 ```
 
 ### Programmatic circuit construction
@@ -124,13 +144,13 @@ let result = CircuitBuilder::new(3)
 use `Circuit` directly:
 
 ```rust
-use prism_q::{Circuit, sim, gates::Gate};
+use prism_q::{simulate, Circuit, gates::Gate};
 
 let mut c = Circuit::new(3, 0);
 c.add_gate(Gate::H, &[0]);
 c.add_gate(Gate::Cx, &[0, 1]);
 c.add_gate(Gate::Cx, &[1, 2]);
-let result = sim::run(&c, 42).unwrap();
+let result = simulate(&c).seed(42).run().unwrap();
 ```
 
 ## Backends
@@ -198,17 +218,16 @@ covered by a dedicated kernel, including batched kernels for `BatchPhase`, `Batc
 [`tests/golden_gpu.rs`](tests/golden_gpu.rs) verify amplitude equivalence against the
 CPU statevector within 1e-10.
 
-`BackendKind::Auto` does not yet route to GPU. Opt in explicitly. The recommended
-entry point is `run_with_gpu`, which dispatches through `BackendKind::StatevectorGpu`
-so the circuit picks up fusion plus independent-subsystem decomposition and applies
+`BackendKind::Auto` does not yet route to GPU. Opt in explicitly with the
+simulation builder so the circuit picks up fusion plus independent-subsystem decomposition and applies
 a size-aware crossover (default: GPU only for `≥ gpu::MIN_QUBITS_DEFAULT` qubit
 sub-circuits, overridable via `PRISM_GPU_MIN_QUBITS`):
 
 ```rust
-use prism_q::{gpu::GpuContext, run_with_gpu};
+use prism_q::{gpu::GpuContext, simulate};
 
 let ctx = GpuContext::new(0)?;
-let result = run_with_gpu(&circuit, 42, ctx)?;
+let result = simulate(&circuit).gpu(ctx).seed(42).run()?;
 ```
 
 Introspect whether the default GPU dispatch footprint is likely to fit before
@@ -232,8 +251,7 @@ crossover by design.
 
 ### Stabilizer GPU (experimental)
 
-`BackendKind::StabilizerGpu` and `run_with_stabilizer_gpu` route Clifford
-circuits through CUDA. Gate application uses one batched kernel
+`BackendKind::StabilizerGpu` routes Clifford circuits through CUDA. Gate application uses one batched kernel
 (`stab_apply_batch`). Measurement and reset stay on the device, including pivot
 search, row operations, phase fixup, and deterministic outcomes. Golden tests
 cover 100 to 5000 qubits.
@@ -281,7 +299,7 @@ cargo bench --features "parallel,bench-fast"                 # quick smoke test
 `StabilizerBackend::apply_instructions` without probability readback. It also
 includes GPU BTS marginal and device count groups for the reduced transfer
 compiled sampler path. Use direct stabilizer groups for GPU crossover and
-throughput claims. Treat `run_with` groups as public API timings.
+throughput claims. Treat `simulate(...).run()` groups as public API timings.
 
 Always use `--features parallel`. Baselines were taken with Rayon enabled. Never run
 two `cargo bench` invocations at the same time on the same machine. Rayon thread pools

--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -11,6 +11,14 @@ use prism_q::sim;
 use prism_q::{BackendKind, StatevectorBackend};
 use std::time::Duration;
 
+fn run_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
 fn is_fast() -> bool {
     cfg!(feature = "bench-fast")
 }
@@ -36,7 +44,7 @@ fn bench_single_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::H, &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -44,7 +52,7 @@ fn bench_single_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Rx(1.234), &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -52,7 +60,7 @@ fn bench_single_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::T, &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -69,7 +77,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Cx, &[0, 1]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -80,7 +88,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Cx, &[1, 0]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -92,7 +100,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Cx, &[0, n - 1]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -104,7 +112,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Cx, &[n - 1, 0]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -113,7 +121,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Cz, &[0, 1]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -121,7 +129,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Cz, &[0, n - 1]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -132,7 +140,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Swap, &[0, 1]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -144,7 +152,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, 1]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -156,7 +164,7 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, n - 1]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -289,7 +297,7 @@ fn bench_measurement(c: &mut Criterion) {
                 circuit.add_gate(Gate::H, &[0]);
                 circuit.add_measure(0, 0);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -348,7 +356,7 @@ fn bench_high_target_qubit(c: &mut Criterion) {
             let mut circuit = Circuit::new(n_qubits, 0);
             circuit.add_gate(Gate::H, &[target]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -367,7 +375,7 @@ fn bench_controlled_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::cu(h_mat), &[0, 1]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -381,7 +389,7 @@ fn bench_controlled_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::mcu(x_mat, 2), &[0, 1, 2]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -390,7 +398,7 @@ fn bench_controlled_gates(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::mcu(x_mat, 3), &[0, 1, 2, 3]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             });
         }
@@ -408,7 +416,7 @@ fn bench_diagonal_parametric_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Rz(1.234), &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -416,7 +424,7 @@ fn bench_diagonal_parametric_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::Ry(1.234), &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -424,7 +432,7 @@ fn bench_diagonal_parametric_gates(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::P(1.234), &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -446,7 +454,7 @@ fn bench_cphase_kernel(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::cphase(theta), &[0, 1]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -458,7 +466,7 @@ fn bench_cphase_kernel(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::cphase(theta), &[1, 0]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -476,7 +484,7 @@ fn bench_new_gate_types(c: &mut Criterion) {
             let mut circuit = Circuit::new(n, 0);
             circuit.add_gate(Gate::SX, &[0]);
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
 
@@ -487,7 +495,7 @@ fn bench_new_gate_types(c: &mut Criterion) {
                 let mut circuit = Circuit::new(n, 0);
                 circuit.add_gate(Gate::SXdg, &[0]);
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
                 });
             },
         );
@@ -515,7 +523,7 @@ fn bench_classical_only(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                    run_with(BackendKind::Statevector, circ, 42).unwrap();
                 });
             },
         );
@@ -525,7 +533,7 @@ fn bench_classical_only(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                    run_with(BackendKind::Statevector, circ, 42).unwrap();
                 });
             },
         );

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -32,6 +32,26 @@ use prism_q::{sim, BackendKind, StabilizerBackend, StatevectorBackend};
 
 const SEED: u64 = 0xDEAD_BEEF;
 
+fn run_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
+fn run_shots_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .seed(seed)
+        .shots(num_shots)
+}
+
 fn is_fast() -> bool {
     cfg!(feature = "bench-fast")
 }
@@ -86,7 +106,7 @@ fn bench_gpu_random(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -104,7 +124,7 @@ fn bench_gpu_qft(c: &mut Criterion) {
         let circuit = circuits::qft_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -122,7 +142,7 @@ fn bench_gpu_hea(c: &mut Criterion) {
         let circuit = circuits::hardware_efficient_ansatz(n, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -140,7 +160,7 @@ fn bench_gpu_qaoa(c: &mut Criterion) {
         let circuit = circuits::qaoa_circuit(n, 3, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -163,7 +183,7 @@ fn bench_gpu_decomposed(c: &mut Criterion) {
         let n = circuit.num_qubits;
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -172,7 +192,7 @@ fn bench_gpu_decomposed(c: &mut Criterion) {
 }
 
 /// Direct-kernel path via `StatevectorBackend::new(seed).with_gpu(ctx)`.
-/// Bypasses `sim::run_with`, so fusion, decomposition, and crossover do not
+/// Bypasses `simulate(...).run()`, so fusion, decomposition, and crossover do not
 /// run. Excludes backend init and first-use scratch allocation from the timed
 /// region so it tracks kernel and launcher cost more directly than the
 /// dispatched groups above.
@@ -242,7 +262,7 @@ fn bench_gpu_measurement(c: &mut Criterion) {
         let circuit = mid_measure_circuit(n, 4);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -296,7 +316,7 @@ fn bts_gpu_shot_sizes() -> Vec<usize> {
     }
 }
 
-/// Stabilizer CPU dispatch baseline through `sim::run_with`.
+/// Stabilizer CPU dispatch baseline through `simulate(...).run()`.
 ///
 /// Includes the default probability extraction at the end of the run, so this
 /// is an API-level end-to-end measurement rather than the hot-path throughput
@@ -308,14 +328,14 @@ fn bench_stab_cpu_clifford_d10(c: &mut Criterion) {
         let circuit = prism_q::circuits::clifford_heavy_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Stabilizer, circ, 42).unwrap();
+                run_with(BackendKind::Stabilizer, circ, 42).unwrap();
             });
         });
     }
     group.finish();
 }
 
-/// Stabilizer GPU dispatch through `run_with_stabilizer_gpu`.
+/// Stabilizer GPU dispatch through `BackendKind::StabilizerGpu`.
 ///
 /// Includes the default probability extraction at the end of the run. Use the
 /// direct backend groups below for hot-path throughput comparisons.
@@ -333,7 +353,7 @@ fn bench_stab_gpu_clifford_d10(c: &mut Criterion) {
         let circuit = prism_q::circuits::clifford_heavy_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -436,7 +456,7 @@ fn bench_stab_gpu_ghz_measure(c: &mut Criterion) {
         }
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(kind.clone(), circ, 42).unwrap();
+                run_with(kind.clone(), circ, 42).unwrap();
             });
         });
     }
@@ -723,7 +743,7 @@ fn bench_stab_gpu_shots_explicit(c: &mut Criterion) {
         for &shots in &shot_sizes {
             group.bench_with_input(BenchmarkId::from_parameter(shots), &circuit, |b, circ| {
                 b.iter(|| {
-                    sim::run_shots_with(kind.clone(), circ, shots, SEED).unwrap();
+                    run_shots_with(kind.clone(), circ, shots, SEED).unwrap();
                 });
             });
         }

--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -19,11 +19,38 @@ use prism_q::{compile_qec_profiled_sampler, parse_qec_program};
 use prism_q::{
     run_qec_program, HomologicalSampler, QecNoise, QecOptions, QecPauli, QecProgram, QecRecordRef,
 };
+use std::collections::HashMap;
 #[cfg(feature = "bench-internal")]
 use std::hint::black_box;
 use std::time::Duration;
 
 const SEED: u64 = 0xDEAD_BEEF;
+const API_QUERY_SHOTS: usize = 100_000;
+
+fn run_shots_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .seed(seed)
+        .shots(num_shots)
+}
+
+fn run_counts_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<HashMap<Vec<u64>, u64>> {
+    Ok(sim::simulate(circuit)
+        .backend(kind)
+        .seed(seed)
+        .sample_counts(num_shots)?
+        .into_counts())
+}
 
 fn bell_circuit_with_measurements(n_qubits: usize) -> Circuit {
     let mut c = Circuit::new(n_qubits, n_qubits);
@@ -51,6 +78,104 @@ fn ghz_circuit_with_measurements(n_qubits: usize) -> Circuit {
     c
 }
 
+fn non_clifford_terminal_circuit(n_qubits: usize, measured_qubits: usize) -> Circuit {
+    let mut c = Circuit::new(n_qubits, n_qubits);
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Ry(0.17 + q as f64 * 0.013), &[q]);
+        c.add_gate(Gate::Rz(0.29 + q as f64 * 0.017), &[q]);
+    }
+    for q in 0..n_qubits - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Rx(0.11 + q as f64 * 0.019), &[q]);
+    }
+    for q in 0..measured_qubits.min(n_qubits) {
+        c.add_measure(q, q);
+    }
+    c
+}
+
+fn api_redesign_circuit(n_qubits: usize, with_measurements: bool) -> Circuit {
+    let mut c = Circuit::new(n_qubits, if with_measurements { n_qubits } else { 0 });
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Ry(0.13 + q as f64 * 0.011), &[q]);
+        c.add_gate(Gate::Rz(0.19 + q as f64 * 0.017), &[q]);
+    }
+    for q in 0..n_qubits - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Rx(0.07 + q as f64 * 0.023), &[q]);
+    }
+    if with_measurements {
+        for q in 0..n_qubits {
+            c.add_measure(q, q);
+        }
+    }
+    c
+}
+
+fn clifford_t_marginal_circuit(n_qubits: usize) -> Circuit {
+    let mut c = Circuit::new(n_qubits, 0);
+    for q in 0..n_qubits {
+        c.add_gate(Gate::H, &[q]);
+        if q % 3 == 0 {
+            c.add_gate(Gate::T, &[q]);
+        }
+    }
+    for q in 0..n_qubits - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in (1..n_qubits).step_by(4) {
+        c.add_gate(Gate::Tdg, &[q]);
+    }
+    c
+}
+
+fn bench_api_queries(c: &mut Criterion) {
+    let mut group = c.benchmark_group("api_queries");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+
+    let run_circuit = api_redesign_circuit(12, false);
+    group.bench_function("run_auto_12q", |b| {
+        b.iter(|| sim::simulate(&run_circuit).seed(SEED).run().unwrap());
+    });
+
+    let shots_circuit = api_redesign_circuit(12, true);
+    group.bench_function("shots_terminal_12q_100000", |b| {
+        b.iter(|| {
+            sim::simulate(&shots_circuit)
+                .seed(SEED)
+                .shots(API_QUERY_SHOTS)
+                .unwrap()
+        });
+    });
+
+    group.bench_function("sample_counts_terminal_12q_100000", |b| {
+        b.iter(|| {
+            sim::simulate(&shots_circuit)
+                .seed(SEED)
+                .sample_counts(API_QUERY_SHOTS)
+                .unwrap()
+        });
+    });
+
+    let marginal_circuit = clifford_t_marginal_circuit(14);
+    group.bench_function("marginals_auto_clifford_t_14q", |b| {
+        b.iter(|| {
+            sim::simulate(&marginal_circuit)
+                .seed(SEED)
+                .marginals()
+                .unwrap()
+        });
+    });
+
+    group.finish();
+}
+
 fn bench_run_shots(c: &mut Criterion) {
     let mut group = c.benchmark_group("run_shots");
     group.sample_size(10);
@@ -63,7 +188,7 @@ fn bench_run_shots(c: &mut Criterion) {
             BenchmarkId::new("bell_16q", n_shots),
             &n_shots,
             |b, &shots| {
-                b.iter(|| sim::run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
+                b.iter(|| run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
             },
         );
     }
@@ -74,7 +199,29 @@ fn bench_run_shots(c: &mut Criterion) {
             BenchmarkId::new("ghz_20q", n_shots),
             &n_shots,
             |b, &shots| {
-                b.iter(|| sim::run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
+                b.iter(|| run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
+            },
+        );
+    }
+
+    for &n_shots in &[1_000, 10_000, 100_000] {
+        let circuit = non_clifford_terminal_circuit(18, 18);
+        group.bench_with_input(
+            BenchmarkId::new("nonclifford_full_18q", n_shots),
+            &n_shots,
+            |b, &shots| {
+                b.iter(|| run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
+            },
+        );
+    }
+
+    for &n_shots in &[1_000, 10_000, 100_000] {
+        let circuit = non_clifford_terminal_circuit(20, 8);
+        group.bench_with_input(
+            BenchmarkId::new("nonclifford_subset_20q_8m", n_shots),
+            &n_shots,
+            |b, &shots| {
+                b.iter(|| run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
             },
         );
     }
@@ -90,13 +237,44 @@ fn bench_counts(c: &mut Criterion) {
 
     for &n_shots in &[10_000, 100_000, 1_000_000] {
         let circuit = bell_circuit_with_measurements(16);
-        let result = sim::run_shots_with(BackendKind::Auto, &circuit, n_shots, SEED).unwrap();
+        let result = run_shots_with(BackendKind::Auto, &circuit, n_shots, SEED).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("ShotsResult_counts_16q", n_shots),
             &result,
             |b, res| {
                 b.iter(|| res.counts());
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_run_counts_terminal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("run_counts_terminal");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+
+    for &n_shots in &[10_000, 100_000] {
+        let circuit = non_clifford_terminal_circuit(18, 18);
+        group.bench_with_input(
+            BenchmarkId::new("nonclifford_full_18q", n_shots),
+            &n_shots,
+            |b, &shots| {
+                b.iter(|| run_counts_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
+            },
+        );
+    }
+
+    for &n_shots in &[10_000, 100_000] {
+        let circuit = non_clifford_terminal_circuit(20, 8);
+        group.bench_with_input(
+            BenchmarkId::new("nonclifford_subset_20q_8m", n_shots),
+            &n_shots,
+            |b, &shots| {
+                b.iter(|| run_counts_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
             },
         );
     }
@@ -616,8 +794,10 @@ fn bench_analytical_marginals(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_api_queries,
     bench_run_shots,
     bench_counts,
+    bench_run_counts_terminal,
     bench_compiled_counts,
     bench_histogram_counts,
     bench_rank_space_counts,

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -17,6 +17,28 @@ use std::time::Duration;
 
 const SEED: u64 = 0xDEAD_BEEF;
 
+fn run_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
+fn run_shots_with_noise(
+    kind: BackendKind,
+    circuit: &Circuit,
+    noise: &prism_q::NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .noise(noise)
+        .seed(seed)
+        .shots(num_shots)
+}
+
 fn is_fast() -> bool {
     cfg!(feature = "bench-fast")
 }
@@ -228,7 +250,7 @@ fn bench_statevector_random(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -244,7 +266,7 @@ fn bench_statevector_qft(c: &mut Criterion) {
         let circuit = qft_like_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -260,7 +282,7 @@ fn bench_statevector_hea(c: &mut Criterion) {
         let circuit = circuits::hardware_efficient_ansatz(n, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -276,7 +298,7 @@ fn bench_statevector_clifford(c: &mut Criterion) {
         let circuit = circuits::clifford_heavy_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -292,7 +314,7 @@ fn bench_statevector_qft_textbook(c: &mut Criterion) {
         let circuit = circuits::qft_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -309,7 +331,7 @@ fn bench_statevector_qpe(c: &mut Criterion) {
         let label = format!("{}q", n);
         group.bench_with_input(BenchmarkId::from_parameter(label), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -327,7 +349,7 @@ fn bench_statevector_qaoa(c: &mut Criterion) {
         let circuit = circuits::qaoa_circuit(n, 3, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -343,7 +365,7 @@ fn bench_statevector_qv(c: &mut Criterion) {
         let circuit = circuits::quantum_volume_circuit(n, n, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -359,7 +381,7 @@ fn bench_statevector_w_state(c: &mut Criterion) {
         let circuit = circuits::w_state_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -378,7 +400,7 @@ fn bench_statevector_depth_sweep(c: &mut Criterion) {
         let circuit = circuits::random_circuit(12, depth, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(depth), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -395,14 +417,14 @@ fn bench_statevector_entanglement(c: &mut Criterion) {
     let sparse = sparse_entanglement_circuit(16, 10);
     group.bench_function("sparse", |b| {
         b.iter(|| {
-            sim::run_with(BackendKind::Statevector, &sparse, 42).unwrap();
+            run_with(BackendKind::Statevector, &sparse, 42).unwrap();
         });
     });
 
     let dense = dense_entanglement_circuit(16, 10);
     group.bench_function("dense", |b| {
         b.iter(|| {
-            sim::run_with(BackendKind::Statevector, &dense, 42).unwrap();
+            run_with(BackendKind::Statevector, &dense, 42).unwrap();
         });
     });
 
@@ -421,7 +443,7 @@ fn bench_statevector_scalability(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
             });
         });
     }
@@ -439,7 +461,7 @@ fn bench_stabilizer_scaling(c: &mut Criterion) {
         let circuit = random_clifford_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Stabilizer, circ, 42).unwrap();
+                run_with(BackendKind::Stabilizer, circ, 42).unwrap();
             });
         });
     }
@@ -465,7 +487,7 @@ fn bench_stabilizer_measurement(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::Stabilizer, circ, 42).unwrap();
+                    run_with(BackendKind::Stabilizer, circ, 42).unwrap();
                 });
             },
         );
@@ -483,7 +505,7 @@ fn bench_factored_stabilizer_scaling(c: &mut Criterion) {
         let circuit = random_clifford_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
+                run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
             });
         });
     }
@@ -502,7 +524,7 @@ fn bench_factored_stabilizer_local(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
+                    run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
                 });
             },
         );
@@ -529,7 +551,7 @@ fn bench_factored_stabilizer_measurement(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
+                    run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
                 });
             },
         );
@@ -547,7 +569,7 @@ fn bench_sparse_scaling(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Sparse, circ, 42).unwrap();
+                run_with(BackendKind::Sparse, circ, 42).unwrap();
             });
         });
     }
@@ -562,7 +584,7 @@ fn bench_sparse_low_entanglement(c: &mut Criterion) {
         let circuit = sparse_entanglement_circuit(n, 5);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Sparse, circ, 42).unwrap();
+                run_with(BackendKind::Sparse, circ, 42).unwrap();
             });
         });
     }
@@ -579,7 +601,7 @@ fn bench_mps_scaling(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Mps { max_bond_dim: 64 }, circ, 42).unwrap();
+                run_with(BackendKind::Mps { max_bond_dim: 64 }, circ, 42).unwrap();
             });
         });
     }
@@ -594,7 +616,7 @@ fn bench_mps_linear_chain(c: &mut Criterion) {
         let circuit = dense_entanglement_circuit(n, 10);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Mps { max_bond_dim: 64 }, circ, 42).unwrap();
+                run_with(BackendKind::Mps { max_bond_dim: 64 }, circ, 42).unwrap();
             });
         });
     }
@@ -643,7 +665,7 @@ fn bench_product_scaling(c: &mut Criterion) {
         let circuit = random_single_qubit_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::ProductState, circ, 42).unwrap();
+                run_with(BackendKind::ProductState, circ, 42).unwrap();
             });
         });
     }
@@ -660,7 +682,7 @@ fn bench_tn_scaling(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::TensorNetwork, circ, 42).unwrap();
+                run_with(BackendKind::TensorNetwork, circ, 42).unwrap();
             });
         });
     }
@@ -675,7 +697,7 @@ fn bench_tn_linear_chain(c: &mut Criterion) {
         let circuit = dense_entanglement_circuit(n, 5);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::TensorNetwork, circ, 42).unwrap();
+                run_with(BackendKind::TensorNetwork, circ, 42).unwrap();
             });
         });
     }
@@ -701,7 +723,7 @@ fn bench_compare_clifford(c: &mut Criterion) {
         for &(name, ref kind) in backends {
             group.bench_with_input(BenchmarkId::new(name, n), &circuit, |b, circ| {
                 b.iter(|| {
-                    sim::run_with(kind.clone(), circ, 42).unwrap();
+                    run_with(kind.clone(), circ, 42).unwrap();
                 });
             });
         }
@@ -724,7 +746,7 @@ fn bench_compare_single_qubit(c: &mut Criterion) {
         for &(name, ref kind) in backends {
             group.bench_with_input(BenchmarkId::new(name, n), &circuit, |b, circ| {
                 b.iter(|| {
-                    sim::run_with(kind.clone(), circ, 42).unwrap();
+                    run_with(kind.clone(), circ, 42).unwrap();
                 });
             });
         }
@@ -748,7 +770,7 @@ fn bench_compare_general(c: &mut Criterion) {
         for &(name, ref kind) in backends {
             group.bench_with_input(BenchmarkId::new(name, n), &circuit, |b, circ| {
                 b.iter(|| {
-                    sim::run_with(kind.clone(), circ, 42).unwrap();
+                    run_with(kind.clone(), circ, 42).unwrap();
                 });
             });
         }
@@ -766,7 +788,7 @@ fn bench_auto_random(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -782,7 +804,7 @@ fn bench_auto_qft(c: &mut Criterion) {
         let circuit = qft_like_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -798,7 +820,7 @@ fn bench_auto_qft_textbook(c: &mut Criterion) {
         let circuit = circuits::qft_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -815,7 +837,7 @@ fn bench_auto_qpe(c: &mut Criterion) {
         let label = format!("{}q", n);
         group.bench_with_input(BenchmarkId::from_parameter(label), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -831,7 +853,7 @@ fn bench_auto_hea(c: &mut Criterion) {
         let circuit = circuits::hardware_efficient_ansatz(n, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -847,7 +869,7 @@ fn bench_auto_clifford(c: &mut Criterion) {
         let circuit = circuits::clifford_heavy_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -865,7 +887,7 @@ fn bench_auto_scalability(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                sim::run_with(BackendKind::Auto, circ, 42).unwrap();
+                run_with(BackendKind::Auto, circ, 42).unwrap();
             });
         });
     }
@@ -888,7 +910,7 @@ fn bench_decomposition(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                    run_with(BackendKind::Statevector, circ, 42).unwrap();
                 });
             },
         );
@@ -914,7 +936,7 @@ fn bench_decomposition(c: &mut Criterion) {
             &circuit,
             |b, circ| {
                 b.iter(|| {
-                    sim::run_with(BackendKind::Statevector, circ, 42).unwrap();
+                    run_with(BackendKind::Statevector, circ, 42).unwrap();
                 });
             },
         );
@@ -944,10 +966,10 @@ fn bench_factored_random(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
 
         group.bench_with_input(BenchmarkId::new("statevector", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Statevector, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
         });
         group.bench_with_input(BenchmarkId::new("factored", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Factored, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
         });
     }
 
@@ -965,14 +987,14 @@ fn bench_factored_independent(c: &mut Criterion) {
             BenchmarkId::new("statevector", total_q),
             &circuit,
             |b, circ| {
-                b.iter(|| sim::run_with(BackendKind::Statevector, circ, 42).unwrap());
+                b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
             },
         );
         group.bench_with_input(
             BenchmarkId::new("factored", total_q),
             &circuit,
             |b, circ| {
-                b.iter(|| sim::run_with(BackendKind::Factored, circ, 42).unwrap());
+                b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
             },
         );
     }
@@ -988,10 +1010,10 @@ fn bench_factored_sim_only(c: &mut Criterion) {
         let circuit = circuits::random_circuit(n, 10, SEED);
 
         group.bench_with_input(BenchmarkId::new("statevector", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Statevector, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
         });
         group.bench_with_input(BenchmarkId::new("factored", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Factored, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
         });
     }
 
@@ -1016,14 +1038,14 @@ fn bench_factored_dynamic(c: &mut Criterion) {
             BenchmarkId::new("statevector", total_q),
             &circuit,
             |b, circ| {
-                b.iter(|| sim::run_with(BackendKind::Statevector, circ, 42).unwrap());
+                b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
             },
         );
         group.bench_with_input(
             BenchmarkId::new("factored", total_q),
             &circuit,
             |b, circ| {
-                b.iter(|| sim::run_with(BackendKind::Factored, circ, 42).unwrap());
+                b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
             },
         );
     }
@@ -1039,10 +1061,10 @@ fn bench_factored_dense(c: &mut Criterion) {
         let circuit = circuits::hardware_efficient_ansatz(n, 3, SEED);
 
         group.bench_with_input(BenchmarkId::new("statevector", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Statevector, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
         });
         group.bench_with_input(BenchmarkId::new("factored", n), &circuit, |b, circ| {
-            b.iter(|| sim::run_with(BackendKind::Factored, circ, 42).unwrap());
+            b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
         });
     }
 
@@ -1107,7 +1129,7 @@ fn bench_clifford_t(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("statevector", format!("{n}q_{t}t")), |b| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -1123,7 +1145,7 @@ fn bench_clifford_t(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("statevector", format!("{n}q_4t")), |b| {
             b.iter(|| {
-                sim::run_with(BackendKind::Statevector, &circuit, 42).unwrap();
+                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
         });
     }
@@ -1227,14 +1249,8 @@ fn bench_noisy_sampling(c: &mut Criterion) {
         BenchmarkId::new("compiled_pauli", "clifford_100q_10k"),
         |b| {
             b.iter(|| {
-                prism_q::run_shots_with_noise(
-                    BackendKind::Auto,
-                    &clifford,
-                    &clifford_noise,
-                    10_000,
-                    SEED,
-                )
-                .unwrap();
+                run_shots_with_noise(BackendKind::Auto, &clifford, &clifford_noise, 10_000, SEED)
+                    .unwrap();
             });
         },
     );
@@ -1245,7 +1261,7 @@ fn bench_noisy_sampling(c: &mut Criterion) {
         BenchmarkId::new("trajectory_pauli", "non_clifford_12q_512"),
         |b| {
             b.iter(|| {
-                prism_q::run_shots_with_noise(
+                run_shots_with_noise(
                     BackendKind::Auto,
                     &non_clifford,
                     &non_clifford_noise,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,15 +206,17 @@ Orchestration layer in `src/sim/mod.rs`. Entry points:
 
 | Function | Description |
 |----------|-------------|
-| `run(circuit, seed)` | Auto-dispatch, full output |
-| `run_with(kind, circuit, seed)` | Explicit backend selection |
+| `simulate(circuit).seed(seed).run()` | Auto-dispatch, full output |
+| `simulate(circuit).backend(kind).seed(seed).run()` | Explicit backend selection |
+| `simulate(circuit).seed(seed).shots(shots)` | Multi-shot sampling |
+| `simulate(circuit).backend(kind).seed(seed).shots(shots)` | Multi-shot with backend selection |
+| `simulate(circuit).backend(kind).noise(noise).seed(seed).shots(shots)` | Noisy multi-shot |
+| `simulate(circuit).seed(seed).sample_counts(shots)` | Auto-dispatched frequency histogram |
+| `simulate(circuit).backend(kind).seed(seed).sample_counts(shots)` | Frequency histogram with backend selection |
+| `simulate(circuit).seed(seed).marginals()` | Auto-dispatched per-qubit marginal probabilities |
+| `simulate(circuit).backend(kind).seed(seed).marginals()` | Per-qubit marginal probabilities with backend selection |
 | `run_on(backend, circuit)` | Pre-constructed backend |
 | `run_qasm(qasm, seed)` | Parse + simulate |
-| `run_shots(circuit, shots, seed)` | Multi-shot sampling |
-| `run_shots_with(kind, circuit, shots, seed)` | Multi-shot with backend selection |
-| `run_shots_with_noise(kind, circuit, noise, shots, seed)` | Noisy multi-shot |
-| `run_counts(kind, circuit, shots, seed)` | Frequency histogram |
-| `run_marginals(kind, circuit, seed)` | Per-qubit marginal probabilities |
 
 ### Auto-dispatch decision tree
 
@@ -291,7 +293,8 @@ CUDA acceleration covers statevector execution, stabilizer execution, and compil
 BTS sampling. Five entry points are available:
 
 - **`BackendKind::StatevectorGpu { context }`**. Public dispatch path for statevector
-  GPU execution. It routes through `sim::run_with`, keeps fusion and subsystem
+  GPU execution. It routes through `simulate(circuit).backend(kind).seed(seed).run()`,
+  keeps fusion and subsystem
   decomposition, and uses `crate::gpu::min_qubits()` (default 14,
   `PRISM_GPU_MIN_QUBITS` override) to keep small sub-circuits on CPU.
 - **`BackendKind::StabilizerGpu { context }`**. Public dispatch path for stabilizer
@@ -549,7 +552,7 @@ No panics on user input. `debug_assert!` for internal invariants only.
 Top-level re-exports from `src/lib.rs`:
 
 **Simulation:**
-`run`, `run_with`, `run_on`, `run_qasm`, `run_shots`, `run_shots_with`, `run_shots_with_noise`, `run_counts`, `run_marginals`, `bitstring`
+`simulate`, `run_on`, `run_qasm`, `bitstring`
 
 **Compiled sampling:**
 `compile_measurements`, `compile_forward`, `compile_detector_sampler`, `compile_noisy`, `run_shots_compiled`, `run_shots_noisy`, `run_shots_homological`, `noisy_marginals_analytical`
@@ -558,10 +561,10 @@ Top-level re-exports from `src/lib.rs`:
 `parse_qec_program`, `compile_qec_program_rows`, `run_qec_program`, `run_qec_program_reference`, `QecProgram`, `QecOp`, `QecOptions`, `QecSampleResult`, `QecBasis`, `QecPauli`, `QecRecordRef`, `QecNoise`, `QecMeasurementRow`, `QecCompiledRows`
 
 **Clifford+T:**
-`run_stabilizer_rank`, `run_stabilizer_rank_approx`, `stabilizer_overlap_sq`, `run_spp`, `run_spd`, `spp_to_probabilities`, `spd_to_probabilities`
+`run_stabilizer_rank`, `run_stabilizer_rank_approx`, `stabilizer_overlap_sq`, `run_spp`, `run_spd`
 
 **Types:**
-`Circuit`, `CircuitBuilder`, `Instruction`, `ClassicalCondition`, `Gate`, `BackendKind`, `SimulationResult`, `Probabilities`, `FactoredBlock`, `ShotsResult`, `PrismError`, `Result`
+`Circuit`, `CircuitBuilder`, `Instruction`, `ClassicalCondition`, `Gate`, `BackendKind`, `RunOutcome`, `CountsResult`, `MarginalsResult`, `Probabilities`, `FactoredBlock`, `ShotsResult`, `PrismError`, `Result`
 
 **Backends:**
 `StatevectorBackend`, `StabilizerBackend`, `SparseBackend`, `MpsBackend`, `ProductStateBackend`, `TensorNetworkBackend`, `FactoredBackend`

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -11,7 +11,7 @@ A simulation strategy implementing the `Backend` trait (e.g., statevector, stabi
 A class of quantum gates (H, S, CNOT, etc.) that can be simulated efficiently on stabilizer tableaus in O(n²) time.
 
 **Count**
-A frequency histogram of measured bitstrings across multiple shots, returned by `run_counts`.
+A frequency histogram of measured bitstrings across multiple shots, returned by `simulate(circuit).seed(seed).sample_counts(shots)`.
 
 **Fusion**
 The pre-simulation optimization pipeline that merges, cancels, and reorders gates to reduce execution cost.

--- a/examples/backends.rs
+++ b/examples/backends.rs
@@ -1,5 +1,5 @@
 use prism_q::circuits::clifford_heavy_circuit;
-use prism_q::{run_with, BackendKind};
+use prism_q::{simulate, BackendKind};
 
 fn main() {
     // A Clifford-only 4-qubit circuit with entangling gates.
@@ -17,7 +17,11 @@ fn main() {
     ];
 
     for (name, kind) in &backends {
-        let result = run_with(kind.clone(), &circuit, 42).expect("simulation failed");
+        let result = simulate(&circuit)
+            .backend(kind.clone())
+            .seed(42)
+            .run()
+            .expect("simulation failed");
         let probs = result.probabilities.expect("no probabilities").to_vec();
 
         let nonzero: Vec<(usize, f64)> = probs

--- a/examples/bench_gpu_dispatch.rs
+++ b/examples/bench_gpu_dispatch.rs
@@ -1,5 +1,5 @@
 //! Three-path timing for the GPU crossover work: CPU direct, GPU direct
-//! (`.with_gpu(ctx)`), GPU dispatched (`run_with(BackendKind::StatevectorGpu)`).
+//! (`.with_gpu(ctx)`), GPU dispatched (`simulate(...).gpu(ctx)`).
 //!
 //! Runs each path three times per (circuit, qubits) pair and reports the minimum.
 //! The "GPU direct" path bypasses fusion + decomposition + crossover; the "GPU
@@ -19,9 +19,6 @@ use prism_q::{sim, BackendKind, Circuit, StatevectorBackend};
 
 #[cfg(feature = "gpu")]
 use prism_q::gpu::GpuContext;
-
-#[cfg(feature = "gpu")]
-use prism_q::run_with_gpu;
 
 #[cfg(feature = "gpu")]
 const SEED: u64 = 0xDEAD_BEEF;
@@ -53,7 +50,11 @@ fn time_cpu_dispatched(circuit: &Circuit) -> f64 {
     let mut best = f64::INFINITY;
     for _ in 0..REPS {
         let start = Instant::now();
-        let _ = sim::run_with(BackendKind::Statevector, circuit, 42).unwrap();
+        let _ = sim::simulate(circuit)
+            .backend(BackendKind::Statevector)
+            .seed(42)
+            .run()
+            .unwrap();
         let t = start.elapsed().as_secs_f64();
         if t < best {
             best = t;
@@ -87,7 +88,11 @@ fn time_gpu_dispatched(circuit: &Circuit, ctx: &std::sync::Arc<GpuContext>) -> f
     let mut best = f64::INFINITY;
     for _ in 0..REPS {
         let start = Instant::now();
-        let _ = run_with_gpu(circuit, 42, ctx.clone()).unwrap();
+        let _ = sim::simulate(circuit)
+            .gpu(ctx.clone())
+            .seed(42)
+            .run()
+            .unwrap();
         let t = start.elapsed().as_secs_f64();
         if t < best {
             best = t;

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -34,5 +34,5 @@ fn main() {
 
     // Alternative: use the pre-built qft_circuit() from circuits module
     // let circuit = prism_q::circuits::qft_circuit(n);
-    // let result = prism_q::run(&circuit, 42).expect("simulation failed");
+    // let result = prism_q::simulate(&circuit).seed(42).run().expect("simulation failed");
 }

--- a/examples/shots.rs
+++ b/examples/shots.rs
@@ -1,5 +1,5 @@
 use prism_q::circuit::openqasm;
-use prism_q::run_shots;
+use prism_q::simulate;
 
 fn main() {
     let qasm = r#"
@@ -16,12 +16,18 @@ fn main() {
     let circuit = openqasm::parse(qasm).expect("failed to parse QASM");
 
     // Deterministic: 1024 shots with fixed seed
-    let result = run_shots(&circuit, 1024, 42).expect("shots failed");
+    let result = simulate(&circuit)
+        .seed(42)
+        .shots(1024)
+        .expect("shots failed");
     println!("Deterministic (seed=42), 1024 shots:");
     print!("{result}");
 
     // Random seed: non-deterministic sampling
-    let result = run_shots(&circuit, 1024, rand::random()).expect("shots failed");
+    let result = simulate(&circuit)
+        .seed(rand::random())
+        .shots(1024)
+        .expect("shots failed");
     println!("Random seed, 1024 shots:");
     print!("{result}");
 }

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -200,7 +200,7 @@ impl StatevectorBackend {
         // (`StatevectorBackend::with_gpu(ctx)`) and intentionally skips the
         // dispatch-level crossover. Direct `with_gpu` callers request
         // kernel behavior. For size-based crossover plus decomposition-aware
-        // routing, enter via `sim::run_with(BackendKind::StatevectorGpu
+        // routing, use `sim::simulate(...).backend(BackendKind::StatevectorGpu
         // { context })`, which honors `gpu_min_qubits()` per sub-block.
         //
         // Caveat: Multi2q launches one kernel for each subgate (rare in practice).
@@ -386,6 +386,10 @@ impl StatevectorBackend {
     /// for a properly normalized copy.
     pub fn state_vector(&self) -> &[Complex64] {
         &self.state
+    }
+
+    pub(crate) fn probability_scale(&self) -> f64 {
+        self.pending_norm * self.pending_norm
     }
 
     /// Initialize the backend from a pre-computed state vector.

--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -177,8 +177,8 @@ impl CircuitBuilder {
     }
 
     /// Execute with automatic backend selection.
-    pub fn run(&self, seed: u64) -> crate::Result<crate::sim::SimulationResult> {
-        crate::sim::run(&self.circuit, seed)
+    pub fn run(&self, seed: u64) -> crate::Result<crate::sim::RunOutcome> {
+        crate::sim::simulate(&self.circuit).seed(seed).run()
     }
 
     /// Execute with explicit backend selection.
@@ -186,13 +186,18 @@ impl CircuitBuilder {
         &self,
         kind: crate::sim::BackendKind,
         seed: u64,
-    ) -> crate::Result<crate::sim::SimulationResult> {
-        crate::sim::run_with(kind, &self.circuit, seed)
+    ) -> crate::Result<crate::sim::RunOutcome> {
+        crate::sim::simulate(&self.circuit)
+            .backend(kind)
+            .seed(seed)
+            .run()
     }
 
     /// Execute multi-shot sampling.
     pub fn run_shots(&self, num_shots: usize, seed: u64) -> crate::Result<crate::sim::ShotsResult> {
-        crate::sim::run_shots(&self.circuit, num_shots, seed)
+        crate::sim::simulate(&self.circuit)
+            .seed(seed)
+            .shots(num_shots)
     }
 }
 
@@ -260,7 +265,10 @@ mod tests {
         let mut c = Circuit::new(2, 0);
         c.add_gate(Gate::H, &[0]);
         c.add_gate(Gate::Cx, &[0, 1]);
-        let direct_result = crate::sim::run(&c, 42).expect("direct run failed");
+        let direct_result = crate::sim::simulate(&c)
+            .seed(42)
+            .run()
+            .expect("direct run failed");
         let dp = direct_result.probabilities.expect("no probs").to_vec();
 
         assert_eq!(bp.len(), dp.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,16 +90,11 @@ pub use sim::noise::{
 pub use sim::stabilizer_rank::{
     run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_overlap_sq, StabRankResult,
 };
-pub use sim::unified_pauli::{
-    run_spd, run_spp, spd_to_probabilities, spp_to_probabilities, SpdResult, SppResult,
-};
+pub use sim::unified_pauli::{run_spd, run_spp, SpdResult, SppResult};
 pub use sim::{
-    bitstring, run, run_counts, run_marginals, run_on, run_qasm, run_shots, run_shots_with,
-    run_shots_with_noise, run_with, BackendKind, FactoredBlock, Probabilities, ShotsResult,
-    SimulationResult,
+    bitstring, run_on, run_qasm, simulate, BackendKind, CountsResult, FactoredBlock,
+    MarginalsResult, Probabilities, RunOutcome, Seeded, ShotsResult, Simulate, Unseeded,
 };
 
 #[cfg(feature = "gpu")]
 pub use sim::compiled::{run_shots_compiled_with_gpu, DevicePackedShots};
-#[cfg(feature = "gpu")]
-pub use sim::{run_with_gpu, run_with_stabilizer_gpu};

--- a/src/sim/decomposed.rs
+++ b/src/sim/decomposed.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 
 use super::{
     execute_circuit, select_backend, validate_explicit_backend, BackendKind, FactoredBlock,
-    Probabilities, SimOptions, SimulationResult,
+    Probabilities, RunOutcome, SimOptions,
 };
 
 pub(super) const MIN_DECOMPOSITION_QUBITS: usize = 8;
@@ -23,7 +23,7 @@ fn run_blocks_maybe_par(
     seed: u64,
     opts: &SimOptions,
     k: usize,
-) -> Vec<Result<SimulationResult>> {
+) -> Vec<Result<RunOutcome>> {
     #[cfg(feature = "parallel")]
     {
         let all_small = _components
@@ -48,7 +48,7 @@ fn run_subcircuit(
     sub_circuit: &Circuit,
     block_seed: u64,
     opts: &SimOptions,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     let block_kind = if matches!(kind, BackendKind::Auto) {
         BackendKind::Auto
     } else {
@@ -63,7 +63,7 @@ pub(super) fn run_decomposed(
     circuit: &Circuit,
     seed: u64,
     opts: &SimOptions,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     let partitions = circuit.partition_subcircuits(components);
     let k = partitions.len();
 
@@ -72,7 +72,7 @@ pub(super) fn run_decomposed(
     } else {
         *opts
     };
-    let results: Vec<Result<SimulationResult>> =
+    let results: Vec<Result<RunOutcome>> =
         run_blocks_maybe_par(kind, &partitions, components, seed, &block_opts, k);
 
     merge_decomposed_results(
@@ -86,13 +86,13 @@ pub(super) fn run_decomposed(
 }
 
 fn merge_decomposed_results(
-    results: Vec<Result<SimulationResult>>,
+    results: Vec<Result<RunOutcome>>,
     components: &[Vec<usize>],
     partitions: &[(Circuit, Vec<usize>, Vec<usize>)],
     num_classical_bits: usize,
     num_qubits: usize,
     opts: &SimOptions,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     let mut factored_blocks: Vec<FactoredBlock> = Vec::new();
     let mut merged_classical = vec![false; num_classical_bits];
 
@@ -125,7 +125,7 @@ fn merge_decomposed_results(
         None
     };
 
-    Ok(SimulationResult {
+    Ok(RunOutcome {
         classical_bits: merged_classical,
         probabilities,
     })
@@ -139,14 +139,14 @@ pub(super) fn run_decomposed_prefused(
     seed: u64,
     opts: &SimOptions,
     original_circuit: &Circuit,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     let k = partitions.len();
     let block_opts = if original_circuit.num_qubits > 64 {
         SimOptions::classical_only()
     } else {
         *opts
     };
-    let results: Vec<Result<SimulationResult>> = (0..k)
+    let results: Vec<Result<RunOutcome>> = (0..k)
         .map(|i| {
             let block_seed = seed.wrapping_add(i as u64);
             let sub = &partitions[i].0;

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[cfg(feature = "gpu")]
 use crate::gpu::GpuContext;
 
-use super::{Probabilities, SimulationResult};
+use super::{Probabilities, RunOutcome};
 
 pub(super) enum DispatchAction {
     Backend(Box<dyn Backend>),
@@ -99,10 +99,9 @@ pub enum BackendKind {
     /// Larger circuits allocate a device-resident state and route gate
     /// application through GPU kernels.
     ///
-    /// Compose with [`crate::sim::run_with`] to get fusion + independent-
-    /// subsystem decomposition for free; each sub-block is evaluated against
-    /// the crossover independently. See [`crate::sim::run_with_gpu`] for a
-    /// one-liner wrapper when you already have an `Arc<GpuContext>`.
+    /// Compose with `simulate(...).backend(...).seed(...).run()` to get fusion
+    /// plus independent-subsystem decomposition; each sub-block is evaluated
+    /// against the crossover independently.
     #[cfg(feature = "gpu")]
     StatevectorGpu {
         context: Arc<GpuContext>,
@@ -117,9 +116,9 @@ pub enum BackendKind {
     /// kernels. Measurement and reset stay on device, while probabilities and
     /// export-style helpers still read back to the CPU algorithms.
     ///
-    /// Compose with [`crate::sim::run_with`] to pick up independent-subsystem
-    /// decomposition; non-Clifford circuits are rejected at dispatch time with
-    /// the same error shape as [`BackendKind::Stabilizer`].
+    /// Compose with `simulate(...).backend(...).seed(...).run()` to pick up
+    /// independent-subsystem decomposition; non-Clifford circuits are rejected
+    /// at dispatch time with the same error shape as [`BackendKind::Stabilizer`].
     #[cfg(feature = "gpu")]
     StabilizerGpu {
         context: Arc<GpuContext>,
@@ -217,6 +216,47 @@ pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> 
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoBackendChoice {
+    ProductState,
+    Stabilizer,
+    Sparse,
+    Mps,
+    Factored,
+    Statevector,
+}
+
+fn select_auto_backend_choice(
+    circuit: &Circuit,
+    has_partial_independence: bool,
+) -> AutoBackendChoice {
+    if !circuit.has_entangling_gates() {
+        AutoBackendChoice::ProductState
+    } else if circuit.is_clifford_only() {
+        AutoBackendChoice::Stabilizer
+    } else if circuit.num_qubits > max_statevector_qubits() {
+        if circuit.is_sparse_friendly() {
+            AutoBackendChoice::Sparse
+        } else {
+            AutoBackendChoice::Mps
+        }
+    } else if has_partial_independence {
+        AutoBackendChoice::Factored
+    } else {
+        AutoBackendChoice::Statevector
+    }
+}
+
+pub(super) fn auto_selects_cpu_statevector(
+    circuit: &Circuit,
+    has_partial_independence: bool,
+) -> bool {
+    matches!(
+        select_auto_backend_choice(circuit, has_partial_independence),
+        AutoBackendChoice::Statevector
+    )
+}
+
 /// Build a `StatevectorBackend` configured for GPU execution if the circuit
 /// is large enough to clear the crossover, otherwise a plain host
 /// backend. Called from `select_dispatch` (which runs per sub-block after
@@ -257,25 +297,26 @@ pub(super) fn select_dispatch(
     has_partial_independence: bool,
 ) -> DispatchAction {
     match kind {
-        BackendKind::Auto => {
-            if !circuit.has_entangling_gates() {
+        BackendKind::Auto => match select_auto_backend_choice(circuit, has_partial_independence) {
+            AutoBackendChoice::ProductState => {
                 DispatchAction::Backend(Box::new(ProductStateBackend::new(seed)))
-            } else if circuit.is_clifford_only() {
+            }
+            AutoBackendChoice::Stabilizer => {
                 DispatchAction::Backend(Box::new(StabilizerBackend::new(seed)))
-            } else if circuit.num_qubits > max_statevector_qubits() {
-                if circuit.is_sparse_friendly() {
-                    DispatchAction::Backend(Box::new(SparseBackend::new(seed)))
-                } else {
-                    DispatchAction::Backend(Box::new(MpsBackend::new(seed, AUTO_MPS_BOND_DIM)))
-                }
-            } else if has_partial_independence {
-                DispatchAction::Backend(Box::new(crate::backend::factored::FactoredBackend::new(
-                    seed,
-                )))
-            } else {
+            }
+            AutoBackendChoice::Sparse => {
+                DispatchAction::Backend(Box::new(SparseBackend::new(seed)))
+            }
+            AutoBackendChoice::Mps => {
+                DispatchAction::Backend(Box::new(MpsBackend::new(seed, AUTO_MPS_BOND_DIM)))
+            }
+            AutoBackendChoice::Factored => DispatchAction::Backend(Box::new(
+                crate::backend::factored::FactoredBackend::new(seed),
+            )),
+            AutoBackendChoice::Statevector => {
                 DispatchAction::Backend(Box::new(StatevectorBackend::new(seed)))
             }
-        }
+        },
         BackendKind::Statevector => {
             DispatchAction::Backend(Box::new(StatevectorBackend::new(seed)))
         }
@@ -364,7 +405,7 @@ pub(super) fn try_temporal_clifford(
     kind: &BackendKind,
     circuit: &Circuit,
     seed: u64,
-) -> Option<Result<SimulationResult>> {
+) -> Option<Result<RunOutcome>> {
     if !matches!(kind, BackendKind::Auto) {
         return None;
     }
@@ -406,7 +447,7 @@ pub(super) fn try_temporal_clifford(
 
     let probs = sv.probabilities().ok().map(Probabilities::Dense);
 
-    Some(Ok(SimulationResult {
+    Some(Ok(RunOutcome {
         classical_bits: sv.classical_results().to_vec(),
         probabilities: probs,
     }))
@@ -416,7 +457,6 @@ pub(super) fn try_temporal_clifford(
 mod gpu_crossover_tests {
     use super::*;
     use crate::gates::Gate;
-    use crate::sim::run_with;
 
     fn stub_kind() -> BackendKind {
         BackendKind::StatevectorGpu {
@@ -424,19 +464,30 @@ mod gpu_crossover_tests {
         }
     }
 
-    /// `run_with_gpu` must compose identically to constructing the variant
-    /// manually. Uses the stub context at a small circuit so crossover fires
-    /// and proves the composition is side-effect equivalent.
+    fn run_query(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<RunOutcome> {
+        crate::sim::simulate(circuit).backend(kind).seed(seed).run()
+    }
+
+    /// The builder GPU shortcut must compose identically to constructing the
+    /// variant manually. Uses the stub context at a small circuit so crossover
+    /// fires and proves the composition is side-effect equivalent.
     #[test]
-    fn run_with_gpu_wraps_statevector_gpu_variant() {
+    fn builder_gpu_wraps_statevector_gpu_variant() {
         let ctx = GpuContext::stub_for_tests();
         let mut circuit = Circuit::new(4, 0);
         circuit.add_gate(Gate::H, &[0]);
         circuit.add_gate(Gate::Cx, &[0, 1]);
 
-        let direct = crate::sim::run_with_gpu(&circuit, 42, ctx.clone())
-            .expect("run_with_gpu must honor crossover and route to CPU");
-        let manual = run_with(stub_kind(), &circuit, 42).expect("manual variant reference");
+        let direct = crate::sim::simulate(&circuit)
+            .gpu(ctx.clone())
+            .seed(42)
+            .run()
+            .expect("builder GPU shortcut must honor crossover and route to CPU");
+        let manual = crate::sim::simulate(&circuit)
+            .backend(stub_kind())
+            .seed(42)
+            .run()
+            .expect("manual variant reference");
 
         let dp = direct.probabilities.expect("direct probs").to_vec();
         let mp = manual.probabilities.expect("manual probs").to_vec();
@@ -456,7 +507,7 @@ mod gpu_crossover_tests {
         circuit.add_gate(Gate::H, &[2]);
         circuit.add_gate(Gate::Cx, &[2, 3]);
 
-        let result = run_with(stub_kind(), &circuit, 42)
+        let result = run_query(stub_kind(), &circuit, 42)
             .expect("stub context must not be touched for a 4q circuit");
         let probs = result
             .probabilities
@@ -484,8 +535,8 @@ mod gpu_crossover_tests {
         let circuit = crate::circuits::independent_bell_pairs(8);
         assert_eq!(circuit.num_qubits, 16);
 
-        let cpu = run_with(BackendKind::Statevector, &circuit, 42).expect("cpu baseline");
-        let gpu = run_with(stub_kind(), &circuit, 42).expect("stub must stay out of the way");
+        let cpu = run_query(BackendKind::Statevector, &circuit, 42).expect("cpu baseline");
+        let gpu = run_query(stub_kind(), &circuit, 42).expect("stub must stay out of the way");
 
         let cpu_p = cpu.probabilities.expect("cpu probs").to_vec();
         let gpu_p = gpu.probabilities.expect("gpu probs").to_vec();
@@ -520,8 +571,8 @@ mod gpu_crossover_tests {
         circuit.add_measure(2, 2);
         circuit.add_measure(3, 3);
 
-        let cpu_run = run_with(BackendKind::Stabilizer, &circuit, 42).expect("cpu baseline");
-        let gpu_run = run_with(stabilizer_stub_kind(), &circuit, 42)
+        let cpu_run = run_query(BackendKind::Stabilizer, &circuit, 42).expect("cpu baseline");
+        let gpu_run = run_query(stabilizer_stub_kind(), &circuit, 42)
             .expect("stub must stay out of the way for small circuits");
         assert_eq!(cpu_run.classical_bits, gpu_run.classical_bits);
     }
@@ -532,7 +583,7 @@ mod gpu_crossover_tests {
     fn stabilizer_gpu_rejects_non_clifford_at_dispatch() {
         let mut circuit = Circuit::new(2, 0);
         circuit.add_gate(Gate::T, &[0]);
-        let err = run_with(stabilizer_stub_kind(), &circuit, 42).unwrap_err();
+        let err = run_query(stabilizer_stub_kind(), &circuit, 42).unwrap_err();
         assert!(matches!(err, PrismError::IncompatibleBackend { .. }));
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -11,6 +11,7 @@ pub mod noise;
 mod probability;
 mod shots;
 pub mod stabilizer_rank;
+mod terminal_sampling;
 mod trajectory;
 pub mod unified_pauli;
 
@@ -20,21 +21,26 @@ use decomposed::{
 };
 pub use dispatch::BackendKind;
 use dispatch::{
-    has_temporal_clifford_opportunity, select_backend, select_dispatch, stabilizer_rank_budget,
-    supports_fused_for_kind, try_temporal_clifford, validate_explicit_backend, DispatchAction,
-    AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM, AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX,
-    MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS, MAX_STABILIZER_RANK_QUBITS,
-    MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS, MIN_QUBITS_FOR_SPD_AUTO,
+    auto_selects_cpu_statevector, has_temporal_clifford_opportunity, select_backend,
+    select_dispatch, stabilizer_rank_budget, supports_fused_for_kind, try_temporal_clifford,
+    validate_explicit_backend, DispatchAction, AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM,
+    AUTO_SPD_MAX_TERMS, MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
+    MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
+    MIN_QUBITS_FOR_SPD_AUTO,
 };
 pub use probability::{FactoredBlock, Probabilities, ProbabilitiesIter};
 pub use shots::{bitstring, ShotsResult};
 
 use std::collections::HashMap;
 
+use crate::backend::statevector::StatevectorBackend;
 use crate::backend::{max_statevector_qubits, Backend};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::Result;
 use shots::{packed_shots_to_classical_bits, sample_shots};
+use terminal_sampling::{sample_counts_from_state, sample_shots_from_state};
+
+type TerminalStatevector = (StatevectorBackend, Vec<(usize, usize)>);
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SimOptions {
@@ -57,9 +63,9 @@ impl SimOptions {
     }
 }
 
-/// Result of a simulation run.
+/// Result of a generic simulation run.
 #[derive(Debug, Clone)]
-pub struct SimulationResult {
+pub struct RunOutcome {
     /// Classical measurement outcomes, indexed by classical bit number.
     /// `true` = measured |1⟩.
     pub classical_bits: Vec<bool>,
@@ -68,20 +74,154 @@ pub struct SimulationResult {
     pub probabilities: Option<Probabilities>,
 }
 
+/// Frequency histogram returned by query-aware count sampling.
+#[derive(Debug, Clone)]
+pub struct CountsResult {
+    pub counts: HashMap<Vec<u64>, u64>,
+    pub num_classical_bits: usize,
+}
+
+impl CountsResult {
+    pub fn into_counts(self) -> HashMap<Vec<u64>, u64> {
+        self.counts
+    }
+}
+
+/// Per-qubit marginal probabilities returned by query-aware marginal sampling.
+#[derive(Debug, Clone)]
+pub struct MarginalsResult {
+    pub marginals: Vec<(f64, f64)>,
+}
+
+impl MarginalsResult {
+    pub fn into_vec(self) -> Vec<(f64, f64)> {
+        self.marginals
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Unseeded;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Seeded {
+    seed: u64,
+}
+
+/// Builder for query-aware simulation requests.
+pub struct Simulate<'c, SeedState> {
+    circuit: &'c Circuit,
+    kind: BackendKind,
+    seed: SeedState,
+    noise_model: Option<&'c noise::NoiseModel>,
+}
+
+impl<'c, SeedState> Simulate<'c, SeedState> {
+    #[inline]
+    pub fn backend(mut self, kind: BackendKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    #[inline]
+    pub fn noise(mut self, model: &'c noise::NoiseModel) -> Self {
+        self.noise_model = Some(model);
+        self
+    }
+
+    #[cfg(feature = "gpu")]
+    #[inline]
+    pub fn gpu(self, context: std::sync::Arc<crate::gpu::GpuContext>) -> Self {
+        self.backend(BackendKind::StatevectorGpu { context })
+    }
+}
+
+impl<'c> Simulate<'c, Unseeded> {
+    #[inline]
+    pub fn seed(self, seed: u64) -> Simulate<'c, Seeded> {
+        Simulate {
+            circuit: self.circuit,
+            kind: self.kind,
+            seed: Seeded { seed },
+            noise_model: self.noise_model,
+        }
+    }
+}
+
+impl<'c> Simulate<'c, Seeded> {
+    #[inline]
+    fn seed_value(&self) -> u64 {
+        self.seed.seed
+    }
+
+    #[inline]
+    pub fn run(self) -> Result<RunOutcome> {
+        let seed = self.seed_value();
+        if self.noise_model.is_some() {
+            return Err(crate::error::PrismError::BackendUnsupported {
+                backend: format!("{:?}", self.kind),
+                operation: "single-run noisy simulation through `run`".into(),
+            });
+        }
+        run_with_internal(self.kind, self.circuit, seed, SimOptions::default())
+    }
+
+    #[inline]
+    pub fn shots(self, num_shots: usize) -> Result<ShotsResult> {
+        let seed = self.seed_value();
+        if let Some(noise_model) = self.noise_model {
+            run_shots_with_noise(self.kind, self.circuit, noise_model, num_shots, seed)
+        } else {
+            run_shots_with(self.kind, self.circuit, num_shots, seed)
+        }
+    }
+
+    #[inline]
+    pub fn sample_counts(self, num_shots: usize) -> Result<CountsResult> {
+        let seed = self.seed_value();
+        let counts = if let Some(noise_model) = self.noise_model {
+            run_shots_with_noise(self.kind, self.circuit, noise_model, num_shots, seed)?.counts()
+        } else {
+            run_counts_with(self.kind, self.circuit, num_shots, seed)?
+        };
+        Ok(CountsResult {
+            counts,
+            num_classical_bits: self.circuit.num_classical_bits,
+        })
+    }
+
+    #[inline]
+    pub fn marginals(self) -> Result<MarginalsResult> {
+        let seed = self.seed_value();
+        if self.noise_model.is_some() {
+            return Err(crate::error::PrismError::BackendUnsupported {
+                backend: format!("{:?}", self.kind),
+                operation: "marginals with inline noise model".into(),
+            });
+        }
+        run_marginals_result_with(self.kind, self.circuit, seed)
+    }
+}
+
 #[inline]
-fn probs_only_result(probs: Vec<f64>) -> SimulationResult {
-    SimulationResult {
+pub fn simulate(circuit: &Circuit) -> Simulate<'_, Unseeded> {
+    Simulate {
+        circuit,
+        kind: BackendKind::Auto,
+        seed: Unseeded,
+        noise_model: None,
+    }
+}
+
+#[inline]
+fn probs_only_result(probs: Vec<f64>) -> RunOutcome {
+    RunOutcome {
         probabilities: Some(Probabilities::Dense(probs)),
         classical_bits: vec![],
     }
 }
 
 /// Core execution: fuse, init, apply, extract.
-fn execute(
-    backend: &mut dyn Backend,
-    circuit: &Circuit,
-    opts: &SimOptions,
-) -> Result<SimulationResult> {
+fn execute(backend: &mut dyn Backend, circuit: &Circuit, opts: &SimOptions) -> Result<RunOutcome> {
     let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
         std::borrow::Cow::Borrowed(circuit)
     } else {
@@ -96,7 +236,7 @@ fn execute_circuit(
     backend: &mut dyn Backend,
     circuit: &Circuit,
     opts: &SimOptions,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
     backend.apply_instructions(&circuit.instructions)?;
 
@@ -106,7 +246,7 @@ fn execute_circuit(
         None
     };
 
-    Ok(SimulationResult {
+    Ok(RunOutcome {
         classical_bits: backend.classical_results().to_vec(),
         probabilities: probs,
     })
@@ -116,7 +256,8 @@ fn execute_circuit(
 ///
 /// The simplest entry point. Uses [`BackendKind::Auto`] to select the
 /// optimal backend based on circuit properties, then runs the circuit.
-pub fn run(circuit: &Circuit, seed: u64) -> Result<SimulationResult> {
+#[cfg(test)]
+fn run(circuit: &Circuit, seed: u64) -> Result<RunOutcome> {
     run_with(BackendKind::Auto, circuit, seed)
 }
 
@@ -124,62 +265,8 @@ pub fn run(circuit: &Circuit, seed: u64) -> Result<SimulationResult> {
 ///
 /// Constructs the backend internally based on [`BackendKind`], then runs
 /// the circuit. For a pre-constructed backend instance, use [`run_on`].
-pub fn run_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<SimulationResult> {
+pub(crate) fn run_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<RunOutcome> {
     run_with_internal(kind, circuit, seed, SimOptions::default())
-}
-
-/// Execute a circuit on the CUDA GPU statevector dispatch.
-///
-/// Wraps [`run_with`] with `BackendKind::StatevectorGpu { context }`. The
-/// dispatch still applies fusion, independent-subsystem decomposition, and
-/// the qubit-count crossover ([`crate::gpu::min_qubits`]); sub-circuits
-/// below threshold automatically run on the host statevector.
-///
-/// ```no_run
-/// # #[cfg(feature = "gpu")] {
-/// use prism_q::gpu::GpuContext;
-/// use prism_q::{run_with_gpu, Circuit};
-///
-/// let ctx = GpuContext::new(0).expect("no usable GPU");
-/// let circuit = Circuit::new(16, 0);
-/// let _result = run_with_gpu(&circuit, 42, ctx).unwrap();
-/// # }
-/// ```
-#[cfg(feature = "gpu")]
-pub fn run_with_gpu(
-    circuit: &Circuit,
-    seed: u64,
-    context: std::sync::Arc<crate::gpu::GpuContext>,
-) -> Result<SimulationResult> {
-    run_with(BackendKind::StatevectorGpu { context }, circuit, seed)
-}
-
-/// Execute a Clifford-only circuit on the CUDA GPU stabilizer dispatch.
-///
-/// Wraps [`run_with`] with `BackendKind::StabilizerGpu { context }`. The
-/// dispatch applies independent-subsystem decomposition and the qubit-count
-/// crossover ([`crate::gpu::stabilizer_min_qubits`]); sub-circuits below
-/// threshold automatically run on the CPU stabilizer. Non-Clifford circuits
-/// are rejected at dispatch time with the same error shape as
-/// [`BackendKind::Stabilizer`].
-///
-/// ```no_run
-/// # #[cfg(feature = "gpu")] {
-/// use prism_q::gpu::GpuContext;
-/// use prism_q::{run_with_stabilizer_gpu, Circuit};
-///
-/// let ctx = GpuContext::new(0).expect("no usable GPU");
-/// let circuit = Circuit::new(1024, 0);
-/// let _result = run_with_stabilizer_gpu(&circuit, 42, ctx).unwrap();
-/// # }
-/// ```
-#[cfg(feature = "gpu")]
-pub fn run_with_stabilizer_gpu(
-    circuit: &Circuit,
-    seed: u64,
-    context: std::sync::Arc<crate::gpu::GpuContext>,
-) -> Result<SimulationResult> {
-    run_with(BackendKind::StabilizerGpu { context }, circuit, seed)
 }
 
 fn run_with_internal(
@@ -187,7 +274,7 @@ fn run_with_internal(
     circuit: &Circuit,
     seed: u64,
     opts: SimOptions,
-) -> Result<SimulationResult> {
+) -> Result<RunOutcome> {
     if !matches!(kind, BackendKind::Auto) {
         validate_explicit_backend(&kind, circuit)?;
     }
@@ -245,12 +332,22 @@ fn run_with_internal(
             Ok(probs_only_result(sr.probabilities))
         }
         DispatchAction::StochasticPauli { num_samples } => {
-            let spp = unified_pauli::run_spp(circuit, num_samples, seed)?;
-            Ok(probs_only_result(unified_pauli::spp_to_probabilities(&spp)))
+            Err(crate::error::PrismError::IncompatibleBackend {
+                backend: format!(
+                    "{:?}",
+                    BackendKind::StochasticPauli { num_samples }
+                ),
+                reason: "StochasticPauli produces marginal estimates only; use `simulate(...).marginals()`".into(),
+            })
         }
         DispatchAction::DeterministicPauli { epsilon, max_terms } => {
-            let spd = unified_pauli::run_spd(circuit, epsilon, max_terms)?;
-            Ok(probs_only_result(unified_pauli::spd_to_probabilities(&spd)))
+            Err(crate::error::PrismError::IncompatibleBackend {
+                backend: format!(
+                    "{:?}",
+                    BackendKind::DeterministicPauli { epsilon, max_terms }
+                ),
+                reason: "DeterministicPauli produces marginals only; use `simulate(...).marginals()`".into(),
+            })
         }
     }
 }
@@ -259,18 +356,19 @@ fn run_with_internal(
 ///
 /// Use this when you need direct control over the backend instance
 /// (e.g., testing a specific backend). For automatic dispatch, use [`run`].
-pub fn run_on(backend: &mut dyn Backend, circuit: &Circuit) -> Result<SimulationResult> {
+pub fn run_on(backend: &mut dyn Backend, circuit: &Circuit) -> Result<RunOutcome> {
     execute(backend, circuit, &SimOptions::default())
 }
 
 /// Parse an OpenQASM string and execute with automatic backend selection.
-pub fn run_qasm(qasm: &str, seed: u64) -> Result<SimulationResult> {
+pub fn run_qasm(qasm: &str, seed: u64) -> Result<RunOutcome> {
     let circuit = crate::circuit::openqasm::parse(qasm)?;
-    run(&circuit, seed)
+    simulate(&circuit).seed(seed).run()
 }
 
 /// Execute a circuit multiple times, collecting measurement outcomes.
-pub fn run_shots(circuit: &Circuit, num_shots: usize, seed: u64) -> Result<ShotsResult> {
+#[cfg(test)]
+fn run_shots(circuit: &Circuit, num_shots: usize, seed: u64) -> Result<ShotsResult> {
     run_shots_with(BackendKind::Auto, circuit, num_shots, seed)
 }
 
@@ -344,7 +442,86 @@ fn compile_measurements_for_kind(
     Ok(sampler)
 }
 
-/// Execute a circuit multiple times and return outcome counts directly.
+fn auto_terminal_statevector_candidate(circuit: &Circuit) -> bool {
+    let mut has_partial_independence = false;
+    if circuit.num_qubits >= MIN_DECOMPOSITION_QUBITS {
+        let components = circuit.independent_subsystems();
+        if components.len() > 1 {
+            if should_decompose(&components, circuit.num_qubits) {
+                return false;
+            }
+            has_partial_independence = true;
+        }
+    }
+
+    if !auto_selects_cpu_statevector(circuit, has_partial_independence) {
+        return false;
+    }
+
+    if circuit.is_clifford_plus_t()
+        && circuit.has_t_gates()
+        && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
+    {
+        let t = circuit.t_count();
+        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
+        if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
+            return false;
+        }
+    }
+
+    !has_temporal_clifford_opportunity(&BackendKind::Auto, circuit)
+}
+
+fn terminal_statevector_candidate(kind: &BackendKind, circuit: &Circuit) -> bool {
+    match kind {
+        BackendKind::Statevector => true,
+        BackendKind::Auto => auto_terminal_statevector_candidate(circuit),
+        _ => false,
+    }
+}
+
+fn try_terminal_statevector_backend(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> Result<Option<TerminalStatevector>> {
+    if !circuit.has_terminal_measurements_only() {
+        return Ok(None);
+    }
+
+    let meas_map = circuit.measurement_map();
+    if meas_map.is_empty() {
+        return Ok(None);
+    }
+
+    let stripped = circuit.without_measurements();
+    if !terminal_statevector_candidate(kind, &stripped) {
+        return Ok(None);
+    }
+
+    let mut backend = StatevectorBackend::new(seed);
+    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
+        std::borrow::Cow::Borrowed(&stripped)
+    } else {
+        crate::circuit::expand_qft_blocks(&stripped)
+    };
+    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    backend.init(fused.num_qubits, fused.num_classical_bits)?;
+    backend.apply_instructions(&fused.instructions)?;
+
+    Ok(Some((backend, meas_map)))
+}
+
+/// Execute a circuit multiple times with automatic backend selection and return counts.
+///
+/// Use this when only a frequency histogram is needed. Optimized paths can
+/// avoid materializing per-shot bit vectors.
+#[cfg(test)]
+fn run_counts(circuit: &Circuit, num_shots: usize, seed: u64) -> Result<HashMap<Vec<u64>, u64>> {
+    run_counts_with(BackendKind::Auto, circuit, num_shots, seed)
+}
+
+/// Execute a circuit multiple times with explicit backend selection and return counts.
 ///
 /// For Clifford circuits with terminal measurements and no resets, Auto,
 /// Stabilizer, FactoredStabilizer, and explicit `StabilizerGpu` route through
@@ -352,7 +529,11 @@ fn compile_measurements_for_kind(
 /// carries its GPU context into the compiled sampler so large shot runs avoid
 /// the raw tableau measurement round-trips. Other circuits fall back to
 /// per-shot simulation with counting.
-pub fn run_counts(
+///
+/// Optimized terminal statevector paths sample counts directly from the output
+/// distribution. The distribution is equivalent to materializing shots first,
+/// but finite seeded counts may differ from `run_shots_with(...).counts()`.
+pub(crate) fn run_counts_with(
     kind: BackendKind,
     circuit: &Circuit,
     num_shots: usize,
@@ -361,6 +542,17 @@ pub fn run_counts(
     if should_use_compiled_clifford_sampling(&kind, circuit, num_shots) {
         let mut sampler = compile_measurements_for_kind(&kind, circuit, seed)?;
         return sampler.try_sample_counts(num_shots);
+    }
+
+    if let Some((backend, meas_map)) = try_terminal_statevector_backend(&kind, circuit, seed)? {
+        return Ok(sample_counts_from_state(
+            backend.state_vector(),
+            backend.probability_scale(),
+            &meas_map,
+            circuit.num_classical_bits,
+            num_shots,
+            seed,
+        ));
     }
 
     let result = run_shots_with(kind, circuit, num_shots, seed)?;
@@ -382,48 +574,75 @@ pub fn run_counts(
 ///
 /// For other circuits, falls back to statevector probabilities and extracts
 /// marginals.
-pub fn run_marginals(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<Vec<(f64, f64)>> {
+#[cfg(test)]
+fn run_marginals(circuit: &Circuit, seed: u64) -> Result<Vec<(f64, f64)>> {
+    run_marginals_result_with(BackendKind::Auto, circuit, seed).map(MarginalsResult::into_vec)
+}
+
+/// Compute per-qubit marginal probabilities with explicit backend selection.
+#[cfg(test)]
+fn run_marginals_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<Vec<(f64, f64)>> {
+    run_marginals_result_with(kind, circuit, seed).map(MarginalsResult::into_vec)
+}
+
+fn expectations_to_marginals(expectations: &[f64]) -> Vec<(f64, f64)> {
+    expectations
+        .iter()
+        .map(|ez| {
+            let p0 = ((1.0 + ez) / 2.0).clamp(0.0, 1.0);
+            (p0, 1.0 - p0)
+        })
+        .collect()
+}
+
+fn run_marginals_result_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> Result<MarginalsResult> {
     let n = circuit.num_qubits;
 
-    if (matches!(
-        kind,
-        BackendKind::Auto | BackendKind::DeterministicPauli { .. }
-    )) && circuit.is_clifford_plus_t()
+    match kind {
+        BackendKind::StochasticPauli { num_samples } => {
+            let spp = unified_pauli::run_spp(circuit, num_samples, seed)?;
+            return Ok(MarginalsResult {
+                marginals: expectations_to_marginals(&spp.expectations),
+            });
+        }
+        BackendKind::DeterministicPauli { epsilon, max_terms } => {
+            let spd = unified_pauli::run_spd(circuit, epsilon, max_terms)?;
+            return Ok(MarginalsResult {
+                marginals: expectations_to_marginals(&spd.expectations),
+            });
+        }
+        _ => {}
+    }
+
+    if matches!(kind, BackendKind::Auto)
+        && circuit.is_clifford_plus_t()
         && circuit.has_t_gates()
         && n >= MIN_QUBITS_FOR_SPD_AUTO
     {
         let spd = unified_pauli::run_spd(circuit, 0.0, AUTO_SPD_MAX_TERMS)?;
-        return Ok(spd
-            .expectations
-            .iter()
-            .map(|ez| {
-                let p0 = ((1.0 + ez) / 2.0).clamp(0.0, 1.0);
-                (p0, 1.0 - p0)
-            })
-            .collect());
+        return Ok(MarginalsResult {
+            marginals: expectations_to_marginals(&spd.expectations),
+        });
     }
 
     let result = run_with(kind, circuit, seed)?;
     if let Some(probs) = &result.probabilities {
-        let mut marginals = vec![(0.0f64, 0.0f64); n];
-        let dense = probs.to_vec();
-        for (idx, &p) in dense.iter().enumerate() {
-            for (q, m) in marginals.iter_mut().enumerate() {
-                if (idx >> q) & 1 == 0 {
-                    m.0 += p;
-                } else {
-                    m.1 += p;
-                }
-            }
-        }
-        Ok(marginals)
+        Ok(MarginalsResult {
+            marginals: probs.marginals(),
+        })
     } else {
-        Ok(vec![(0.5, 0.5); n])
+        Ok(MarginalsResult {
+            marginals: vec![(0.5, 0.5); n],
+        })
     }
 }
 
 /// Execute a circuit multiple times with explicit backend selection.
-pub fn run_shots_with(
+pub(crate) fn run_shots_with(
     kind: BackendKind,
     circuit: &Circuit,
     num_shots: usize,
@@ -459,6 +678,21 @@ pub fn run_shots_with(
                 num_classical_bits: circuit.num_classical_bits,
             });
         }
+    }
+
+    if let Some((backend, meas_map)) = try_terminal_statevector_backend(&kind, circuit, seed)? {
+        let shots = sample_shots_from_state(
+            backend.state_vector(),
+            backend.probability_scale(),
+            &meas_map,
+            circuit.num_classical_bits,
+            num_shots,
+            seed,
+        );
+        return Ok(ShotsResult {
+            shots,
+            num_classical_bits: circuit.num_classical_bits,
+        });
     }
 
     if circuit.has_terminal_measurements_only() {
@@ -593,7 +827,7 @@ fn auto_general_noise_backend(circuit: &Circuit) -> BackendKind {
     }
 }
 
-pub fn run_shots_with_noise(
+pub(crate) fn run_shots_with_noise(
     kind: BackendKind,
     circuit: &Circuit,
     noise_model: &noise::NoiseModel,
@@ -1296,7 +1530,7 @@ mod tests {
     #[test]
     fn test_run_counts_factored_stabilizer() {
         let circuit = make_bell_with_measure();
-        let counts = run_counts(BackendKind::FactoredStabilizer, &circuit, 128, 42).unwrap();
+        let counts = run_counts_with(BackendKind::FactoredStabilizer, &circuit, 128, 42).unwrap();
         let total: u64 = counts.values().sum();
         let bell_total = counts.get(&vec![0u64]).copied().unwrap_or(0)
             + counts.get(&vec![3u64]).copied().unwrap_or(0);
@@ -1539,6 +1773,112 @@ mod tests {
         for shot in &result.shots {
             assert_eq!(shot, &vec![false, false, true]);
         }
+    }
+
+    #[test]
+    fn test_terminal_statevector_sampling_matches_probability_path() {
+        let mut c = Circuit::new(5, 5);
+        for q in 0..5 {
+            c.add_gate(Gate::Ry(0.17 + q as f64 * 0.11), &[q]);
+        }
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        c.add_gate(Gate::Rz(0.41), &[3]);
+        c.add_gate(Gate::Rx(0.23), &[4]);
+        c.add_measure(3, 1);
+        c.add_measure(0, 4);
+
+        let stripped = c.without_measurements();
+        let reference = run_with_internal(
+            BackendKind::Statevector,
+            &stripped,
+            42,
+            SimOptions::default(),
+        )
+        .unwrap();
+        let probs = reference.probabilities.unwrap();
+        let expected =
+            shots::sample_shots(&probs, &c.measurement_map(), c.num_classical_bits, 256, 42);
+
+        let actual = run_shots_with(BackendKind::Statevector, &c, 256, 42).unwrap();
+        assert_eq!(actual.shots, expected);
+    }
+
+    #[test]
+    fn test_terminal_statevector_counts_match_probability_path_all_measured() {
+        let mut c = Circuit::new(4, 4);
+        c.add_gate(Gate::Ry(0.31), &[0]);
+        c.add_gate(Gate::Ry(0.47), &[1]);
+        c.add_gate(Gate::Cx, &[0, 2]);
+        c.add_gate(Gate::Rx(0.19), &[3]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+        c.add_measure(2, 2);
+        c.add_measure(3, 3);
+
+        let stripped = c.without_measurements();
+        let reference = run_with_internal(
+            BackendKind::Statevector,
+            &stripped,
+            7,
+            SimOptions::default(),
+        )
+        .unwrap();
+        let probs = reference.probabilities.unwrap();
+        let expected_shots =
+            shots::sample_shots(&probs, &c.measurement_map(), c.num_classical_bits, 512, 7);
+        let expected = ShotsResult {
+            shots: expected_shots,
+            num_classical_bits: c.num_classical_bits,
+        }
+        .counts();
+
+        let actual = run_counts_with(BackendKind::Statevector, &c, 512, 7).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_terminal_statevector_duplicate_classical_bit_uses_last_measurement() {
+        let mut c = Circuit::new(2, 1);
+        c.add_gate(Gate::X, &[0]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 0);
+
+        let shots = run_shots_with(BackendKind::Statevector, &c, 16, 42).unwrap();
+        for shot in &shots.shots {
+            assert_eq!(shot, &vec![false]);
+        }
+
+        let counts = run_counts_with(BackendKind::Statevector, &c, 16, 42).unwrap();
+        assert_eq!(counts.get(&vec![0]), Some(&16));
+    }
+
+    #[test]
+    fn test_terminal_statevector_counts_wide_classical_register() {
+        let mut c = Circuit::new(2, 72);
+        c.add_gate(Gate::X, &[0]);
+        c.add_measure(0, 70);
+
+        let counts = run_counts_with(BackendKind::Statevector, &c, 10, 11).unwrap();
+        let mut expected = vec![0u64; 2];
+        expected[1] = 1u64 << 6;
+        assert_eq!(counts.get(&expected), Some(&10));
+    }
+
+    #[test]
+    fn test_terminal_statevector_subset_counts_sum_to_shots() {
+        let mut c = Circuit::new(5, 5);
+        for q in 0..5 {
+            c.add_gate(Gate::Ry(0.21 + q as f64 * 0.07), &[q]);
+        }
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cx, &[3, 4]);
+        c.add_measure(1, 4);
+        c.add_measure(4, 0);
+
+        let counts = run_counts_with(BackendKind::Statevector, &c, 1024, 42).unwrap();
+        assert_eq!(counts.values().sum::<u64>(), 1024);
+        assert!(counts.keys().all(|key| key[0] & !0b1_0001 == 0));
     }
 
     #[test]
@@ -1841,7 +2181,7 @@ mod tests {
         let mut c = Circuit::new(2, 0);
         c.add_gate(Gate::H, &[0]);
         c.add_gate(Gate::Cx, &[0, 1]);
-        let m = run_marginals(BackendKind::Auto, &c, 42).unwrap();
+        let m = run_marginals(&c, 42).unwrap();
         assert_eq!(m.len(), 2);
         assert!((m[0].0 - 0.5).abs() < 1e-10);
         assert!((m[0].1 - 0.5).abs() < 1e-10);
@@ -1853,7 +2193,7 @@ mod tests {
     fn test_run_marginals_x_gate() {
         let mut c = Circuit::new(2, 0);
         c.add_gate(Gate::X, &[0]);
-        let m = run_marginals(BackendKind::Auto, &c, 42).unwrap();
+        let m = run_marginals(&c, 42).unwrap();
         assert!((m[0].0 - 0.0).abs() < 1e-10);
         assert!((m[0].1 - 1.0).abs() < 1e-10);
         assert!((m[1].0 - 1.0).abs() < 1e-10);
@@ -1863,14 +2203,14 @@ mod tests {
     #[test]
     fn test_run_marginals_clifford_t_spd_path() {
         let c = crate::circuits::clifford_t_circuit(14, 10, 0.1, 42);
-        let m_spd = run_marginals(BackendKind::Auto, &c, 42).unwrap();
+        let m_spd = run_marginals(&c, 42).unwrap();
         assert_eq!(m_spd.len(), 14);
         for (p0, p1) in &m_spd {
             assert!(*p0 >= 0.0 && *p0 <= 1.0);
             assert!((p0 + p1 - 1.0).abs() < 1e-10);
         }
 
-        let m_sv = run_marginals(BackendKind::Statevector, &c, 42).unwrap();
+        let m_sv = run_marginals_with(BackendKind::Statevector, &c, 42).unwrap();
         for i in 0..14 {
             assert!(
                 (m_spd[i].0 - m_sv[i].0).abs() < 1e-6,
@@ -1882,6 +2222,54 @@ mod tests {
     }
 
     // ── Dispatch validation ───────────────────────────────────────────
+
+    #[test]
+    fn test_simulate_builder_run_matches_run() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Ry(0.31), &[2]);
+
+        let expected = run(&c, 42).unwrap();
+        let actual = simulate(&c).seed(42).run().unwrap();
+
+        assert_eq!(actual.classical_bits, expected.classical_bits);
+        assert_eq!(
+            actual.probabilities.unwrap().to_vec(),
+            expected.probabilities.unwrap().to_vec()
+        );
+    }
+
+    #[test]
+    fn test_simulate_builder_sample_counts_matches_run_counts() {
+        let mut c = Circuit::new(4, 4);
+        c.add_gate(Gate::Ry(0.25), &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Rx(0.17), &[2]);
+        c.add_measure(0, 0);
+        c.add_measure(1, 1);
+        c.add_measure(2, 2);
+        c.add_measure(3, 3);
+
+        let expected = run_counts(&c, 256, 42).unwrap();
+        let actual = simulate(&c).seed(42).sample_counts(256).unwrap();
+
+        assert_eq!(actual.num_classical_bits, c.num_classical_bits);
+        assert_eq!(actual.counts, expected);
+    }
+
+    #[test]
+    fn test_simulate_builder_marginals_matches_run_marginals() {
+        let c = crate::circuits::clifford_t_circuit(14, 10, 0.1, 42);
+        let expected = run_marginals(&c, 42).unwrap();
+        let actual = simulate(&c).seed(42).marginals().unwrap();
+
+        assert_eq!(actual.marginals.len(), expected.len());
+        for (a, b) in actual.marginals.iter().zip(expected.iter()) {
+            assert!((a.0 - b.0).abs() < 1e-12);
+            assert!((a.1 - b.1).abs() < 1e-12);
+        }
+    }
 
     #[test]
     fn test_validate_factored_stabilizer_rejects_non_clifford() {
@@ -1952,6 +2340,58 @@ mod tests {
     }
 
     // ── Noisy simulation error paths ────────────────────────────────────
+
+    #[test]
+    fn test_pauli_backends_reject_generic_run() {
+        let c = crate::circuits::clifford_t_circuit(4, 2, 0.1, 42);
+
+        assert!(matches!(
+            simulate(&c)
+                .backend(BackendKind::StochasticPauli { num_samples: 100 })
+                .seed(42)
+                .run()
+                .unwrap_err(),
+            crate::error::PrismError::IncompatibleBackend { .. }
+        ));
+        assert!(matches!(
+            simulate(&c)
+                .backend(BackendKind::DeterministicPauli {
+                    epsilon: 0.0,
+                    max_terms: 0
+                })
+                .seed(42)
+                .run()
+                .unwrap_err(),
+            crate::error::PrismError::IncompatibleBackend { .. }
+        ));
+    }
+
+    #[test]
+    fn test_pauli_backends_return_marginals_through_builder() {
+        let c = crate::circuits::clifford_t_circuit(4, 2, 0.1, 42);
+
+        let spp = simulate(&c)
+            .backend(BackendKind::StochasticPauli { num_samples: 1_000 })
+            .seed(42)
+            .marginals()
+            .unwrap();
+        let spd = simulate(&c)
+            .backend(BackendKind::DeterministicPauli {
+                epsilon: 0.0,
+                max_terms: 0,
+            })
+            .seed(42)
+            .marginals()
+            .unwrap();
+
+        assert_eq!(spp.marginals.len(), c.num_qubits);
+        assert_eq!(spd.marginals.len(), c.num_qubits);
+        assert!(spp
+            .marginals
+            .iter()
+            .chain(spd.marginals.iter())
+            .all(|(p0, p1)| *p0 >= 0.0 && *p0 <= 1.0 && (p0 + p1 - 1.0).abs() < 1e-10));
+    }
 
     #[test]
     fn test_noise_rejects_stabilizer_rank() {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -355,7 +355,7 @@ fn run_with_internal(
 /// Execute a circuit on a pre-constructed backend.
 ///
 /// Use this when you need direct control over the backend instance
-/// (e.g., testing a specific backend). For automatic dispatch, use [`run`].
+/// (e.g., testing a specific backend). For automatic dispatch, use [`simulate`].
 pub fn run_on(backend: &mut dyn Backend, circuit: &Circuit) -> Result<RunOutcome> {
     execute(backend, circuit, &SimOptions::default())
 }

--- a/src/sim/probability.rs
+++ b/src/sim/probability.rs
@@ -44,6 +44,55 @@ impl Probabilities {
         false
     }
 
+    /// Compute per-qubit marginal probabilities from an existing joint distribution.
+    ///
+    /// Returns `(P(0), P(1))` for each qubit. This is a view over already
+    /// materialized probability data. Query APIs can still choose faster direct
+    /// marginal algorithms before producing a joint distribution.
+    pub fn marginals(&self) -> Vec<(f64, f64)> {
+        match self {
+            Probabilities::Dense(v) => {
+                let n = v.len().ilog2() as usize;
+                let mut marginals = vec![(0.0f64, 0.0f64); n];
+                for (idx, &p) in v.iter().enumerate() {
+                    for (q, m) in marginals.iter_mut().enumerate() {
+                        if (idx >> q) & 1 == 0 {
+                            m.0 += p;
+                        } else {
+                            m.1 += p;
+                        }
+                    }
+                }
+                marginals
+            }
+            Probabilities::Factored {
+                blocks,
+                total_qubits,
+            } => {
+                let mut marginals = vec![(0.0f64, 0.0f64); *total_qubits];
+                for block in blocks {
+                    let mut qubits = Vec::new();
+                    let mut mask = block.mask;
+                    while mask != 0 {
+                        qubits.push(mask.trailing_zeros() as usize);
+                        mask &= mask.wrapping_sub(1);
+                    }
+
+                    for (idx, &p) in block.probs.iter().enumerate() {
+                        for (local_bit, &qubit) in qubits.iter().enumerate() {
+                            if (idx >> local_bit) & 1 == 0 {
+                                marginals[qubit].0 += p;
+                            } else {
+                                marginals[qubit].1 += p;
+                            }
+                        }
+                    }
+                }
+                marginals
+            }
+        }
+    }
+
     /// Probability of a single computational basis state. O(1) for dense,
     /// O(K) for factored where K is the number of independent blocks.
     ///

--- a/src/sim/shots.rs
+++ b/src/sim/shots.rs
@@ -75,7 +75,7 @@ pub fn bitstring(key: &[u64], num_bits: usize) -> String {
     s
 }
 
-fn build_cdf(probs: &[f64]) -> Vec<f64> {
+pub(super) fn build_cdf(probs: &[f64]) -> Vec<f64> {
     let mut cdf = Vec::with_capacity(probs.len());
     let mut acc = 0.0;
     for &p in probs {
@@ -88,7 +88,7 @@ fn build_cdf(probs: &[f64]) -> Vec<f64> {
     cdf
 }
 
-fn sample_from_cdf(cdf: &[f64], r: f64) -> usize {
+pub(super) fn sample_from_cdf(cdf: &[f64], r: f64) -> usize {
     match cdf.binary_search_by(|p| p.partial_cmp(&r).unwrap_or(std::cmp::Ordering::Equal)) {
         Ok(i) => i,
         Err(i) => i.min(cdf.len() - 1),

--- a/src/sim/terminal_sampling.rs
+++ b/src/sim/terminal_sampling.rs
@@ -1,0 +1,411 @@
+use std::collections::HashMap;
+
+#[cfg(target_arch = "x86_64")]
+use std::sync::OnceLock;
+
+use num_complex::Complex64;
+use rand::Rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use super::shots::{build_cdf, sample_from_cdf};
+
+const MAX_DENSE_OUTCOME_BITS: usize = 22;
+const MAX_DENSE_COUNT_BINS: usize = 1 << 20;
+
+#[derive(Clone)]
+struct CompactMeasurementMap {
+    cbits: Vec<usize>,
+    qubits: Vec<usize>,
+    prefix_bits: Option<usize>,
+    pext_mask: Option<u64>,
+}
+
+impl CompactMeasurementMap {
+    fn new(meas_map: &[(usize, usize)], num_classical_bits: usize) -> Self {
+        let mut final_qubit_for_cbit = vec![None; num_classical_bits];
+        for &(qubit, cbit) in meas_map {
+            final_qubit_for_cbit[cbit] = Some(qubit);
+        }
+
+        let mut cbits = Vec::with_capacity(meas_map.len());
+        let mut qubits = Vec::with_capacity(meas_map.len());
+        for (cbit, qubit) in final_qubit_for_cbit.into_iter().enumerate() {
+            if let Some(qubit) = qubit {
+                cbits.push(cbit);
+                qubits.push(qubit);
+            }
+        }
+
+        let prefix_bits = qubits
+            .iter()
+            .enumerate()
+            .all(|(bit, &qubit)| bit == qubit)
+            .then_some(qubits.len());
+
+        let pext_mask = if qubits.len() <= u64::BITS as usize
+            && qubits.iter().all(|&qubit| qubit < u64::BITS as usize)
+            && qubits.windows(2).all(|w| w[0] < w[1])
+        {
+            let mut mask = 0u64;
+            for &qubit in &qubits {
+                mask |= 1u64 << qubit;
+            }
+            Some(mask)
+        } else {
+            None
+        };
+
+        Self {
+            cbits,
+            qubits,
+            prefix_bits,
+            pext_mask,
+        }
+    }
+
+    #[inline]
+    fn num_bits(&self) -> usize {
+        self.cbits.len()
+    }
+
+    #[inline]
+    fn compact_key(&self, state_idx: usize) -> usize {
+        debug_assert!(self.num_bits() < usize::BITS as usize);
+        if let Some(bits) = self.prefix_bits {
+            return state_idx & ((1usize << bits) - 1);
+        }
+        if let Some(mask) = self.pext_mask {
+            return extract_masked_bits(state_idx, mask);
+        }
+
+        let mut key = 0usize;
+        for (bit, &qubit) in self.qubits.iter().enumerate() {
+            key |= ((state_idx >> qubit) & 1) << bit;
+        }
+        key
+    }
+
+    #[inline]
+    fn direct_state_key(&self, state_len: usize) -> bool {
+        self.prefix_bits == Some(self.num_bits()) && (1usize << self.num_bits()) == state_len
+    }
+
+    fn fill_shot_from_state_index(&self, state_idx: usize, shot: &mut [bool]) {
+        for (&qubit, &cbit) in self.qubits.iter().zip(self.cbits.iter()) {
+            shot[cbit] = (state_idx >> qubit) & 1 == 1;
+        }
+    }
+
+    fn packed_key_from_compact(&self, key: usize, m_words: usize) -> Vec<u64> {
+        let mut packed = vec![0u64; m_words];
+        for (bit, &cbit) in self.cbits.iter().enumerate() {
+            if (key >> bit) & 1 == 1 {
+                packed[cbit / 64] |= 1u64 << (cbit % 64);
+            }
+        }
+        packed
+    }
+
+    fn packed_key_from_state_index(&self, state_idx: usize, m_words: usize) -> Vec<u64> {
+        let mut packed = vec![0u64; m_words];
+        for (&qubit, &cbit) in self.qubits.iter().zip(self.cbits.iter()) {
+            if (state_idx >> qubit) & 1 == 1 {
+                packed[cbit / 64] |= 1u64 << (cbit % 64);
+            }
+        }
+        packed
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn bmi2_available() -> bool {
+    static BMI2: OnceLock<bool> = OnceLock::new();
+    *BMI2.get_or_init(|| is_x86_feature_detected!("bmi2"))
+}
+
+#[inline]
+fn extract_masked_bits(index: usize, mask: u64) -> usize {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if bmi2_available() {
+            // SAFETY: BMI2 availability is checked immediately before this call.
+            return unsafe { core::arch::x86_64::_pext_u64(index as u64, mask) as usize };
+        }
+    }
+
+    let mut result = 0usize;
+    let mut bit = 0;
+    let mut m = mask;
+    while m != 0 {
+        let pos = m.trailing_zeros() as usize;
+        if index & (1usize << pos) != 0 {
+            result |= 1usize << bit;
+        }
+        bit += 1;
+        m &= m.wrapping_sub(1);
+    }
+    result
+}
+
+fn build_state_outcome_distribution(
+    state: &[Complex64],
+    norm_sq: f64,
+    map: &CompactMeasurementMap,
+) -> Option<Vec<f64>> {
+    if map.num_bits() > MAX_DENSE_OUTCOME_BITS {
+        return None;
+    }
+
+    let outcomes = 1usize << map.num_bits();
+
+    #[cfg(feature = "parallel")]
+    {
+        if map.direct_state_key(state.len()) {
+            let mut probs = vec![0.0f64; outcomes];
+            probs
+                .par_iter_mut()
+                .zip(state.par_iter())
+                .for_each(|(p, amp)| {
+                    *p = amp.norm_sqr() * norm_sq;
+                });
+            return Some(probs);
+        }
+
+        if state.len() >= crate::backend::MIN_PAR_ELEMS && outcomes <= (1usize << 16) {
+            let probs = state
+                .par_chunks(crate::backend::MIN_PAR_ELEMS)
+                .enumerate()
+                .map(|(chunk_idx, chunk)| {
+                    let mut local = vec![0.0f64; outcomes];
+                    let base = chunk_idx * crate::backend::MIN_PAR_ELEMS;
+                    for (offset, amp) in chunk.iter().enumerate() {
+                        let key = map.compact_key(base + offset);
+                        local[key] += amp.norm_sqr() * norm_sq;
+                    }
+                    local
+                })
+                .reduce(
+                    || vec![0.0f64; outcomes],
+                    |mut a, b| {
+                        for (dst, src) in a.iter_mut().zip(b) {
+                            *dst += src;
+                        }
+                        a
+                    },
+                );
+            return Some(probs);
+        }
+    }
+
+    let mut probs = vec![0.0f64; outcomes];
+    if map.direct_state_key(state.len()) {
+        for (idx, amp) in state.iter().enumerate() {
+            probs[idx] = amp.norm_sqr() * norm_sq;
+        }
+    } else {
+        for (idx, amp) in state.iter().enumerate() {
+            let key = map.compact_key(idx);
+            probs[key] += amp.norm_sqr() * norm_sq;
+        }
+    }
+    Some(probs)
+}
+
+fn packed_counts_from_dense(
+    compact_counts: Vec<u64>,
+    map: &CompactMeasurementMap,
+    m_words: usize,
+) -> HashMap<Vec<u64>, u64> {
+    let nonzero = compact_counts.iter().filter(|&&count| count != 0).count();
+    let mut counts = HashMap::with_capacity(nonzero);
+    for (key, count) in compact_counts.into_iter().enumerate() {
+        if count != 0 {
+            counts.insert(map.packed_key_from_compact(key, m_words), count);
+        }
+    }
+    counts
+}
+
+fn packed_counts_from_sparse(
+    compact_counts: HashMap<usize, u64>,
+    map: &CompactMeasurementMap,
+    m_words: usize,
+) -> HashMap<Vec<u64>, u64> {
+    let mut counts = HashMap::with_capacity(compact_counts.len());
+    for (key, count) in compact_counts {
+        counts.insert(map.packed_key_from_compact(key, m_words), count);
+    }
+    counts
+}
+
+fn sample_counts_from_outcome_distribution(
+    probs: &[f64],
+    map: &CompactMeasurementMap,
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> HashMap<Vec<u64>, u64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let cdf = build_cdf(probs);
+    let m_words = num_classical_bits.div_ceil(64).max(1);
+
+    if probs.len() <= MAX_DENSE_COUNT_BINS {
+        let mut compact_counts = vec![0u64; probs.len()];
+        for _ in 0..num_shots {
+            let r: f64 = rng.random();
+            let key = sample_from_cdf(&cdf, r);
+            compact_counts[key] += 1;
+        }
+        return packed_counts_from_dense(compact_counts, map, m_words);
+    }
+
+    let mut compact_counts = HashMap::with_capacity(num_shots.min(probs.len()));
+    for _ in 0..num_shots {
+        let r: f64 = rng.random();
+        let key = sample_from_cdf(&cdf, r);
+        *compact_counts.entry(key).or_insert(0) += 1;
+    }
+    packed_counts_from_sparse(compact_counts, map, m_words)
+}
+
+fn sorted_thresholds(num_shots: usize, seed: u64) -> Vec<(f64, usize)> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut thresholds: Vec<_> = (0..num_shots)
+        .map(|shot| (rng.random::<f64>(), shot))
+        .collect();
+    thresholds.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    thresholds
+}
+
+fn sample_shots_streaming_from_state(
+    state: &[Complex64],
+    norm_sq: f64,
+    map: &CompactMeasurementMap,
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> Vec<Vec<bool>> {
+    let thresholds = sorted_thresholds(num_shots, seed);
+    let mut shots = vec![vec![false; num_classical_bits]; num_shots];
+    let mut cumulative = 0.0f64;
+    let mut next = 0usize;
+
+    for (state_idx, amp) in state.iter().enumerate() {
+        cumulative += amp.norm_sqr() * norm_sq;
+        while next < thresholds.len() && thresholds[next].0 <= cumulative {
+            let shot_idx = thresholds[next].1;
+            map.fill_shot_from_state_index(state_idx, &mut shots[shot_idx]);
+            next += 1;
+        }
+    }
+
+    let fallback_idx = state.len().saturating_sub(1);
+    while next < thresholds.len() {
+        let shot_idx = thresholds[next].1;
+        map.fill_shot_from_state_index(fallback_idx, &mut shots[shot_idx]);
+        next += 1;
+    }
+
+    shots
+}
+
+fn sample_counts_streaming_from_state(
+    state: &[Complex64],
+    norm_sq: f64,
+    map: &CompactMeasurementMap,
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> HashMap<Vec<u64>, u64> {
+    let thresholds = sorted_thresholds(num_shots, seed);
+    let m_words = num_classical_bits.div_ceil(64).max(1);
+    let mut counts = HashMap::with_capacity(num_shots.min(state.len()));
+    let mut cumulative = 0.0f64;
+    let mut next = 0usize;
+
+    for (state_idx, amp) in state.iter().enumerate() {
+        cumulative += amp.norm_sqr() * norm_sq;
+        let start = next;
+        while next < thresholds.len() && thresholds[next].0 <= cumulative {
+            next += 1;
+        }
+        let hits = next - start;
+        if hits != 0 {
+            let packed = map.packed_key_from_state_index(state_idx, m_words);
+            *counts.entry(packed).or_insert(0) += hits as u64;
+        }
+    }
+
+    let fallback_idx = state.len().saturating_sub(1);
+    let fallback_hits = thresholds.len() - next;
+    if fallback_hits != 0 {
+        let packed = map.packed_key_from_state_index(fallback_idx, m_words);
+        *counts.entry(packed).or_insert(0) += fallback_hits as u64;
+    }
+
+    counts
+}
+
+pub(super) fn sample_shots_from_state(
+    state: &[Complex64],
+    norm_sq: f64,
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> Vec<Vec<bool>> {
+    if meas_map.is_empty() {
+        return vec![vec![false; num_classical_bits]; num_shots];
+    }
+
+    let map = CompactMeasurementMap::new(meas_map, num_classical_bits);
+    if map.num_bits() == 0 {
+        return vec![vec![false; num_classical_bits]; num_shots];
+    }
+
+    sample_shots_streaming_from_state(state, norm_sq, &map, num_classical_bits, num_shots, seed)
+}
+
+pub(super) fn sample_counts_from_state(
+    state: &[Complex64],
+    norm_sq: f64,
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> HashMap<Vec<u64>, u64> {
+    if num_shots == 0 {
+        return HashMap::new();
+    }
+
+    let m_words = num_classical_bits.div_ceil(64).max(1);
+    if meas_map.is_empty() {
+        let mut counts = HashMap::with_capacity(1);
+        counts.insert(vec![0u64; m_words], num_shots as u64);
+        return counts;
+    }
+
+    let map = CompactMeasurementMap::new(meas_map, num_classical_bits);
+    if map.num_bits() == 0 {
+        let mut counts = HashMap::with_capacity(1);
+        counts.insert(vec![0u64; m_words], num_shots as u64);
+        return counts;
+    }
+
+    if let Some(probs) = build_state_outcome_distribution(state, norm_sq, &map) {
+        sample_counts_from_outcome_distribution(&probs, &map, num_classical_bits, num_shots, seed)
+    } else {
+        sample_counts_streaming_from_state(
+            state,
+            norm_sq,
+            &map,
+            num_classical_bits,
+            num_shots,
+            seed,
+        )
+    }
+}

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -426,7 +426,8 @@ pub fn run_spp(circuit: &Circuit, num_samples: usize, seed: u64) -> Result<SppRe
     })
 }
 
-pub fn spp_to_probabilities(result: &SppResult) -> Vec<f64> {
+#[cfg(test)]
+fn spp_to_probabilities(result: &SppResult) -> Vec<f64> {
     result
         .expectations
         .iter()
@@ -657,7 +658,8 @@ pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdR
     })
 }
 
-pub fn spd_to_probabilities(result: &SpdResult) -> Vec<f64> {
+#[cfg(test)]
+fn spd_to_probabilities(result: &SpdResult) -> Vec<f64> {
     result
         .expectations
         .iter()

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -473,7 +473,7 @@ fn batch_rzz_14q_qaoa_matches_cpu() {
 fn batch_phase_16q_matches_cpu() {
     // QFT at 16q exercises the `fuse_controlled_phases` pass which emits
     // `Gate::BatchPhase`. The batched GPU kernel must match the CPU tiled kernel
-    // within tolerance. The test drives through `sim::run_with` so fusion fires
+    // within tolerance. The test drives through `simulate(...).run()` so fusion fires
     // normally, then compares probabilities between plain statevector and GPU statevector.
     let Some(f) = Fixture::try_new() else { return };
 
@@ -608,23 +608,25 @@ fn probabilities_match_cpu_on_random_circuit() {
 /// circuit at 14q (at the crossover threshold) must match CPU to within
 /// 1e-10. Exercises the dispatch → fusion → GPU kernel → probabilities path.
 #[test]
-fn statevector_gpu_run_with_matches_cpu_random() {
+fn statevector_gpu_builder_matches_cpu_random() {
     use prism_q::BackendKind;
 
     let Some(f) = Fixture::try_new() else { return };
 
     let circuit = prism_q::circuits::random_circuit(14, 10, 0xDEAD_BEEF);
 
-    let cpu = prism_q::sim::run_with(BackendKind::Statevector, &circuit, 42)
-        .expect("cpu run_with failed");
-    let gpu = prism_q::sim::run_with(
-        BackendKind::StatevectorGpu {
+    let cpu = prism_q::simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(42)
+        .run()
+        .expect("cpu run failed");
+    let gpu = prism_q::simulate(&circuit)
+        .backend(BackendKind::StatevectorGpu {
             context: f.ctx.clone(),
-        },
-        &circuit,
-        42,
-    )
-    .expect("gpu run_with failed");
+        })
+        .seed(42)
+        .run()
+        .expect("gpu run failed");
 
     let cpu_p = cpu.probabilities.expect("cpu probs missing").to_vec();
     let gpu_p = gpu.probabilities.expect("gpu probs missing").to_vec();
@@ -1335,13 +1337,13 @@ fn stabilizer_gpu_export_statevector_matches_cpu() {
 // Stabilizer GPU public dispatch
 // ============================================================================
 
-/// `run_with_stabilizer_gpu` routes through `BackendKind::StabilizerGpu` and the
+/// `simulate(...).backend(BackendKind::StabilizerGpu)` routes through the
 /// crossover. For small n the crossover sends the circuit to the CPU
 /// stabilizer automatically. Verifies end-to-end dispatch matches a direct
 /// `BackendKind::Stabilizer` run.
 #[test]
-fn run_with_stabilizer_gpu_matches_cpu_below_threshold() {
-    use prism_q::{run_with, run_with_stabilizer_gpu, BackendKind, Circuit};
+fn stabilizer_gpu_builder_matches_cpu_below_threshold() {
+    use prism_q::{simulate, BackendKind, Circuit};
 
     let Some(f) = Fixture::try_new() else { return };
 
@@ -1354,8 +1356,18 @@ fn run_with_stabilizer_gpu_matches_cpu_below_threshold() {
         circuit.add_measure(i, i);
     }
 
-    let cpu = run_with(BackendKind::Stabilizer, &circuit, 42).unwrap();
-    let gpu = run_with_stabilizer_gpu(&circuit, 42, f.ctx.clone()).unwrap();
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Stabilizer)
+        .seed(42)
+        .run()
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .backend(BackendKind::StabilizerGpu {
+            context: f.ctx.clone(),
+        })
+        .seed(42)
+        .run()
+        .unwrap();
     assert_eq!(cpu.classical_bits, gpu.classical_bits);
 }
 
@@ -1365,8 +1377,8 @@ fn run_with_stabilizer_gpu_matches_cpu_below_threshold() {
 /// threshold the same test exercises the real GPU path and the assertion
 /// still holds.
 #[test]
-fn run_with_stabilizer_gpu_matches_cpu_at_scale() {
-    use prism_q::{run_with, run_with_stabilizer_gpu, BackendKind};
+fn stabilizer_gpu_builder_matches_cpu_at_scale() {
+    use prism_q::{simulate, BackendKind};
 
     let Some(f) = Fixture::try_new() else { return };
 
@@ -1379,8 +1391,18 @@ fn run_with_stabilizer_gpu_matches_cpu_at_scale() {
         circuit.add_measure(i, i);
     }
 
-    let cpu = run_with(BackendKind::Stabilizer, &circuit, 42).unwrap();
-    let gpu = run_with_stabilizer_gpu(&circuit, 42, f.ctx.clone()).unwrap();
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Stabilizer)
+        .seed(42)
+        .run()
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .backend(BackendKind::StabilizerGpu {
+            context: f.ctx.clone(),
+        })
+        .seed(42)
+        .run()
+        .unwrap();
     assert_eq!(
         cpu.classical_bits, gpu.classical_bits,
         "CPU and GPU stabilizer measurement bits must agree"
@@ -1478,12 +1500,12 @@ fn run_shots_compiled_with_gpu_distribution_matches_cpu() {
     }
 }
 
-/// `run_shots_with(BackendKind::StabilizerGpu)` should route Clifford shot
-/// sampling through the same compiled GPU sampler as
+/// `simulate(...).backend(BackendKind::StabilizerGpu).shots(...)` should route
+/// Clifford shot sampling through the same compiled GPU sampler as
 /// `run_shots_compiled_with_gpu`, not the raw tableau measurement loop.
 #[test]
-fn run_shots_with_stabilizer_gpu_matches_compiled_gpu_sampling() {
-    use prism_q::{run_shots_compiled_with_gpu, run_shots_with, BackendKind, Circuit};
+fn builder_stabilizer_gpu_shots_match_compiled_gpu_sampling() {
+    use prism_q::{run_shots_compiled_with_gpu, simulate, BackendKind, Circuit};
 
     let Some(f) = Fixture::try_new() else { return };
 
@@ -1498,15 +1520,13 @@ fn run_shots_with_stabilizer_gpu_matches_compiled_gpu_sampling() {
     }
 
     let compiled = run_shots_compiled_with_gpu(&circuit, num_shots, 42, f.ctx.clone()).unwrap();
-    let explicit = run_shots_with(
-        BackendKind::StabilizerGpu {
+    let explicit = simulate(&circuit)
+        .backend(BackendKind::StabilizerGpu {
             context: f.ctx.clone(),
-        },
-        &circuit,
-        num_shots,
-        42,
-    )
-    .unwrap();
+        })
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
 
     assert_eq!(explicit.shots, compiled.shots);
 }

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -18,6 +18,14 @@ use prism_q::Instruction;
 
 const EPS: f64 = 1e-12;
 
+fn run_with(
+    kind: prism_q::BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
 fn run_and_probs(circuit: &Circuit) -> Vec<f64> {
     let mut backend = StatevectorBackend::new(42);
     sim::run_on(&mut backend, circuit).unwrap();
@@ -1068,7 +1076,7 @@ fn decomposed_two_independent_bell_pairs() {
     assert_eq!(subs.len(), 2);
 
     // Decomposed via run_with (triggers decomposition)
-    let decomposed = sim::run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
+    let decomposed = run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
     // Monolithic via run_on (skips decomposition)
     let mut sv = StatevectorBackend::new(42);
     let monolithic = sim::run_on(&mut sv, &c).unwrap();
@@ -1100,7 +1108,7 @@ fn decomposed_three_independent_blocks() {
     let subs = c.independent_subsystems();
     assert_eq!(subs.len(), 3);
 
-    let decomposed = sim::run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
+    let decomposed = run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
     let mut sv = StatevectorBackend::new(42);
     let monolithic = sim::run_on(&mut sv, &c).unwrap();
 
@@ -1126,7 +1134,7 @@ fn decomposed_with_measurements() {
     c.add_gate(Gate::Cx, &[2, 3]);
     c.add_measure(2, 1);
 
-    let result = sim::run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
+    let result = run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
     assert_eq!(result.classical_bits.len(), 2);
 }
 
@@ -1141,7 +1149,7 @@ fn decomposed_fully_entangled_same_as_monolithic() {
     let subs = c.independent_subsystems();
     assert_eq!(subs.len(), 1); // no decomposition
 
-    let via_run_with = sim::run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
+    let via_run_with = run_with(prism_q::BackendKind::Statevector, &c, 42).unwrap();
     let mut sv = StatevectorBackend::new(42);
     let via_run_on = sim::run_on(&mut sv, &c).unwrap();
 
@@ -1166,7 +1174,7 @@ fn decomposed_auto_mixed_backends() {
     c.add_gate(Gate::Cx, &[3, 4]);
     c.add_gate(Gate::Cx, &[4, 5]);
 
-    let result = sim::run_with(prism_q::BackendKind::Auto, &c, 42).unwrap();
+    let result = run_with(prism_q::BackendKind::Auto, &c, 42).unwrap();
     let mut sv = StatevectorBackend::new(42);
     let monolithic = sim::run_on(&mut sv, &c).unwrap();
 

--- a/tests/smoke_openqasm.rs
+++ b/tests/smoke_openqasm.rs
@@ -5,6 +5,18 @@ use prism_q::backend::Backend;
 use prism_q::circuit::openqasm;
 use prism_q::sim;
 
+fn run(circuit: &prism_q::Circuit, seed: u64) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).seed(seed).run()
+}
+
+fn run_shots(
+    circuit: &prism_q::Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit).seed(seed).shots(num_shots)
+}
+
 fn assert_probs(probs: &[f64], expected: &[f64], eps: f64) {
     assert_eq!(probs.len(), expected.len());
     for (i, (a, e)) in probs.iter().zip(expected).enumerate() {
@@ -502,7 +514,7 @@ fn conditional_gate_executed() {
         if (c[0]) x q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = sim::run(&circuit, 42).unwrap();
+    let result = run(&circuit, 42).unwrap();
     let probs = result.probabilities.unwrap().to_vec();
     // q[0] measured |1⟩, so c[0]=1, conditional fires, q[1] → |1⟩
     // After measurement q[0] collapsed to |1⟩, q[1] flipped to |1⟩ → state |11⟩ = index 3
@@ -519,7 +531,7 @@ fn conditional_gate_not_executed() {
         if (c[0]) x q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = sim::run(&circuit, 42).unwrap();
+    let result = run(&circuit, 42).unwrap();
     let probs = result.probabilities.unwrap().to_vec();
     // q[0] starts as |0⟩, measured → c[0]=0, conditional doesn't fire
     // State stays |00⟩ = index 0
@@ -537,7 +549,7 @@ fn conditional_oq2_register_equals() {
         if(c==1) x q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = sim::run(&circuit, 42).unwrap();
+    let result = run(&circuit, 42).unwrap();
     let probs = result.probabilities.unwrap().to_vec();
     // c[0]=1 (from X then measure), c[1]=0 → c = 0b01 = 1
     // Condition c==1 is true → X applied to q[1] → state |11⟩
@@ -555,7 +567,7 @@ fn conditional_oq2_register_no_match() {
         if(c==2) x q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = sim::run(&circuit, 42).unwrap();
+    let result = run(&circuit, 42).unwrap();
     let probs = result.probabilities.unwrap().to_vec();
     // c = 0b01 = 1, condition c==2 is false → q[1] stays |0⟩
     // q[0] collapsed to |1⟩ → state |01⟩ = index 1
@@ -612,7 +624,7 @@ fn broadcast_measure_all() {
         c[1] = measure q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = sim::run(&circuit, 42).unwrap();
+    let result = run(&circuit, 42).unwrap();
     assert!(result.classical_bits[0]);
     assert!(!result.classical_bits[1]);
 }
@@ -652,7 +664,7 @@ fn run_shots_via_qasm() {
         c[1] = measure q[1];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = prism_q::run_shots(&circuit, 100, 42).unwrap();
+    let result = run_shots(&circuit, 100, 42).unwrap();
     let counts = result.counts();
     assert_eq!(counts.len(), 1);
     assert_eq!(*counts.get(&vec![1u64]).unwrap_or(&0), 100);
@@ -668,7 +680,7 @@ fn run_shots_superposition_via_qasm() {
         c[0] = measure q[0];
     "#;
     let circuit = openqasm::parse(qasm).unwrap();
-    let result = prism_q::run_shots(&circuit, 1000, 42).unwrap();
+    let result = run_shots(&circuit, 1000, 42).unwrap();
     let counts = result.counts();
     let zeros = *counts.get(&vec![0u64]).unwrap_or(&0);
     let ones = *counts.get(&vec![1u64]).unwrap_or(&0);

--- a/tests/trajectory_correctness.rs
+++ b/tests/trajectory_correctness.rs
@@ -1,6 +1,29 @@
 use prism_q::circuit::SmallVec;
 use prism_q::*;
 
+fn run_shots_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    simulate(circuit).backend(kind).seed(seed).shots(num_shots)
+}
+
+fn run_shots_with_noise(
+    kind: BackendKind,
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    simulate(circuit)
+        .backend(kind)
+        .noise(noise)
+        .seed(seed)
+        .shots(num_shots)
+}
+
 #[test]
 fn depolarizing_trajectory_cross_check_with_compiled() {
     let n = 6;


### PR DESCRIPTION
## Summary

Streamline simulation queries around the API and remove redundant public wrappers. Add terminal measurement fast paths for statevector sampling and counts so common query paths avoid unnecessary shot materialization.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| api_queries/run_auto_12q | 162820.31 ns | 116798.84 ns | -28.27% | Yes |
| api_queries/shots_terminal_12q_100000 | 20863721.94 ns | 13851434.80 ns | -33.61% | Yes |
| api_queries/sample_counts_terminal_12q_100000 | 2634687.73 ns | 1984829.98 ns | -24.67% | Yes |
| api_queries/marginals_auto_clifford_t_14q | 92243.24 ns | 69869.88 ns | -24.25% | Yes |

Regression verdict: PASS


## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Additional local checks run:

- `cargo check --features parallel --all-targets`
- `cargo check --features "parallel gpu" --all-targets`
- `cargo clippy --features parallel --all-targets -- -D warnings`
- `cargo clippy --features "parallel gpu" --all-targets -- -D warnings`
- `cargo test --features parallel --lib`
- `cargo test --features parallel --tests`
- `cargo test --doc --features parallel`

## Hotspot notes

Touched query dispatch and terminal sampling paths: `Simulate::run`, `Simulate::shots`, `Simulate::sample_counts`, `Simulate::marginals`, and terminal statevector sampling helpers. Terminal final measurements can now compact outcomes directly from the statevector and use dense count accumulation when the measured bit width is small enough, with a streaming fallback for wider measured outputs.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems

## Breaking changes

The public simulation surface now favors `simulate(circuit).run()`, `.shots(...)`, `.sample_counts(...)`, and `.marginals()`. Redundant wrappers were removed from the public API.

## Risks and rollback

Risk is concentrated in simulation dispatch and terminal measurement sampling. Rollback can restore the previous wrapper exports and route terminal measurement queries through the existing general shot path while retaining unrelated documentation and example updates.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green