### PR TITLE
feat: expand benchmark regression tests

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -108,9 +108,13 @@ Representative CI workloads:
 | `statevector/scalability_d5/22` | Dense statevector scaling at a larger qubit count |
 | `statevector/qft_textbook/22` | Structured controlled phase and swap workload |
 | `statevector/qpe_t_gate/22q` | Phase estimation with non-Clifford gates |
+| `statevector/qaoa_l3/20` | QAOA workload with ZZ rotations and mixer layers |
 | `stabilizer/scaling/1000` | Large Clifford stabilizer backend path |
+| `stabilizer/measurement/ghz_measure_all/1000` | Large GHZ preparation plus terminal measurements |
 | `auto/qft_textbook/22` | Auto dispatch on a structured dense circuit |
+| `auto/qpe_t_gate/22q` | Auto dispatch on a non-Clifford phase estimation circuit |
 | `compiled_sampler/noiseless/noiseless_1000q_10k` | Compiled shot sampling path |
+| `compiled_sampler/noisy/noisy_1000q_10k` | Compiled Pauli-noise shot sampling path |
 
 The script builds the `circuits` benchmark binary once with
 `cargo bench --no-run`, then runs the compiled executable directly with

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -82,11 +82,11 @@ run_bench() {
     echo ""
 }
 
-# Keep CI filters on benchmark IDs that exist on the base branch. All selected
-# circuits are at least 22 qubits.
-CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q)"
-CIRCUITS_FILTER+="|stabilizer/scaling/1000"
-CIRCUITS_FILTER+="|auto/qft_textbook/22"
-CIRCUITS_FILTER+="|compiled_sampler/noiseless/noiseless_1000q_10k)$"
+# Keep CI filters on benchmark IDs that exist on the base branch. Prefer larger
+# rows while keeping hosted runner cost bounded.
+CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q|qaoa_l3/20)"
+CIRCUITS_FILTER+="|stabilizer/(scaling/1000|measurement/ghz_measure_all/1000)"
+CIRCUITS_FILTER+="|auto/(qft_textbook/22|qpe_t_gate/22q)"
+CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_1000q_10k|noisy/noisy_1000q_10k))$"
 
-run_bench "circuits" "$CIRCUITS_FILTER" 6
+run_bench "circuits" "$CIRCUITS_FILTER" 10


### PR DESCRIPTION
Expanding performance regression for PRs. Also I want to bump the version to kick off the new category addition. This should not be a `feat` in practice but I can make some exceptions for the automated workflow...