### PR TITLE
fix(sim): tighten packed shots and dispatch metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,6 +218,16 @@ Orchestration layer in `src/sim/mod.rs`. Entry points:
 | `run_on(backend, circuit)` | Pre-constructed backend |
 | `run_qasm(qasm, seed)` | Parse + simulate |
 
+`RunOutcome::probabilities` is `None` only when the selected backend cannot
+expose a dense probability distribution for the requested circuit, such as
+factored stabilizer or decomposed runs above the dense output cap. Other
+probability extraction failures propagate as errors. `marginals()` requires
+either a direct Pauli marginal route or backend probability output; it returns
+`BackendUnsupported` instead of fabricating uniform marginals when neither path
+is available. Stochastic and deterministic Pauli marginal backends accept only
+unitary Clifford+T circuits without measurement, reset, or conditional
+instructions.
+
 ### Auto-dispatch decision tree
 
 ```text
@@ -398,6 +408,16 @@ For multi-shot sampling without materializing the full statevector on every shot
 | `PauliExpectationAccumulator` | ⟨P⟩ for Pauli observables | VQE/QAOA |
 | `CorrelatorAccumulator` | ⟨Z_i Z_j⟩ correlations | Entanglement analysis |
 | `NullAccumulator` | Nothing | Benchmarking raw sampling speed |
+
+**PackedShots raw format**: `PackedShots::RAW_FORMAT_VERSION` is the replay
+contract for `raw_data()` and `into_data()`. Version 1 stores little-endian bit
+order within each `u64`. `ShotMajor` stores one row per shot with
+`m_words() = ceil(num_measurements / 64)`. `MeasMajor` stores one row per
+measurement with `s_words() = ceil(num_shots / 64)`. The checked
+`try_from_shot_major` and `try_from_meas_major` constructors reject shape
+mismatches and non-zero semantic padding. Histograms, marginals, parity rows,
+and accumulators mask only semantic padding: measurement-tail bits in
+shot-major data and shot-tail bits in measurement-major data.
 
 **Detector sampler** (`compile_detector_sampler`): Compiles Clifford circuits
 with measurement and reset reuse into the same packed measurement sampler, then

--- a/src/gpu/kernels/bts.rs
+++ b/src/gpu/kernels/bts.rs
@@ -17,6 +17,7 @@ use crate::error::Result;
 use crate::gpu::GpuBuffer;
 use crate::sim::compiled::parity::SparseParity;
 use crate::sim::compiled::rng::Xoshiro256PlusPlus;
+use crate::sim::compiled::shot_tail_mask;
 
 use super::super::GpuContext;
 use super::{div_ceil_grid, launch_err, require_i32, require_u32};
@@ -91,6 +92,7 @@ extern "C" __global__ void bts_sample_meas_major(
     int rank,
     int out_stride_words,
     int out_word_offset,
+    unsigned long long tail_mask,
     unsigned long long *meas_major
 ) {
     int m = blockIdx.x;
@@ -108,6 +110,7 @@ extern "C" __global__ void bts_sample_meas_major(
     unsigned long long ref_word = ref_bits[m >> 6];
     unsigned long long ref_bit = (ref_word >> (m & 63)) & 1ULL;
     if (ref_bit != 0ULL) acc = ~acc;
+    if (batch == s_words - 1) acc &= tail_mask;
 
     meas_major[
         (unsigned long long)m * (unsigned long long)out_stride_words +
@@ -693,14 +696,7 @@ impl GpuBtsCache {
                             ]
                         })
                         .collect();
-                    let tail_mask: Option<u64> = {
-                        let rem = chunk_shots % 64;
-                        if rem == 0 {
-                            None
-                        } else {
-                            Some((1u64 << rem) - 1)
-                        }
-                    };
+                    let tail_mask = shot_tail_mask(chunk_shots);
                     let last_batch = chunk_s_words - 1;
                     use rayon::prelude::*;
                     self.random_bits_host[..required]
@@ -717,11 +713,9 @@ impl GpuBtsCache {
                                     *word = trng.next_u64();
                                 }
                                 let absolute_batch = first_batch + b;
-                                if absolute_batch == last_batch {
-                                    if let Some(mask) = tail_mask {
-                                        for word in &mut slab[start..end] {
-                                            *word &= mask;
-                                        }
+                                if absolute_batch == last_batch && tail_mask != u64::MAX {
+                                    for word in &mut slab[start..end] {
+                                        *word &= tail_mask;
                                     }
                                 }
                             }
@@ -739,24 +733,14 @@ impl GpuBtsCache {
                 *word = rng.next_u64();
             }
             if batch == chunk_s_words - 1 {
-                let rem = chunk_shots % 64;
-                if rem != 0 {
-                    let mask = (1u64 << rem) - 1;
+                let mask = shot_tail_mask(chunk_shots);
+                if mask != u64::MAX {
                     for word in &mut self.random_bits_host[start..end] {
                         *word &= mask;
                     }
                 }
             }
         }
-    }
-}
-
-fn tail_mask(num_shots: usize) -> u64 {
-    let rem = num_shots % 64;
-    if rem == 0 {
-        !0u64
-    } else {
-        (1u64 << rem) - 1
     }
 }
 
@@ -893,6 +877,7 @@ pub(crate) fn launch_bts_sample(
         let out_stride_words_i =
             require_i32("bts_sample_meas_major", "out_stride_words", chunk_s_words)?;
         let out_word_offset_i = 0i32;
+        let tail_mask_u64 = shot_tail_mask(chunk_shots);
         let batch_blocks = div_ceil_grid(
             "bts_sample_meas_major",
             "chunk_s_words",
@@ -925,6 +910,7 @@ pub(crate) fn launch_bts_sample(
             .arg(&rank_i)
             .arg(&out_stride_words_i)
             .arg(&out_word_offset_i)
+            .arg(&tail_mask_u64)
             .arg(&mut chunk_output_dev);
         // SAFETY: kernel signature matches the call shape. Each thread writes
         // one unique output word (indexed by m and batch), so there is no
@@ -1003,6 +989,7 @@ pub(crate) fn launch_bts_sample_device(
         let out_stride_words_i = require_i32("bts_sample_meas_major", "out_stride_words", s_words)?;
         let out_word_offset_i =
             require_i32("bts_sample_meas_major", "out_word_offset", shots_done / 64)?;
+        let tail_mask_u64 = shot_tail_mask(chunk_shots);
         let batch_blocks = div_ceil_grid(
             "bts_sample_meas_major",
             "chunk_s_words",
@@ -1032,6 +1019,7 @@ pub(crate) fn launch_bts_sample_device(
             .arg(&rank_i)
             .arg(&out_stride_words_i)
             .arg(&out_word_offset_i)
+            .arg(&tail_mask_u64)
             .arg(&mut output_view);
         // SAFETY: kernel signature matches the call shape. Each thread writes
         // one unique output word addressed by measurement row and chunk-local
@@ -1350,7 +1338,7 @@ pub(crate) fn count_meas_major_marginals(
     let num_meas_i = require_i32("bts_popcount_rows", "num_meas", num_meas)?;
     let s_words_i = require_i32("bts_popcount_rows", "s_words", s_words)?;
     let num_meas_grid = require_u32("bts_popcount_rows", "num_meas", num_meas)?;
-    let tail_mask_u64 = tail_mask(num_shots);
+    let tail_mask_u64 = shot_tail_mask(num_shots);
     let cfg = LaunchConfig {
         grid_dim: (num_meas_grid, 1, 1),
         block_dim: (POPCOUNT_BLOCK_SIZE, 1, 1),

--- a/src/sim/compiled/accumulator.rs
+++ b/src/sim/compiled/accumulator.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hasher};
 
-use super::{PackedShots, ShotLayout};
+use super::{
+    count_vec_key, count_vec_key_masked, shot_major_padding_bits_set, shot_tail_mask, PackedShots,
+    ShotLayout,
+};
 
 const DEFAULT_TARGET_BYTES: usize = 256 * 1024 * 1024;
 
@@ -156,11 +159,9 @@ fn count_shot_typed<const M: usize>(counts: &mut FxHashMap<[u64; M], u64>, key: 
 }
 
 #[inline]
-fn count_shot_wide(counts: &mut FxHashMap<Vec<u64>, u64>, key: &[u64]) {
-    if let Some(count) = counts.get_mut(key) {
-        *count += 1;
-    } else {
-        counts.insert(key.to_vec(), 1);
+fn mask_typed_tail<const M: usize>(key: &mut [u64; M], tail_mask: u64) {
+    if M > 0 {
+        key[M - 1] &= tail_mask;
     }
 }
 
@@ -400,7 +401,7 @@ fn accumulate_meas_major_wide(
         for s in 0..batch_len {
             let base = s * m_words;
             let key = &batch_buf[base..base + m_words];
-            count_shot_wide(counts, key);
+            count_vec_key(counts, key);
         }
     }
 }
@@ -441,6 +442,7 @@ fn count_shard_shot_major_typed<const M: usize>(
     data: &[u64],
     shard_start: usize,
     shard_end: usize,
+    tail_mask: u64,
 ) -> FxHashMap<[u64; M], u64> {
     let shard_len = shard_end - shard_start;
     let mut local: FxHashMap<[u64; M], u64> = FxHashMap::default();
@@ -450,6 +452,7 @@ fn count_shard_shot_major_typed<const M: usize>(
         let base = s * M;
         let mut key = [0u64; M];
         key.copy_from_slice(&data[base..base + M]);
+        mask_typed_tail(&mut key, tail_mask);
         count_shot_typed(&mut local, key);
     }
 
@@ -462,15 +465,24 @@ fn count_shard_shot_major_wide(
     shard_start: usize,
     shard_end: usize,
     m_words: usize,
+    tail_mask: u64,
 ) -> FxHashMap<Vec<u64>, u64> {
     let shard_len = shard_end - shard_start;
     let mut local = FxHashMap::default();
     local.reserve(shard_len.min(65536));
+    let mut scratch = Vec::new();
 
-    for s in shard_start..shard_end {
-        let base = s * m_words;
-        let key = &data[base..base + m_words];
-        count_shot_wide(&mut local, key);
+    if tail_mask == u64::MAX {
+        for s in shard_start..shard_end {
+            let base = s * m_words;
+            count_vec_key(&mut local, &data[base..base + m_words]);
+        }
+    } else {
+        for s in shard_start..shard_end {
+            let base = s * m_words;
+            let key = &data[base..base + m_words];
+            count_vec_key_masked(&mut local, key, tail_mask, &mut scratch);
+        }
     }
 
     local
@@ -500,7 +512,7 @@ fn count_shard_wide(
         for s in 0..batch_len {
             let base = s * m_words;
             let key = &buf[base..base + m_words];
-            count_shot_wide(&mut local, key);
+            count_vec_key(&mut local, key);
         }
     }
 
@@ -638,6 +650,12 @@ impl ShotAccumulator for HistogramAccumulator {
             }
             ShotLayout::ShotMajor => {
                 let data = chunk.raw_data();
+                let raw_tail_mask = chunk.measurement_tail_mask();
+                let tail_mask = if shot_major_padding_bits_set(data, n, m_words, raw_tail_mask) {
+                    raw_tail_mask
+                } else {
+                    u64::MAX
+                };
 
                 macro_rules! shot_major_dispatch {
                     ($($variant:ident, $M:expr);+ $(;)?) => {
@@ -657,7 +675,7 @@ impl ShotAccumulator for HistogramAccumulator {
                                                 if start >= n { return None; }
                                                 let end = (start + shots_per_thread).min(n);
                                                 Some(count_shard_shot_major_typed::<$M>(
-                                                    data, start, end,
+                                                    data, start, end, tail_mask,
                                                 ))
                                             })
                                             .collect();
@@ -670,6 +688,7 @@ impl ShotAccumulator for HistogramAccumulator {
                                         let base = s * $M;
                                         let mut key = [0u64; $M];
                                         key.copy_from_slice(&data[base..base + $M]);
+                                        mask_typed_tail(&mut key, tail_mask);
                                         count_shot_typed(counts, key);
                                     }
                                 }
@@ -679,6 +698,7 @@ impl ShotAccumulator for HistogramAccumulator {
                                     let base = s * $M;
                                     let mut key = [0u64; $M];
                                     key.copy_from_slice(&data[base..base + $M]);
+                                    mask_typed_tail(&mut key, tail_mask);
                                     count_shot_typed(counts, key);
                                 }
                             })+
@@ -697,7 +717,7 @@ impl ShotAccumulator for HistogramAccumulator {
                                                 if start >= n { return None; }
                                                 let end = (start + shots_per_thread).min(n);
                                                 Some(count_shard_shot_major_wide(
-                                                    data, start, end, m_words,
+                                                    data, start, end, m_words, tail_mask,
                                                 ))
                                             })
                                             .collect();
@@ -706,16 +726,40 @@ impl ShotAccumulator for HistogramAccumulator {
                                         merge_shard_wide(counts, shard);
                                     }
                                 } else {
-                                    for s in 0..n {
-                                        let key = chunk.shot_words(s);
-                                        count_shot_wide(counts, key);
+                                    if tail_mask == u64::MAX {
+                                        for s in 0..n {
+                                            let key = chunk.shot_words(s);
+                                            count_vec_key(counts, key);
+                                        }
+                                    } else {
+                                        for s in 0..n {
+                                            let key = chunk.shot_words(s);
+                                            count_vec_key_masked(
+                                                counts,
+                                                key,
+                                                tail_mask,
+                                                &mut self.batch_buf,
+                                            );
+                                        }
                                     }
                                 }
 
                                 #[cfg(not(feature = "parallel"))]
-                                for s in 0..n {
-                                    let key = chunk.shot_words(s);
-                                    count_shot_wide(counts, key);
+                                if tail_mask == u64::MAX {
+                                    for s in 0..n {
+                                        let key = chunk.shot_words(s);
+                                        count_vec_key(counts, key);
+                                    }
+                                } else {
+                                    for s in 0..n {
+                                        let key = chunk.shot_words(s);
+                                        count_vec_key_masked(
+                                            counts,
+                                            key,
+                                            tail_mask,
+                                            &mut self.batch_buf,
+                                        );
+                                    }
                                 }
                             }
                             InlineCounts::Uninit => unreachable!(),
@@ -768,12 +812,7 @@ impl ShotAccumulator for MarginalsAccumulator {
         match chunk.layout() {
             ShotLayout::MeasMajor => {
                 let s_words = chunk.s_words();
-                let tail_bits = n % 64;
-                let tail_mask = if tail_bits == 0 {
-                    !0u64
-                } else {
-                    (1u64 << tail_bits) - 1
-                };
+                let tail_mask = shot_tail_mask(n);
                 for mi in 0..m {
                     let row = chunk.meas_words(mi);
                     let mut count = 0u64;
@@ -856,12 +895,7 @@ impl ShotAccumulator for PauliExpectationAccumulator {
         match chunk.layout() {
             ShotLayout::MeasMajor => {
                 let s_words = chunk.s_words();
-                let tail_bits = n % 64;
-                let tail_mask = if tail_bits == 0 {
-                    !0u64
-                } else {
-                    (1u64 << tail_bits) - 1
-                };
+                let tail_mask = shot_tail_mask(n);
                 self.parity_buf.resize(s_words, 0);
                 for (k, obs) in self.observables.iter().enumerate() {
                     self.parity_buf.fill(0);
@@ -967,12 +1001,7 @@ impl ShotAccumulator for CorrelatorAccumulator {
         match chunk.layout() {
             ShotLayout::MeasMajor => {
                 let s_words = chunk.s_words();
-                let tail_bits = n % 64;
-                let tail_mask = if tail_bits == 0 {
-                    !0u64
-                } else {
-                    (1u64 << tail_bits) - 1
-                };
+                let tail_mask = shot_tail_mask(n);
                 for (k, &(i, j)) in self.pairs.iter().enumerate() {
                     let row_i = chunk.meas_words(i);
                     let row_j = chunk.meas_words(j);
@@ -1116,11 +1145,11 @@ mod tests {
     }
 
     #[test]
-    fn count_shot_wide_insert_and_update() {
+    fn count_vec_key_insert_and_update() {
         let mut m: FxHashMap<Vec<u64>, u64> = FxHashMap::default();
-        count_shot_wide(&mut m, &[1, 2, 3]);
-        count_shot_wide(&mut m, &[1, 2, 3]);
-        count_shot_wide(&mut m, &[4, 5, 6]);
+        count_vec_key(&mut m, &[1, 2, 3]);
+        count_vec_key(&mut m, &[1, 2, 3]);
+        count_vec_key(&mut m, &[4, 5, 6]);
         assert_eq!(m.get(&vec![1u64, 2, 3]), Some(&2));
         assert_eq!(m.get(&vec![4u64, 5, 6]), Some(&1));
     }

--- a/src/sim/compiled/bts.rs
+++ b/src/sim/compiled/bts.rs
@@ -4,6 +4,7 @@ use super::rng::Xoshiro256PlusPlus;
 use super::rng::Xoshiro256PlusPlusX2;
 #[cfg(target_arch = "x86_64")]
 use super::rng::Xoshiro256PlusPlusX4;
+use super::shot_tail_mask;
 
 pub(super) const BTS_BATCH_SHOTS: usize = 65536;
 
@@ -240,9 +241,8 @@ pub(super) fn sample_bts_meas_major(
             *r = rng.next_u64();
         }
         if batch == s_words - 1 {
-            let rem = num_shots % 64;
-            if rem != 0 {
-                let mask = (1u64 << rem) - 1;
+            let mask = shot_tail_mask(num_shots);
+            if mask != u64::MAX {
                 for r in random_bits.iter_mut().take(rank) {
                     *r &= mask;
                 }
@@ -257,7 +257,7 @@ pub(super) fn sample_bts_meas_major(
         }
     }
 
-    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words);
+    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words, num_shots);
     meas_major
 }
 
@@ -266,6 +266,7 @@ pub(super) fn apply_ref_bits_meas_major(
     ref_bits: &[u64],
     num_meas: usize,
     s_words: usize,
+    num_shots: usize,
 ) {
     for m in 0..num_meas {
         let ref_bit = (ref_bits[m / 64] >> (m % 64)) & 1;
@@ -276,6 +277,7 @@ pub(super) fn apply_ref_bits_meas_major(
             }
         }
     }
+    super::clear_meas_major_shot_padding(meas_major, num_shots, num_meas, s_words);
 }
 
 fn sample_bts_meas_major_dag(
@@ -307,9 +309,8 @@ fn sample_bts_meas_major_dag(
             *r = rng.next_u64();
         }
         if batch == s_words - 1 {
-            let rem = num_shots % 64;
-            if rem != 0 {
-                let mask = (1u64 << rem) - 1;
+            let mask = shot_tail_mask(num_shots);
+            if mask != u64::MAX {
                 for r in random_bits.iter_mut().take(rank) {
                     *r &= mask;
                 }
@@ -332,7 +333,7 @@ fn sample_bts_meas_major_dag(
         }
     }
 
-    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words);
+    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words, num_shots);
     meas_major
 }
 
@@ -474,7 +475,7 @@ unsafe fn sample_bts_meas_major_avx2(
         );
     }
 
-    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words);
+    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words, num_shots);
     meas_major
 }
 
@@ -783,7 +784,7 @@ unsafe fn sample_bts_meas_major_dag_avx2(
         }
     }
 
-    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words);
+    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words, num_shots);
     meas_major
 }
 
@@ -931,7 +932,7 @@ unsafe fn sample_bts_meas_major_neon(
         );
     }
 
-    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words);
+    apply_ref_bits_meas_major(&mut meas_major, ref_bits, num_meas, s_words, num_shots);
     meas_major
 }
 
@@ -1177,7 +1178,7 @@ mod tests {
         m[1] = 0x0F;
         m[2] = 0x0F;
         let ref_bits = vec![0b101u64];
-        apply_ref_bits_meas_major(&mut m, &ref_bits, num_meas, s_words);
+        apply_ref_bits_meas_major(&mut m, &ref_bits, num_meas, s_words, 64);
         assert_eq!(m[0], !0x0Fu64);
         assert_eq!(m[1], 0x0F);
         assert_eq!(m[2], !0x0Fu64);

--- a/src/sim/compiled/mod.rs
+++ b/src/sim/compiled/mod.rs
@@ -1530,6 +1530,171 @@ pub enum ShotLayout {
     MeasMajor,
 }
 
+#[inline]
+pub(crate) fn measurement_tail_mask(num_measurements: usize) -> u64 {
+    let tail = num_measurements % 64;
+    if tail == 0 {
+        u64::MAX
+    } else {
+        (1u64 << tail) - 1
+    }
+}
+
+#[inline]
+pub(crate) fn shot_tail_mask(num_shots: usize) -> u64 {
+    let tail = num_shots % 64;
+    if tail == 0 {
+        u64::MAX
+    } else {
+        (1u64 << tail) - 1
+    }
+}
+
+fn checked_packed_len(label: &str, rows: usize, words_per_row: usize) -> Result<usize> {
+    rows.checked_mul(words_per_row)
+        .ok_or_else(|| PrismError::InvalidParameter {
+            message: format!("{label} packed raw shape overflows usize"),
+        })
+}
+
+fn validate_packed_len(
+    label: &str,
+    actual: usize,
+    rows: usize,
+    words_per_row: usize,
+) -> Result<usize> {
+    let expected = checked_packed_len(label, rows, words_per_row)?;
+    if actual != expected {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "{label} packed raw length {actual} does not match expected length {expected}"
+            ),
+        });
+    }
+    Ok(expected)
+}
+
+fn validate_shot_major_padding(
+    data: &[u64],
+    num_shots: usize,
+    num_measurements: usize,
+    m_words: usize,
+) -> Result<()> {
+    let valid_mask = measurement_tail_mask(num_measurements);
+    if let Some(shot) = first_shot_major_padding_violation(data, num_shots, m_words, valid_mask) {
+        return Err(PrismError::InvalidParameter {
+            message: format!("shot-major raw padding bits are set in shot {shot}"),
+        });
+    }
+    Ok(())
+}
+
+fn first_shot_major_padding_violation(
+    data: &[u64],
+    num_shots: usize,
+    m_words: usize,
+    tail_mask: u64,
+) -> Option<usize> {
+    if m_words == 0 || tail_mask == u64::MAX {
+        return None;
+    }
+    let invalid_mask = !tail_mask;
+    (0..num_shots).find(|&shot| data[shot * m_words + m_words - 1] & invalid_mask != 0)
+}
+
+pub(crate) fn shot_major_padding_bits_set(
+    data: &[u64],
+    num_shots: usize,
+    m_words: usize,
+    tail_mask: u64,
+) -> bool {
+    first_shot_major_padding_violation(data, num_shots, m_words, tail_mask).is_some()
+}
+
+fn validate_meas_major_padding(
+    data: &[u64],
+    num_shots: usize,
+    num_measurements: usize,
+    s_words: usize,
+) -> Result<()> {
+    if s_words == 0 {
+        return Ok(());
+    }
+    let valid_mask = shot_tail_mask(num_shots);
+    if valid_mask == u64::MAX {
+        return Ok(());
+    }
+    let invalid_mask = !valid_mask;
+    for measurement in 0..num_measurements {
+        let idx = measurement * s_words + s_words - 1;
+        if data[idx] & invalid_mask != 0 {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "measurement-major raw padding bits are set in measurement {measurement}"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn clear_meas_major_shot_padding(
+    data: &mut [u64],
+    num_shots: usize,
+    num_measurements: usize,
+    s_words: usize,
+) {
+    if s_words == 0 {
+        return;
+    }
+    let valid_mask = shot_tail_mask(num_shots);
+    if valid_mask == u64::MAX {
+        return;
+    }
+    for measurement in 0..num_measurements {
+        data[measurement * s_words + s_words - 1] &= valid_mask;
+    }
+}
+
+#[inline]
+pub(crate) fn count_vec_key<S>(
+    counts: &mut std::collections::HashMap<Vec<u64>, u64, S>,
+    key: &[u64],
+) where
+    S: std::hash::BuildHasher,
+{
+    if let Some(count) = counts.get_mut(key) {
+        *count += 1;
+    } else {
+        counts.insert(key.to_vec(), 1);
+    }
+}
+
+#[inline]
+pub(crate) fn count_vec_key_masked<S>(
+    counts: &mut std::collections::HashMap<Vec<u64>, u64, S>,
+    key: &[u64],
+    tail_mask: u64,
+    scratch: &mut Vec<u64>,
+) where
+    S: std::hash::BuildHasher,
+{
+    if key.is_empty() || tail_mask == u64::MAX || (key[key.len() - 1] & !tail_mask) == 0 {
+        count_vec_key(counts, key);
+        return;
+    }
+
+    scratch.clear();
+    scratch.extend_from_slice(key);
+    let last = scratch.len() - 1;
+    scratch[last] &= tail_mask;
+    if let Some(count) = counts.get_mut(scratch.as_slice()) {
+        *count += 1;
+    } else {
+        counts.insert(scratch.clone(), 1);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PackedShots {
     data: Vec<u64>,
@@ -1541,6 +1706,12 @@ pub struct PackedShots {
 }
 
 impl PackedShots {
+    pub const RAW_FORMAT_VERSION: u32 = 1;
+
+    pub fn raw_format_version(&self) -> u32 {
+        Self::RAW_FORMAT_VERSION
+    }
+
     pub fn num_shots(&self) -> usize {
         self.num_shots
     }
@@ -1577,6 +1748,10 @@ impl PackedShots {
         self.m_words
     }
 
+    pub(crate) fn measurement_tail_mask(&self) -> u64 {
+        measurement_tail_mask(self.num_measurements)
+    }
+
     pub fn shot_words(&self, shot: usize) -> &[u64] {
         assert!(
             self.layout == ShotLayout::ShotMajor,
@@ -1595,32 +1770,61 @@ impl PackedShots {
         &self.data[base..base + self.s_words]
     }
 
-    pub fn from_shot_major(data: Vec<u64>, num_shots: usize, num_measurements: usize) -> Self {
+    pub fn try_from_shot_major(
+        data: Vec<u64>,
+        num_shots: usize,
+        num_measurements: usize,
+    ) -> Result<Self> {
         let m_words = num_measurements.div_ceil(64);
         let s_words = num_shots.div_ceil(64);
-        Self {
+        validate_packed_len("shot-major", data.len(), num_shots, m_words)?;
+        validate_shot_major_padding(&data, num_shots, num_measurements, m_words)?;
+        Ok(Self {
             data,
             num_shots,
             num_measurements,
             m_words,
             s_words,
             layout: ShotLayout::ShotMajor,
-        }
+        })
     }
 
-    pub fn from_meas_major(data: Vec<u64>, num_shots: usize, num_measurements: usize) -> Self {
+    pub fn from_shot_major(data: Vec<u64>, num_shots: usize, num_measurements: usize) -> Self {
+        Self::try_from_shot_major(data, num_shots, num_measurements)
+            .unwrap_or_else(|e| panic!("invalid shot-major PackedShots raw data: {e}"))
+    }
+
+    pub fn try_from_meas_major(
+        data: Vec<u64>,
+        num_shots: usize,
+        num_measurements: usize,
+    ) -> Result<Self> {
         let m_words = num_measurements.div_ceil(64);
         let s_words = num_shots.div_ceil(64);
-        Self {
+        validate_packed_len("measurement-major", data.len(), num_measurements, s_words)?;
+        validate_meas_major_padding(&data, num_shots, num_measurements, s_words)?;
+        Ok(Self {
             data,
             num_shots,
             num_measurements,
             m_words,
             s_words,
             layout: ShotLayout::MeasMajor,
-        }
+        })
     }
 
+    pub fn from_meas_major(data: Vec<u64>, num_shots: usize, num_measurements: usize) -> Self {
+        Self::try_from_meas_major(data, num_shots, num_measurements)
+            .unwrap_or_else(|e| panic!("invalid measurement-major PackedShots raw data: {e}"))
+    }
+
+    /// Return the raw words for [`PackedShots::RAW_FORMAT_VERSION`].
+    ///
+    /// Version 1 stores little-endian bit order within each `u64`. Shot-major
+    /// layout stores `num_shots` rows of `m_words()` words. Measurement-major
+    /// layout stores `num_measurements` rows of `s_words()` words. Semantic
+    /// padding bits are outside `num_measurements` for shot-major data and
+    /// outside `num_shots` for measurement-major data.
     pub fn raw_data(&self) -> &[u64] {
         &self.data
     }
@@ -1672,12 +1876,7 @@ impl PackedShots {
         let mut shots = vec![vec![false; self.num_measurements]; self.num_shots];
         match self.layout {
             ShotLayout::ShotMajor => {
-                let tail = self.num_measurements % 64;
-                let last_mask = if tail == 0 {
-                    u64::MAX
-                } else {
-                    (1u64 << tail) - 1
-                };
+                let last_mask = self.measurement_tail_mask();
                 for (s, shot) in shots.iter_mut().enumerate() {
                     let row = &self.data[s * self.m_words..(s + 1) * self.m_words];
                     for (mw, mut bits) in row.iter().copied().enumerate() {
@@ -1694,12 +1893,7 @@ impl PackedShots {
                 }
             }
             ShotLayout::MeasMajor => {
-                let tail = self.num_shots % 64;
-                let last_mask = if tail == 0 {
-                    u64::MAX
-                } else {
-                    (1u64 << tail) - 1
-                };
+                let last_mask = shot_tail_mask(self.num_shots);
                 let mut measurement = 0;
                 while measurement < self.num_measurements {
                     let row =
@@ -1742,6 +1936,12 @@ impl PackedShots {
                                 xor_words(dst, &self.data[src_start..src_start + self.s_words]);
                             }
                         });
+                    clear_meas_major_shot_padding(
+                        &mut data,
+                        self.num_shots,
+                        rows.len(),
+                        self.s_words,
+                    );
                     return Ok(PackedShots::from_meas_major(
                         data,
                         self.num_shots,
@@ -1756,6 +1956,7 @@ impl PackedShots {
                         xor_words(dst, &self.data[src_start..src_start + self.s_words]);
                     }
                 }
+                clear_meas_major_shot_padding(&mut data, self.num_shots, rows.len(), self.s_words);
                 Ok(PackedShots::from_meas_major(
                     data,
                     self.num_shots,
@@ -1801,12 +2002,26 @@ impl PackedShots {
 
         let mut map = HashMap::new();
         let mw = self.m_words;
+        let tail_mask = self.measurement_tail_mask();
+        let mut scratch = Vec::new();
 
         match self.layout {
             ShotLayout::ShotMajor => {
-                for s in 0..self.num_shots {
-                    let base = s * mw;
-                    *map.entry(self.data[base..base + mw].to_vec()).or_insert(0) += 1;
+                if shot_major_padding_bits_set(&self.data, self.num_shots, mw, tail_mask) {
+                    for s in 0..self.num_shots {
+                        let base = s * mw;
+                        count_vec_key_masked(
+                            &mut map,
+                            &self.data[base..base + mw],
+                            tail_mask,
+                            &mut scratch,
+                        );
+                    }
+                } else {
+                    for s in 0..self.num_shots {
+                        let base = s * mw;
+                        count_vec_key(&mut map, &self.data[base..base + mw]);
+                    }
                 }
             }
             ShotLayout::MeasMajor => {
@@ -1835,7 +2050,7 @@ impl PackedShots {
 
                     for s in 0..batch_len {
                         let base = s * mw;
-                        *map.entry(shot_buf[base..base + mw].to_vec()).or_insert(0) += 1;
+                        count_vec_key(&mut map, &shot_buf[base..base + mw]);
                     }
                 }
             }
@@ -1849,6 +2064,7 @@ impl PackedShots {
         let mut map = HashMap::new();
         let mw = self.m_words;
         debug_assert!(mw <= 8);
+        let tail_mask = self.measurement_tail_mask();
 
         match self.layout {
             ShotLayout::ShotMajor => {
@@ -1856,6 +2072,9 @@ impl PackedShots {
                     let base = s * mw;
                     let mut key = [0u64; 8];
                     key[..mw].copy_from_slice(&self.data[base..base + mw]);
+                    if mw > 0 {
+                        key[mw - 1] &= tail_mask;
+                    }
                     *map.entry(key).or_insert(0) += 1;
                 }
             }

--- a/src/sim/compiled/tests.rs
+++ b/src/sim/compiled/tests.rs
@@ -675,6 +675,93 @@ fn packed_shots_parity_rows_rejects_bad_index() {
 }
 
 #[test]
+fn packed_shots_try_constructors_reject_invalid_raw_data() {
+    for (name, result) in [
+        (
+            "shot-major shape",
+            PackedShots::try_from_shot_major(vec![0], 2, 65),
+        ),
+        (
+            "measurement-major shape",
+            PackedShots::try_from_meas_major(vec![0], 65, 2),
+        ),
+        (
+            "shot-major tail",
+            PackedShots::try_from_shot_major(vec![0b1000], 1, 3),
+        ),
+        (
+            "measurement-major tail",
+            PackedShots::try_from_meas_major(vec![0b1000], 3, 1),
+        ),
+    ] {
+        assert!(
+            matches!(result.unwrap_err(), PrismError::InvalidParameter { .. }),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn packed_shots_reports_raw_format_version() {
+    let packed = PackedShots::from_shot_major(vec![0], 1, 1);
+    assert_eq!(packed.raw_format_version(), PackedShots::RAW_FORMAT_VERSION);
+    assert_eq!(PackedShots::RAW_FORMAT_VERSION, 1);
+}
+
+#[test]
+fn packed_shots_counts_ignore_shot_major_padding() {
+    let packed = PackedShots {
+        data: vec![0b1000, 0b1001, 0b0000],
+        num_shots: 3,
+        num_measurements: 3,
+        m_words: 1,
+        s_words: 1,
+        layout: ShotLayout::ShotMajor,
+    };
+
+    let counts = packed.counts();
+    assert_eq!(counts.get(&vec![0]), Some(&2));
+    assert_eq!(counts.get(&vec![1]), Some(&1));
+
+    let mut acc = HistogramAccumulator::new();
+    acc.accumulate(&packed);
+    let acc_counts = acc.into_counts();
+    assert_eq!(acc_counts.get(&vec![0]), Some(&2));
+    assert_eq!(acc_counts.get(&vec![1]), Some(&1));
+}
+
+#[test]
+fn packed_shots_marginals_ignore_meas_major_padding() {
+    let packed = PackedShots {
+        data: vec![0b1001],
+        num_shots: 3,
+        num_measurements: 1,
+        m_words: 1,
+        s_words: 1,
+        layout: ShotLayout::MeasMajor,
+    };
+
+    let mut acc = MarginalsAccumulator::new(1);
+    acc.accumulate(&packed);
+    assert!((acc.marginals()[0] - (1.0 / 3.0)).abs() < 1e-12);
+}
+
+#[test]
+fn packed_shots_parity_rows_clear_meas_major_padding() {
+    let packed = PackedShots {
+        data: vec![0b1001, 0b1000],
+        num_shots: 3,
+        num_measurements: 2,
+        m_words: 1,
+        s_words: 1,
+        layout: ShotLayout::MeasMajor,
+    };
+
+    let parity = packed.parity_rows(&[vec![0], vec![0, 1]]).unwrap();
+    assert_eq!(parity.raw_data(), &[0b001, 0b001]);
+}
+
+#[test]
 fn detector_sampler_preserves_bell_measure_reset_correlation() {
     let mut c = Circuit::new(2, 2);
     c.add_gate(Gate::H, &[0]);

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[cfg(feature = "gpu")]
 use crate::gpu::GpuContext;
 
-use super::{Probabilities, RunOutcome};
+use super::{try_backend_probabilities, RunOutcome};
 
 pub(super) enum DispatchAction {
     Backend(Box<dyn Backend>),
@@ -445,11 +445,14 @@ pub(super) fn try_temporal_clifford(
         }
     }
 
-    let probs = sv.probabilities().ok().map(Probabilities::Dense);
+    let probabilities = match try_backend_probabilities(&sv) {
+        Ok(probs) => probs,
+        Err(e) => return Some(Err(e)),
+    };
 
     Some(Ok(RunOutcome {
         classical_bits: sv.classical_results().to_vec(),
-        probabilities: probs,
+        probabilities,
     }))
 }
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::{max_statevector_qubits, Backend};
 use crate::circuit::{Circuit, Instruction};
-use crate::error::Result;
+use crate::error::{PrismError, Result};
 use shots::{packed_shots_to_classical_bits, sample_shots};
 use terminal_sampling::{sample_counts_from_state, sample_shots_from_state};
 
@@ -70,7 +70,10 @@ pub struct RunOutcome {
     /// `true` = measured |1⟩.
     pub classical_bits: Vec<bool>,
     /// Probability of each computational basis state (length 2^n).
-    /// `None` if the backend does not support probability extraction.
+    ///
+    /// `None` means the selected backend cannot expose a dense probability
+    /// distribution for this circuit. Other probability extraction failures
+    /// are returned as errors by the query that produced this result.
     pub probabilities: Option<Probabilities>,
 }
 
@@ -220,6 +223,14 @@ fn probs_only_result(probs: Vec<f64>) -> RunOutcome {
     }
 }
 
+fn try_backend_probabilities(backend: &dyn Backend) -> Result<Option<Probabilities>> {
+    match backend.probabilities() {
+        Ok(probs) => Ok(Some(Probabilities::Dense(probs))),
+        Err(PrismError::BackendUnsupported { .. }) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
 /// Core execution: fuse, init, apply, extract.
 fn execute(backend: &mut dyn Backend, circuit: &Circuit, opts: &SimOptions) -> Result<RunOutcome> {
     let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
@@ -240,15 +251,15 @@ fn execute_circuit(
     backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
     backend.apply_instructions(&circuit.instructions)?;
 
-    let probs = if opts.probabilities {
-        backend.probabilities().ok().map(Probabilities::Dense)
+    let probabilities = if opts.probabilities {
+        try_backend_probabilities(backend)?
     } else {
         None
     };
 
     Ok(RunOutcome {
         classical_bits: backend.classical_results().to_vec(),
-        probabilities: probs,
+        probabilities,
     })
 }
 
@@ -595,6 +606,37 @@ fn expectations_to_marginals(expectations: &[f64]) -> Vec<(f64, f64)> {
         .collect()
 }
 
+fn has_nonunitary_or_classical_ops(circuit: &Circuit) -> bool {
+    circuit.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Measure { .. }
+                | Instruction::Reset { .. }
+                | Instruction::Conditional { .. }
+        )
+    })
+}
+
+fn supports_pauli_marginal_backend(circuit: &Circuit) -> bool {
+    circuit.is_clifford_plus_t() && !has_nonunitary_or_classical_ops(circuit)
+}
+
+fn validate_pauli_marginal_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
+    if !circuit.is_clifford_plus_t() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "Pauli marginal backends require Clifford+T gates".into(),
+        });
+    }
+    if has_nonunitary_or_classical_ops(circuit) {
+        return Err(PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "Pauli marginal backends require a unitary circuit without measurements, resets, or conditionals".into(),
+        });
+    }
+    Ok(())
+}
+
 fn run_marginals_result_with(
     kind: BackendKind,
     circuit: &Circuit,
@@ -602,15 +644,17 @@ fn run_marginals_result_with(
 ) -> Result<MarginalsResult> {
     let n = circuit.num_qubits;
 
-    match kind {
+    match &kind {
         BackendKind::StochasticPauli { num_samples } => {
-            let spp = unified_pauli::run_spp(circuit, num_samples, seed)?;
+            validate_pauli_marginal_backend(&kind, circuit)?;
+            let spp = unified_pauli::run_spp(circuit, *num_samples, seed)?;
             return Ok(MarginalsResult {
                 marginals: expectations_to_marginals(&spp.expectations),
             });
         }
         BackendKind::DeterministicPauli { epsilon, max_terms } => {
-            let spd = unified_pauli::run_spd(circuit, epsilon, max_terms)?;
+            validate_pauli_marginal_backend(&kind, circuit)?;
+            let spd = unified_pauli::run_spd(circuit, *epsilon, *max_terms)?;
             return Ok(MarginalsResult {
                 marginals: expectations_to_marginals(&spd.expectations),
             });
@@ -619,7 +663,7 @@ fn run_marginals_result_with(
     }
 
     if matches!(kind, BackendKind::Auto)
-        && circuit.is_clifford_plus_t()
+        && supports_pauli_marginal_backend(circuit)
         && circuit.has_t_gates()
         && n >= MIN_QUBITS_FOR_SPD_AUTO
     {
@@ -635,8 +679,12 @@ fn run_marginals_result_with(
             marginals: probs.marginals(),
         })
     } else {
-        Ok(MarginalsResult {
-            marginals: vec![(0.5, 0.5); n],
+        Err(PrismError::BackendUnsupported {
+            backend: "simulate".into(),
+            operation: format!(
+                "marginals for {} qubits without backend probability output",
+                circuit.num_qubits
+            ),
         })
     }
 }
@@ -977,6 +1025,83 @@ mod tests {
         c.add_gate(Gate::T, &[0]);
         c.add_gate(Gate::Cx, &[0, 1]);
         c
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ProbabilityFailure {
+        Unsupported,
+        Invalid,
+    }
+
+    struct ProbabilityFailureBackend {
+        failure: ProbabilityFailure,
+        classical_bits: Vec<bool>,
+        num_qubits: usize,
+    }
+
+    impl ProbabilityFailureBackend {
+        fn new(failure: ProbabilityFailure) -> Self {
+            Self {
+                failure,
+                classical_bits: Vec::new(),
+                num_qubits: 0,
+            }
+        }
+    }
+
+    impl Backend for ProbabilityFailureBackend {
+        fn name(&self) -> &'static str {
+            "probability_failure"
+        }
+
+        fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+            self.num_qubits = num_qubits;
+            self.classical_bits = vec![false; num_classical_bits];
+            Ok(())
+        }
+
+        fn apply(&mut self, _instruction: &Instruction) -> Result<()> {
+            Ok(())
+        }
+
+        fn classical_results(&self) -> &[bool] {
+            &self.classical_bits
+        }
+
+        fn probabilities(&self) -> Result<Vec<f64>> {
+            match self.failure {
+                ProbabilityFailure::Unsupported => Err(PrismError::BackendUnsupported {
+                    backend: self.name().to_string(),
+                    operation: "probabilities".to_string(),
+                }),
+                ProbabilityFailure::Invalid => Err(PrismError::InvalidParameter {
+                    message: "probability extraction failed".to_string(),
+                }),
+            }
+        }
+
+        fn num_qubits(&self) -> usize {
+            self.num_qubits
+        }
+    }
+
+    fn assert_pauli_marginals_reject(circuit: &Circuit) {
+        for backend in [
+            BackendKind::StochasticPauli { num_samples: 100 },
+            BackendKind::DeterministicPauli {
+                epsilon: 0.0,
+                max_terms: 0,
+            },
+        ] {
+            assert!(matches!(
+                simulate(circuit)
+                    .backend(backend)
+                    .seed(42)
+                    .marginals()
+                    .unwrap_err(),
+                PrismError::IncompatibleBackend { .. }
+            ));
+        }
     }
 
     #[test]
@@ -2201,6 +2326,39 @@ mod tests {
     }
 
     #[test]
+    fn test_run_handles_backend_probability_failures() {
+        let circuit = Circuit::new(1, 0);
+
+        let mut unsupported = ProbabilityFailureBackend::new(ProbabilityFailure::Unsupported);
+        let result = run_on(&mut unsupported, &circuit).unwrap();
+        assert!(result.classical_bits.is_empty());
+        assert!(result.probabilities.is_none());
+
+        let mut invalid = ProbabilityFailureBackend::new(ProbabilityFailure::Invalid);
+        let err = run_on(&mut invalid, &circuit).unwrap_err();
+
+        assert!(matches!(err, PrismError::InvalidParameter { .. }));
+    }
+
+    #[test]
+    fn test_run_marginals_rejects_missing_probability_output() {
+        let circuit = Circuit::new(65, 0);
+        let run_result = simulate(&circuit)
+            .backend(BackendKind::FactoredStabilizer)
+            .seed(42)
+            .run()
+            .unwrap();
+        assert!(run_result.probabilities.is_none());
+
+        let err = simulate(&circuit)
+            .backend(BackendKind::FactoredStabilizer)
+            .seed(42)
+            .marginals()
+            .unwrap_err();
+        assert!(matches!(err, PrismError::BackendUnsupported { .. }));
+    }
+
+    #[test]
     fn test_run_marginals_clifford_t_spd_path() {
         let c = crate::circuits::clifford_t_circuit(14, 10, 0.1, 42);
         let m_spd = run_marginals(&c, 42).unwrap();
@@ -2391,6 +2549,38 @@ mod tests {
             .iter()
             .chain(spd.marginals.iter())
             .all(|(p0, p1)| *p0 >= 0.0 && *p0 <= 1.0 && (p0 + p1 - 1.0).abs() < 1e-10));
+    }
+
+    #[test]
+    fn test_pauli_marginals_reject_non_clifford_t_gates() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::Rx(0.25), &[0]);
+
+        assert_pauli_marginals_reject(&c);
+    }
+
+    #[test]
+    fn test_pauli_marginals_reject_measurements_resets_and_conditionals() {
+        let mut measured = Circuit::new(1, 1);
+        measured.add_gate(Gate::H, &[0]);
+        measured.add_gate(Gate::T, &[0]);
+        measured.add_measure(0, 0);
+
+        let mut reset = Circuit::new(1, 0);
+        reset.add_gate(Gate::T, &[0]);
+        reset.add_reset(0);
+
+        let mut conditional = Circuit::new(2, 1);
+        conditional.add_measure(0, 0);
+        conditional.instructions.push(Instruction::Conditional {
+            condition: crate::circuit::ClassicalCondition::BitIsOne(0),
+            gate: Gate::T,
+            targets: smallvec![1],
+        });
+
+        for circuit in [&measured, &reset, &conditional] {
+            assert_pauli_marginals_reject(circuit);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Tighten packed shot raw data handling and probability dispatch behavior. Packed shots now validate shape and padding, mask semantic padding in counts, marginals, parity rows, CPU BTS, and GPU BTS, and expose a raw format version for replay. Marginals now fail when probability output is missing instead of returning uniform values.

## Scope

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Command: `cargo bench --bench bench_shots_perf -- histogram_counts/ghz_1000q/10000`

Machine: Windows NT 10.0.19045.0, Intel64 Family 6 Model 94 Stepping 3, rustc 1.93.0, default release flags.

| Benchmark | Before | After | Change | Within 5 percent threshold? |
| --- | --- | --- | --- | --- |
| `histogram_counts/ghz_1000q/10000` | 2.838 ms | 2.838 ms | +0.10 percent, CI -2.87 percent to +3.21 percent | Yes |

Regression verdict: PASS

## Correctness

- [x] `cargo test -q`
- [x] `cargo fmt --check`
- [x] `cargo check --features gpu`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --features gpu --all-targets -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo doc --no-deps --all-features`

## Hotspot notes

Functions touched: packed shot constructors, histogram accumulation, marginal accumulation, packed parity rows, CPU BTS packed output, GPU BTS packed output, and marginal dispatch.

Wide shot major histogram counting now uses borrowed keys when padding is already clean. Dirty tail rows use one scratch buffer per shard.

## Architecture or design changes

- [x] `docs/architecture.md` updated for packed shot raw format
- [x] `docs/architecture.md` updated for probability output and marginal dispatch behavior

## Breaking changes

None for valid callers. Invalid packed raw data now returns `InvalidParameter` from checked constructors or panics from `from_*` helpers.

## Risks and rollback

Risk: stricter packed raw validation could expose bad replay data sooner.

Rollback: revert the packed raw validation, padding masks, and BTS tail mask changes.

## Ready checklist

- [x] Commit message follows the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green