### PR TITLE
feat(qec): add T strategy ladder for stabilizer simulator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,7 @@ harness = false
 name = "bench_gpu"
 harness = false
 required-features = ["gpu"]
+
+[[bench]]
+name = "qec_t_strategies"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -28,6 +28,8 @@ Criterion.rs with HTML reports. Two benchmark binaries:
 | `qubit_sweep/clifford_d10` | Clifford-heavy circuits, depth 10, 4–20 qubits |
 | `depth_sweep/12q_random` | 12-qubit random circuits, depth 5–100 |
 | `entanglement_structure` | Sparse vs dense entanglement, 16 qubits |
+| `stabilizer_rank/shots_terminal` | Clifford+T shot sampling with terminal measurements, including 1000q chi2 |
+| `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 
 ### Shot and QEC benchmarks (bench_shots_perf)
 

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -5,11 +5,11 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use prism_q::backend::Backend;
-use prism_q::circuit::Circuit;
+use prism_q::circuit::{Circuit, SmallVec};
 use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::sim;
-use prism_q::{BackendKind, MpsBackend};
+use prism_q::{BackendKind, ClassicalCondition, Instruction, MpsBackend};
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -23,6 +23,18 @@ fn run_with(
     seed: u64,
 ) -> prism_q::Result<prism_q::RunOutcome> {
     sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
+fn run_shots_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .seed(seed)
+        .shots(num_shots)
 }
 
 fn run_shots_with_noise(
@@ -1107,6 +1119,65 @@ fn clifford_t_circuit(n_qubits: usize, t_count: usize, seed: u64) -> Circuit {
     circuit
 }
 
+fn stabilizer_rank_terminal_shot_circuit(n_qubits: usize, t_count: usize, seed: u64) -> Circuit {
+    let mut circuit = clifford_t_circuit(n_qubits, t_count, seed);
+    let measured = n_qubits.min(4);
+    circuit.num_classical_bits = measured;
+    for q in 0..measured {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn stabilizer_rank_mid_circuit_shot_circuit(n_qubits: usize, t_count: usize, seed: u64) -> Circuit {
+    let mut circuit = clifford_t_circuit(n_qubits, t_count, seed);
+    circuit.num_classical_bits = 2;
+    circuit.add_measure(0, 0);
+    circuit.instructions.push(Instruction::Conditional {
+        condition: ClassicalCondition::BitIsOne(0),
+        gate: Gate::X,
+        targets: SmallVec::from_slice(&[1]),
+    });
+    circuit.add_reset(0);
+    circuit.add_measure(1, 1);
+    circuit
+}
+
+fn bench_stabilizer_rank_shot_case(
+    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+    n_qubits: usize,
+    t_count: usize,
+    shot_count: usize,
+) {
+    let branch_count = 1usize << t_count;
+    let terminal = stabilizer_rank_terminal_shot_circuit(n_qubits, t_count, SEED);
+    let id = format!("{n_qubits}q_chi{branch_count}_{shot_count}shots");
+    group.bench_function(BenchmarkId::new("shots_terminal", &id), |b| {
+        b.iter(|| {
+            run_shots_with(
+                BackendKind::StabilizerRank,
+                black_box(&terminal),
+                black_box(shot_count),
+                SEED,
+            )
+            .unwrap();
+        });
+    });
+
+    let mid = stabilizer_rank_mid_circuit_shot_circuit(n_qubits, t_count, SEED);
+    group.bench_function(BenchmarkId::new("shots_mid_circuit", &id), |b| {
+        b.iter(|| {
+            run_shots_with(
+                BackendKind::StabilizerRank,
+                black_box(&mid),
+                black_box(shot_count),
+                SEED,
+            )
+            .unwrap();
+        });
+    });
+}
+
 fn bench_clifford_t(c: &mut Criterion) {
     let mut group = c.benchmark_group("clifford_t");
     configure_group(&mut group);
@@ -1193,6 +1264,14 @@ fn bench_stabilizer_rank(c: &mut Criterion) {
             });
         });
     }
+
+    let shot_count = 64;
+    for &n in &[32, 64, 128] {
+        for &t in &[1, 2, 3, 4] {
+            bench_stabilizer_rank_shot_case(&mut group, n, t, shot_count);
+        }
+    }
+    bench_stabilizer_rank_shot_case(&mut group, 1000, 1, shot_count);
 
     group.finish();
 }

--- a/benches/qec_t_strategies.rs
+++ b/benches/qec_t_strategies.rs
@@ -1,0 +1,795 @@
+//! T-gate strategy benchmark harness.
+//!
+//! Run with:
+//!   cargo bench --bench qec_t_strategies --features parallel
+//!
+//! Groups:
+//! - `qec_t_strategies/<strategy>/<fixture>`: wall-clock to sample the
+//!   shot budget for that fixture under that strategy.
+//! - `qec_t_strategies_scaling`: production T-count scaling for Auto, SPD,
+//!   and CAMPS.
+//! - `spd_light_cone`: production SPD cone-skip scaling.
+//!
+//! Reference and internal sweeps are opt-in benchmarks. Enable them with
+//! `--features parallel,bench-internal`.
+
+#[cfg(feature = "bench-internal")]
+use criterion::{black_box, measurement::WallTime, BenchmarkGroup};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+#[cfg(feature = "bench-internal")]
+use prism_q::qec::cut_selection::{cut_score, min_fill_treewidth_proxy, InteractionGraph};
+#[cfg(feature = "bench-internal")]
+use prism_q::qec::observable_reroute::{cone_telemetry, min_cone_z_representative, xor_z_support};
+use prism_q::{
+    run_qec_program_with_strategy, run_spd_observable, run_spd_observable_light_cone, Circuit,
+    Gate, PauliTerm, QecOptions, QecProgram, QecRecordRef, QecTStrategy,
+};
+#[cfg(feature = "bench-internal")]
+use std::collections::HashSet;
+use std::time::Duration;
+
+const SEED: u64 = 0xDEAD_BEEF;
+
+fn options(shots: usize) -> QecOptions {
+    QecOptions {
+        shots,
+        seed: SEED,
+        chunk_size: Some(2048),
+        keep_measurements: false,
+    }
+}
+
+fn one_qubit_clifford_t_program(shots: usize) -> QecProgram {
+    let mut program = QecProgram::with_options(1, options(shots));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+}
+
+fn two_qubit_single_t_per_path(shots: usize) -> QecProgram {
+    let mut p = QecProgram::with_options(2, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    p.push_gate(Gate::T, &[0]).unwrap();
+    p.push_gate(Gate::H, &[0]).unwrap();
+    p.push_gate(Gate::H, &[1]).unwrap();
+    p.push_gate(Gate::T, &[1]).unwrap();
+    p.push_gate(Gate::H, &[1]).unwrap();
+    let m0 = p.measure_z(0).unwrap();
+    let m1 = p.measure_z(1).unwrap();
+    p.observable_include(0, &[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+    p
+}
+
+fn cx_t_zz_program(shots: usize) -> QecProgram {
+    let mut p = QecProgram::with_options(2, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    p.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    p.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = p.measure_z(0).unwrap();
+    let m1 = p.measure_z(1).unwrap();
+    p.observable_include(0, &[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+    p
+}
+
+fn multi_t_single_path_program(shots: usize) -> QecProgram {
+    t_chain_program(shots, 2)
+}
+
+/// Single-qubit `(H*T)^t*H` rotation. T-count `t` parametrizes the
+/// scaling fixture used to compare strategies as the non-Clifford
+/// budget grows. The logical observable is Z on the final state.
+fn t_chain_program(shots: usize, t_count: usize) -> QecProgram {
+    let mut p = QecProgram::with_options(1, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    for _ in 0..t_count {
+        p.push_gate(Gate::T, &[0]).unwrap();
+        p.push_gate(Gate::H, &[0]).unwrap();
+    }
+    let m0 = p.measure_z(0).unwrap();
+    p.observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    p
+}
+
+type FixtureBuilder = fn(usize) -> QecProgram;
+
+struct FixtureSpec {
+    label: &'static str,
+    builder: FixtureBuilder,
+    skipped: &'static [QecTStrategy],
+}
+
+fn fixtures() -> Vec<FixtureSpec> {
+    vec![
+        FixtureSpec {
+            label: "h_t_h_1q",
+            builder: one_qubit_clifford_t_program,
+            skipped: &[],
+        },
+        FixtureSpec {
+            label: "two_qubit_single_t",
+            builder: two_qubit_single_t_per_path,
+            skipped: &[],
+        },
+        FixtureSpec {
+            label: "cx_t_zz",
+            builder: cx_t_zz_program,
+            skipped: &[],
+        },
+        FixtureSpec {
+            label: "h_t_t_h_1q",
+            builder: multi_t_single_path_program,
+            skipped: &[],
+        },
+    ]
+}
+
+fn strategies() -> Vec<QecTStrategy> {
+    #[cfg(feature = "bench-internal")]
+    {
+        vec![
+            QecTStrategy::Auto,
+            QecTStrategy::Spd,
+            QecTStrategy::Camps,
+            QecTStrategy::Reference,
+        ]
+    }
+    #[cfg(not(feature = "bench-internal"))]
+    {
+        vec![QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps]
+    }
+}
+
+fn bench_qec_t_strategies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_t_strategies");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_millis(400));
+    group.measurement_time(Duration::from_secs(3));
+
+    let shots = 1_000usize;
+    for fixture in fixtures() {
+        for strategy in strategies() {
+            if fixture.skipped.contains(&strategy) {
+                continue;
+            }
+            let program = (fixture.builder)(shots);
+            let id = BenchmarkId::new(strategy.label(), fixture.label);
+            group.bench_function(id, |b| {
+                b.iter(|| {
+                    run_qec_program_with_strategy(&program, strategy)
+                        .expect("strategy must succeed on benchmark fixture")
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+/// T-scaling sweep: single-qubit `(H*T)^t*H` over several T counts.
+fn bench_qec_t_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_t_strategies_scaling");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(400));
+    group.measurement_time(Duration::from_secs(3));
+
+    let shots = 1_000usize;
+    let t_counts = [1usize, 2, 4, 8, 12, 16, 20, 24, 32];
+    let strategies = strategies();
+
+    for &t in &t_counts {
+        let program = t_chain_program(shots, t);
+        for &strategy in &strategies {
+            let id = BenchmarkId::new(strategy.label(), format!("t{t}"));
+            group.bench_function(id, |b| {
+                b.iter(|| {
+                    run_qec_program_with_strategy(&program, strategy)
+                        .expect("strategy must succeed on scaling fixture")
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+fn local_observable_with_disjoint_t_block(t_outside: usize) -> Circuit {
+    let mut c = Circuit::new(6, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::H, &[0]);
+    for _ in 0..t_outside {
+        c.add_gate(Gate::H, &[3]);
+        c.add_gate(Gate::T, &[3]);
+        c.add_gate(Gate::Cx, &[3, 4]);
+        c.add_gate(Gate::T, &[4]);
+        c.add_gate(Gate::Cx, &[4, 5]);
+        c.add_gate(Gate::T, &[5]);
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn telemetry_label(
+    base: &str,
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    peak_terms: usize,
+    total_discarded: f64,
+) -> String {
+    let t = cone_telemetry(circuit, observable);
+    format!(
+        "{base}_gt{}_gc{}_tt{}_tc{}_k{}_discarded{:.3e}",
+        t.gates_total, t.gates_in_cone, t.t_total, t.t_in_cone, peak_terms, total_discarded
+    )
+}
+
+#[cfg(feature = "bench-internal")]
+fn local_observable_with_local_t_block(depth: usize) -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    for _ in 0..depth {
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::T, &[1]);
+        c.add_gate(Gate::Cx, &[1, 0]);
+    }
+    c.add_gate(Gate::H, &[0]);
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn local_observable_with_uniform_t(depth: usize) -> Circuit {
+    let mut c = Circuit::new(6, 0);
+    c.add_gate(Gate::H, &[0]);
+    for _ in 0..depth {
+        for q in 0..6 {
+            c.add_gate(Gate::T, &[q]);
+        }
+        for q in 0..5 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    c.add_gate(Gate::H, &[0]);
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn strip_qubit(row: usize, col: usize, cols: usize) -> usize {
+    row * cols + col
+}
+
+#[cfg(feature = "bench-internal")]
+fn strip_support(rows: usize, cols: usize, col: usize) -> Vec<usize> {
+    (0..rows).map(|row| strip_qubit(row, col, cols)).collect()
+}
+
+#[cfg(feature = "bench-internal")]
+fn strip_swap_stabilizers(rows: usize, cols: usize, base_col: usize) -> Vec<Vec<usize>> {
+    let base = strip_support(rows, cols, base_col);
+    (0..cols)
+        .filter(|&col| col != base_col)
+        .map(|col| {
+            let mut support = base.clone();
+            support.extend(strip_support(rows, cols, col));
+            support.sort_unstable();
+            support
+        })
+        .collect()
+}
+
+#[cfg(feature = "bench-internal")]
+fn strip_chain_stabilizers(rows: usize, cols: usize) -> Vec<Vec<usize>> {
+    (0..cols.saturating_sub(1))
+        .map(|col| {
+            let mut support = strip_support(rows, cols, col);
+            support.extend(strip_support(rows, cols, col + 1));
+            support.sort_unstable();
+            support
+        })
+        .collect()
+}
+
+#[cfg(feature = "bench-internal")]
+fn surface_strip_t_circuit(rows: usize, cols: usize, depth: usize, t_cols: &[usize]) -> Circuit {
+    let mut c = Circuit::new(rows * cols, 0);
+    let t_cols: HashSet<usize> = t_cols.iter().copied().collect();
+    for _ in 0..depth {
+        for col in 0..cols {
+            for row in 0..rows {
+                let q = strip_qubit(row, col, cols);
+                c.add_gate(Gate::S, &[q]);
+                if t_cols.contains(&col) {
+                    c.add_gate(Gate::T, &[q]);
+                }
+            }
+            for row in 0..rows.saturating_sub(1) {
+                c.add_gate(
+                    Gate::Cz,
+                    &[strip_qubit(row, col, cols), strip_qubit(row + 1, col, cols)],
+                );
+            }
+        }
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn surface_site_t_circuit(
+    rows: usize,
+    cols: usize,
+    depth: usize,
+    t_sites: &[(usize, usize)],
+) -> Circuit {
+    let mut c = Circuit::new(rows * cols, 0);
+    let t_sites: HashSet<(usize, usize)> = t_sites.iter().copied().collect();
+    for _ in 0..depth {
+        for col in 0..cols {
+            for row in 0..rows {
+                let q = strip_qubit(row, col, cols);
+                c.add_gate(Gate::S, &[q]);
+                if t_sites.contains(&(row, col)) {
+                    c.add_gate(Gate::T, &[q]);
+                }
+            }
+            for row in 0..rows.saturating_sub(1) {
+                c.add_gate(
+                    Gate::Cz,
+                    &[strip_qubit(row, col, cols), strip_qubit(row + 1, col, cols)],
+                );
+            }
+        }
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn stabilizer_preserving_branch_circuit(rows: usize, depth: usize) -> Circuit {
+    let cols = 2usize;
+    let mut c = Circuit::new(rows * cols, 0);
+    for _ in 0..depth {
+        for row in 0..rows {
+            let hot = strip_qubit(row, 0, cols);
+            let cold = strip_qubit(row, 1, cols);
+            c.add_gate(Gate::Cx, &[hot, cold]);
+            c.add_gate(Gate::H, &[hot]);
+            c.add_gate(Gate::T, &[hot]);
+            c.add_gate(Gate::H, &[hot]);
+            c.add_gate(Gate::Cx, &[hot, cold]);
+        }
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn column_sites(rows: usize, col: usize) -> Vec<(usize, usize)> {
+    (0..rows).map(|row| (row, col)).collect()
+}
+
+#[cfg(feature = "bench-internal")]
+fn coset_patchy_sites(rows: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    out.extend(column_sites(rows, 0));
+    out.extend(
+        [0usize, 2, 4]
+            .into_iter()
+            .filter(|&row| row < rows)
+            .map(|row| (row, 1)),
+    );
+    out.extend(
+        [1usize, 3]
+            .into_iter()
+            .filter(|&row| row < rows)
+            .map(|row| (row, 2)),
+    );
+    out
+}
+
+#[cfg(feature = "bench-internal")]
+fn coset_residual_sites(rows: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    out.extend(column_sites(rows, 0));
+    out.extend(column_sites(rows, 1));
+    out.extend(
+        [(1usize, 2), (3usize, 3)]
+            .into_iter()
+            .filter(|&(row, _)| row < rows),
+    );
+    out
+}
+
+#[cfg(feature = "bench-internal")]
+fn z_terms(support: &[usize]) -> Vec<PauliTerm> {
+    let mut out: Vec<_> = support.iter().copied().map(PauliTerm::z).collect();
+    out.sort_by_key(|t| t.qubit);
+    out
+}
+
+#[cfg(feature = "bench-internal")]
+fn support_label(support: &[usize]) -> String {
+    support
+        .iter()
+        .map(|q| q.to_string())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+#[cfg(feature = "bench-internal")]
+fn reroute_localized_t_circuit(depth: usize) -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    for _ in 0..depth {
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::S, &[0]);
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn reroute_uniform_t_circuit(depth: usize) -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    for _ in 0..depth {
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::T, &[3]);
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn path_graph_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n.saturating_sub(1) {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn grid_graph_circuit(side: usize) -> Circuit {
+    let mut c = Circuit::new(side * side, 0);
+    for r in 0..side {
+        for col in 0..side {
+            let q = r * side + col;
+            if col + 1 < side {
+                c.add_gate(Gate::Cx, &[q, q + 1]);
+            }
+            if r + 1 < side {
+                c.add_gate(Gate::Cx, &[q, q + side]);
+            }
+        }
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn complete_graph_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for a in 0..n {
+        for b in (a + 1)..n {
+            c.add_gate(Gate::Cz, &[a, b]);
+        }
+    }
+    c
+}
+
+#[cfg(feature = "bench-internal")]
+fn bench_reroute_coset_case(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    name: &str,
+    circuit: Circuit,
+    observable: Vec<usize>,
+    stabilizers: Vec<Vec<usize>>,
+) {
+    let route = min_cone_z_representative(&circuit, &observable, &stabilizers).unwrap();
+    let original_terms = z_terms(&route.original_support);
+    let rerouted_terms = z_terms(&route.rerouted_support);
+    let unrestricted = run_spd_observable(&circuit, &original_terms, 0.0, 0).unwrap();
+    let original = run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap();
+    let rerouted = run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap();
+    assert!((unrestricted.mean - original.mean).abs() < 1e-10);
+    assert!((unrestricted.mean - rerouted.mean).abs() < 1e-10);
+    let label = format!(
+        "{name}_full_k{}_orig_tc{}_gc{}_k{}_discarded{:.3e}_reroute_tc{}_gc{}_k{}_discarded{:.3e}_support{}",
+        unrestricted.peak_terms,
+        route.original.t_in_cone,
+        route.original.gates_in_cone,
+        original.peak_terms,
+        original.total_discarded,
+        route.rerouted.t_in_cone,
+        route.rerouted.gates_in_cone,
+        rerouted.peak_terms,
+        rerouted.total_discarded,
+        support_label(&route.rerouted_support)
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_coset_unrestricted_spd", label.clone()),
+        |b| b.iter(|| run_spd_observable(&circuit, &original_terms, 0.0, 0).unwrap()),
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_coset_original_lc_spd", label.clone()),
+        |b| b.iter(|| run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap()),
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_coset_rerouted_lc_spd", label),
+        |b| b.iter(|| run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap()),
+    );
+}
+
+#[cfg(feature = "bench-internal")]
+fn bench_reroute_branch_preserving_case(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    rows: usize,
+    depth: usize,
+) {
+    let cols = 2usize;
+    let name = format!("reroute_branch_preserving_r{rows}_d{depth}");
+    let circuit = stabilizer_preserving_branch_circuit(rows, depth);
+    let observable = strip_support(rows, cols, 0);
+    let alternate_support = strip_support(rows, cols, 1);
+    let stabilizers = strip_swap_stabilizers(rows, cols, 0);
+    let route = min_cone_z_representative(&circuit, &observable, &stabilizers).unwrap();
+    let original_terms = z_terms(&observable);
+    let alternate_terms = z_terms(&alternate_support);
+    let stabilizer_terms = z_terms(&xor_z_support(&observable, &alternate_support));
+    let original = run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap();
+    let alternate = run_spd_observable_light_cone(&circuit, &alternate_terms, 0.0, 0).unwrap();
+    let stabilizer = run_spd_observable(&circuit, &stabilizer_terms, 0.0, 0).unwrap();
+    let original_unrestricted = run_spd_observable(&circuit, &original_terms, 0.0, 0).unwrap();
+    let alternate_telemetry = cone_telemetry(&circuit, &alternate_terms);
+
+    assert!((original_unrestricted.mean - original.mean).abs() < 1e-10);
+    assert!((original.mean - alternate.mean).abs() < 1e-10);
+    assert!((stabilizer.mean - 1.0).abs() < 1e-10);
+    assert_eq!(route.rerouted_support, observable);
+    assert_eq!(route.original.t_in_cone, alternate_telemetry.t_in_cone);
+    assert!(original.peak_terms > 1);
+    assert!(alternate.peak_terms > 1);
+
+    let label = format!(
+        "{name}_orig_tc{}_gc{}_k{}_alt_tc{}_gc{}_k{}_stab_k{}_support{}",
+        route.original.t_in_cone,
+        route.original.gates_in_cone,
+        original.peak_terms,
+        alternate_telemetry.t_in_cone,
+        alternate_telemetry.gates_in_cone,
+        alternate.peak_terms,
+        stabilizer.peak_terms,
+        support_label(&alternate_support)
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_branch_unrestricted_spd", label.clone()),
+        |b| b.iter(|| run_spd_observable(&circuit, &original_terms, 0.0, 0).unwrap()),
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_branch_original_lc_spd", label.clone()),
+        |b| b.iter(|| run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap()),
+    );
+    group.bench_function(
+        BenchmarkId::new("reroute_branch_alternate_lc_spd", label),
+        |b| b.iter(|| run_spd_observable_light_cone(&circuit, &alternate_terms, 0.0, 0).unwrap()),
+    );
+}
+
+fn bench_spd_light_cone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spd_light_cone");
+    group
+        .sample_size(20)
+        .warm_up_time(Duration::from_millis(500));
+
+    for &t_outside in &[2usize, 4, 8, 16] {
+        let circuit = local_observable_with_disjoint_t_block(t_outside);
+        let obs = [PauliTerm::z(0)];
+
+        group.bench_with_input(BenchmarkId::new("unrestricted", t_outside), &(), |b, _| {
+            b.iter(|| run_spd_observable(&circuit, &obs, 0.0, 0).unwrap())
+        });
+        group.bench_with_input(BenchmarkId::new("light_cone", t_outside), &(), |b, _| {
+            b.iter(|| run_spd_observable_light_cone(&circuit, &obs, 0.0, 0).unwrap())
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(feature = "bench-internal")]
+fn bench_qec_internal_sweeps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("qec_internal_sweeps");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(300));
+    group.measurement_time(Duration::from_secs(1));
+
+    let obs0 = [PauliTerm::z(0)];
+
+    for (name, circuit) in [
+        ("spd_disjoint", local_observable_with_disjoint_t_block(8)),
+        ("spd_localized", local_observable_with_local_t_block(6)),
+        ("spd_uniform", local_observable_with_uniform_t(3)),
+    ] {
+        let full = run_spd_observable(&circuit, &obs0, 0.0, 0).unwrap();
+        let cone = run_spd_observable_light_cone(&circuit, &obs0, 0.0, 0).unwrap();
+        assert!((full.mean - cone.mean).abs() < 1e-10);
+        let unrestricted_label = telemetry_label(
+            &format!("{name}_spd"),
+            &circuit,
+            &obs0,
+            full.peak_terms,
+            full.total_discarded,
+        );
+        let cone_label = telemetry_label(
+            &format!("{name}_lc"),
+            &circuit,
+            &obs0,
+            cone.peak_terms,
+            cone.total_discarded,
+        );
+        group.bench_function(
+            BenchmarkId::new("spd_unrestricted", unrestricted_label),
+            |b| b.iter(|| run_spd_observable(&circuit, &obs0, 0.0, 0).unwrap()),
+        );
+        group.bench_function(BenchmarkId::new("spd_light_cone", cone_label), |b| {
+            b.iter(|| run_spd_observable_light_cone(&circuit, &obs0, 0.0, 0).unwrap())
+        });
+    }
+
+    for (name, circuit) in [
+        ("reroute_localized", reroute_localized_t_circuit(16)),
+        ("reroute_uniform_noop", reroute_uniform_t_circuit(8)),
+    ] {
+        let route = min_cone_z_representative(&circuit, &[0], &[vec![0, 3]]).unwrap();
+        let original_terms = z_terms(&route.original_support);
+        let rerouted_terms = z_terms(&route.rerouted_support);
+        let original = run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap();
+        let rerouted = run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap();
+        assert!((original.mean - rerouted.mean).abs() < 1e-10);
+        let label = format!(
+            "{name}_orig_tc{}_gc{}_k{}_discarded{:.3e}_reroute_tc{}_gc{}_k{}_discarded{:.3e}_support{}",
+            route.original.t_in_cone,
+            route.original.gates_in_cone,
+            original.peak_terms,
+            original.total_discarded,
+            route.rerouted.t_in_cone,
+            route.rerouted.gates_in_cone,
+            rerouted.peak_terms,
+            rerouted.total_discarded,
+            support_label(&route.rerouted_support)
+        );
+        group.bench_function(
+            BenchmarkId::new("reroute_original_light_cone_spd", label.clone()),
+            |b| {
+                b.iter(|| run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap())
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("reroute_rerouted_light_cone_spd", label),
+            |b| {
+                b.iter(|| run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap())
+            },
+        );
+    }
+
+    for (name, circuit, observable, stabilizers) in [
+        (
+            "strip_localized",
+            surface_strip_t_circuit(5, 3, 12, &[0]),
+            strip_support(5, 3, 0),
+            strip_swap_stabilizers(5, 3, 0),
+        ),
+        (
+            "strip_uniform_noop",
+            surface_strip_t_circuit(5, 3, 8, &[0, 1, 2]),
+            strip_support(5, 3, 0),
+            strip_swap_stabilizers(5, 3, 0),
+        ),
+    ] {
+        let route = min_cone_z_representative(&circuit, &observable, &stabilizers).unwrap();
+        let original_terms = z_terms(&route.original_support);
+        let rerouted_terms = z_terms(&route.rerouted_support);
+        let original = run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap();
+        let rerouted = run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap();
+        assert!((original.mean - rerouted.mean).abs() < 1e-10);
+        let label = format!(
+            "{name}_orig_tc{}_gc{}_k{}_discarded{:.3e}_reroute_tc{}_gc{}_k{}_discarded{:.3e}_support{}",
+            route.original.t_in_cone,
+            route.original.gates_in_cone,
+            original.peak_terms,
+            original.total_discarded,
+            route.rerouted.t_in_cone,
+            route.rerouted.gates_in_cone,
+            rerouted.peak_terms,
+            rerouted.total_discarded,
+            support_label(&route.rerouted_support)
+        );
+        group.bench_function(
+            BenchmarkId::new("strip_original_lc_spd", label.clone()),
+            |b| {
+                b.iter(|| run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap())
+            },
+        );
+        group.bench_function(BenchmarkId::new("strip_rerouted_lc_spd", label), |b| {
+            b.iter(|| run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap())
+        });
+    }
+
+    bench_reroute_coset_case(
+        &mut group,
+        "coset_localized_multihop",
+        surface_strip_t_circuit(5, 4, 10, &[0, 1]),
+        strip_support(5, 4, 0),
+        strip_chain_stabilizers(5, 4),
+    );
+    bench_reroute_coset_case(
+        &mut group,
+        "coset_patchy_threehop",
+        surface_site_t_circuit(5, 4, 10, &coset_patchy_sites(5)),
+        strip_support(5, 4, 0),
+        strip_chain_stabilizers(5, 4),
+    );
+    bench_reroute_coset_case(
+        &mut group,
+        "coset_uniform_noop",
+        surface_strip_t_circuit(5, 4, 6, &[0, 1, 2, 3]),
+        strip_support(5, 4, 0),
+        strip_chain_stabilizers(5, 4),
+    );
+    bench_reroute_coset_case(
+        &mut group,
+        "coset_residual",
+        surface_site_t_circuit(5, 4, 10, &coset_residual_sites(5)),
+        strip_support(5, 4, 0),
+        strip_chain_stabilizers(5, 4),
+    );
+    bench_reroute_branch_preserving_case(&mut group, 3, 3);
+
+    for (name, circuit, cut) in [
+        ("cut_path", path_graph_circuit(16), vec![8usize]),
+        ("cut_grid", grid_graph_circuit(4), vec![5usize, 6, 9, 10]),
+        ("cut_complete", complete_graph_circuit(8), vec![0usize, 1]),
+    ] {
+        let graph = InteractionGraph::from_circuit(&circuit);
+        let excluded: HashSet<usize> = cut.into_iter().collect();
+        let width = min_fill_treewidth_proxy(&graph, &HashSet::new());
+        let cut_width = min_fill_treewidth_proxy(&graph, &excluded);
+        let score = cut_score(&graph, &excluded, 1.0);
+        let label = format!(
+            "{name}_edges{}_w{}_cutw{}_score{score:.3}",
+            graph.num_edges(),
+            width,
+            cut_width
+        );
+        group.bench_function(BenchmarkId::new("cut_width_proxy", label), |b| {
+            b.iter(|| {
+                let graph = black_box(&graph);
+                let excluded = black_box(&excluded);
+                (
+                    min_fill_treewidth_proxy(graph, &HashSet::new()),
+                    min_fill_treewidth_proxy(graph, excluded),
+                    cut_score(graph, excluded, 1.0),
+                )
+            })
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(not(feature = "bench-internal"))]
+criterion_group!(
+    qec_t_strategy_benches,
+    bench_qec_t_strategies,
+    bench_qec_t_scaling,
+    bench_spd_light_cone
+);
+
+#[cfg(feature = "bench-internal")]
+criterion_group!(
+    qec_t_strategy_benches,
+    bench_qec_t_strategies,
+    bench_qec_t_scaling,
+    bench_spd_light_cone,
+    bench_qec_internal_sweeps
+);
+criterion_main!(qec_t_strategy_benches);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -445,11 +445,23 @@ Three strategies for circuits mixing Clifford and T gates:
 
 ### Stabilizer rank (`src/sim/stabilizer_rank.rs`)
 
-Maintains a weighted sum of stabilizer states. Each T gate doubles the term count via T = α·I + β·Z decomposition. Clifford gates are O(n²) per term. Accumulates weighted amplitudes for exact probabilities.
+Exact probability output remains capped because it returns a dense vector with
+2^n entries. Shot sampling uses coherent weighted MPS branches instead of a
+dense statevector fallback. Clifford gates mutate each branch state, `T` and
+`Tdg` split branches, and measurement computes outcome probabilities from the
+weighted branch ensemble before projecting every branch to the sampled outcome.
+This removes the hard qubit-count cap from `run_stabilizer_rank_shots`;
+practical scaling is governed by branch count, MPS bond growth, and measurement
+count.
 
-- `run_stabilizer_rank`: Exact probabilities (t ≤ 20, n ≤ 25)
+The dense probability path maintains a weighted sum of stabilizer states. Each T
+gate doubles the term count via the `T = alpha*I + beta*Z` decomposition.
+Clifford gates are O(n^2) per term and weighted amplitudes are accumulated for
+exact probabilities.
+
+- `run_stabilizer_rank`: Exact probabilities (t <= 20, n <= 25)
 - `run_stabilizer_rank_approx`: Approximate with Monte Carlo (higher t counts)
-- `run_stabilizer_rank_shots`: Shot-based sampling
+- `run_stabilizer_rank_shots`: Shot-based sampling with no fixed qubit cap
 - `stabilizer_overlap_sq`: Inner product between stabilizer states
 
 ### Stochastic Pauli Propagation (`src/sim/unified_pauli.rs`)
@@ -463,6 +475,32 @@ Backward-propagates measurement observables as Pauli strings. Clifford gates con
 Backward-propagates as a weighted sum of Pauli strings stored in a HashMap. T gates deterministically branch X/Y terms. Identical strings auto-merge. Optional ε-truncation for approximate mode. Exact for small T-counts, approximate with bounded error for larger ones.
 
 `run_spd(circuit, epsilon, max_terms) → SpdResult`
+
+## Performance decision log
+
+### 2026-05-28 Remove dense fallback from stabilizer-rank shots
+- **Context**: T-containing stabilizer-rank shot sampling rejected circuits
+  above 25 qubits because it reused the dense probability-vector path. Large
+  low-T circuits should be sampleable when branch count and MPS bond growth
+  remain within budget.
+- **Options considered**: Keep the statevector fallback and document the limit,
+  use dense probability extraction only for terminal measurements, or sample
+  online from coherent weighted branches. The first two options kept the
+  25-qubit cap for user-facing sampling.
+- **Decision**: Use coherent weighted MPS branches for
+  `run_stabilizer_rank_shots`. Keep the 25-qubit limit only on APIs that
+  explicitly return dense probability vectors.
+- **Measurement**: `cargo bench --bench circuits --features bench-fast --
+  "stabilizer_rank/shots_(terminal|mid_circuit)"` on Windows, rustc 1.93.0,
+  8 logical processors. Criterion mean estimates for 64 shots: 32q chi2
+  terminal 21.380 ms, mid-circuit 28.531 ms; 128q chi16 terminal 4.0263 s,
+  mid-circuit 3.2277 s; 1000q chi2 terminal 838.02 ms, mid-circuit 1.1196 s.
+  Old implementation was unsupported above 25 qubits for T-containing shot
+  circuits.
+- **Revisit trigger**: Optimize branch overlap and projection if 1000q chi2
+  exceeds 2 seconds for 64 shots on the release benchmark runner, or if chi16
+  terminal sampling regresses by more than 5 percent against the saved Criterion
+  baseline.
 
 ## Memory layout
 
@@ -581,7 +619,7 @@ Top-level re-exports from `src/lib.rs`:
 `parse_qec_program`, `compile_qec_program_rows`, `run_qec_program`, `run_qec_program_reference`, `QecProgram`, `QecOp`, `QecOptions`, `QecSampleResult`, `QecBasis`, `QecPauli`, `QecRecordRef`, `QecNoise`, `QecMeasurementRow`, `QecCompiledRows`
 
 **Clifford+T:**
-`run_stabilizer_rank`, `run_stabilizer_rank_approx`, `stabilizer_overlap_sq`, `run_spp`, `run_spd`
+`run_stabilizer_rank`, `run_stabilizer_rank_approx`, `stabilizer_overlap_sq`, `stabilizer_inner_product`, `run_spp`, `run_spp_observable`, `run_spd`, `run_spd_observable`, `run_spd_observable_light_cone`
 
 **Types:**
 `Circuit`, `CircuitBuilder`, `Instruction`, `ClassicalCondition`, `Gate`, `BackendKind`, `RunOutcome`, `CountsResult`, `MarginalsResult`, `Probabilities`, `FactoredBlock`, `ShotsResult`, `PrismError`, `Result`

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -55,6 +55,7 @@ const MIN_DIM_FOR_PAR: usize = 1 << 14;
 #[cfg(feature = "parallel")]
 const MIN_BOND_FOR_PAR: usize = 32;
 
+#[derive(Clone)]
 struct SiteTensor {
     bond_left: usize,
     bond_right: usize,
@@ -435,7 +436,33 @@ pub fn svd_faer(a: &[Complex64], m: usize, n: usize) -> SvdResult {
     }
 }
 
+/// Pauli axis for [`MpsBackend::pauli_expectation`]. Identity factors
+/// are conveyed by omission from the factor list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpsPauliAxis {
+    X,
+    Y,
+    Z,
+}
+
+#[inline]
+fn pauli_matrix_entry(axis: Option<MpsPauliAxis>, j: usize, k: usize) -> Complex64 {
+    match (axis, j, k) {
+        (None, 0, 0) | (None, 1, 1) => ONE,
+        (None, _, _) => ZERO,
+        (Some(MpsPauliAxis::X), 0, 1) | (Some(MpsPauliAxis::X), 1, 0) => ONE,
+        (Some(MpsPauliAxis::X), _, _) => ZERO,
+        (Some(MpsPauliAxis::Y), 0, 1) => Complex64::new(0.0, -1.0),
+        (Some(MpsPauliAxis::Y), 1, 0) => Complex64::new(0.0, 1.0),
+        (Some(MpsPauliAxis::Y), _, _) => ZERO,
+        (Some(MpsPauliAxis::Z), 0, 0) => ONE,
+        (Some(MpsPauliAxis::Z), 1, 1) => Complex64::new(-1.0, 0.0),
+        (Some(MpsPauliAxis::Z), _, _) => ZERO,
+    }
+}
+
 /// Matrix Product State backend with bounded bond dimension.
+#[derive(Clone)]
 pub struct MpsBackend {
     num_qubits: usize,
     max_bond_dim: usize,
@@ -445,6 +472,8 @@ pub struct MpsBackend {
     site_to_logical: Vec<usize>,
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
+    track_truncation: bool,
+    truncation_discarded: f64,
 }
 
 impl MpsBackend {
@@ -459,7 +488,259 @@ impl MpsBackend {
             site_to_logical: Vec::new(),
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
+            track_truncation: false,
+            truncation_discarded: 0.0,
         }
+    }
+
+    /// Create an MPS backend that keeps every non-zero singular value.
+    pub(crate) fn new_exact(seed: u64) -> Self {
+        let mut backend = Self::new(seed, usize::MAX);
+        backend.svd_epsilon = 0.0;
+        backend
+    }
+
+    /// Begin tracking the cumulative SVD-truncation weight, resetting the
+    /// running total to zero. Callers that need to know whether a bounded
+    /// sequence of operations truncated any state weight (for example the CAMPS
+    /// T-gate path, which must reject silent truncation) call this before the
+    /// sequence and read [`Self::truncation_discarded`] after. Tracking is off
+    /// by default so the common simulation path pays only a single branch per
+    /// SVD, not an extra pass over the singular values.
+    pub fn reset_truncation_tracking(&mut self) {
+        self.track_truncation = true;
+        self.truncation_discarded = 0.0;
+    }
+
+    /// Cumulative relative state weight discarded by SVD truncation since the
+    /// last [`Self::reset_truncation_tracking`]. Epsilon-threshold truncation
+    /// contributes negligibly (`~svd_epsilon²`); a meaningful value indicates
+    /// the bond-dimension cap discarded real weight.
+    pub fn truncation_discarded(&self) -> f64 {
+        self.truncation_discarded
+    }
+
+    fn record_truncation(&mut self, singular_values: &[f64], chi_kept: usize) {
+        if !self.track_truncation || chi_kept >= singular_values.len() {
+            return;
+        }
+        let total: f64 = singular_values.iter().map(|s| s * s).sum();
+        if total <= 0.0 {
+            return;
+        }
+        let discarded: f64 = singular_values[chi_kept..].iter().map(|s| s * s).sum();
+        self.truncation_discarded += discarded / total;
+    }
+
+    /// Peak bond dimension across all internal bonds. Returns 1 for a
+    /// freshly initialized product state. Intended for diagnostics and
+    /// regression tests that monitor entanglement growth.
+    pub fn current_max_bond_dim(&self) -> usize {
+        self.sites.iter().map(|s| s.bond_right).max().unwrap_or(1)
+    }
+
+    /// Configured bond-dimension cap. SVD truncation engages when a bond
+    /// would exceed this value.
+    pub fn max_bond_dim_cap(&self) -> usize {
+        self.max_bond_dim
+    }
+
+    /// Restore the internal MPS site order to logical qubit order without
+    /// changing the represented logical state.
+    pub fn canonicalize_logical_order(&mut self) {
+        let swap_mat = swap_matrix_4x4();
+        for target_site in 0..self.num_qubits {
+            while self.site_to_logical[target_site] != target_site {
+                let logical = target_site;
+                let site = self.logical_to_site[logical];
+                debug_assert!(site > target_site);
+                self.apply_virtual_swap(site - 1, &swap_mat);
+            }
+        }
+    }
+
+    /// Inner product between two MPS values that share the same site
+    /// layout. Returns an error if the qubit counts or layout differ.
+    ///
+    /// Contracts left-to-right through the environment tensor in two
+    /// passes per site, avoiding the naive four-loop sum.
+    pub fn inner_product(&self, other: &Self) -> Result<Complex64> {
+        if self.num_qubits != other.num_qubits {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: format!(
+                    "MPS inner product requires equal qubit counts; got {} vs {}",
+                    self.num_qubits, other.num_qubits,
+                ),
+            });
+        }
+        if self.logical_to_site != other.logical_to_site {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: "MPS inner product requires identical logical_to_site permutations"
+                    .to_string(),
+            });
+        }
+        if self.num_qubits == 0 {
+            return Ok(ONE);
+        }
+
+        let mut env: Vec<Complex64> = vec![ONE; 1];
+        let mut env_cols: usize = 1;
+
+        for i in 0..self.num_qubits {
+            let a = &self.sites[i];
+            let b = &other.sites[i];
+            let bl_a = a.bond_left;
+            let br_a = a.bond_right;
+            let bl_b = b.bond_left;
+            let br_b = b.bond_right;
+
+            // Step 1: tmp[β, j, α'] = Σ_α env[α, β] · conj(A[α, j, α'])
+            let mut tmp = vec![ZERO; bl_b * 2 * br_a];
+            for alpha in 0..bl_a {
+                for j in 0..2 {
+                    for alpha_p in 0..br_a {
+                        let a_val = a.data[a.idx(alpha, j, alpha_p)].conj();
+                        if a_val == ZERO {
+                            continue;
+                        }
+                        for beta in 0..bl_b {
+                            let e_ab = env[alpha * env_cols + beta];
+                            tmp[beta * (2 * br_a) + j * br_a + alpha_p] += a_val * e_ab;
+                        }
+                    }
+                }
+            }
+
+            // Step 2: new_env[α', β'] = Σ_{β, j} tmp[β, j, α'] · B[β, j, β']
+            let mut new_env = vec![ZERO; br_a * br_b];
+            for beta in 0..bl_b {
+                for j in 0..2 {
+                    for beta_p in 0..br_b {
+                        let b_val = b.data[b.idx(beta, j, beta_p)];
+                        if b_val == ZERO {
+                            continue;
+                        }
+                        for alpha_p in 0..br_a {
+                            let t = tmp[beta * (2 * br_a) + j * br_a + alpha_p];
+                            new_env[alpha_p * br_b + beta_p] += t * b_val;
+                        }
+                    }
+                }
+            }
+
+            env = new_env;
+            env_cols = br_b;
+        }
+
+        Ok(env[0])
+    }
+
+    /// Compute `⟨ψ|P|ψ⟩` for a Pauli string `P = ⊗_i P_i` with one
+    /// factor per listed `(qubit, axis)`. Missing factors are implicit
+    /// `I`. Walks the contraction once `(O(N·χ³))` and applies each
+    /// site's Pauli matrix inline; no MPS clone, no gate apply pass.
+    /// Duplicate factors on the same qubit are rejected.
+    pub fn pauli_expectation(&self, pauli_factors: &[(usize, MpsPauliAxis)]) -> Result<Complex64> {
+        if self.num_qubits == 0 {
+            return Ok(ONE);
+        }
+
+        let mut site_axis: Vec<Option<MpsPauliAxis>> = vec![None; self.num_qubits];
+        for &(qubit, axis) in pauli_factors {
+            if qubit >= self.num_qubits {
+                return Err(crate::error::PrismError::InvalidParameter {
+                    message: format!(
+                        "MPS Pauli expectation: qubit {qubit} out of range (n={})",
+                        self.num_qubits
+                    ),
+                });
+            }
+            let site = self.logical_to_site[qubit];
+            if site_axis[site].is_some() {
+                return Err(crate::error::PrismError::InvalidParameter {
+                    message: format!("MPS Pauli expectation: duplicate factor on qubit {qubit}"),
+                });
+            }
+            site_axis[site] = Some(axis);
+        }
+
+        let mut env: Vec<Complex64> = vec![ONE; 1];
+        let mut env_cols: usize = 1;
+
+        for (i, a) in self.sites.iter().enumerate().take(self.num_qubits) {
+            let bl = a.bond_left;
+            let br = a.bond_right;
+
+            // Step 1: tmp[β, j, α'] = Σ_α env[α, β] · conj(A[α, j, α'])
+            let mut tmp = vec![ZERO; bl * 2 * br];
+            for alpha in 0..bl {
+                for j in 0..2 {
+                    for alpha_p in 0..br {
+                        let a_val = a.data[a.idx(alpha, j, alpha_p)].conj();
+                        if a_val == ZERO {
+                            continue;
+                        }
+                        for beta in 0..bl {
+                            let e_ab = env[alpha * env_cols + beta];
+                            tmp[beta * (2 * br) + j * br + alpha_p] += a_val * e_ab;
+                        }
+                    }
+                }
+            }
+
+            // Step 2: new_env[α', β'] = Σ_{β, j, k} tmp[β, j, α'] · M[j,k] · A[β, k, β']
+            // with M = local Pauli matrix at site i (or identity if no factor).
+            let mut new_env = vec![ZERO; br * br];
+            let axis = site_axis[i];
+            for beta in 0..bl {
+                for j in 0..2 {
+                    for k in 0..2 {
+                        let m_jk = pauli_matrix_entry(axis, j, k);
+                        if m_jk == ZERO {
+                            continue;
+                        }
+                        for beta_p in 0..br {
+                            let a_bk = a.data[a.idx(beta, k, beta_p)];
+                            if a_bk == ZERO {
+                                continue;
+                            }
+                            let ma_val = m_jk * a_bk;
+                            for alpha_p in 0..br {
+                                let t = tmp[beta * (2 * br) + j * br + alpha_p];
+                                new_env[alpha_p * br + beta_p] += t * ma_val;
+                            }
+                        }
+                    }
+                }
+            }
+
+            env = new_env;
+            env_cols = br;
+        }
+
+        Ok(env[0])
+    }
+
+    /// MPS site index currently hosting logical qubit `q`. SWAP-routing
+    /// changes this mapping; non-adjacent two-qubit gates are realized
+    /// as sequences of nearest-neighbour SWAPs and grow bond dimension
+    /// in proportion to site-coordinate distance. Anchor-selection
+    /// heuristics in CAMPS use this to score candidate cascades.
+    pub fn site_for_qubit(&self, q: usize) -> usize {
+        self.logical_to_site[q]
+    }
+
+    /// Test whether logical qubit `q` has zero marginal probability of
+    /// being measured as `|1⟩`, within `tol`. For a state where qubit
+    /// `q` has just been disentangled by an OFD cascade, this is
+    /// equivalent to qubit `q` being in the pure `|0⟩` state on that
+    /// site.
+    ///
+    /// Computed as `(1 − Re⟨Z_q⟩)/2 < tol` via [`Self::pauli_expectation`].
+    pub fn is_qubit_in_zero_state(&self, q: usize, tol: f64) -> Result<bool> {
+        let z = self.pauli_expectation(&[(q, MpsPauliAxis::Z)])?;
+        let p_one = 0.5 * (1.0 - z.re);
+        Ok(p_one < tol)
     }
 
     #[inline(always)]
@@ -671,6 +952,7 @@ impl MpsBackend {
 
         let svd_result = svd(&mat, rows, cols);
         let chi_new = truncated_svd_rank(&svd_result.s, self.svd_epsilon, self.max_bond_dim);
+        self.record_truncation(&svd_result.s, chi_new);
 
         // A[k] from U: shape (bl, 2, chi_new)
         // U is column-major: U[col * rows + row]
@@ -1004,6 +1286,7 @@ impl MpsBackend {
 
             let svd_result = svd(&mat, rows, cols);
             let chi_new = truncated_svd_rank(&svd_result.s, self.svd_epsilon, self.max_bond_dim);
+            self.record_truncation(&svd_result.s, chi_new);
 
             // Extract left site from U: shape (cur_bl, 2, chi_new)
             let left_data = svd_left_site_data(&svd_result, cur_bl, chi_new);
@@ -1066,7 +1349,7 @@ impl MpsBackend {
             self.apply_adjacent_n_qubit(&reordered_gate, dim, start);
         } else {
             let swap_mat = swap_matrix_4x4();
-            let mut current_positions = sorted_positions.clone();
+            let mut current_positions = sorted_positions;
             let mut swap_log: Vec<usize> = Vec::new();
 
             for i in 1..n {
@@ -1306,9 +1589,21 @@ impl MpsBackend {
     }
 
     fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
-        let l_env = self.compute_left_env(qubit);
-        let r_env = self.compute_right_env(qubit);
-        let t = &self.sites[qubit];
+        let prob = self.site_outcome_probabilities(qubit);
+
+        let measured = if self.rng.random::<f64>() < prob[1].clamp(0.0, 1.0) {
+            1usize
+        } else {
+            0usize
+        };
+        self.classical_bits[classical_bit] = measured == 1;
+        self.project_site_outcome(qubit, measured);
+    }
+
+    fn site_outcome_probabilities(&self, site: usize) -> [f64; 2] {
+        let l_env = self.compute_left_env(site);
+        let r_env = self.compute_right_env(site);
+        let t = &self.sites[site];
         let bl = t.bond_left;
         let br = t.bond_right;
 
@@ -1368,27 +1663,39 @@ impl MpsBackend {
             }
             *prob_out = val.re;
         }
+        prob
+    }
 
-        let measured = if self.rng.random::<f64>() < prob[1] {
-            1usize
-        } else {
-            0usize
-        };
-        self.classical_bits[classical_bit] = measured == 1;
-
-        let inv_sqrt_prob = 1.0 / prob[measured].clamp(NORM_CLAMP_MIN, 1.0).sqrt();
+    fn project_site_outcome(&mut self, site: usize, outcome: usize) -> f64 {
+        let prob = self.site_outcome_probabilities(site)[outcome].clamp(0.0, 1.0);
+        if prob <= NORM_CLAMP_MIN {
+            return 0.0;
+        }
+        let inv_sqrt_prob = 1.0 / prob.sqrt();
         let scale = Complex64::new(inv_sqrt_prob, 0.0);
-        let other = 1 - measured;
+        let other = 1 - outcome;
 
-        let t = &mut self.sites[qubit];
+        let t = &mut self.sites[site];
+        let bl = t.bond_left;
+        let br = t.bond_right;
         for alpha in 0..bl {
             for beta in 0..br {
-                let idx_m = alpha * (2 * br) + measured * br + beta;
+                let idx_m = alpha * (2 * br) + outcome * br + beta;
                 let idx_o = alpha * (2 * br) + other * br + beta;
                 t.data[idx_m] *= scale;
                 t.data[idx_o] = ZERO;
             }
         }
+        prob
+    }
+
+    /// Project a logical qubit onto a requested computational-basis outcome.
+    ///
+    /// Returns the branch-local Born probability. A zero return means the
+    /// requested branch should be discarded by the caller.
+    pub(crate) fn project_z_outcome(&mut self, qubit: usize, outcome: bool) -> f64 {
+        let site = self.site_for_logical(qubit);
+        self.project_site_outcome(site, usize::from(outcome))
     }
 
     fn reduced_density_site(&self, site: usize) -> [[Complex64; 2]; 2] {
@@ -1659,6 +1966,121 @@ mod tests {
         for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
             assert!((a - e).abs() < EPS, "prob[{i}]: expected {e}, got {a}");
         }
+    }
+
+    fn statevector_pauli_expectation(
+        circuit: &Circuit,
+        pauli_factors: &[(usize, MpsPauliAxis)],
+    ) -> Complex64 {
+        // Build dense amplitudes and contract the Pauli expectation directly.
+        let n = circuit.num_qubits;
+        let mut backend = crate::backend::statevector::StatevectorBackend::new(42);
+        crate::backend::Backend::init(&mut backend, n, 0).unwrap();
+        crate::backend::Backend::apply_instructions(&mut backend, &circuit.instructions).unwrap();
+        let amps = crate::backend::Backend::export_statevector(&backend).unwrap();
+
+        // ⟨ψ|P|ψ⟩ = Σ_{x,y} ψ*_x P_{x,y} ψ_y
+        // For a Pauli string P = ⊗ P_i, the matrix element is non-zero
+        // only when y differs from x by the X-bits of P, and the value
+        // is (-1)^(z_bits·x) · i^(num_y_factors).
+        let mut x_mask = 0usize;
+        let mut z_mask = 0usize;
+        let mut num_y = 0usize;
+        for &(q, axis) in pauli_factors {
+            match axis {
+                MpsPauliAxis::X => x_mask |= 1 << q,
+                MpsPauliAxis::Z => z_mask |= 1 << q,
+                MpsPauliAxis::Y => {
+                    x_mask |= 1 << q;
+                    z_mask |= 1 << q;
+                    num_y += 1;
+                }
+            }
+        }
+        let i_factor = match num_y % 4 {
+            0 => Complex64::new(1.0, 0.0),
+            1 => Complex64::new(0.0, 1.0),
+            2 => Complex64::new(-1.0, 0.0),
+            _ => Complex64::new(0.0, -1.0),
+        };
+        let mut sum = Complex64::new(0.0, 0.0);
+        for x in 0..(1 << n) {
+            let y = x ^ x_mask;
+            let sign = if (z_mask & x).count_ones() & 1 == 1 {
+                -1.0
+            } else {
+                1.0
+            };
+            sum += amps[x].conj() * (Complex64::new(sign, 0.0) * i_factor) * amps[y];
+        }
+        sum
+    }
+
+    #[test]
+    fn mps_pauli_expectation_z_string_matches_statevector_on_h_t_circuit() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        let mps = run_mps(&c);
+
+        for factors in [
+            vec![(0usize, MpsPauliAxis::Z)],
+            vec![(1, MpsPauliAxis::Z)],
+            vec![(2, MpsPauliAxis::Z)],
+            vec![(0, MpsPauliAxis::Z), (1, MpsPauliAxis::Z)],
+            vec![(0, MpsPauliAxis::Z), (2, MpsPauliAxis::Z)],
+            vec![
+                (0, MpsPauliAxis::Z),
+                (1, MpsPauliAxis::Z),
+                (2, MpsPauliAxis::Z),
+            ],
+        ] {
+            let mps_val = mps.pauli_expectation(&factors).unwrap();
+            let sv_val = statevector_pauli_expectation(&c, &factors);
+            assert!(
+                (mps_val - sv_val).norm() < 1e-8,
+                "factors={factors:?}: mps={mps_val:?}, sv={sv_val:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mps_pauli_expectation_mixed_xyz_matches_statevector() {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        let mps = run_mps(&c);
+
+        for factors in [
+            vec![(0usize, MpsPauliAxis::X)],
+            vec![(0, MpsPauliAxis::Y)],
+            vec![(1, MpsPauliAxis::X), (0, MpsPauliAxis::Z)],
+            vec![(0, MpsPauliAxis::Y), (1, MpsPauliAxis::Y)],
+        ] {
+            let mps_val = mps.pauli_expectation(&factors).unwrap();
+            let sv_val = statevector_pauli_expectation(&c, &factors);
+            assert!(
+                (mps_val - sv_val).norm() < 1e-8,
+                "factors={factors:?}: mps={mps_val:?}, sv={sv_val:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mps_pauli_expectation_returns_one_for_normalized_state() {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        let mps = run_mps(&c);
+        let val = mps.pauli_expectation(&[]).unwrap();
+        assert!(
+            (val - Complex64::new(1.0, 0.0)).norm() < 1e-10,
+            "⟨ψ|ψ⟩ = {val:?}, expected 1"
+        );
     }
 
     #[test]
@@ -2072,6 +2494,28 @@ mod tests {
     }
 
     #[test]
+    fn canonicalize_logical_order_preserves_state() {
+        let mut c = Circuit::new(6, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::X, &[5]);
+        c.add_gate(Gate::Cx, &[0, 5]);
+        c.add_gate(Gate::Ry(0.37), &[2]);
+        c.add_gate(Gate::Cz, &[2, 5]);
+
+        let mut b = run_mps(&c);
+        let before = b.export_statevector().unwrap();
+        b.canonicalize_logical_order();
+        assert_eq!(b.logical_to_site, vec![0, 1, 2, 3, 4, 5]);
+        let after = b.export_statevector().unwrap();
+        for (i, (a, e)) in after.iter().zip(&before).enumerate() {
+            assert!(
+                (*a - *e).norm() < EPS,
+                "amp[{i}] differs: actual={a:?}, expected={e:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_measure_after_non_adjacent_routing_uses_logical_qubit() {
         let mut c = Circuit::new(5, 1);
         c.add_gate(Gate::X, &[0]);
@@ -2091,6 +2535,41 @@ mod tests {
         c.add_reset(0);
         c.add_gate(Gate::H, &[4]);
         assert_mps_matches_statevector(&c);
+    }
+
+    #[test]
+    fn is_qubit_in_zero_state_basic() {
+        use crate::circuit::Circuit;
+
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::X, &[1]);
+        let b = run_mps(&c);
+        assert!(b.is_qubit_in_zero_state(0, 1e-10).unwrap());
+        assert!(!b.is_qubit_in_zero_state(1, 1e-10).unwrap());
+        assert!(b.is_qubit_in_zero_state(2, 1e-10).unwrap());
+    }
+
+    #[test]
+    fn is_qubit_in_zero_state_superposition_not_zero() {
+        use crate::circuit::Circuit;
+
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        let b = run_mps(&c);
+        assert!(!b.is_qubit_in_zero_state(0, 1e-10).unwrap());
+        assert!(b.is_qubit_in_zero_state(1, 1e-10).unwrap());
+    }
+
+    #[test]
+    fn is_qubit_in_zero_state_entangled_marginal_nonzero() {
+        use crate::circuit::Circuit;
+
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        let b = run_mps(&c);
+        assert!(!b.is_qubit_in_zero_state(0, 1e-10).unwrap());
+        assert!(!b.is_qubit_in_zero_state(1, 1e-10).unwrap());
     }
 
     #[test]

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -21,9 +21,10 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
 use crate::backend::{dense_statevector_len, tensor_probability_len, Backend, NORM_CLAMP_MIN};
-use crate::circuit::Instruction;
-use crate::error::Result;
+use crate::circuit::{Circuit, Instruction};
+use crate::error::{PrismError, Result};
 use crate::gates::Gate;
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -49,7 +50,7 @@ impl Tensor {
     }
 
     fn rank(&self) -> usize {
-        self.shape.len()
+        self.legs.len()
     }
 }
 
@@ -370,6 +371,422 @@ fn find_best_pair(tensors: &[Tensor], len: usize) -> (usize, usize) {
     (best_i, best_j)
 }
 
+struct ScalarExpectationNetwork {
+    num_qubits: usize,
+    tensors: Vec<Tensor>,
+    ket_legs: Vec<LegId>,
+    bra_legs: Vec<LegId>,
+    next_leg: LegId,
+}
+
+impl ScalarExpectationNetwork {
+    fn new(num_qubits: usize) -> Self {
+        let mut network = Self {
+            num_qubits,
+            tensors: Vec::with_capacity(num_qubits * 4),
+            ket_legs: Vec::with_capacity(num_qubits),
+            bra_legs: Vec::with_capacity(num_qubits),
+            next_leg: 0,
+        };
+        let zero_state = vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)];
+        for _ in 0..num_qubits {
+            let ket_leg = network.fresh_leg();
+            network.ket_legs.push(ket_leg);
+            network.tensors.push(Tensor {
+                data: zero_state.clone(),
+                shape: smallvec::smallvec![2],
+                legs: smallvec::smallvec![ket_leg],
+            });
+
+            let bra_leg = network.fresh_leg();
+            network.bra_legs.push(bra_leg);
+            network.tensors.push(Tensor {
+                data: zero_state.clone(),
+                shape: smallvec::smallvec![2],
+                legs: smallvec::smallvec![bra_leg],
+            });
+        }
+        network
+    }
+
+    fn fresh_leg(&mut self) -> LegId {
+        let leg = self.next_leg;
+        self.next_leg += 1;
+        leg
+    }
+
+    fn validate_qubit(&self, qubit: usize) -> Result<()> {
+        if qubit >= self.num_qubits {
+            return Err(PrismError::InvalidQubit {
+                index: qubit,
+                register_size: self.num_qubits,
+            });
+        }
+        Ok(())
+    }
+
+    fn append_1q_matrix(
+        &mut self,
+        target: usize,
+        mat: &[[Complex64; 2]; 2],
+        conjugate: bool,
+    ) -> Result<()> {
+        self.validate_qubit(target)?;
+        let in_leg = if conjugate {
+            self.bra_legs[target]
+        } else {
+            self.ket_legs[target]
+        };
+        let out_leg = self.fresh_leg();
+        let data = if conjugate {
+            vec![
+                mat[0][0].conj(),
+                mat[0][1].conj(),
+                mat[1][0].conj(),
+                mat[1][1].conj(),
+            ]
+        } else {
+            vec![mat[0][0], mat[0][1], mat[1][0], mat[1][1]]
+        };
+        self.tensors.push(Tensor {
+            data,
+            shape: smallvec::smallvec![2, 2],
+            legs: smallvec::smallvec![out_leg, in_leg],
+        });
+        if conjugate {
+            self.bra_legs[target] = out_leg;
+        } else {
+            self.ket_legs[target] = out_leg;
+        }
+        Ok(())
+    }
+
+    fn append_2q_matrix(
+        &mut self,
+        q0: usize,
+        q1: usize,
+        mat: &[[Complex64; 4]; 4],
+        conjugate: bool,
+    ) -> Result<()> {
+        self.validate_qubit(q0)?;
+        self.validate_qubit(q1)?;
+        let (in0, in1) = if conjugate {
+            (self.bra_legs[q0], self.bra_legs[q1])
+        } else {
+            (self.ket_legs[q0], self.ket_legs[q1])
+        };
+        let out0 = self.fresh_leg();
+        let out1 = self.fresh_leg();
+        let mut data = vec![Complex64::new(0.0, 0.0); 16];
+        for i0 in 0..2usize {
+            for i1 in 0..2usize {
+                for j0 in 0..2usize {
+                    for j1 in 0..2usize {
+                        let value = mat[i0 * 2 + i1][j0 * 2 + j1];
+                        data[i0 * 8 + i1 * 4 + j0 * 2 + j1] =
+                            if conjugate { value.conj() } else { value };
+                    }
+                }
+            }
+        }
+        self.tensors.push(Tensor {
+            data,
+            shape: SmallVec::from_slice(&[2, 2, 2, 2]),
+            legs: SmallVec::from_slice(&[out0, out1, in0, in1]),
+        });
+        if conjugate {
+            self.bra_legs[q0] = out0;
+            self.bra_legs[q1] = out1;
+        } else {
+            self.ket_legs[q0] = out0;
+            self.ket_legs[q1] = out1;
+        }
+        Ok(())
+    }
+
+    fn append_nq_matrix(
+        &mut self,
+        qubits: &[usize],
+        full_mat: &[Vec<Complex64>],
+        conjugate: bool,
+    ) -> Result<()> {
+        for &qubit in qubits {
+            self.validate_qubit(qubit)?;
+        }
+        let m = qubits.len();
+        let dim = 1usize << m;
+        if full_mat.len() != dim || full_mat.iter().any(|row| row.len() != dim) {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "tensor-network scalar expected a {dim} by {dim} matrix for {} targets",
+                    qubits.len()
+                ),
+            });
+        }
+        let in_legs: SmallVec<[LegId; 6]> = if conjugate {
+            qubits.iter().map(|&q| self.bra_legs[q]).collect()
+        } else {
+            qubits.iter().map(|&q| self.ket_legs[q]).collect()
+        };
+        let out_legs: SmallVec<[LegId; 6]> = (0..m).map(|_| self.fresh_leg()).collect();
+        let mut data = vec![Complex64::new(0.0, 0.0); dim * dim];
+
+        for (out_idx, row) in full_mat.iter().enumerate() {
+            for (in_idx, &raw) in row.iter().enumerate() {
+                let value = if conjugate { raw.conj() } else { raw };
+                let mut flat = 0usize;
+                for bit in 0..m {
+                    let out_bit = (out_idx >> (m - 1 - bit)) & 1;
+                    flat = flat * 2 + out_bit;
+                }
+                for bit in 0..m {
+                    let in_bit = (in_idx >> (m - 1 - bit)) & 1;
+                    flat = flat * 2 + in_bit;
+                }
+                data[flat] = value;
+            }
+        }
+
+        let mut shape: SmallVec<[usize; 6]> = SmallVec::new();
+        let mut legs: SmallVec<[LegId; 6]> = SmallVec::new();
+        for &leg in &out_legs {
+            shape.push(2);
+            legs.push(leg);
+        }
+        for &leg in &in_legs {
+            shape.push(2);
+            legs.push(leg);
+        }
+        self.tensors.push(Tensor { data, shape, legs });
+
+        let legs = if conjugate {
+            &mut self.bra_legs
+        } else {
+            &mut self.ket_legs
+        };
+        for (idx, &qubit) in qubits.iter().enumerate() {
+            legs[qubit] = out_legs[idx];
+        }
+        Ok(())
+    }
+
+    fn append_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        let num_qubits = self.num_qubits;
+        for_each_gate_tensor(gate, targets, num_qubits, |op| match op {
+            GateTensorOp::OneQ(q, mat) => {
+                self.append_1q_matrix(q, &mat, false)?;
+                self.append_1q_matrix(q, &mat, true)
+            }
+            GateTensorOp::TwoQ(q0, q1, mat) => {
+                self.append_2q_matrix(q0, q1, &mat, false)?;
+                self.append_2q_matrix(q0, q1, &mat, true)
+            }
+            GateTensorOp::NQ(qubits, full) => {
+                self.append_nq_matrix(qubits, &full, false)?;
+                self.append_nq_matrix(qubits, &full, true)
+            }
+        })
+    }
+
+    fn append_observable(&mut self, terms: &[PauliTerm]) -> Result<()> {
+        let mut axes = vec![None; self.num_qubits];
+        for term in terms {
+            self.validate_qubit(term.qubit)?;
+            if axes[term.qubit].is_some() {
+                return Err(PrismError::InvalidParameter {
+                    message: format!(
+                        "tensor-network scalar observable has duplicate factor on qubit {}",
+                        term.qubit
+                    ),
+                });
+            }
+            axes[term.qubit] = Some(term.axis);
+        }
+
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let neg_one = Complex64::new(-1.0, 0.0);
+        let i = Complex64::new(0.0, 1.0);
+        let neg_i = Complex64::new(0.0, -1.0);
+        for (qubit, axis) in axes.into_iter().enumerate() {
+            let data = match axis {
+                None => vec![one, zero, zero, one],
+                Some(PauliAxis::X) => vec![zero, one, one, zero],
+                Some(PauliAxis::Y) => vec![zero, neg_i, i, zero],
+                Some(PauliAxis::Z) => vec![one, zero, zero, neg_one],
+            };
+            self.tensors.push(Tensor {
+                data,
+                shape: smallvec::smallvec![2, 2],
+                legs: smallvec::smallvec![self.bra_legs[qubit], self.ket_legs[qubit]],
+            });
+        }
+        Ok(())
+    }
+
+    fn contract(mut self) -> Result<f64> {
+        if self.tensors.is_empty() {
+            return Ok(1.0);
+        }
+        let result = greedy_contract(&mut self.tensors);
+        if result.data.len() != 1 || !result.legs.is_empty() {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "tensor-network scalar contraction left {} amplitudes and {} open legs",
+                    result.data.len(),
+                    result.legs.len()
+                ),
+            });
+        }
+        Ok(result.data[0].re)
+    }
+}
+
+/// Contract `<0| U^dag P U |0>` without materializing a full statevector.
+pub(crate) fn expectation_zero_state(circuit: &Circuit, pauli_terms: &[PauliTerm]) -> Result<f64> {
+    let mut network = ScalarExpectationNetwork::new(circuit.num_qubits);
+    for instruction in &circuit.instructions {
+        match instruction {
+            Instruction::Gate { gate, targets } => network.append_gate(gate, targets)?,
+            Instruction::Barrier { .. } => {}
+            Instruction::Measure { .. }
+            | Instruction::Reset { .. }
+            | Instruction::Conditional { .. } => {
+                return Err(PrismError::BackendUnsupported {
+                    backend: "tensor_network_scalar".to_string(),
+                    operation: format!("non-unitary instruction {instruction:?}"),
+                });
+            }
+        }
+    }
+    network.append_observable(pauli_terms)?;
+    network.contract()
+}
+
+/// Elementary tensor operation a gate decomposes into when appended to a
+/// tensor network. `NQ` carries the full `2^k × 2^k` matrix for
+/// multi-controlled unitaries.
+enum GateTensorOp<'a> {
+    OneQ(usize, [[Complex64; 2]; 2]),
+    TwoQ(usize, usize, [[Complex64; 4]; 4]),
+    NQ(&'a [usize], Vec<Vec<Complex64>>),
+}
+
+/// Decompose `gate` into the elementary 1q/2q/nq matrix operations a tensor
+/// network applies, invoking `emit` once per operation in application order.
+///
+/// Shared by the deferred-contraction backend ([`TensorNetworkBackend`], which
+/// appends ket tensors only) and the scalar-expectation network
+/// ([`ScalarExpectationNetwork`], which appends a conjugated ket+bra pair). The
+/// two differ only in their sink, so routing both through this keeps their gate
+/// coverage and matrices identical.
+fn for_each_gate_tensor<'a, F>(
+    gate: &Gate,
+    targets: &'a [usize],
+    num_qubits: usize,
+    mut emit: F,
+) -> Result<()>
+where
+    F: FnMut(GateTensorOp<'a>) -> Result<()>,
+{
+    let check_qubit = |q: usize| -> Result<()> {
+        if q >= num_qubits {
+            return Err(PrismError::InvalidQubit {
+                index: q,
+                register_size: num_qubits,
+            });
+        }
+        Ok(())
+    };
+    let check_arity = |expected: usize| -> Result<()> {
+        if targets.len() != expected {
+            return Err(PrismError::GateArity {
+                gate: gate.name().to_string(),
+                expected,
+                got: targets.len(),
+            });
+        }
+        for &t in targets {
+            check_qubit(t)?;
+        }
+        Ok(())
+    };
+
+    match gate {
+        Gate::Rzz(_) | Gate::Cx | Gate::Cz | Gate::Swap | Gate::Cu(_) | Gate::Fused2q(_) => {
+            check_arity(2)?;
+            emit(GateTensorOp::TwoQ(
+                targets[0],
+                targets[1],
+                gate.matrix_4x4(),
+            ))
+        }
+        Gate::Mcu(data) => {
+            check_arity(data.num_controls as usize + 1)?;
+            let full = TensorNetworkBackend::mcu_full_matrix(data.num_controls as usize, &data.mat);
+            emit(GateTensorOp::NQ(targets, full))
+        }
+        Gate::BatchPhase(data) => {
+            if targets.is_empty() {
+                return Err(PrismError::GateArity {
+                    gate: gate.name().to_string(),
+                    expected: 1,
+                    got: 0,
+                });
+            }
+            check_qubit(targets[0])?;
+            let one = Complex64::new(1.0, 0.0);
+            let zero = Complex64::new(0.0, 0.0);
+            for &(target_qubit, phase) in &data.phases {
+                let mat = [
+                    [one, zero, zero, zero],
+                    [zero, one, zero, zero],
+                    [zero, zero, one, zero],
+                    [zero, zero, zero, phase],
+                ];
+                emit(GateTensorOp::TwoQ(targets[0], target_qubit, mat))?;
+            }
+            Ok(())
+        }
+        Gate::BatchRzz(data) => {
+            for &(q0, q1, theta) in &data.edges {
+                emit(GateTensorOp::TwoQ(q0, q1, Gate::Rzz(theta).matrix_4x4()))?;
+            }
+            Ok(())
+        }
+        Gate::DiagonalBatch(data) => {
+            for entry in &data.entries {
+                if let Some((q, mat)) = entry.as_1q_matrix() {
+                    emit(GateTensorOp::OneQ(q, mat))?;
+                } else if let Some((q0, q1, mat)) = entry.as_2q_matrix() {
+                    emit(GateTensorOp::TwoQ(q0, q1, mat))?;
+                }
+            }
+            Ok(())
+        }
+        Gate::MultiFused(data) => {
+            for &(target, ref mat) in &data.gates {
+                emit(GateTensorOp::OneQ(target, *mat))?;
+            }
+            Ok(())
+        }
+        Gate::Multi2q(data) => {
+            for &(q0, q1, ref mat) in &data.gates {
+                emit(GateTensorOp::TwoQ(q0, q1, *mat))?;
+            }
+            Ok(())
+        }
+        Gate::QftBlock { .. } => Err(PrismError::BackendUnsupported {
+            backend: "tensor_network".to_string(),
+            operation: "QFT block scalar contraction without prior expansion".to_string(),
+        }),
+        _ => {
+            check_arity(1)?;
+            emit(GateTensorOp::OneQ(targets[0], gate.matrix_2x2()))
+        }
+    }
+}
+
 /// Tensor-network simulation backend with deferred contraction.
 pub struct TensorNetworkBackend {
     num_qubits: usize,
@@ -593,74 +1010,16 @@ impl TensorNetworkBackend {
         Ok(ordered.data)
     }
 
-    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
-        match gate {
-            Gate::Rzz(_) | Gate::Cx | Gate::Cz | Gate::Swap => {
-                self.apply_2q_matrix(targets[0], targets[1], &gate.matrix_4x4());
+    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        let num_qubits = self.num_qubits;
+        for_each_gate_tensor(gate, targets, num_qubits, |op| {
+            match op {
+                GateTensorOp::OneQ(q, mat) => self.append_1q_matrix(q, &mat),
+                GateTensorOp::TwoQ(q0, q1, mat) => self.apply_2q_matrix(q0, q1, &mat),
+                GateTensorOp::NQ(qubits, full) => self.apply_nq_matrix(qubits, &full),
             }
-            Gate::Cu(mat) => {
-                let z = Complex64::new(0.0, 0.0);
-                let o = Complex64::new(1.0, 0.0);
-                let m4 = [
-                    [o, z, z, z],
-                    [z, o, z, z],
-                    [z, z, mat[0][0], mat[0][1]],
-                    [z, z, mat[1][0], mat[1][1]],
-                ];
-                self.apply_2q_matrix(targets[0], targets[1], &m4);
-            }
-            Gate::Fused2q(mat) => {
-                self.apply_2q_matrix(targets[0], targets[1], mat);
-            }
-            Gate::Mcu(data) => {
-                let qubits: Vec<usize> = targets.to_vec();
-                let full = Self::mcu_full_matrix(data.num_controls as usize, &data.mat);
-                self.apply_nq_matrix(&qubits, &full);
-            }
-            Gate::BatchPhase(data) => {
-                let control = targets[0];
-                let one = Complex64::new(1.0, 0.0);
-                let zero = Complex64::new(0.0, 0.0);
-                for &(target_qubit, phase) in &data.phases {
-                    let m4 = [
-                        [one, zero, zero, zero],
-                        [zero, one, zero, zero],
-                        [zero, zero, one, zero],
-                        [zero, zero, zero, phase],
-                    ];
-                    self.apply_2q_matrix(control, target_qubit, &m4);
-                }
-            }
-            Gate::BatchRzz(data) => {
-                for &(q0, q1, theta) in &data.edges {
-                    let m4 = Gate::Rzz(theta).matrix_4x4();
-                    self.apply_2q_matrix(q0, q1, &m4);
-                }
-            }
-            Gate::DiagonalBatch(data) => {
-                for entry in &data.entries {
-                    if let Some((q, mat)) = entry.as_1q_matrix() {
-                        self.append_1q_matrix(q, &mat);
-                    } else if let Some((q0, q1, mat)) = entry.as_2q_matrix() {
-                        self.apply_2q_matrix(q0, q1, &mat);
-                    }
-                }
-            }
-            Gate::MultiFused(data) => {
-                for &(target, ref mat) in &data.gates {
-                    self.append_1q_matrix(target, mat);
-                }
-            }
-            Gate::Multi2q(data) => {
-                for &(q0, q1, ref mat) in &data.gates {
-                    self.apply_2q_matrix(q0, q1, mat);
-                }
-            }
-            _ => {
-                let mat = gate.matrix_2x2();
-                self.append_1q_matrix(targets[0], &mat);
-            }
-        }
+            Ok(())
+        })
     }
 }
 
@@ -691,7 +1050,7 @@ impl Backend for TensorNetworkBackend {
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         match instruction {
-            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets),
+            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
             Instruction::Measure {
                 qubit,
                 classical_bit,
@@ -737,7 +1096,7 @@ impl Backend for TensorNetworkBackend {
                 targets,
             } => {
                 if condition.evaluate(&self.classical_bits) {
-                    self.dispatch_gate(gate, targets);
+                    self.dispatch_gate(gate, targets)?;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,9 @@ pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
 pub use qec::{compile_qec_profiled_sampler, QecProfiledCounts, QecProfiledSampler};
 pub use qec::{
     compile_qec_program_rows, parse_qec_program, run_qec_program, run_qec_program_reference,
-    QecBasis, QecCompiledRows, QecMeasurementRow, QecNoise, QecOp, QecOptions, QecPauli,
-    QecProgram, QecRecordRef, QecSampleResult,
+    run_qec_program_spd_rerouted, run_qec_program_with_strategy, QecBasis, QecCompiledRows,
+    QecMeasurementRow, QecNoise, QecObservableEstimate, QecObservableReroute, QecOp, QecOptions,
+    QecPauli, QecProgram, QecRecordRef, QecSampleResult, QecTStrategy,
 };
 pub use sim::compiled::{
     compile_detector_sampler, compile_forward, compile_measurements, run_shots_compiled,
@@ -88,9 +89,14 @@ pub use sim::noise::{
     ReadoutError,
 };
 pub use sim::stabilizer_rank::{
-    run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_overlap_sq, StabRankResult,
+    run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_inner_product,
+    stabilizer_overlap_sq, StabRankResult,
 };
-pub use sim::unified_pauli::{run_spd, run_spp, SpdResult, SppResult};
+pub use sim::unified_pauli::{
+    inverse_light_cone, run_spd, run_spd_observable, run_spd_observable_light_cone, run_spp,
+    run_spp_observable, PauliAxis, PauliTerm, SpdObservableResult, SpdResult, SppObservableResult,
+    SppResult,
+};
 pub use sim::{
     bitstring, run_on, run_qasm, simulate, BackendKind, CountsResult, FactoredBlock,
     MarginalsResult, Probabilities, RunOutcome, Seeded, ShotsResult, Simulate, Unseeded,

--- a/src/qec/camps_prefix.rs
+++ b/src/qec/camps_prefix.rs
@@ -1,0 +1,2290 @@
+//! Signed-Clifford prefix tracker for the CAMPS path.
+//!
+//! Maintains a Clifford unitary `C` implicitly via its inverse tableau:
+//! `inv_x[q] = C† · X_q · C` and `inv_z[q] = C† · Z_q · C`, each a
+//! signed Pauli string with a phase in `{1, i, -1, -i}` (encoded as
+//! `phase4 ∈ {0, 1, 2, 3}` so that the operator value is `i^phase4`).
+//! For Hermitian images of Hermitian Paulis the phase is always `0`
+//! or `2` once a row is settled; intermediate `phase4` of `1` or `3`
+//! can occur during a `rowmul` and clears by the end of the gate.
+//!
+//! The OFD disentangler reads `C† · Z_q · C` directly from the
+//! inverse-tableau row. Final-observable evaluation
+//! `⟨ψ| O |ψ⟩ = ⟨ψ'| C† O C |ψ'⟩` factors the observable into single-
+//! qubit `X`/`Z` components and reads from the same row.
+//!
+//! Per-gate updates use the rule
+//! `new inv_x[q] = C† · (U · X_q · U†) · C` (and analogous for Z),
+//! expanded by linearity over the existing tableau rows. This is the
+//! correct cumulative composition for sequential state-gate
+//! application `C ← U·C`.
+
+use crate::gates::Gate;
+
+/// Packed signed Pauli row for the inverse Clifford tableau. `(x, z)` bit
+/// pairs encode the letter directly ((0,0)=I, (1,0)=X, (0,1)=Z, (1,1)=Y)
+/// and `phase4` is the `i^{phase4}` global factor; this matches the
+/// convention in [`crate::sim::stabilizer_rank`]'s `SignedPauli`. The two
+/// are deliberately distinct: this one uses packed `Vec<u64>` rows and
+/// `rowmul` for full-tableau composition, while that one uses dense
+/// `Vec<bool>` storage and forward conjugation for a single string. Keep
+/// the letter and phase conventions in sync across both.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SignedPauli {
+    pub x: Vec<u64>,
+    pub z: Vec<u64>,
+    pub phase4: u8,
+}
+
+impl SignedPauli {
+    fn zero(num_words: usize) -> Self {
+        Self {
+            x: vec![0u64; num_words],
+            z: vec![0u64; num_words],
+            phase4: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_x(&self, q: usize) -> bool {
+        (self.x[q >> 6] >> (q & 63)) & 1 == 1
+    }
+
+    #[inline(always)]
+    pub fn get_z(&self, q: usize) -> bool {
+        (self.z[q >> 6] >> (q & 63)) & 1 == 1
+    }
+
+    #[inline(always)]
+    fn set_x(&mut self, q: usize, b: bool) {
+        let m = 1u64 << (q & 63);
+        if b {
+            self.x[q >> 6] |= m;
+        } else {
+            self.x[q >> 6] &= !m;
+        }
+    }
+
+    #[inline(always)]
+    fn set_z(&mut self, q: usize, b: bool) {
+        let m = 1u64 << (q & 63);
+        if b {
+            self.z[q >> 6] |= m;
+        } else {
+            self.z[q >> 6] &= !m;
+        }
+    }
+
+    pub fn pauli_at(&self, q: usize) -> PauliKind {
+        match (self.get_x(q), self.get_z(q)) {
+            (false, false) => PauliKind::I,
+            (true, false) => PauliKind::X,
+            (true, true) => PauliKind::Y,
+            (false, true) => PauliKind::Z,
+        }
+    }
+
+    /// Collect the non-identity letters as MPS Pauli-axis factors, ready
+    /// for [`crate::backend::mps::MpsBackend::pauli_expectation`].
+    pub(crate) fn mps_factors(&self, n: usize) -> Vec<(usize, crate::backend::mps::MpsPauliAxis)> {
+        (0..n)
+            .filter_map(|q| self.pauli_at(q).to_mps_axis().map(|axis| (q, axis)))
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PauliKind {
+    I,
+    X,
+    Y,
+    Z,
+}
+
+impl PauliKind {
+    /// Map a Pauli letter to its MPS axis, or `None` for identity.
+    pub(crate) fn to_mps_axis(self) -> Option<crate::backend::mps::MpsPauliAxis> {
+        use crate::backend::mps::MpsPauliAxis;
+        match self {
+            PauliKind::I => None,
+            PauliKind::X => Some(MpsPauliAxis::X),
+            PauliKind::Y => Some(MpsPauliAxis::Y),
+            PauliKind::Z => Some(MpsPauliAxis::Z),
+        }
+    }
+}
+
+/// Per-qubit phase contribution when multiplying Pauli letter `a` by
+/// Pauli letter `b` (in that order). Returns the `phase4` increment
+/// such that `(letter a) · (letter b) = i^{increment} · (letter a XOR b
+/// in (x,z) bits)`.
+#[inline(always)]
+fn letter_product_phase(ax: bool, az: bool, bx: bool, bz: bool) -> u8 {
+    match ((ax, az), (bx, bz)) {
+        ((false, false), _) | (_, (false, false)) => 0,
+        ((true, false), (true, false)) => 0,
+        ((false, true), (false, true)) => 0,
+        ((true, true), (true, true)) => 0,
+        ((true, false), (true, true)) => 1,
+        ((true, false), (false, true)) => 3,
+        ((true, true), (true, false)) => 3,
+        ((true, true), (false, true)) => 1,
+        ((false, true), (true, false)) => 1,
+        ((false, true), (true, true)) => 3,
+    }
+}
+
+/// `dst ← (i^extra_phase4) · dst · src`, with phase tracking across
+/// each qubit position.
+fn rowmul_into(dst: &mut SignedPauli, src: &SignedPauli, n: usize, extra_phase4: u8) {
+    let mut total: u32 = u32::from(dst.phase4) + u32::from(src.phase4) + u32::from(extra_phase4);
+    for q in 0..n {
+        let ax = dst.get_x(q);
+        let az = dst.get_z(q);
+        let bx = src.get_x(q);
+        let bz = src.get_z(q);
+        total += u32::from(letter_product_phase(ax, az, bx, bz));
+    }
+    for w in 0..dst.x.len() {
+        dst.x[w] ^= src.x[w];
+        dst.z[w] ^= src.z[w];
+    }
+    dst.phase4 = (total & 3) as u8;
+}
+
+/// `rows[dst] ← (i^extra_phase4) · rows[dst] · rows[src]` for two distinct
+/// indices into the same row vector. Splits the borrow so neither row is
+/// cloned. `dst == src` is a logic error (a row times itself).
+fn rowmul_within(rows: &mut [SignedPauli], dst: usize, src: usize, n: usize, extra_phase4: u8) {
+    debug_assert_ne!(dst, src, "rowmul_within requires distinct rows");
+    let hi = dst.max(src);
+    let (left, right) = rows.split_at_mut(hi);
+    if dst < src {
+        rowmul_into(&mut left[dst], &right[0], n, extra_phase4);
+    } else {
+        rowmul_into(&mut right[0], &left[src], n, extra_phase4);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SignedCliffordPrefix {
+    num_qubits: usize,
+    pub(crate) inv_x: Vec<SignedPauli>,
+    pub(crate) inv_z: Vec<SignedPauli>,
+}
+
+impl SignedCliffordPrefix {
+    pub fn identity(num_qubits: usize) -> Self {
+        let num_words = num_qubits.div_ceil(64).max(1);
+        let mut inv_x = Vec::with_capacity(num_qubits);
+        let mut inv_z = Vec::with_capacity(num_qubits);
+        for q in 0..num_qubits {
+            let mut x = SignedPauli::zero(num_words);
+            x.set_x(q, true);
+            inv_x.push(x);
+            let mut z = SignedPauli::zero(num_words);
+            z.set_z(q, true);
+            inv_z.push(z);
+        }
+        Self {
+            num_qubits,
+            inv_x,
+            inv_z,
+        }
+    }
+
+    pub fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    pub fn conjugate_z(&self, q: usize) -> SignedPauli {
+        self.inv_z[q].clone()
+    }
+
+    #[cfg(test)]
+    pub fn conjugate_x(&self, q: usize) -> SignedPauli {
+        self.inv_x[q].clone()
+    }
+
+    pub fn apply_state_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<(), &'static str> {
+        match gate {
+            Gate::Id => Ok(()),
+            Gate::H => {
+                self.apply_h(targets[0]);
+                Ok(())
+            }
+            Gate::S => {
+                self.apply_s(targets[0]);
+                Ok(())
+            }
+            Gate::Sdg => {
+                self.apply_sdg(targets[0]);
+                Ok(())
+            }
+            Gate::SX => {
+                self.apply_sx(targets[0]);
+                Ok(())
+            }
+            Gate::SXdg => {
+                self.apply_sxdg(targets[0]);
+                Ok(())
+            }
+            Gate::X => {
+                self.apply_x(targets[0]);
+                Ok(())
+            }
+            Gate::Y => {
+                self.apply_y(targets[0]);
+                Ok(())
+            }
+            Gate::Z => {
+                self.apply_z(targets[0]);
+                Ok(())
+            }
+            Gate::Cx => {
+                self.apply_cx(targets[0], targets[1]);
+                Ok(())
+            }
+            Gate::Cz => {
+                self.apply_cz(targets[0], targets[1]);
+                Ok(())
+            }
+            Gate::Swap => {
+                self.apply_swap(targets[0], targets[1]);
+                Ok(())
+            }
+            _ => Err("non-Clifford gate cannot be absorbed into the SignedCliffordPrefix"),
+        }
+    }
+
+    fn apply_h(&mut self, p: usize) {
+        std::mem::swap(&mut self.inv_x[p], &mut self.inv_z[p]);
+    }
+
+    fn apply_s(&mut self, p: usize) {
+        // State-gate S: new inv_x[p] = C† (S† X S) C = C† (-Y) C = -i X Z propagated.
+        let n = self.num_qubits;
+        rowmul_into(&mut self.inv_x[p], &self.inv_z[p], n, 3);
+    }
+
+    fn apply_sdg(&mut self, p: usize) {
+        // State-gate Sdg: new inv_x[p] = C† (S X S†) C = C† Y C = i X Z propagated.
+        let n = self.num_qubits;
+        rowmul_into(&mut self.inv_x[p], &self.inv_z[p], n, 1);
+    }
+
+    fn apply_sx(&mut self, p: usize) {
+        // State-gate SX: new inv_z[p] = C† (SX† Z SX) C = C† Y C.
+        // Rowmul order here is inv_z[p] · inv_x[p] = Z·X = iY, so landing on
+        // +Y needs an extra `i^3 = -i` factor: (-i)·iY = Y.
+        let n = self.num_qubits;
+        rowmul_into(&mut self.inv_z[p], &self.inv_x[p], n, 3);
+    }
+
+    fn apply_sxdg(&mut self, p: usize) {
+        // State-gate SXdg: new inv_z[p] = C† (-Y) C. With Z·X = iY order and
+        // an extra factor `i`: i · iY = -Y.
+        let n = self.num_qubits;
+        rowmul_into(&mut self.inv_z[p], &self.inv_x[p], n, 1);
+    }
+
+    fn apply_x(&mut self, p: usize) {
+        // X X X = X, X Z X = -Z → flip inv_z[p] sign (phase4 += 2)
+        self.inv_z[p].phase4 = (self.inv_z[p].phase4 + 2) & 3;
+    }
+
+    fn apply_y(&mut self, p: usize) {
+        self.inv_x[p].phase4 = (self.inv_x[p].phase4 + 2) & 3;
+        self.inv_z[p].phase4 = (self.inv_z[p].phase4 + 2) & 3;
+    }
+
+    fn apply_z(&mut self, p: usize) {
+        self.inv_x[p].phase4 = (self.inv_x[p].phase4 + 2) & 3;
+    }
+
+    fn apply_cx(&mut self, ctrl: usize, tgt: usize) {
+        // CX X_c CX = X_c X_t → new inv_x[c] = inv_x[c] · inv_x[t]
+        // CX X_t CX = X_t → unchanged
+        // CX Z_c CX = Z_c → unchanged
+        // CX Z_t CX = Z_c Z_t → new inv_z[t] = inv_z[c] · inv_z[t]
+        let n = self.num_qubits;
+        rowmul_within(&mut self.inv_x, ctrl, tgt, n, 0);
+        rowmul_within(&mut self.inv_z, tgt, ctrl, n, 0);
+    }
+
+    fn apply_cz(&mut self, a: usize, b: usize) {
+        // CZ X_a CZ = X_a Z_b → new inv_x[a] = inv_x[a] · inv_z[b]
+        // CZ X_b CZ = Z_a X_b → new inv_x[b] = inv_z[a] · inv_x[b]
+        // Z_a, Z_b unchanged
+        let n = self.num_qubits;
+        rowmul_into(&mut self.inv_x[a], &self.inv_z[b], n, 0);
+        rowmul_into(&mut self.inv_x[b], &self.inv_z[a], n, 0);
+    }
+
+    fn apply_swap(&mut self, a: usize, b: usize) {
+        self.inv_x.swap(a, b);
+        self.inv_z.swap(a, b);
+    }
+
+    /// Right-composition state-gate fold: `C ← C · U`. Used to absorb
+    /// the disentangler inverse `D†` into the Clifford prefix after a
+    /// CAMPS T-gate. Implementing this via `apply_state_gate` would
+    /// compose on the wrong side (`U · C`), which only coincides with
+    /// `C · U` when `C` and `U` commute or `D` is trivial.
+    ///
+    /// Each inverse-tableau row `R = C† P C` transforms as
+    /// `R → U† R U` (Heisenberg conjugation by `U` of the existing
+    /// Pauli row), so the update is local to the columns touched by
+    /// `U` and tracks any phase introduced by the conjugation.
+    pub(crate) fn fold_right_state_gate(
+        &mut self,
+        gate: &Gate,
+        targets: &[usize],
+    ) -> Result<(), &'static str> {
+        match gate {
+            Gate::Id => Ok(()),
+            Gate::H => {
+                self.fold_right_h(targets[0]);
+                Ok(())
+            }
+            Gate::S => {
+                self.fold_right_s(targets[0]);
+                Ok(())
+            }
+            Gate::Sdg => {
+                self.fold_right_sdg(targets[0]);
+                Ok(())
+            }
+            Gate::X => {
+                self.fold_right_x(targets[0]);
+                Ok(())
+            }
+            Gate::Y => {
+                self.fold_right_y(targets[0]);
+                Ok(())
+            }
+            Gate::Z => {
+                self.fold_right_z(targets[0]);
+                Ok(())
+            }
+            Gate::Cx => {
+                self.fold_right_cx(targets[0], targets[1]);
+                Ok(())
+            }
+            Gate::Cz => {
+                self.fold_right_cz(targets[0], targets[1]);
+                Ok(())
+            }
+            _ => Err("gate not supported in fold_right_state_gate"),
+        }
+    }
+
+    fn fold_right_h(&mut self, p: usize) {
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            let xp = row.get_x(p);
+            let zp = row.get_z(p);
+            row.set_x(p, zp);
+            row.set_z(p, xp);
+            if xp && zp {
+                row.phase4 = (row.phase4 + 2) & 3;
+            }
+        }
+    }
+
+    fn fold_right_s(&mut self, p: usize) {
+        // Sdg · P · S at position p: X → -Y, Y → X, Z/I unchanged.
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            if row.get_x(p) {
+                let had_z = row.get_z(p);
+                row.set_z(p, !had_z);
+                if !had_z {
+                    row.phase4 = (row.phase4 + 2) & 3;
+                }
+            }
+        }
+    }
+
+    fn fold_right_sdg(&mut self, p: usize) {
+        // S · P · Sdg at position p: X → Y, Y → -X, Z/I unchanged.
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            if row.get_x(p) {
+                let had_z = row.get_z(p);
+                row.set_z(p, !had_z);
+                if had_z {
+                    row.phase4 = (row.phase4 + 2) & 3;
+                }
+            }
+        }
+    }
+
+    fn fold_right_x(&mut self, p: usize) {
+        // X · P · X at position p: Y → -Y, Z → -Z, X/I unchanged.
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            if row.get_z(p) {
+                row.phase4 = (row.phase4 + 2) & 3;
+            }
+        }
+    }
+
+    fn fold_right_y(&mut self, p: usize) {
+        // Y · P · Y at position p: X → -X, Z → -Z, Y/I unchanged.
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            let xp = row.get_x(p);
+            let zp = row.get_z(p);
+            if xp ^ zp {
+                row.phase4 = (row.phase4 + 2) & 3;
+            }
+        }
+    }
+
+    fn fold_right_z(&mut self, p: usize) {
+        // Z · P · Z at position p: X → -X, Y → -Y, Z/I unchanged.
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            if row.get_x(p) {
+                row.phase4 = (row.phase4 + 2) & 3;
+            }
+        }
+    }
+
+    fn fold_right_cx(&mut self, c: usize, t: usize) {
+        // CX · P · CX: X_c → X_c X_t, Z_t → Z_c Z_t. Phase increment per
+        // Aaronson-Gottesman: x_c · z_t · (x_t XOR z_c XOR 1).
+        for row in self.inv_x.iter_mut().chain(self.inv_z.iter_mut()) {
+            let xc = row.get_x(c);
+            let zc = row.get_z(c);
+            let xt = row.get_x(t);
+            let zt = row.get_z(t);
+            if xc && zt && (xt ^ zc ^ true) {
+                row.phase4 = (row.phase4 + 2) & 3;
+            }
+            if xc {
+                row.set_x(t, !xt);
+            }
+            if zt {
+                row.set_z(c, !zc);
+            }
+        }
+    }
+
+    fn fold_right_cz(&mut self, a: usize, b: usize) {
+        // CZ = H_b · CX(a,b) · H_b, fold-right composes left-to-right.
+        self.fold_right_h(b);
+        self.fold_right_cx(a, b);
+        self.fold_right_h(b);
+    }
+}
+
+/// Optimization-Free Disentangler (Algorithm 1 of Liu & Clark
+/// arXiv:2412.17209). Given an MPS state `|ψ'⟩` and a Pauli string `P`
+/// expressed as a [`SignedPauli`], constructs a Clifford disentangler
+/// `D` such that applying `D` to `|ψ'⟩` leaves at least one qubit
+/// disentangled in the `|0⟩` state and rotates `P` to act trivially
+/// on that qubit.
+///
+/// The returned cascade is a sequence of gates with their target
+/// qubits, intended to be applied to the MPS via the existing
+/// [`crate::backend::Backend`] dispatch. All gates share a single
+/// control qubit `n` chosen as the first index where MPS site `n` is
+/// in `|0⟩` and `P[n] ∈ {X, Y}`. For each other qubit `m` with non-
+/// identity Pauli factor:
+/// - `P[m] = X` → `CX(n, m)`
+/// - `P[m] = Y` → `Sdg(m), CX(n, m), S(m)` (CY decomposition)
+/// - `P[m] = Z` → `CZ(n, m)`
+///
+/// Returns an empty cascade when no such `n` exists. The disentangler
+/// inverse `D†` is what gets folded into the Clifford prefix.
+pub(crate) type OfdGate = (Gate, Vec<usize>);
+
+fn build_xy_anchor_cascade(p: &SignedPauli, n: usize, num_qubits: usize) -> Vec<OfdGate> {
+    let mut cascade: Vec<OfdGate> = Vec::new();
+    for m in 0..num_qubits {
+        if m == n {
+            continue;
+        }
+        match p.pauli_at(m) {
+            PauliKind::I => continue,
+            PauliKind::X => cascade.push((Gate::Cx, vec![n, m])),
+            PauliKind::Y => {
+                cascade.push((Gate::Sdg, vec![m]));
+                cascade.push((Gate::Cx, vec![n, m]));
+                cascade.push((Gate::S, vec![m]));
+            }
+            PauliKind::Z => cascade.push((Gate::Cz, vec![n, m])),
+        }
+    }
+    cascade
+}
+
+fn support_qubits(p: &SignedPauli, num_qubits: usize) -> Vec<usize> {
+    (0..num_qubits)
+        .filter(|&q| !matches!(p.pauli_at(q), PauliKind::I))
+        .collect()
+}
+
+/// Sum of MPS-site distances over every two-qubit gate in a cascade.
+/// Same routing-cost proxy as [`anchor_routing_cost`] but evaluated on
+/// the assembled cascade so OFD and OFDS variants (which can pick
+/// different anchors and different gate sequences) can be compared
+/// directly. Single-qubit cascade gates contribute 0 since they do not
+/// route across MPS sites.
+pub(crate) fn cascade_routing_cost(
+    mps: &crate::backend::mps::MpsBackend,
+    cascade: &[OfdGate],
+) -> usize {
+    cascade
+        .iter()
+        .filter(|(_, targets)| targets.len() == 2)
+        .map(|(_, targets)| {
+            mps.site_for_qubit(targets[0])
+                .abs_diff(mps.site_for_qubit(targets[1]))
+        })
+        .sum()
+}
+
+/// Which disentangler tier produced a chosen cascade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DisentanglerKind {
+    /// OFD (Algorithm 1), bond-dimension preserving when applied to
+    /// the chosen `|0⟩` anchor.
+    Ofd,
+    /// OFDS (Algorithm 2), works without the `|0⟩` precondition; may
+    /// grow bond dimension on the MPS.
+    Ofds,
+}
+
+/// Cost-compare OFD vs OFDS and return the cheaper cascade, biased to
+/// OFD on ties since OFD is bond-dimension safe by construction. Caller
+/// must handle empty / single-qubit support before calling this. Only
+/// multi-qubit support paths reach disentangler dispatch.
+///
+/// Returns `Ok(None)` when neither OFD nor OFDS can produce a cascade
+/// (an invariant violation given the empty / single-qubit short-circuit
+/// happened upstream).
+pub(crate) fn choose_disentangler(
+    mps: &crate::backend::mps::MpsBackend,
+    p: &SignedPauli,
+    num_qubits: usize,
+    tol: f64,
+) -> crate::error::Result<Option<(usize, Vec<OfdGate>, DisentanglerKind)>> {
+    let ofd = build_ofd_disentangler(mps, p, num_qubits, tol)?;
+    let ofds = build_ofds_disentangler(mps, p, num_qubits);
+    Ok(match (ofd, ofds) {
+        (Some((n, c_ofd)), Some((m, c_ofds))) => {
+            if cascade_routing_cost(mps, &c_ofds) < cascade_routing_cost(mps, &c_ofd) {
+                Some((m, c_ofds, DisentanglerKind::Ofds))
+            } else {
+                Some((n, c_ofd, DisentanglerKind::Ofd))
+            }
+        }
+        (Some((n, c)), None) => Some((n, c, DisentanglerKind::Ofd)),
+        (None, Some((m, c))) => Some((m, c, DisentanglerKind::Ofds)),
+        (None, None) => None,
+    })
+}
+
+/// Sum of MPS-site distances from `anchor` to every other qubit in
+/// `support`. Proxy for the SWAP-routing cost of the resulting CX/CZ
+/// cascade and therefore for bond-dimension growth on the MPS.
+fn anchor_routing_cost(
+    mps: &crate::backend::mps::MpsBackend,
+    anchor: usize,
+    support: &[usize],
+) -> usize {
+    let anchor_site = mps.site_for_qubit(anchor);
+    support
+        .iter()
+        .filter(|&&q| q != anchor)
+        .map(|&q| mps.site_for_qubit(q).abs_diff(anchor_site))
+        .sum()
+}
+
+pub(crate) fn build_ofd_disentangler(
+    mps: &crate::backend::mps::MpsBackend,
+    p: &SignedPauli,
+    num_qubits: usize,
+    tol: f64,
+) -> crate::error::Result<Option<(usize, Vec<OfdGate>)>> {
+    let support = support_qubits(p, num_qubits);
+    let mut best: Option<(usize, usize)> = None;
+    for &n in &support {
+        if !matches!(p.pauli_at(n), PauliKind::X | PauliKind::Y) {
+            continue;
+        }
+        if !mps.is_qubit_in_zero_state(n, tol)? {
+            continue;
+        }
+        let cost = anchor_routing_cost(mps, n, &support);
+        if best.map_or(true, |(_, c)| cost < c) {
+            best = Some((n, cost));
+        }
+    }
+    Ok(best.map(|(n, _)| (n, build_xy_anchor_cascade(p, n, num_qubits))))
+}
+
+/// Optimization-Free Disentangler with State support (Algorithm 2 of
+/// Liu & Clark arXiv:2412.17209). Same cascade structure as
+/// [`build_ofd_disentangler`] but with no `|0⟩` precondition on the
+/// anchor qubit. The `|0⟩` requirement in OFD is a bond-dimension-
+/// preservation optimization; OFDS produces a correct disentangler for
+/// any MPS state at the cost of possibly growing bond dimension when
+/// the cascade is applied.
+///
+/// Anchor selection:
+/// - First qubit with `P[n] ∈ {X, Y}` if any. Cascade matches OFD.
+/// - Otherwise (`P` has only `Z` letters and `>= 2` of them), anchors
+///   at the last `Z` qubit and reduces support via a CX ladder
+///   `CX(q_i, q_{i+1})` over consecutive `Z` positions. Each rung
+///   maps `Z_{q_i} Z_{q_{i+1}} → Z_{q_{i+1}}` (Heisenberg picture),
+///   leaving a single `Z` on the anchor after `k - 1` CXs.
+///
+/// Returns `None` only when `P` has fewer than two non-identity
+/// letters and none of them are `X`/`Y`. The caller already handles
+/// the empty- and single-support cases directly.
+pub(crate) fn build_ofds_disentangler(
+    mps: &crate::backend::mps::MpsBackend,
+    p: &SignedPauli,
+    num_qubits: usize,
+) -> Option<(usize, Vec<OfdGate>)> {
+    let support = support_qubits(p, num_qubits);
+    let xy_candidates: Vec<usize> = support
+        .iter()
+        .copied()
+        .filter(|&n| matches!(p.pauli_at(n), PauliKind::X | PauliKind::Y))
+        .collect();
+    if let Some(&anchor) = xy_candidates
+        .iter()
+        .min_by_key(|&&n| anchor_routing_cost(mps, n, &support))
+    {
+        return Some((anchor, build_xy_anchor_cascade(p, anchor, num_qubits)));
+    }
+    let z_support: Vec<usize> = support
+        .iter()
+        .copied()
+        .filter(|&q| matches!(p.pauli_at(q), PauliKind::Z))
+        .collect();
+    if z_support.len() < 2 {
+        return None;
+    }
+    let anchor = *z_support
+        .iter()
+        .min_by_key(|&&q| anchor_routing_cost(mps, q, &z_support))
+        .unwrap();
+    let mut z_sites: Vec<(usize, usize)> = z_support
+        .iter()
+        .map(|&q| (mps.site_for_qubit(q), q))
+        .collect();
+    z_sites.sort_by_key(|&(s, _)| s);
+    let ordered: Vec<usize> = z_sites.into_iter().map(|(_, q)| q).collect();
+    let anchor_pos = ordered.iter().position(|&q| q == anchor).unwrap();
+    let mut cascade: Vec<OfdGate> = Vec::with_capacity(ordered.len() - 1);
+    for i in 0..anchor_pos {
+        cascade.push((Gate::Cx, vec![ordered[i], ordered[i + 1]]));
+    }
+    for i in (anchor_pos + 1..ordered.len()).rev() {
+        cascade.push((Gate::Cx, vec![ordered[i], ordered[i - 1]]));
+    }
+    Some((anchor, cascade))
+}
+
+/// Evaluate `⟨ψ|Π_q Z_q|ψ⟩` for a CAMPS state `|ψ⟩ = C|ϕ⟩` where the
+/// Clifford prefix `C` is tracked by `prefix` and the MPS holds `|ϕ⟩`.
+///
+/// Rewrites the observable as `⟨ϕ| C† (Π Z_q) C |ϕ⟩` by composing
+/// `Π_q (C† Z_q C)` via signed-Pauli multiplication, then evaluates
+/// the resulting Pauli string on the MPS via [`crate::backend::mps::MpsBackend::pauli_expectation`].
+///
+/// The composed string is canonicalized for the MPS evaluator: each
+/// qubit's `(x, z)` bit pattern is mapped to letter `I`/`X`/`Y`/`Z`,
+/// with the residual `(-i)` factor from rewriting `X·Z = -i·Y`
+/// absorbed into the overall coefficient alongside the stored `i^phase4`.
+/// For a Hermitian observable (which `C† O C` is whenever `O` is
+/// Hermitian and `C` unitary) the coefficient lands at `±1`.
+pub(crate) fn evaluate_z_observable_camps(
+    prefix: &SignedCliffordPrefix,
+    mps: &crate::backend::mps::MpsBackend,
+    z_qubits: &[usize],
+) -> crate::error::Result<f64> {
+    let n = prefix.num_qubits();
+    let num_words = n.div_ceil(64).max(1);
+    let mut combined = SignedPauli::zero(num_words);
+    for &q in z_qubits {
+        let row = prefix.conjugate_z(q);
+        rowmul_into(&mut combined, &row, n, 0);
+    }
+    let factors = combined.mps_factors(n);
+    let p = u32::from(combined.phase4);
+    let coef_re = match p {
+        0 => 1.0,
+        2 => -1.0,
+        _ => {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: format!(
+                    "CAMPS observable: expected Hermitian (real ±1) twisted coefficient, \
+                     got i^{p}"
+                ),
+            });
+        }
+    };
+    let val = mps.pauli_expectation(&factors)?;
+    Ok(coef_re * val.re)
+}
+
+/// Maximum relative state weight a CAMPS T-gate may discard to SVD truncation
+/// before its result is rejected as inexact. Epsilon-threshold truncation
+/// contributes `~svd_epsilon²` (negligible); a value above this means the MPS
+/// bond-dim cap discarded real weight and the observable would be wrong.
+const CAMPS_TRUNCATION_TOL: f64 = 1e-12;
+
+/// Reject a CAMPS T-gate application that silently truncated state weight.
+///
+/// The MPS truncates inside `apply` (clamping bond dim to its cap) with no
+/// signal, so peeking at the post-application bond dimension misses both
+/// already-applied truncations and transient peaks that relaxed below the cap.
+/// Reading the cumulative discarded weight catches every truncation since the
+/// tracker was reset, regardless of the final bond dimension. The corrupted
+/// state is discarded by erroring, letting the auto dispatcher fall back.
+fn check_camps_truncation(
+    mps: &crate::backend::mps::MpsBackend,
+    target: usize,
+) -> crate::error::Result<()> {
+    let discarded = mps.truncation_discarded();
+    if discarded > CAMPS_TRUNCATION_TOL {
+        return Err(crate::error::PrismError::InvalidParameter {
+            message: format!(
+                "CAMPS T-gate on qubit {target}: disentangler cascade exceeded the MPS bond-dim \
+                 cap and SVD truncation discarded {discarded:.3e} of the state weight. Raise \
+                 `max_bond_dim` or use a less-entangling disentangler."
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Apply a T or Tdg gate to a CAMPS state `|ψ⟩ = C |ϕ⟩`.
+///
+/// The twisted Pauli `C† Z_target C` is reduced to single-qubit support with
+/// a chosen disentangler, then absorbed as a one-qubit MPS rotation. Identity
+/// support is a global phase, single-qubit support uses the direct rotation
+/// when OFD cannot apply, and multi-qubit support chooses the cheaper OFD or
+/// OFDS cascade. The truncation tracker is reset around each cascade so any
+/// discarded weight becomes a hard error.
+pub(crate) fn apply_t_via_camps(
+    prefix: &mut SignedCliffordPrefix,
+    mps: &mut crate::backend::mps::MpsBackend,
+    target: usize,
+    is_dagger: bool,
+    tol: f64,
+) -> crate::error::Result<()> {
+    let z_bar = prefix.conjugate_z(target);
+    let n_qubits = prefix.num_qubits();
+
+    let support: Vec<usize> = (0..n_qubits)
+        .filter(|&q| !matches!(z_bar.pauli_at(q), PauliKind::I))
+        .collect();
+    if support.is_empty() {
+        return Ok(());
+    }
+
+    if support.len() == 1 {
+        mps.reset_truncation_tracking();
+        if let Some((n, cascade)) = build_ofd_disentangler(mps, &z_bar, n_qubits, tol)? {
+            apply_cascade_and_rotate(prefix, mps, &cascade, n, target, is_dagger)?;
+        } else {
+            apply_single_qubit_rotation_to_mps(mps, &z_bar, support[0], is_dagger)?;
+        }
+        return check_camps_truncation(mps, target);
+    }
+
+    match choose_disentangler(mps, &z_bar, n_qubits, tol)? {
+        Some((n, cascade, _kind)) => {
+            mps.reset_truncation_tracking();
+            apply_cascade_and_rotate(prefix, mps, &cascade, n, target, is_dagger)?;
+            check_camps_truncation(mps, target)
+        }
+        None => {
+            let letters: String = (0..n_qubits)
+                .map(|q| match z_bar.pauli_at(q) {
+                    PauliKind::I => '.',
+                    PauliKind::X => 'X',
+                    PauliKind::Y => 'Y',
+                    PauliKind::Z => 'Z',
+                })
+                .collect();
+            Err(crate::error::PrismError::InvalidParameter {
+                message: format!(
+                    "CAMPS T-gate on qubit {target}: invariant violation in disentangler dispatch. \
+                     Twisted Pauli has support size {sz} (>=2 expected) at qubits {support:?} with letters \
+                     `{letters}`, phase4={phase}. Both OFD and OFDS declined a multi-qubit support. \
+                     Add an explicit fallback for this support pattern in `apply_t_via_camps`.",
+                    sz = support.len(),
+                    phase = z_bar.phase4,
+                ),
+            })
+        }
+    }
+}
+
+fn apply_cascade_and_rotate(
+    prefix: &mut SignedCliffordPrefix,
+    mps: &mut crate::backend::mps::MpsBackend,
+    cascade: &[OfdGate],
+    anchor_n: usize,
+    target: usize,
+    is_dagger: bool,
+) -> crate::error::Result<()> {
+    use crate::backend::Backend;
+    use crate::circuit::{Instruction, SmallVec};
+
+    for (gate, targets) in cascade {
+        mps.apply(&Instruction::Gate {
+            gate: gate.clone(),
+            targets: SmallVec::from_slice(targets),
+        })?;
+    }
+
+    for (gate, targets) in cascade.iter() {
+        let inv = match gate {
+            Gate::S => Gate::Sdg,
+            Gate::Sdg => Gate::S,
+            Gate::Cx | Gate::Cz => gate.clone(),
+            other => {
+                return Err(crate::error::PrismError::InvalidParameter {
+                    message: format!(
+                        "CAMPS T-gate: cascade emitted unexpected gate {other:?} (no inverse rule)"
+                    ),
+                });
+            }
+        };
+        prefix.fold_right_state_gate(&inv, targets).map_err(|e| {
+            crate::error::PrismError::InvalidParameter {
+                message: format!("CAMPS T-gate: prefix update failed: {e}"),
+            }
+        })?;
+    }
+
+    let new_z_bar = prefix.conjugate_z(target);
+    let n_qubits = prefix.num_qubits();
+    let stray: Vec<usize> = (0..n_qubits)
+        .filter(|&q| q != anchor_n && !matches!(new_z_bar.pauli_at(q), PauliKind::I))
+        .collect();
+    if !stray.is_empty() {
+        return Err(crate::error::PrismError::InvalidParameter {
+            message: format!(
+                "CAMPS T-gate on qubit {target}: disentangler did not concentrate the twisted \
+                 Pauli onto anchor qubit {anchor_n}; residual support remains on qubits {stray:?}. \
+                 The single-qubit rotation would silently drop those factors and corrupt the state."
+            ),
+        });
+    }
+    apply_single_qubit_rotation_to_mps(mps, &new_z_bar, anchor_n, is_dagger)
+}
+
+fn apply_single_qubit_rotation_to_mps(
+    mps: &mut crate::backend::mps::MpsBackend,
+    pauli: &SignedPauli,
+    q: usize,
+    is_dagger: bool,
+) -> crate::error::Result<()> {
+    use crate::backend::Backend;
+    use crate::circuit::{Instruction, SmallVec};
+    use num_complex::Complex64;
+
+    let phase = match pauli.phase4 & 3 {
+        0 => Complex64::new(1.0, 0.0),
+        1 => Complex64::new(0.0, 1.0),
+        2 => Complex64::new(-1.0, 0.0),
+        3 => Complex64::new(0.0, -1.0),
+        _ => unreachable!(),
+    };
+    let bx = pauli.get_x(q);
+    let bz = pauli.get_z(q);
+    let zc = Complex64::new(0.0, 0.0);
+    let i = Complex64::new(0.0, 1.0);
+    let op_at_q: [[Complex64; 2]; 2] = match (bx, bz) {
+        (true, false) => [[zc, phase], [phase, zc]],
+        (true, true) => [[zc, -i * phase], [i * phase, zc]],
+        (false, true) => [[phase, zc], [zc, -phase]],
+        _ => {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: format!("CAMPS rotation: Pauli at qubit {q} is identity; expected X/Y/Z"),
+            });
+        }
+    };
+
+    let alpha = (std::f64::consts::FRAC_PI_8).cos();
+    let sin_pi8 = (std::f64::consts::FRAC_PI_8).sin();
+    let beta = if is_dagger {
+        Complex64::new(0.0, sin_pi8)
+    } else {
+        Complex64::new(0.0, -sin_pi8)
+    };
+
+    let alpha_c = Complex64::new(alpha, 0.0);
+    let mat: [[Complex64; 2]; 2] = [
+        [alpha_c + beta * op_at_q[0][0], beta * op_at_q[0][1]],
+        [beta * op_at_q[1][0], alpha_c + beta * op_at_q[1][1]],
+    ];
+
+    mps.apply(&Instruction::Gate {
+        gate: Gate::Fused(Box::new(mat)),
+        targets: SmallVec::from_slice(&[q]),
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::statevector::StatevectorBackend;
+    use crate::backend::Backend;
+    use crate::circuit::{Instruction, SmallVec};
+    use num_complex::Complex64;
+
+    fn pauli_action_on_basis(p: &SignedPauli, i: usize, n: usize) -> (Complex64, usize) {
+        let mut j = i;
+        let mut phase4: u32 = u32::from(p.phase4);
+        for q in 0..n {
+            let b = (i >> q) & 1;
+            match p.pauli_at(q) {
+                PauliKind::I => {}
+                PauliKind::X => {
+                    j ^= 1 << q;
+                }
+                PauliKind::Y => {
+                    j ^= 1 << q;
+                    phase4 = phase4.wrapping_add(if b == 0 { 1 } else { 3 });
+                }
+                PauliKind::Z => {
+                    if b == 1 {
+                        phase4 = phase4.wrapping_add(2);
+                    }
+                }
+            }
+        }
+        let phase = match phase4 & 3 {
+            0 => Complex64::new(1.0, 0.0),
+            1 => Complex64::new(0.0, 1.0),
+            2 => Complex64::new(-1.0, 0.0),
+            _ => Complex64::new(0.0, -1.0),
+        };
+        (phase, j)
+    }
+
+    fn pauli_string_expectation(state: &[Complex64], n: usize, p: &SignedPauli) -> Complex64 {
+        let dim = 1usize << n;
+        assert_eq!(state.len(), dim);
+        let mut acc = Complex64::new(0.0, 0.0);
+        for i in 0..dim {
+            let (phase, j) = pauli_action_on_basis(p, i, n);
+            acc += state[j].conj() * (phase * state[i]);
+        }
+        acc
+    }
+
+    fn run_gates(n: usize, gates: &[(Gate, Vec<usize>)]) -> Vec<Complex64> {
+        let mut backend = StatevectorBackend::new(0);
+        backend.init(n, 0).unwrap();
+        let instrs: Vec<Instruction> = gates
+            .iter()
+            .map(|(g, t)| Instruction::Gate {
+                gate: g.clone(),
+                targets: SmallVec::from_slice(t),
+            })
+            .collect();
+        backend.apply_instructions(&instrs).unwrap();
+        backend.export_statevector().unwrap()
+    }
+
+    fn randomizing_prefix(n: usize, seed: u64) -> Vec<(Gate, Vec<usize>)> {
+        use rand::Rng;
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+        let mut g = vec![(Gate::H, vec![0])];
+        for q in 0..n {
+            g.push((Gate::Ry(rng.random_range(0.3..2.7)), vec![q]));
+            g.push((Gate::Rz(rng.random_range(0.3..2.7)), vec![q]));
+            if q + 1 < n {
+                g.push((Gate::Cx, vec![q, q + 1]));
+            }
+            g.push((Gate::Rx(rng.random_range(0.3..2.7)), vec![q]));
+        }
+        g
+    }
+
+    fn assert_consistent(n: usize, gates: &[(Gate, Vec<usize>)], seed: u64) {
+        let pre_gates = randomizing_prefix(n, seed);
+        let pre = run_gates(n, &pre_gates);
+        let mut combined = pre_gates;
+        combined.extend_from_slice(gates);
+        let post = run_gates(n, &combined);
+
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        for (g, t) in gates {
+            prefix.apply_state_gate(g, t).unwrap();
+        }
+        for q in 0..n {
+            let twisted_z = prefix.conjugate_z(q);
+            let twisted_x = prefix.conjugate_x(q);
+            let num_words = n.div_ceil(64).max(1);
+            let mut z_only = SignedPauli::zero(num_words);
+            z_only.set_z(q, true);
+            let mut x_only = SignedPauli::zero(num_words);
+            x_only.set_x(q, true);
+            let lhs_z = pauli_string_expectation(&post, n, &z_only);
+            let rhs_z = pauli_string_expectation(&pre, n, &twisted_z);
+            assert!(
+                (lhs_z - rhs_z).norm() < 1e-9,
+                "Z_{q} mismatch: post={lhs_z} expected_from_prefix={rhs_z} (gates={gates:?})"
+            );
+            let lhs_x = pauli_string_expectation(&post, n, &x_only);
+            let rhs_x = pauli_string_expectation(&pre, n, &twisted_x);
+            assert!(
+                (lhs_x - rhs_x).norm() < 1e-9,
+                "X_{q} mismatch: post={lhs_x} expected_from_prefix={rhs_x} (gates={gates:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn identity_is_identity() {
+        let p = SignedCliffordPrefix::identity(3);
+        for q in 0..3 {
+            assert_eq!(p.conjugate_z(q).pauli_at(q), PauliKind::Z);
+            assert_eq!(p.conjugate_z(q).phase4, 0);
+            assert_eq!(p.conjugate_x(q).pauli_at(q), PauliKind::X);
+            assert_eq!(p.conjugate_x(q).phase4, 0);
+        }
+    }
+
+    #[test]
+    fn h_swaps_x_z() {
+        assert_consistent(2, &[(Gate::H, vec![0])], 42);
+        assert_consistent(2, &[(Gate::H, vec![1])], 42);
+    }
+
+    #[test]
+    fn s_and_sdg_signs() {
+        assert_consistent(2, &[(Gate::S, vec![0])], 42);
+        assert_consistent(2, &[(Gate::Sdg, vec![0])], 42);
+        assert_consistent(2, &[(Gate::S, vec![0]), (Gate::S, vec![0])], 42);
+    }
+
+    #[test]
+    fn sx_and_sxdg() {
+        assert_consistent(2, &[(Gate::SX, vec![0])], 42);
+        assert_consistent(2, &[(Gate::SXdg, vec![0])], 42);
+    }
+
+    #[test]
+    fn pauli_gates_only_flip_signs() {
+        assert_consistent(2, &[(Gate::X, vec![0])], 42);
+        assert_consistent(2, &[(Gate::Y, vec![0])], 42);
+        assert_consistent(2, &[(Gate::Z, vec![0])], 42);
+    }
+
+    #[test]
+    fn cx_and_cz() {
+        assert_consistent(3, &[(Gate::Cx, vec![0, 1])], 42);
+        assert_consistent(3, &[(Gate::Cz, vec![1, 2])], 42);
+    }
+
+    #[test]
+    fn swap_permutes_columns() {
+        assert_consistent(3, &[(Gate::Swap, vec![0, 2])], 42);
+    }
+
+    #[test]
+    fn compound_h_cx() {
+        assert_consistent(3, &[(Gate::H, vec![0]), (Gate::Cx, vec![0, 1])], 7);
+    }
+
+    #[test]
+    fn compound_h_cx_s() {
+        assert_consistent(
+            3,
+            &[
+                (Gate::H, vec![0]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::S, vec![1]),
+            ],
+            7,
+        );
+    }
+
+    #[test]
+    fn compound_h_cx_s_cz() {
+        assert_consistent(
+            3,
+            &[
+                (Gate::H, vec![0]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::S, vec![1]),
+                (Gate::Cz, vec![1, 2]),
+            ],
+            7,
+        );
+    }
+
+    #[test]
+    fn random_clifford_sequence_4q() {
+        let seq = vec![
+            (Gate::H, vec![0]),
+            (Gate::Cx, vec![0, 1]),
+            (Gate::S, vec![1]),
+            (Gate::Cz, vec![1, 2]),
+            (Gate::H, vec![3]),
+            (Gate::Cx, vec![2, 3]),
+            (Gate::Sdg, vec![2]),
+            (Gate::SX, vec![3]),
+            (Gate::Z, vec![0]),
+            (Gate::Swap, vec![0, 3]),
+            (Gate::Y, vec![2]),
+            (Gate::SXdg, vec![1]),
+        ];
+        assert_consistent(4, &seq, 17);
+        assert_consistent(4, &seq, 31);
+    }
+
+    fn make_pauli(n: usize, factors: &[(usize, PauliKind)]) -> SignedPauli {
+        let nw = n.div_ceil(64).max(1);
+        let mut p = SignedPauli::zero(nw);
+        for &(q, kind) in factors {
+            match kind {
+                PauliKind::I => {}
+                PauliKind::X => p.set_x(q, true),
+                PauliKind::Y => {
+                    p.set_x(q, true);
+                    p.set_z(q, true);
+                }
+                PauliKind::Z => p.set_z(q, true),
+            }
+        }
+        p
+    }
+
+    fn empty_mps(n: usize) -> crate::backend::mps::MpsBackend {
+        let mut b = crate::backend::mps::MpsBackend::new(0, 64);
+        b.init(n, 0).unwrap();
+        b
+    }
+
+    #[test]
+    fn ofd_no_xy_returns_none() {
+        let mps = empty_mps(3);
+        let p = make_pauli(3, &[(0, PauliKind::Z), (1, PauliKind::Z)]);
+        assert!(build_ofd_disentangler(&mps, &p, 3, 1e-10)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn ofd_x_only_no_other_support_returns_empty_cascade() {
+        let mps = empty_mps(3);
+        let p = make_pauli(3, &[(0, PauliKind::X)]);
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 0);
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn ofd_x0_z1_builds_cz() {
+        let mps = empty_mps(3);
+        let p = make_pauli(3, &[(0, PauliKind::X), (1, PauliKind::Z)]);
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(d.len(), 1);
+        assert!(matches!(d[0].0, Gate::Cz));
+        assert_eq!(d[0].1, vec![0, 1]);
+    }
+
+    #[test]
+    fn ofd_x0_x1_builds_cx() {
+        let mps = empty_mps(3);
+        let p = make_pauli(3, &[(0, PauliKind::X), (1, PauliKind::X)]);
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(d.len(), 1);
+        assert!(matches!(d[0].0, Gate::Cx));
+        assert_eq!(d[0].1, vec![0, 1]);
+    }
+
+    #[test]
+    fn ofd_x0_y1_builds_cy_decomposition() {
+        let mps = empty_mps(3);
+        let p = make_pauli(3, &[(0, PauliKind::X), (1, PauliKind::Y)]);
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(d.len(), 3);
+        assert!(matches!(d[0].0, Gate::Sdg));
+        assert_eq!(d[0].1, vec![1]);
+        assert!(matches!(d[1].0, Gate::Cx));
+        assert_eq!(d[1].1, vec![0, 1]);
+        assert!(matches!(d[2].0, Gate::S));
+        assert_eq!(d[2].1, vec![1]);
+    }
+
+    #[test]
+    fn ofd_multi_target_x_z() {
+        let mps = empty_mps(4);
+        let p = make_pauli(
+            4,
+            &[
+                (0, PauliKind::X),
+                (1, PauliKind::X),
+                (2, PauliKind::Z),
+                (3, PauliKind::I),
+            ],
+        );
+        let (n, d) = build_ofd_disentangler(&mps, &p, 4, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 1, "anchor should sit at the routing-cost minimum");
+        assert_eq!(d.len(), 2);
+        assert!(matches!(d[0].0, Gate::Cx) && d[0].1 == vec![1, 0]);
+        assert!(matches!(d[1].0, Gate::Cz) && d[1].1 == vec![1, 2]);
+    }
+
+    #[test]
+    fn ofd_skips_qubit_not_in_zero_state() {
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(3, 0).unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        let p = make_pauli(
+            3,
+            &[(0, PauliKind::X), (1, PauliKind::Y), (2, PauliKind::Z)],
+        );
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(d.len(), 2);
+        assert!(matches!(d[0].0, Gate::Cx) && d[0].1 == vec![1, 0]);
+        assert!(matches!(d[1].0, Gate::Cz) && d[1].1 == vec![1, 2]);
+    }
+
+    #[test]
+    fn ofd_post_apply_target_qubit_is_disentangled_zero() {
+        let mut mps = empty_mps(3);
+        mps.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[1]),
+        })
+        .unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::Cx,
+            targets: SmallVec::from_slice(&[1, 2]),
+        })
+        .unwrap();
+        let p = make_pauli(
+            3,
+            &[(0, PauliKind::X), (1, PauliKind::X), (2, PauliKind::X)],
+        );
+        let (n, d) = build_ofd_disentangler(&mps, &p, 3, 1e-10).unwrap().unwrap();
+        assert_eq!(n, 0);
+        for (gate, targets) in &d {
+            mps.apply(&Instruction::Gate {
+                gate: gate.clone(),
+                targets: SmallVec::from_slice(targets),
+            })
+            .unwrap();
+        }
+        assert!(mps.is_qubit_in_zero_state(0, 1e-10).unwrap());
+    }
+
+    // apply_t_via_camps end-to-end tests
+
+    fn direct_state(n: usize, gates: &[(Gate, Vec<usize>)]) -> Vec<Complex64> {
+        let mut sb = StatevectorBackend::new(0);
+        sb.init(n, 0).unwrap();
+        for (gate, targets) in gates {
+            sb.apply(&Instruction::Gate {
+                gate: gate.clone(),
+                targets: SmallVec::from_slice(targets),
+            })
+            .unwrap();
+        }
+        sb.export_statevector().unwrap()
+    }
+
+    fn run_camps_then_t(
+        n: usize,
+        prep: &[(Gate, Vec<usize>)],
+        t_target: usize,
+        t_dagger: bool,
+    ) -> (
+        SignedCliffordPrefix,
+        Vec<(Gate, Vec<usize>)>,
+        crate::backend::mps::MpsBackend,
+    ) {
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        let mut prefix_gates: Vec<(Gate, Vec<usize>)> = Vec::new();
+        for (gate, targets) in prep {
+            prefix.apply_state_gate(gate, targets).unwrap();
+            prefix_gates.push((gate.clone(), targets.clone()));
+        }
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, t_target, t_dagger, 1e-10).unwrap();
+        // After call, prefix has been updated to C·D† via fold_right_state_gate.
+        // The tracker doesn't store gates, so callers that need to replay
+        // the prefix onto a materialized state compare via Pauli expectations
+        // instead of gate-list reconstruction.
+        (prefix, prefix_gates, mps)
+    }
+
+    #[test]
+    fn t_via_camps_identity_prefix_falls_back_to_direct_t() {
+        // C = I, so Z̄ = Z_target. OFD finds no disentangler, so the
+        // pure-Z fallback applies T directly on the target qubit.
+        let n = 2;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+
+        let direct = direct_state(n, &[(Gate::T, vec![0])]);
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn t_via_camps_with_h_prefix_matches_direct() {
+        // Prep: H on qubit 0. Then T on qubit 0.
+        // Direct: H, T on statevector.
+        // CAMPS: prefix absorbs H, then apply_t_via_camps(0, T).
+        let n = 2;
+        let prep = vec![(Gate::H, vec![0])];
+        let (prefix, _, mps) = run_camps_then_t(n, &prep, 0, false);
+
+        // Prefix unitary is now H·... folded right by D†, giving C·D†.
+        // Reconstructing C from the inverse tableau is impractical, so
+        // this test compares via Pauli expectations instead of replay.
+        let direct = direct_state(n, &[(Gate::H, vec![0]), (Gate::T, vec![0])]);
+
+        // CAMPS oracle: ⟨ψ|Z_0|ψ⟩ = ⟨ϕ|C†Z_0C|ϕ⟩ = ⟨ϕ|Z̄'|ϕ⟩
+        // where Z̄' = (new_C)†·Z_0·(new_C). Use prefix.conjugate_z(0)
+        // and evaluate via mps.pauli_expectation.
+        let zbar = prefix.conjugate_z(0);
+        let factors = zbar.mps_factors(n);
+        let z0_camps = mps.pauli_expectation(&factors).unwrap();
+        let phase_sign = match zbar.phase4 & 3 {
+            0 => 1.0,
+            2 => -1.0,
+            _ => panic!(
+                "expected Hermitian Z̄ with phase4∈{{0,2}}, got {}",
+                zbar.phase4
+            ),
+        };
+        let z0_camps_real = phase_sign * z0_camps.re;
+
+        let z0_direct: f64 = direct
+            .iter()
+            .enumerate()
+            .map(|(i, amp)| {
+                let sign = if i & 1 == 0 { 1.0 } else { -1.0 };
+                sign * amp.norm_sqr()
+            })
+            .sum();
+
+        assert!(
+            (z0_camps_real - z0_direct).abs() < 1e-9,
+            "Z_0: camps={z0_camps_real} direct={z0_direct}"
+        );
+    }
+
+    #[test]
+    fn t_via_camps_single_y_twisted_pauli_matches_direct() {
+        let n = 1;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        prefix.apply_state_gate(&Gate::SX, &[0]).unwrap();
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+
+        let z_camps = evaluate_z_observable_camps(&prefix, &mps, &[0]).unwrap();
+        let direct = direct_state(
+            n,
+            &[(Gate::SX, vec![0]), (Gate::T, vec![0]), (Gate::H, vec![0])],
+        );
+        let z_direct: f64 = direct
+            .iter()
+            .enumerate()
+            .map(|(i, amp)| {
+                let sign = if i & 1 == 0 { 1.0 } else { -1.0 };
+                sign * amp.norm_sqr()
+            })
+            .sum();
+
+        assert!(
+            (z_camps - z_direct).abs() < 1e-9,
+            "single-Y twisted Pauli: camps={z_camps} direct={z_direct}"
+        );
+    }
+
+    #[test]
+    fn t_via_camps_h_cx_prefix_multi_qubit_pauli() {
+        // Prep: H_0, CX(0,1). Then T on qubit 0.
+        // Z̄_0 = (H_0 CX_01)† Z_0 (H_0 CX_01) = H_0 Z_0 H_0 ⊗ ... etc.
+        // Actually: (CX)†(H†) Z_0 (H)(CX). H Z_0 H = X_0. CX X_0 CX = X_0 X_1.
+        // So Z̄ = X_0 X_1, letter at 0 is X, qubit 0 in |0⟩ (yes, fresh init), OFD succeeds.
+        let n = 2;
+        let prep = vec![(Gate::H, vec![0]), (Gate::Cx, vec![0, 1])];
+        let (prefix, _, mps) = run_camps_then_t(n, &prep, 0, false);
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::H, vec![0]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::T, vec![0]),
+            ],
+        );
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    // deeper multi-qubit OFD success-path coverage
+
+    #[test]
+    fn t_via_camps_ofd_3q_mixed_cascade_matches_direct() {
+        // Build a prefix that produces a 3-qubit twisted Pauli with
+        // mixed X/Y/Z letters anchored on a |0⟩ qubit. The fresh-init
+        // MPS has every qubit in |0⟩, so OFD's anchor selection picks
+        // the first X/Y letter and emits a non-trivial cascade spanning
+        // all remaining qubits (CX + CZ + Sdg/CX/S triplet for Y).
+        //
+        // Prefix construction: H_1, CX(1,0), CX(1,2), S_2.
+        //   prefix C = S_2 · CX(1,2) · CX(1,0) · H_1
+        // Twisted Z_0:
+        //   C† Z_0 C = H_1 · CX(1,0)† · CX(1,2)† · S_2† · Z_0 · S_2 · CX(1,2) · CX(1,0) · H_1
+        // S_2 commutes with Z_0 (different qubit), so reduces to
+        //   H_1 · CX(1,0) · CX(1,2) · Z_0 · CX(1,2) · CX(1,0) · H_1
+        // CX(1,2) commutes with Z_0 (different qubits), so
+        //   H_1 · CX(1,0) · Z_0 · CX(1,0) · H_1 = H_1 · Z_0 Z_1 · H_1 = Z_0 X_1
+        // That setup only gives 2-qubit support, so use a richer prefix.
+        //
+        // Use: H_0, CX(0,1), CX(0,2), S_1. Then for T_target=0:
+        //   C = S_1 · CX(0,2) · CX(0,1) · H_0
+        //   C† Z_0 C = H_0 · CX(0,1) · CX(0,2) · S_1† · Z_0 · S_1 · CX(0,2) · CX(0,1) · H_0
+        //   S_1 commutes with Z_0
+        //   CX(0,2)† Z_0 CX(0,2) = Z_0 (control Z unchanged)
+        //   Still 1-qubit Z, then H_0 gives X_0, a single-qubit Pauli.
+        //
+        // Need to use CX on the *target*-qubit position. T on qubit 2:
+        //   C† Z_2 C, with C above:
+        //   S_1† CX(0,2)† Z_2 CX(0,2) S_1 = S_1† (Z_0 Z_2) S_1 = Z_0 Z_2 (S commutes with Z)
+        //   CX(0,1)† (Z_0 Z_2) CX(0,1) = Z_0 Z_2 (Z_0 unchanged by CX(0,1) control)
+        //   H_0 (Z_0 Z_2) H_0 = X_0 Z_2, still 2-qubit.
+        //
+        // To get 3-qubit, need to fan through both Hadamard and CX
+        // structure. Use: H_0, H_2, CX(0,1), CX(2,1), S_1; T on 1.
+        //   C = S_1 · CX(2,1) · CX(0,1) · H_2 · H_0
+        //   C† Z_1 C = (left-to-right inverse) H_0 H_2 CX(0,1) CX(2,1) S_1† Z_1 S_1 CX(2,1) CX(0,1) H_2 H_0
+        //   S_1† Z_1 S_1 = Z_1
+        //   CX(2,1)† Z_1 CX(2,1) = Z_1 Z_2
+        //   CX(0,1)† (Z_1 Z_2) CX(0,1) = Z_0 Z_1 Z_2 (CX flips Z on target → Z_c Z_t)
+        //   H_2 (Z_0 Z_1 Z_2) H_2 = Z_0 Z_1 X_2
+        //   H_0 (Z_0 Z_1 X_2) H_0 = X_0 Z_1 X_2, 3-qubit mixed letters.
+        // OFD on this: first X/Y letter is q=0 (X). mps[0] is a valid |0> anchor.
+        // Cascade emits CZ(0,1) and CX(0,2). Non-trivial 3-qubit OFD.
+        let n = 3;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        for (g, t) in [
+            (Gate::H, vec![0]),
+            (Gate::H, vec![2]),
+            (Gate::Cx, vec![0, 1]),
+            (Gate::Cx, vec![2, 1]),
+            (Gate::S, vec![1]),
+        ] {
+            prefix.apply_state_gate(&g, &t).unwrap();
+        }
+
+        let zbar_pre = prefix.conjugate_z(1);
+        assert_eq!(zbar_pre.pauli_at(0), PauliKind::X);
+        assert_eq!(zbar_pre.pauli_at(1), PauliKind::Z);
+        assert_eq!(zbar_pre.pauli_at(2), PauliKind::X);
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        // Verify OFD succeeds (fresh MPS, all qubits in |0⟩, X letter at qubit 0).
+        let (anchor, cascade) = build_ofd_disentangler(&mps, &zbar_pre, n, 1e-10)
+            .unwrap()
+            .unwrap();
+        assert_eq!(anchor, 0);
+        assert_eq!(cascade.len(), 2);
+        assert!(matches!(cascade[0].0, Gate::Cz) && cascade[0].1 == vec![0, 1]);
+        assert!(matches!(cascade[1].0, Gate::Cx) && cascade[1].1 == vec![0, 2]);
+
+        apply_t_via_camps(&mut prefix, &mut mps, 1, false, 1e-10).unwrap();
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::H, vec![0]),
+                (Gate::H, vec![2]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::Cx, vec![2, 1]),
+                (Gate::S, vec![1]),
+                (Gate::T, vec![1]),
+            ],
+        );
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "OFD-3q Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn t_via_camps_ofd_with_y_letter_triplet_cascade() {
+        // Force a Y letter to land in the twisted Pauli so OFD emits
+        // the (Sdg, CX, S) Y-decomposition triplet.
+        //
+        // Prefix: S_1, H_0, CX(0,1). For T on qubit 0:
+        //   C = CX(0,1) · H_0 · S_1
+        //   C† Z_0 C = S_1† H_0 CX(0,1)† Z_0 CX(0,1) H_0 S_1
+        //   CX(0,1)† Z_0 CX(0,1) = Z_0
+        //   H_0 Z_0 H_0 = X_0
+        //   S_1† X_0 S_1 = X_0, still single-qubit. Won't trigger Y.
+        //
+        // Different angle: prefix S_1, CX(0,1), H_1. T on qubit 1.
+        //   C = H_1 · CX(0,1) · S_1
+        //   C† Z_1 C = S_1† CX(0,1)† H_1 Z_1 H_1 CX(0,1) S_1
+        //   H_1 Z_1 H_1 = X_1
+        //   CX(0,1)† X_1 CX(0,1) = X_1 (target X unchanged by CX with target = X_1's qubit? no, X_target → X_target stays, control unchanged for X_t)
+        //   Actually CX(c,t) X_t CX(c,t) = X_t. So X_1 stays.
+        //   S_1† X_1 S_1 = -Y_1. So Z̄ = -Y_1, a single-qubit Y that would use single-qubit fallback, not OFD.
+        //
+        // For multi-qubit with Y letter, need a more layered prefix.
+        // Use: H_0, CX(0,1), S_1, CX(0,2), H_2. T on 2.
+        //   C = H_2 · CX(0,2) · S_1 · CX(0,1) · H_0
+        //   C† Z_2 C = H_0 CX(0,1) S_1† CX(0,2)† H_2 Z_2 H_2 CX(0,2) S_1 CX(0,1) H_0
+        //   H_2 Z_2 H_2 = X_2
+        //   CX(0,2)† X_2 CX(0,2) = X_2 (target X unchanged by CX, but CX(c,t) X_t = X_t. So X_2 stays)
+        //   S_1† X_2 S_1 = X_2 (different qubit)
+        //   CX(0,1)† X_2 CX(0,1) = X_2 (different qubits)
+        //   H_0 X_2 H_0 = X_2, single-qubit Z̄ = X_2. Trivial.
+        //
+        // The issue: CX(0,2)·X_2 doesn't grow because target X is invariant.
+        // To get growth on the target side, the inner gate at the target
+        // must be Z (or Y), not X. Re-pick: H_2 → not at end.
+        //
+        // Try: CX(0,1), H_1, CX(1,2), S_2, H_2. T on 2.
+        //   C = H_2 · S_2 · CX(1,2) · H_1 · CX(0,1)
+        //   C† Z_2 C = CX(0,1) H_1 CX(1,2)† S_2† H_2 Z_2 H_2 S_2 CX(1,2) H_1 CX(0,1)
+        //   H_2 Z_2 H_2 = X_2
+        //   Sdg_2 X_2 S_2 = -Y_2 by direct multiplication.
+        //   So -Y_2 after S†.
+        //   CX(1,2)† (-Y_2) CX(1,2) = -CX(1,2)† Y_2 CX(1,2). Y_2 = i X_2 Z_2. CX(1,2) maps X_2 → X_2, Z_2 → Z_1 Z_2. So Y_2 → i X_2 Z_1 Z_2 = Z_1 · i X_2 Z_2 = Z_1 Y_2.
+        //   So get -Z_1 Y_2.
+        //   H_1 (-Z_1 Y_2) H_1 = -X_1 Y_2.
+        //   CX(0,1)† (-X_1 Y_2) CX(0,1) = -CX(0,1)† X_1 CX(0,1) · Y_2 = -X_1 · Y_2 (X_t unchanged) = -X_1 Y_2.
+        //   So Zbar = -X_1 Y_2, phase4=2. Letters at (0,1,2): I, X, Y.
+        // OFD: first X/Y is q=1 (X). mps[1] is a valid |0> anchor. Cascade emits triplet for Y at q=2.
+        let n = 3;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        for (g, t) in [
+            (Gate::Cx, vec![0, 1]),
+            (Gate::H, vec![1]),
+            (Gate::Cx, vec![1, 2]),
+            (Gate::S, vec![2]),
+            (Gate::H, vec![2]),
+        ] {
+            prefix.apply_state_gate(&g, &t).unwrap();
+        }
+
+        let zbar_pre = prefix.conjugate_z(2);
+        assert_eq!(zbar_pre.pauli_at(0), PauliKind::I);
+        assert_eq!(zbar_pre.pauli_at(1), PauliKind::X);
+        assert_eq!(zbar_pre.pauli_at(2), PauliKind::Y);
+        assert_eq!(zbar_pre.phase4, 2);
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        let (anchor, cascade) = build_ofd_disentangler(&mps, &zbar_pre, n, 1e-10)
+            .unwrap()
+            .unwrap();
+        assert_eq!(anchor, 1);
+        assert_eq!(
+            cascade.len(),
+            3,
+            "Y partner should emit (Sdg, CX, S) triplet"
+        );
+        assert!(matches!(cascade[0].0, Gate::Sdg) && cascade[0].1 == vec![2]);
+        assert!(matches!(cascade[1].0, Gate::Cx) && cascade[1].1 == vec![1, 2]);
+        assert!(matches!(cascade[2].0, Gate::S) && cascade[2].1 == vec![2]);
+
+        apply_t_via_camps(&mut prefix, &mut mps, 2, false, 1e-10).unwrap();
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::Cx, vec![0, 1]),
+                (Gate::H, vec![1]),
+                (Gate::Cx, vec![1, 2]),
+                (Gate::S, vec![2]),
+                (Gate::H, vec![2]),
+                (Gate::T, vec![2]),
+            ],
+        );
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "OFD-Y-triplet Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    // OFDS tests
+
+    #[test]
+    fn ofds_x_anchor_no_zero_state_requirement() {
+        let mut mps = empty_mps(2);
+        mps.apply(&Instruction::Gate {
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[1]),
+        })
+        .unwrap();
+        let p = make_pauli(2, &[(0, PauliKind::X), (1, PauliKind::Z)]);
+        assert!(build_ofd_disentangler(&mps, &p, 2, 1e-10)
+            .unwrap()
+            .is_none());
+        let (n, d) = build_ofds_disentangler(&mps, &p, 2).unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(d.len(), 1);
+        assert!(matches!(d[0].0, Gate::Cz) && d[0].1 == vec![0, 1]);
+    }
+
+    fn fresh_mps(n: usize) -> crate::backend::mps::MpsBackend {
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        mps
+    }
+
+    #[test]
+    fn ofds_all_z_anchor_minimizes_routing() {
+        let p = make_pauli(
+            4,
+            &[
+                (0, PauliKind::Z),
+                (1, PauliKind::I),
+                (2, PauliKind::Z),
+                (3, PauliKind::Z),
+            ],
+        );
+        let mps = fresh_mps(4);
+        let (n, d) = build_ofds_disentangler(&mps, &p, 4).unwrap();
+        assert_eq!(n, 2, "anchor should sit at the routing-cost minimum");
+        assert_eq!(d.len(), 2);
+        assert!(matches!(d[0].0, Gate::Cx) && d[0].1 == vec![0, 2]);
+        assert!(matches!(d[1].0, Gate::Cx) && d[1].1 == vec![3, 2]);
+    }
+
+    #[test]
+    fn ofds_single_z_returns_none() {
+        let p = make_pauli(3, &[(1, PauliKind::Z)]);
+        let mps = fresh_mps(3);
+        assert!(build_ofds_disentangler(&mps, &p, 3).is_none());
+    }
+
+    #[test]
+    fn ofds_empty_returns_none() {
+        let p = SignedPauli::zero(1);
+        let mps = fresh_mps(3);
+        assert!(build_ofds_disentangler(&mps, &p, 3).is_none());
+    }
+
+    #[test]
+    fn t_via_camps_ofds_xy_path_matches_direct() {
+        let n = 2;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        prefix.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::Ry(0.7),
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::Ry(0.5),
+            targets: SmallVec::from_slice(&[1]),
+        })
+        .unwrap();
+
+        let zbar_pre = prefix.conjugate_z(0);
+        assert!(
+            build_ofd_disentangler(&mps, &zbar_pre, n, 1e-10)
+                .unwrap()
+                .is_none(),
+            "test setup error: OFD should have failed so OFDS path is exercised"
+        );
+
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::Ry(0.7), vec![0]),
+                (Gate::Ry(0.5), vec![1]),
+                (Gate::H, vec![0]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::T, vec![0]),
+            ],
+        );
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "OFDS Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn t_via_camps_ofds_all_z_path_matches_direct() {
+        let n = 3;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        prefix.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+        prefix.apply_state_gate(&Gate::Cx, &[1, 2]).unwrap();
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+
+        let zbar_pre = prefix.conjugate_z(2);
+        for q in 0..n {
+            assert!(
+                matches!(zbar_pre.pauli_at(q), PauliKind::Z),
+                "test setup: expected all-Z twisted Pauli, got {:?} at q={q}",
+                zbar_pre.pauli_at(q)
+            );
+        }
+        assert!(
+            build_ofd_disentangler(&mps, &zbar_pre, n, 1e-10)
+                .unwrap()
+                .is_none(),
+            "test setup: OFD should reject all-Z support"
+        );
+
+        apply_t_via_camps(&mut prefix, &mut mps, 2, false, 1e-10).unwrap();
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::Cx, vec![0, 1]),
+                (Gate::Cx, vec![1, 2]),
+                (Gate::T, vec![2]),
+            ],
+        );
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "OFDS all-Z Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn tdag_via_camps_h_prefix() {
+        let n = 2;
+        let prep = vec![(Gate::H, vec![0])];
+        let (prefix, _, mps) = run_camps_then_t(n, &prep, 0, true);
+
+        let direct = direct_state(n, &[(Gate::H, vec![0]), (Gate::Tdg, vec![0])]);
+
+        for q in 0..n {
+            let zbar = prefix.conjugate_z(q);
+            let factors = zbar.mps_factors(n);
+            let zc = mps.pauli_expectation(&factors).unwrap();
+            let phase_sign = match zbar.phase4 & 3 {
+                0 => 1.0,
+                2 => -1.0,
+                _ => panic!("non-real Z̄ phase {}", zbar.phase4),
+            };
+            let z_camps = phase_sign * zc.re;
+            let z_direct: f64 = direct
+                .iter()
+                .enumerate()
+                .map(|(i, amp)| {
+                    let sign = if (i >> q) & 1 == 0 { 1.0 } else { -1.0 };
+                    sign * amp.norm_sqr()
+                })
+                .sum();
+            assert!(
+                (z_camps - z_direct).abs() < 1e-9,
+                "Tdg Z_{q}: camps={z_camps} direct={z_direct}"
+            );
+        }
+    }
+
+    fn two_t_zz_probe(post_cliffords: &[(Gate, Vec<usize>)]) -> (f64, f64) {
+        let n = 2;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        prefix.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+        for (g, t) in post_cliffords {
+            prefix.apply_state_gate(g, t).unwrap();
+        }
+        let zz_camps = evaluate_z_observable_camps(&prefix, &mps, &[0, 1]).unwrap();
+        let mut gates: Vec<(Gate, Vec<usize>)> = vec![
+            (Gate::H, vec![0]),
+            (Gate::Cx, vec![0, 1]),
+            (Gate::T, vec![0]),
+            (Gate::H, vec![0]),
+            (Gate::T, vec![0]),
+        ];
+        gates.extend_from_slice(post_cliffords);
+        let direct = direct_state(n, &gates);
+        let zz_direct: f64 = direct
+            .iter()
+            .enumerate()
+            .map(|(i, amp)| {
+                let s0 = if i & 1 == 0 { 1.0 } else { -1.0 };
+                let s1 = if (i >> 1) & 1 == 0 { 1.0 } else { -1.0 };
+                s0 * s1 * amp.norm_sqr()
+            })
+            .sum();
+        (zz_camps, zz_direct)
+    }
+
+    #[test]
+    fn t_via_camps_two_t_bisect_post_cliffords() {
+        type BisectCase<'a> = (&'a str, &'a [(Gate, &'a [usize])]);
+        let cases: &[BisectCase] = &[
+            ("no_post", &[]),
+            ("h0", &[(Gate::H, &[0])]),
+            ("h1", &[(Gate::H, &[1])]),
+            ("h0_h1", &[(Gate::H, &[0]), (Gate::H, &[1])]),
+            ("h1_h0", &[(Gate::H, &[1]), (Gate::H, &[0])]),
+            ("x0_x1", &[(Gate::X, &[0]), (Gate::X, &[1])]),
+            ("z0_z1", &[(Gate::Z, &[0]), (Gate::Z, &[1])]),
+            ("cx_01", &[(Gate::Cx, &[0, 1])]),
+            ("s0_s1", &[(Gate::S, &[0]), (Gate::S, &[1])]),
+        ];
+        let mut failures = Vec::new();
+        for (label, ops) in cases {
+            let owned: Vec<(Gate, Vec<usize>)> =
+                ops.iter().map(|(g, t)| (g.clone(), t.to_vec())).collect();
+            let (c, d) = two_t_zz_probe(&owned);
+            if (c - d).abs() >= 1e-9 {
+                failures.push(format!("{label}: camps={c} direct={d}"));
+            }
+        }
+        assert!(failures.is_empty(), "fails:\n  {}", failures.join("\n  "));
+    }
+
+    #[test]
+    fn t_via_camps_two_t_multi_qubit_zz_observable() {
+        // Reproduces the prior multi-qubit two-T failure shape on a small fixture
+        // and checks the joint ⟨Z_0 Z_1⟩ against statevector.
+        // Sequence: H_0; CX(0,1); T_0; H_0; T_0
+        let n = 2;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        prefix.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+        prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
+        prefix.apply_state_gate(&Gate::H, &[1]).unwrap();
+
+        let zz_camps = evaluate_z_observable_camps(&prefix, &mps, &[0, 1]).unwrap();
+
+        let direct = direct_state(
+            n,
+            &[
+                (Gate::H, vec![0]),
+                (Gate::Cx, vec![0, 1]),
+                (Gate::T, vec![0]),
+                (Gate::H, vec![0]),
+                (Gate::T, vec![0]),
+                (Gate::H, vec![0]),
+                (Gate::H, vec![1]),
+            ],
+        );
+        let zz_direct: f64 = direct
+            .iter()
+            .enumerate()
+            .map(|(i, amp)| {
+                let s0 = if i & 1 == 0 { 1.0 } else { -1.0 };
+                let s1 = if (i >> 1) & 1 == 0 { 1.0 } else { -1.0 };
+                s0 * s1 * amp.norm_sqr()
+            })
+            .sum();
+
+        assert!(
+            (zz_camps - zz_direct).abs() < 1e-9,
+            "two-T ⟨Z_0 Z_1⟩: camps={zz_camps} direct={zz_direct}"
+        );
+    }
+
+    #[test]
+    fn t_via_camps_bond_dim_stays_bounded_on_ofd_and_ofds_paths() {
+        let max_bond = 64;
+
+        let n_ofd = 3;
+        let mut prefix_ofd = SignedCliffordPrefix::identity(n_ofd);
+        prefix_ofd.apply_state_gate(&Gate::H, &[0]).unwrap();
+        prefix_ofd.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+        prefix_ofd.apply_state_gate(&Gate::Cx, &[1, 2]).unwrap();
+        let mut mps_ofd = crate::backend::mps::MpsBackend::new(0, max_bond);
+        mps_ofd.init(n_ofd, 0).unwrap();
+
+        let zbar_ofd = prefix_ofd.conjugate_z(0);
+        assert!(
+            build_ofd_disentangler(&mps_ofd, &zbar_ofd, n_ofd, 1e-10)
+                .unwrap()
+                .is_some(),
+            "test setup: OFD should succeed for this prefix"
+        );
+
+        apply_t_via_camps(&mut prefix_ofd, &mut mps_ofd, 0, false, 1e-10).unwrap();
+        let ofd_peak = mps_ofd.current_max_bond_dim();
+        assert!(
+            ofd_peak <= max_bond,
+            "OFD path exceeded max_bond_dim cap: peak={ofd_peak} cap={max_bond}"
+        );
+
+        let n_ofds = 3;
+        let mut prefix_ofds = SignedCliffordPrefix::identity(n_ofds);
+        prefix_ofds.apply_state_gate(&Gate::Cx, &[0, 1]).unwrap();
+        prefix_ofds.apply_state_gate(&Gate::Cx, &[1, 2]).unwrap();
+        let mut mps_ofds = crate::backend::mps::MpsBackend::new(0, max_bond);
+        mps_ofds.init(n_ofds, 0).unwrap();
+
+        let zbar_ofds = prefix_ofds.conjugate_z(2);
+        assert!(
+            build_ofd_disentangler(&mps_ofds, &zbar_ofds, n_ofds, 1e-10)
+                .unwrap()
+                .is_none(),
+            "test setup: OFD should reject all-Z support so OFDS is exercised"
+        );
+
+        apply_t_via_camps(&mut prefix_ofds, &mut mps_ofds, 2, false, 1e-10).unwrap();
+        let ofds_peak = mps_ofds.current_max_bond_dim();
+        assert!(
+            ofds_peak <= max_bond,
+            "OFDS path exceeded max_bond_dim cap: peak={ofds_peak} cap={max_bond}"
+        );
+    }
+
+    #[test]
+    fn t_via_camps_ofds_saturation_guard_errors_when_cap_too_small() {
+        let n = 4;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        for q in 0..n - 1 {
+            prefix.apply_state_gate(&Gate::Cx, &[q, q + 1]).unwrap();
+        }
+
+        // Mixed product state: even qubits in |+>, odd qubits in |0>. The
+        // all-Z OFDS CX ladder then has |+>-control / |0>-target rungs, which
+        // create Bell pairs the bond-dim-1 cap must truncate.
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 1);
+        mps.init(n, 0).unwrap();
+        for q in (0..n).step_by(2) {
+            mps.apply(&crate::circuit::Instruction::Gate {
+                gate: Gate::H,
+                targets: crate::circuit::SmallVec::from_slice(&[q]),
+            })
+            .unwrap();
+        }
+
+        let zbar = prefix.conjugate_z(n - 1);
+        assert!(
+            build_ofd_disentangler(&mps, &zbar, n, 1e-10)
+                .unwrap()
+                .is_none(),
+            "test setup: OFD must decline so OFDS path runs"
+        );
+
+        let result = apply_t_via_camps(&mut prefix, &mut mps, n - 1, false, 1e-10);
+        let err = result.expect_err("OFDS truncation at bond cap=1 should trip the guard");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("SVD truncation discarded"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn choose_disentangler_prefers_ofds_when_routing_cost_strictly_lower() {
+        let n = 5;
+        let mut mps = fresh_mps(n);
+        mps.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[2]),
+        })
+        .unwrap();
+        let p = make_pauli(
+            n,
+            &[(0, PauliKind::X), (2, PauliKind::X), (4, PauliKind::X)],
+        );
+
+        let (ofd_anchor, ofd_cascade) = build_ofd_disentangler(&mps, &p, n, 1e-10)
+            .unwrap()
+            .expect("OFD has |0⟩ X anchors at q0 and q4");
+        assert!(
+            ofd_anchor == 0 || ofd_anchor == 4,
+            "OFD must reject q2 because it is in |+⟩, picked {ofd_anchor}"
+        );
+        let ofd_cost = cascade_routing_cost(&mps, &ofd_cascade);
+        assert_eq!(ofd_cost, 6, "OFD anchor at q0/q4 routes |0-2|+|0-4|=6");
+
+        let (ofds_anchor, ofds_cascade) =
+            build_ofds_disentangler(&mps, &p, n).expect("OFDS has full X anchor freedom");
+        assert_eq!(
+            ofds_anchor, 2,
+            "OFDS picks q2 (middle of support, no |0⟩ requirement)"
+        );
+        let ofds_cost = cascade_routing_cost(&mps, &ofds_cascade);
+        assert_eq!(ofds_cost, 4, "OFDS anchor at q2 routes |2-0|+|2-4|=4");
+
+        let (chosen_anchor, chosen_cascade, chosen_kind) = choose_disentangler(&mps, &p, n, 1e-10)
+            .unwrap()
+            .expect("cost-compare picks the cheaper cascade");
+        assert_eq!(chosen_kind, DisentanglerKind::Ofds);
+        assert_eq!(chosen_anchor, 2);
+        assert_eq!(cascade_routing_cost(&mps, &chosen_cascade), 4);
+    }
+
+    #[test]
+    fn choose_disentangler_breaks_ties_in_favor_of_ofd_for_bond_dim_safety() {
+        let n = 3;
+        let mps = fresh_mps(n);
+        let p = make_pauli(
+            n,
+            &[(0, PauliKind::X), (1, PauliKind::X), (2, PauliKind::X)],
+        );
+
+        let (_, ofd_cascade) = build_ofd_disentangler(&mps, &p, n, 1e-10)
+            .unwrap()
+            .expect("OFD finds anchor on |0...0⟩");
+        let (_, ofds_cascade) =
+            build_ofds_disentangler(&mps, &p, n).expect("OFDS also finds anchor");
+        assert_eq!(
+            cascade_routing_cost(&mps, &ofd_cascade),
+            cascade_routing_cost(&mps, &ofds_cascade),
+            "this fixture must produce a routing-cost tie"
+        );
+
+        let (_, _, chosen_kind) = choose_disentangler(&mps, &p, n, 1e-10)
+            .unwrap()
+            .expect("dispatch returns Some on a viable support");
+        assert_eq!(
+            chosen_kind,
+            DisentanglerKind::Ofd,
+            "ties must go to OFD because OFD preserves bond dimension"
+        );
+    }
+
+    #[test]
+    fn apply_t_via_camps_with_cost_compare_dispatch_matches_statevector() {
+        let n = 5;
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        let mut mps = crate::backend::mps::MpsBackend::new(0, 64);
+        mps.init(n, 0).unwrap();
+        mps.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[2]),
+        })
+        .unwrap();
+
+        let mut sv = StatevectorBackend::new(0);
+        sv.init(n, 0).unwrap();
+        sv.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[2]),
+        })
+        .unwrap();
+
+        apply_t_via_camps(&mut prefix, &mut mps, 2, false, 1e-10).unwrap();
+        sv.apply(&Instruction::Gate {
+            gate: Gate::T,
+            targets: SmallVec::from_slice(&[2]),
+        })
+        .unwrap();
+
+        let probs = sv.probabilities().unwrap();
+        for q in 0..n {
+            let camps = evaluate_z_observable_camps(&prefix, &mps, &[q]).unwrap();
+            let mask = 1usize << q;
+            let direct: f64 = probs
+                .iter()
+                .enumerate()
+                .map(|(i, &p)| if i & mask == 0 { p } else { -p })
+                .sum();
+            assert!(
+                (camps - direct).abs() < 1e-9,
+                "Z_{q}: camps={camps:.12}, statevector={direct:.12}"
+            );
+        }
+    }
+
+    #[test]
+    fn ofd_anchor_heuristic_picks_routing_minimum() {
+        let n = 5;
+        let mps = fresh_mps(n);
+        let p = make_pauli(
+            n,
+            &[
+                (0, PauliKind::X),
+                (2, PauliKind::Z),
+                (3, PauliKind::X),
+                (4, PauliKind::Z),
+            ],
+        );
+        let (anchor, _) = build_ofd_disentangler(&mps, &p, n, 1e-10)
+            .unwrap()
+            .expect("OFD should succeed on fresh |0...0⟩");
+        let support = support_qubits(&p, n);
+        let xy_candidates: Vec<usize> = support
+            .iter()
+            .copied()
+            .filter(|&q| matches!(p.pauli_at(q), PauliKind::X | PauliKind::Y))
+            .collect();
+        let chosen_cost = anchor_routing_cost(&mps, anchor, &support);
+        for &alt in &xy_candidates {
+            let alt_cost = anchor_routing_cost(&mps, alt, &support);
+            assert!(
+                chosen_cost <= alt_cost,
+                "heuristic picked anchor {anchor} (cost {chosen_cost}) but {alt} costs {alt_cost}"
+            );
+        }
+    }
+}

--- a/src/qec/cut_selection.rs
+++ b/src/qec/cut_selection.rs
@@ -1,0 +1,462 @@
+//! Treewidth-aware cut-cost analysis for QEC observable simulation.
+//!
+//! Scores candidate qubit cuts by the joint cost of branch count `B` and
+//! post-cut contraction width `w_post`, rather than by branch count alone.
+//!
+//! Status: this is analysis tooling, not a live dispatch path. The QEC auto
+//! T-strategy (`run_qec_program_auto`) does not yet consult these scores; it
+//! follows a fixed SPD -> CAMPS -> tensor-network ladder.
+//! These functions are exercised by the cut-cost benchmarks and are intended
+//! to inform a future width-aware dispatcher. Wiring them into the dispatcher
+//! is deferred until the cost model is validated against benchmark results.
+//!
+//! # Definitions
+//!
+//! Let `G(V, E)` be the *interaction graph* of a circuit: `V` is the qubit
+//! set, and `{u, v} in E` if some two-qubit (or larger) gate has support
+//! `{u, v} subseteq T`. A *cut* `S subseteq V` is any qubit subset; removing
+//! `S` from `G` yields a graph `G - S` whose connected components are the
+//! independent sub-problems produced by cutting at those qubits.
+//!
+//! The *post-cut contraction width* `w_post(S)` is the maximum over
+//! components `C` of `G - S` of an upper bound on the treewidth of `C`,
+//! computed by a min-fill elimination heuristic. `w_post` is an upper
+//! bound on the actual treewidth (treewidth itself is NP-hard); using an
+//! upper bound is sound for the dispatch decision (it can only reject a
+//! backend that would have succeeded, never accept one that will fail).
+//!
+//! # Cut score
+//!
+//! For a cut `S` of size `k = |S|` admitting `B(S) = 2^k` branches (each
+//! branch fixes the `k` cut qubits to a computational basis state), the
+//! joint cost model is
+//!
+//! ```text
+//! score(S) = B(S) * exp(c * w_post(S))
+//! ```
+//!
+//! where `c` is the per-treewidth-bit cost constant. The right cut is
+//! `argmin_S score(S)`.
+
+use std::collections::{BTreeSet, HashSet};
+
+use crate::circuit::{Circuit, Instruction};
+use crate::gates::Gate;
+
+/// Undirected interaction graph of a circuit. Adjacency is stored as a
+/// `Vec<BTreeSet<usize>>` indexed by qubit id; `BTreeSet` keeps the
+/// elimination order deterministic.
+#[derive(Debug, Clone)]
+pub struct InteractionGraph {
+    pub num_qubits: usize,
+    pub adj: Vec<BTreeSet<usize>>,
+}
+
+impl InteractionGraph {
+    /// Extract the interaction graph of a circuit. For each instruction with
+    /// `k >= 2` targets, add the complete clique on those targets.
+    pub fn from_circuit(circuit: &Circuit) -> Self {
+        let n = circuit.num_qubits;
+        let mut adj = vec![BTreeSet::<usize>::new(); n];
+        for inst in &circuit.instructions {
+            if let Instruction::Gate { gate, targets } = inst {
+                match gate {
+                    Gate::BatchPhase(data) => {
+                        if let Some(&control) = targets.first() {
+                            for &(target, _) in &data.phases {
+                                add_interaction_edge(&mut adj, control, target);
+                            }
+                        }
+                        continue;
+                    }
+                    Gate::BatchRzz(data) => {
+                        for &(q0, q1, _) in &data.edges {
+                            add_interaction_edge(&mut adj, q0, q1);
+                        }
+                        continue;
+                    }
+                    Gate::DiagonalBatch(data) => {
+                        for entry in &data.entries {
+                            if let Some((q0, q1, _)) = entry.as_2q_matrix() {
+                                add_interaction_edge(&mut adj, q0, q1);
+                            }
+                        }
+                        continue;
+                    }
+                    Gate::Multi2q(data) => {
+                        for &(q0, q1, _) in &data.gates {
+                            add_interaction_edge(&mut adj, q0, q1);
+                        }
+                        continue;
+                    }
+                    _ => {}
+                }
+                if targets.len() < 2 {
+                    continue;
+                }
+                for i in 0..targets.len() {
+                    for j in (i + 1)..targets.len() {
+                        let (a, b) = (targets[i], targets[j]);
+                        add_interaction_edge(&mut adj, a, b);
+                    }
+                }
+            }
+        }
+        Self { num_qubits: n, adj }
+    }
+
+    pub fn num_edges(&self) -> usize {
+        self.adj.iter().map(|s| s.len()).sum::<usize>() / 2
+    }
+
+    /// Connected components of `G - excluded`. Returns one `Vec<usize>` per
+    /// component, in increasing-min-vertex order.
+    pub fn components_excluding(&self, excluded: &HashSet<usize>) -> Vec<Vec<usize>> {
+        let mut visited: HashSet<usize> = (0..self.num_qubits)
+            .filter(|v| excluded.contains(v))
+            .collect();
+        let mut comps = Vec::new();
+        for start in 0..self.num_qubits {
+            if visited.contains(&start) {
+                continue;
+            }
+            let mut stack = vec![start];
+            let mut comp = Vec::new();
+            while let Some(v) = stack.pop() {
+                if !visited.insert(v) {
+                    continue;
+                }
+                comp.push(v);
+                for &u in &self.adj[v] {
+                    if !visited.contains(&u) {
+                        stack.push(u);
+                    }
+                }
+            }
+            comp.sort_unstable();
+            comps.push(comp);
+        }
+        comps
+    }
+}
+
+fn add_interaction_edge(adj: &mut [BTreeSet<usize>], a: usize, b: usize) {
+    if a != b {
+        adj[a].insert(b);
+        adj[b].insert(a);
+    }
+}
+
+/// Upper bound on the treewidth of `G - excluded` via the min-fill
+/// elimination heuristic.
+///
+/// Returns the maximum, over all eliminated vertices, of `|N(v) cap remaining|`
+/// at elimination time. This is the standard `tw <= max_clique_during_elim - 1`
+/// bound expressed as the clique size; the clique size itself is reported
+/// (i.e., `tw_proxy = max_clique`) because the cost model is `exp(c * w)`
+/// and the additive constant absorbs into `c`.
+///
+/// **Soundness.** The produced elimination order has a concrete maximum
+/// induced clique size, and that value is an upper bound on the optimal
+/// treewidth plus one. The heuristic may overestimate, which is acceptable
+/// for dispatch because it can reject a backend but cannot understate the
+/// width of the chosen elimination order.
+pub fn min_fill_treewidth_proxy(graph: &InteractionGraph, excluded: &HashSet<usize>) -> usize {
+    let mut remaining: HashSet<usize> = (0..graph.num_qubits)
+        .filter(|v| !excluded.contains(v))
+        .collect();
+    if remaining.is_empty() {
+        return 0;
+    }
+
+    let mut adj = graph.adj.clone();
+    let mut max_clique = 0usize;
+
+    while !remaining.is_empty() {
+        let mut best: Option<(usize, usize, usize)> = None;
+        for &v in &remaining {
+            let nbrs_in: Vec<usize> = adj[v]
+                .iter()
+                .copied()
+                .filter(|u| remaining.contains(u))
+                .collect();
+            let deg = nbrs_in.len();
+            let mut fill = 0usize;
+            for i in 0..nbrs_in.len() {
+                for j in (i + 1)..nbrs_in.len() {
+                    if !adj[nbrs_in[i]].contains(&nbrs_in[j]) {
+                        fill += 1;
+                    }
+                }
+            }
+            let key = (fill, deg, v);
+            if best.map_or(true, |b| key < b) {
+                best = Some(key);
+            }
+        }
+        let (_, deg, v) = best.unwrap();
+        let clique = deg + 1;
+        if clique > max_clique {
+            max_clique = clique;
+        }
+        let nbrs_in: Vec<usize> = adj[v]
+            .iter()
+            .copied()
+            .filter(|u| remaining.contains(u))
+            .collect();
+        for i in 0..nbrs_in.len() {
+            for j in (i + 1)..nbrs_in.len() {
+                let (a, b) = (nbrs_in[i], nbrs_in[j]);
+                adj[a].insert(b);
+                adj[b].insert(a);
+            }
+        }
+        remaining.remove(&v);
+    }
+    max_clique
+}
+
+/// Score combining branch count and post-cut contraction width.
+///
+/// `score(S) = B(S) * exp(c * w_post(S))`
+/// where `B(S) = 2^|S|` and `w_post(S)` is the per-component max of the
+/// min-fill treewidth proxy on `G - S`.
+///
+/// Returns `f64::INFINITY` if either factor overflows.
+pub fn cut_score(graph: &InteractionGraph, cut: &HashSet<usize>, c: f64) -> f64 {
+    let k = cut.len() as f64;
+    let comps = graph.components_excluding(cut);
+    let mut w_post = 0usize;
+    for comp in &comps {
+        let comp_excluded: HashSet<usize> = (0..graph.num_qubits)
+            .filter(|v| !comp.contains(v))
+            .collect();
+        let w = min_fill_treewidth_proxy(graph, &comp_excluded);
+        if w > w_post {
+            w_post = w;
+        }
+    }
+    let log_score = k * std::f64::consts::LN_2 + c * (w_post as f64);
+    if log_score > 700.0 {
+        f64::INFINITY
+    } else {
+        log_score.exp()
+    }
+}
+
+/// Find the best single-qubit cut by exhaustive search.
+///
+/// Used as a baseline and for small interaction graphs (n <= ~30). Returns
+/// the cut qubit and its score, or `None` if no cut improves on the
+/// uncut score `exp(c * w(G))`.
+pub fn best_single_cut(graph: &InteractionGraph, c: f64) -> Option<(usize, f64)> {
+    let uncut = cut_score(graph, &HashSet::new(), c);
+    let mut best: Option<(usize, f64)> = None;
+    for v in 0..graph.num_qubits {
+        let mut s = HashSet::new();
+        s.insert(v);
+        let score = cut_score(graph, &s, c);
+        if score < uncut && best.map_or(true, |(_, sb)| score < sb) {
+            best = Some((v, score));
+        }
+    }
+    best
+}
+
+/// Nested-dissection cut sequence on a path or grid-like graph.
+///
+/// Recursively cuts at the vertex (or pair of vertices) whose removal
+/// produces the most-balanced split. Returns the sequence of cut sets, in
+/// the order they should be applied. Each successive cut operates on one
+/// component of the previous step.
+///
+/// For a `1 x n` path this returns roughly `log_2(n)` single-vertex cuts at
+/// midpoints. For a `d x d` grid this returns `O(d)` linear separators.
+pub fn nested_dissection_cuts(graph: &InteractionGraph, max_component: usize) -> Vec<Vec<usize>> {
+    let mut cuts = Vec::new();
+    let mut work: Vec<Vec<usize>> = vec![(0..graph.num_qubits).collect()];
+
+    while let Some(component) = work.pop() {
+        if component.len() <= max_component {
+            continue;
+        }
+        let mut best: Option<(usize, isize)> = None;
+        for &v in &component {
+            let mut excl: HashSet<usize> = (0..graph.num_qubits)
+                .filter(|u| !component.contains(u))
+                .collect();
+            excl.insert(v);
+            let sub_comps = graph.components_excluding(&excl);
+            if sub_comps.len() < 2 {
+                continue;
+            }
+            let max_part = sub_comps.iter().map(|c| c.len()).max().unwrap();
+            let balance = -(max_part as isize);
+            if best.map_or(true, |(_, b)| balance > b) {
+                best = Some((v, balance));
+            }
+        }
+        let Some((v, _)) = best else { continue };
+        cuts.push(vec![v]);
+        let mut excl: HashSet<usize> = (0..graph.num_qubits)
+            .filter(|u| !component.contains(u))
+            .collect();
+        excl.insert(v);
+        let new_comps = graph.components_excluding(&excl);
+        for sub in new_comps {
+            work.push(sub);
+        }
+    }
+    cuts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::{Instruction, SmallVec};
+    use crate::gates::{BatchPhaseData, Gate};
+    use num_complex::Complex64;
+
+    fn path_circuit(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, 0);
+        for i in 0..(n - 1) {
+            c.add_gate(Gate::Cx, &[i, i + 1]);
+        }
+        c
+    }
+
+    fn grid_circuit(d: usize) -> Circuit {
+        let mut c = Circuit::new(d * d, 0);
+        for r in 0..d {
+            for cc in 0..d {
+                let v = r * d + cc;
+                if cc + 1 < d {
+                    c.add_gate(Gate::Cx, &[v, v + 1]);
+                }
+                if r + 1 < d {
+                    c.add_gate(Gate::Cx, &[v, v + d]);
+                }
+            }
+        }
+        c
+    }
+
+    #[test]
+    fn interaction_graph_path_has_n_minus_one_edges() {
+        let g = InteractionGraph::from_circuit(&path_circuit(6));
+        assert_eq!(g.num_edges(), 5);
+        for v in 1..5 {
+            assert_eq!(g.adj[v].len(), 2);
+        }
+        assert_eq!(g.adj[0].len(), 1);
+        assert_eq!(g.adj[5].len(), 1);
+    }
+
+    #[test]
+    fn interaction_graph_batch_phase_uses_internal_phase_targets() {
+        let mut c = Circuit::new(3, 0);
+        c.instructions.push(Instruction::Gate {
+            gate: Gate::BatchPhase(Box::new(BatchPhaseData {
+                phases: vec![
+                    (1, Complex64::new(0.0, 1.0)),
+                    (2, Complex64::new(-1.0, 0.0)),
+                ]
+                .into(),
+            })),
+            targets: SmallVec::from_slice(&[0]),
+        });
+
+        let g = InteractionGraph::from_circuit(&c);
+        assert_eq!(g.num_edges(), 2);
+        assert!(g.adj[0].contains(&1));
+        assert!(g.adj[0].contains(&2));
+        assert!(!g.adj[1].contains(&2));
+    }
+
+    #[test]
+    fn min_fill_path_has_clique_two() {
+        let g = InteractionGraph::from_circuit(&path_circuit(10));
+        let w = min_fill_treewidth_proxy(&g, &HashSet::new());
+        assert_eq!(w, 2, "path treewidth proxy should be 2 (clique size)");
+    }
+
+    #[test]
+    fn min_fill_3x3_grid_has_clique_four() {
+        let g = InteractionGraph::from_circuit(&grid_circuit(3));
+        let w = min_fill_treewidth_proxy(&g, &HashSet::new());
+        assert!(
+            (3..=4).contains(&w),
+            "3x3 grid treewidth proxy expected 3 or 4 (got {w})"
+        );
+    }
+
+    #[test]
+    fn components_after_cutting_path_midpoint() {
+        let g = InteractionGraph::from_circuit(&path_circuit(7));
+        let mut cut = HashSet::new();
+        cut.insert(3);
+        let comps = g.components_excluding(&cut);
+        assert_eq!(comps.len(), 2);
+        assert_eq!(comps[0], vec![0, 1, 2]);
+        assert_eq!(comps[1], vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn cut_score_uncut_path_polynomial() {
+        let g = InteractionGraph::from_circuit(&path_circuit(20));
+        let score = cut_score(&g, &HashSet::new(), 1.0);
+        assert!(score.is_finite());
+        assert!(score < 1e4);
+    }
+
+    #[test]
+    fn cut_score_grid_decreases_with_separator() {
+        let g = InteractionGraph::from_circuit(&grid_circuit(4));
+        let uncut = cut_score(&g, &HashSet::new(), 2.0);
+
+        let mut cut: HashSet<usize> = HashSet::new();
+        for r in 0..4 {
+            cut.insert(r * 4 + 2);
+        }
+        let separated = cut_score(&g, &cut, 2.0);
+
+        assert!(
+            separated < uncut,
+            "4-qubit separator on 4x4 grid should beat uncut (got separated={separated}, uncut={uncut})"
+        );
+    }
+
+    #[test]
+    fn nested_dissection_path_recurses() {
+        let g = InteractionGraph::from_circuit(&path_circuit(8));
+        let cuts = nested_dissection_cuts(&g, 2);
+        assert!(!cuts.is_empty());
+        assert!(cuts.iter().all(|c| c.len() == 1));
+    }
+
+    #[test]
+    fn best_single_cut_no_help_on_minimal_width_path() {
+        let g = InteractionGraph::from_circuit(&path_circuit(7));
+        let result = best_single_cut(&g, 1.0);
+        assert!(
+            result.is_none(),
+            "paths already have width 2; branch cost 2 cannot improve"
+        );
+    }
+
+    #[test]
+    fn best_single_cut_helps_on_complete_graph() {
+        let mut c = Circuit::new(5, 0);
+        for i in 0..5 {
+            for j in (i + 1)..5 {
+                c.add_gate(Gate::Cx, &[i, j]);
+            }
+        }
+        let g = InteractionGraph::from_circuit(&c);
+        let result = best_single_cut(&g, 1.0);
+        assert!(
+            result.is_some(),
+            "K_5 has width 5; cutting one vertex gives width 4, saves exp(1) versus branch cost 2"
+        );
+    }
+}

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -16,6 +16,9 @@
 //! - [`run_qec_program_reference`] is the correctness oracle. One state-vector
 //!   simulation per shot. Use it for small semantic cross-checks, not bulk
 //!   sampling.
+//! - [`run_qec_program_with_strategy`] dispatches non-Clifford observable
+//!   programs through exact light-cone SPD, CAMPS, then a private exact
+//!   tensor-network scalar fallback.
 //! - [`compile_qec_program_rows`] lowers basis measurements and `MPP` records
 //!   into the packed X/Z Pauli row representation used by sampler internals.
 //!   It does not execute gates, resets, or active noise.
@@ -24,16 +27,30 @@
 //! shots, plus accepted and discarded shot counts after postselection and
 //! per-observable logical-error counts.
 
+mod camps_prefix;
+/// Treewidth-aware cut-selection heuristics for the QEC T-strategy ladder.
+///
+/// Not yet wired into the production dispatcher (which follows a fixed
+/// SPD -> CAMPS -> tensor-network ladder); exposed only under the
+/// `bench-internal` feature so the heuristics can be benchmarked without
+/// committing them to the stable public API.
+#[cfg(feature = "bench-internal")]
+pub mod cut_selection;
 mod noise;
+pub mod observable_reroute;
 mod parse;
 mod result;
 mod runner;
+mod t_sampler;
 
 pub use parse::parse_qec_program;
-pub use result::QecSampleResult;
+pub use result::{QecObservableEstimate, QecSampleResult};
 #[cfg(feature = "bench-internal")]
 pub use runner::{compile_qec_profiled_sampler, QecProfiledCounts, QecProfiledSampler};
 pub use runner::{run_qec_program, run_qec_program_reference};
+pub use t_sampler::{
+    run_qec_program_spd_rerouted, run_qec_program_with_strategy, QecObservableReroute, QecTStrategy,
+};
 
 use crate::circuit::Circuit;
 use crate::error::{PrismError, Result};

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -18,10 +18,10 @@ struct QecDeferredNoiseEvent {
     position: usize,
 }
 
-struct QecDeferredProgram {
-    circuit: Circuit,
+pub(super) struct QecDeferredProgram {
+    pub(super) circuit: Circuit,
     noise_events: Vec<QecDeferredNoiseEvent>,
-    measurement_qubits: Vec<usize>,
+    pub(super) measurement_qubits: Vec<usize>,
 }
 
 pub(super) struct QecCompiledNoiseSampler {
@@ -225,6 +225,23 @@ fn qec_noise_rng(seed: u64) -> Xoshiro256PlusPlus {
 }
 
 fn lower_qec_program_to_deferred_circuit(program: &QecProgram) -> Result<QecDeferredProgram> {
+    lower_qec_program_to_deferred_circuit_inner(program, false)
+}
+
+/// Variant of [`lower_qec_program_to_deferred_circuit`] that admits T /
+/// Tdg gates. Used by the SPD and CAMPS T-strategy adapters that
+/// evaluate observables analytically over the unitary circuit and so
+/// do not need the Clifford-only restriction.
+pub(super) fn lower_qec_program_to_deferred_circuit_allowing_non_clifford(
+    program: &QecProgram,
+) -> Result<QecDeferredProgram> {
+    lower_qec_program_to_deferred_circuit_inner(program, true)
+}
+
+fn lower_qec_program_to_deferred_circuit_inner(
+    program: &QecProgram,
+    allow_non_clifford: bool,
+) -> Result<QecDeferredProgram> {
     let has_mpp = program
         .ops()
         .iter()
@@ -242,7 +259,7 @@ fn lower_qec_program_to_deferred_circuit(program: &QecProgram) -> Result<QecDefe
     for op in program.ops() {
         match op {
             QecOp::Gate { gate, targets } => {
-                if !gate.is_clifford() {
+                if !allow_non_clifford && !gate.is_clifford() {
                     return Err(PrismError::IncompatibleBackend {
                         backend: "QEC compiled runner".to_string(),
                         reason: format!(

--- a/src/qec/observable_reroute.rs
+++ b/src/qec/observable_reroute.rs
@@ -1,0 +1,139 @@
+//! Product-Z observable rerouting for QEC analytical paths.
+//!
+//! This module implements the production-safe core of Method F for explicit
+//! stabilizer input. It does not infer code stabilizers. Callers must supply
+//! stabilizers that fix the evaluated state or conditioned subspace.
+
+use std::collections::HashSet;
+
+use crate::circuit::{Circuit, Instruction};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::unified_pauli::{inverse_light_cone, PauliTerm};
+
+/// Upper bound on the number of supplied stabilizers the reroute search will
+/// enumerate. The search is a brute-force scan over the `2^k` subset sums of
+/// the stabilizer span, each costing a full light-cone walk, so the candidate
+/// count must stay tractable. `2^20 ≈ 1M` walks is the ceiling.
+pub const MAX_REROUTE_STABILIZERS: usize = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConeTelemetry {
+    pub gates_total: usize,
+    pub gates_in_cone: usize,
+    pub t_total: usize,
+    pub t_in_cone: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservableRerouteResult {
+    pub original_support: Vec<usize>,
+    pub rerouted_support: Vec<usize>,
+    pub original: ConeTelemetry,
+    pub rerouted: ConeTelemetry,
+}
+
+#[inline]
+fn is_t_gate(gate: &Gate) -> bool {
+    matches!(gate, Gate::T | Gate::Tdg)
+}
+
+fn z_terms(support: &[usize]) -> Vec<PauliTerm> {
+    let mut out: Vec<_> = support.iter().copied().map(PauliTerm::z).collect();
+    out.sort_by_key(|t| t.qubit);
+    out
+}
+
+pub fn cone_telemetry(circuit: &Circuit, observable: &[PauliTerm]) -> ConeTelemetry {
+    let keep = inverse_light_cone(circuit, observable);
+    let mut out = ConeTelemetry {
+        gates_total: 0,
+        gates_in_cone: 0,
+        t_total: 0,
+        t_in_cone: 0,
+    };
+    for (idx, inst) in circuit.instructions.iter().enumerate() {
+        if let Instruction::Gate { gate, .. } = inst {
+            out.gates_total += 1;
+            if is_t_gate(gate) {
+                out.t_total += 1;
+            }
+            if keep[idx] {
+                out.gates_in_cone += 1;
+                if is_t_gate(gate) {
+                    out.t_in_cone += 1;
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn xor_z_support(a: &[usize], b: &[usize]) -> Vec<usize> {
+    let mut support: HashSet<usize> = a.iter().copied().collect();
+    for &q in b {
+        if !support.insert(q) {
+            support.remove(&q);
+        }
+    }
+    let mut out: Vec<_> = support.into_iter().collect();
+    out.sort_unstable();
+    out
+}
+
+pub fn min_cone_z_representative(
+    circuit: &Circuit,
+    observable: &[usize],
+    stabilizers: &[Vec<usize>],
+) -> Result<ObservableRerouteResult> {
+    if stabilizers.len() > MAX_REROUTE_STABILIZERS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "QEC observable reroute".to_string(),
+            operation: format!(
+                "reroute search over {} stabilizers (max {}); the 2^k subset scan is intractable beyond the cap",
+                stabilizers.len(),
+                MAX_REROUTE_STABILIZERS
+            ),
+        });
+    }
+
+    let mut original_support = observable.to_vec();
+    original_support.sort_unstable();
+    let original = cone_telemetry(circuit, &z_terms(&original_support));
+    let mut best_support = original_support.clone();
+    let mut best = original;
+
+    let candidate_count = 1usize << stabilizers.len();
+    for mask in 0..candidate_count {
+        let mut candidate = original_support.clone();
+        for (idx, stabilizer) in stabilizers.iter().enumerate() {
+            if (mask >> idx) & 1 == 1 {
+                candidate = xor_z_support(&candidate, stabilizer);
+            }
+        }
+        let telemetry = cone_telemetry(circuit, &z_terms(&candidate));
+        let score = (
+            telemetry.t_in_cone,
+            telemetry.gates_in_cone,
+            candidate.len(),
+            candidate.clone(),
+        );
+        let best_score = (
+            best.t_in_cone,
+            best.gates_in_cone,
+            best_support.len(),
+            best_support.clone(),
+        );
+        if score < best_score {
+            best = telemetry;
+            best_support = candidate;
+        }
+    }
+
+    Ok(ObservableRerouteResult {
+        original_support,
+        rerouted_support: best_support,
+        original,
+        rerouted: best,
+    })
+}

--- a/src/qec/result.rs
+++ b/src/qec/result.rs
@@ -8,7 +8,16 @@ use crate::sim::compiled::PackedShots;
 /// [`super::QecOptions::keep_measurements`] is `false`, [`Self::measurements`]
 /// is returned with zero shots; detector and observable shots are always
 /// populated.
+///
+/// This type is `#[non_exhaustive]`: construct it through [`Self::new`],
+/// [`Self::new_with_total_shots`], or [`Self::empty`] (not a struct
+/// literal), and match its fields with a trailing `..`. New fields may be
+/// added in minor releases without a major version bump; `0.15.0` added
+/// [`Self::observable_expectations`] and the `#[non_exhaustive]` marker
+/// itself, which is a breaking change for crates that previously built or
+/// exhaustively destructured this struct.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct QecSampleResult {
     /// Number of shots requested from the sampler.
     pub total_shots: usize,
@@ -18,6 +27,15 @@ pub struct QecSampleResult {
     /// Detector records: one bit per detector per shot.
     pub detectors: PackedShots,
     /// Logical observable records: one bit per observable per shot.
+    ///
+    /// For sampled strategies each bit is a real per-shot observable
+    /// parity. Analytical T strategies (SPD / CAMPS / tensor network) have
+    /// no per-shot stream, so they synthesize these records to match the
+    /// `logical_errors` popcount: the one-bits occupy positions
+    /// `[0, accepted_shots)` and the remainder up to `total_shots` is inert
+    /// padding. Derive rates with [`Self::logical_error_rates`]
+    /// (denominator `accepted_shots`); do not align these rows
+    /// shot-for-shot with detector rows on the analytical path.
     pub observables: PackedShots,
     /// Number of shots accepted after postselection (or `total_shots` when no
     /// postselection predicate is present).
@@ -27,6 +45,29 @@ pub struct QecSampleResult {
     /// For each observable, count of accepted shots where the observable
     /// parity equals 1. Length equals the number of observables.
     pub logical_errors: Vec<u64>,
+    /// Optional weighted-estimator expectation per observable. When
+    /// `Some`, this is the unbiased estimator's output for
+    /// `⟨1 - 2·parity⟩ ∈ [-γ^t, +γ^t]` (raw signed-importance mean);
+    /// `None` when the strategy emits raw bit counts only. Used by
+    /// analytical or weighted T strategies where the observable expectation
+    /// is not a simple ratio of bit counts.
+    pub observable_expectations: Option<Vec<QecObservableEstimate>>,
+}
+
+/// Unbiased expectation estimate for one observable under a weighted
+/// shot strategy.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QecObservableEstimate {
+    /// Empirical mean of `Re(weight · (1 - 2·parity))` over the shot
+    /// stream. For Z-basis Pauli observables on a true probability
+    /// distribution this lies in `[-1, +1]`; quasi-probability variance
+    /// can push raw shot estimates outside that range.
+    pub mean: f64,
+    /// Empirical variance of the weighted per-shot contribution.
+    pub variance: f64,
+    /// Number of shots that contributed to the estimate (excluding
+    /// postselection rejections).
+    pub num_shots: usize,
 }
 
 impl QecSampleResult {
@@ -40,6 +81,7 @@ impl QecSampleResult {
             accepted_shots: 0,
             discarded_shots: 0,
             logical_errors: vec![0; num_observables],
+            observable_expectations: None,
         }
     }
 
@@ -122,7 +164,28 @@ impl QecSampleResult {
             accepted_shots,
             discarded_shots,
             logical_errors,
+            observable_expectations: None,
         })
+    }
+
+    /// Attach unbiased-estimator outputs alongside the raw bit counts.
+    /// Used by quasi-probability QEC T strategies. Validates that the
+    /// estimate length matches the number of observables.
+    pub fn with_observable_expectations(
+        mut self,
+        estimates: Vec<QecObservableEstimate>,
+    ) -> Result<Self> {
+        if estimates.len() != self.observables.num_measurements() {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "observable expectation length {} does not match {} observables",
+                    estimates.len(),
+                    self.observables.num_measurements()
+                ),
+            });
+        }
+        self.observable_expectations = Some(estimates);
+        Ok(self)
     }
 
     /// Fraction of requested shots accepted after postselection.

--- a/src/qec/t_sampler.rs
+++ b/src/qec/t_sampler.rs
@@ -1,0 +1,1034 @@
+//! T-gate strategy dispatch for native QEC programs.
+//!
+//! Public surface: one strategy enum and a single entry point
+//! [`run_qec_program_with_strategy`]. [`QecTStrategy::Auto`] is the
+//! production dispatcher: exact light-cone SPD, CAMPS, then the private exact
+//! tensor-network scalar fallback. [`QecTStrategy::Reference`] is the
+//! analytical correctness anchor. [`QecTStrategy::Spd`] and
+//! [`QecTStrategy::Camps`] are direct analytical paths.
+
+use super::observable_reroute::{min_cone_z_representative, xor_z_support};
+use super::{run_qec_program_reference, QecObservableEstimate, QecOp, QecProgram, QecSampleResult};
+#[cfg(test)]
+use super::{QecBasis, QecOptions, QecRecordRef};
+use crate::backend::mps::MpsBackend;
+use crate::backend::Backend;
+use crate::circuit::{Circuit, SmallVec};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::compiled::PackedShots;
+use crate::sim::unified_pauli::{run_spd_observable_light_cone, PauliTerm};
+
+/// Strategy used to sample a QEC program that may contain T gates.
+///
+/// Production path is [`QecTStrategy::Auto`], which tries exact light-cone SPD,
+/// then CAMPS, then the private exact tensor-network scalar fallback when CAMPS
+/// cannot run. [`QecTStrategy::Reference`] is the analytical correctness
+/// anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QecTStrategy {
+    /// Production dispatcher. Exact light-cone SPD, CAMPS, then tensor network.
+    Auto,
+    /// One state-vector simulation per shot. Correctness oracle.
+    Reference,
+    /// Clifford-augmented matrix product state Pauli expectation path.
+    Camps,
+    /// Sparse Pauli decomposition after the joint-observable upgrade.
+    Spd,
+}
+
+#[derive(Debug, Clone)]
+pub struct QecObservableReroute {
+    pub observable: usize,
+    pub stabilizers: Vec<Vec<usize>>,
+}
+
+impl QecTStrategy {
+    /// Short human label used in benchmark groups and decision tables.
+    pub fn label(self) -> &'static str {
+        match self {
+            QecTStrategy::Auto => "auto",
+            QecTStrategy::Reference => "reference",
+            QecTStrategy::Camps => "camps",
+            QecTStrategy::Spd => "spd",
+        }
+    }
+}
+
+/// Run a QEC program under the chosen T-gate sampling strategy.
+///
+/// Use [`QecTStrategy::Auto`] for production observable runs. The
+/// [`QecTStrategy::Reference`] strategy is always available and matches
+/// [`run_qec_program_reference`] exactly.
+pub fn run_qec_program_with_strategy(
+    program: &QecProgram,
+    strategy: QecTStrategy,
+) -> Result<QecSampleResult> {
+    match strategy {
+        QecTStrategy::Auto => run_qec_program_auto(program),
+        QecTStrategy::Reference => run_qec_program_reference(program),
+        QecTStrategy::Spd => run_qec_program_spd(program),
+        QecTStrategy::Camps => run_qec_program_camps(program),
+    }
+}
+
+#[cfg(test)]
+mod auto_test_hooks {
+    use std::cell::Cell;
+
+    thread_local! {
+        static FORCE_SPD_NONEXACT: Cell<bool> = const { Cell::new(false) };
+        static FORCE_CAMPS_FAILURE: Cell<bool> = const { Cell::new(false) };
+    }
+
+    pub(super) fn force_spd_nonexact() -> bool {
+        FORCE_SPD_NONEXACT.with(Cell::get)
+    }
+
+    pub(super) fn force_camps_failure() -> bool {
+        FORCE_CAMPS_FAILURE.with(Cell::get)
+    }
+
+    pub(super) fn set_force_spd_nonexact(value: bool) {
+        FORCE_SPD_NONEXACT.with(|flag| flag.set(value));
+    }
+
+    pub(super) fn set_force_camps_failure(value: bool) {
+        FORCE_CAMPS_FAILURE.with(|flag| flag.set(value));
+    }
+}
+
+#[cfg(test)]
+fn run_qec_program_spd_for_auto(program: &QecProgram) -> Result<QecSampleResult> {
+    let mut result = run_qec_program_spd(program)?;
+    if auto_test_hooks::force_spd_nonexact() {
+        if let Some(estimates) = result.observable_expectations.as_mut() {
+            for estimate in estimates {
+                estimate.variance = estimate.variance.max(1.0);
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(not(test))]
+fn run_qec_program_spd_for_auto(program: &QecProgram) -> Result<QecSampleResult> {
+    run_qec_program_spd(program)
+}
+
+#[cfg(test)]
+fn run_qec_program_camps_for_auto(program: &QecProgram) -> Result<QecSampleResult> {
+    if auto_test_hooks::force_camps_failure() {
+        return Err(PrismError::BackendUnsupported {
+            backend: "QEC CAMPS".to_string(),
+            operation: "forced CAMPS failure for auto-dispatch test".to_string(),
+        });
+    }
+    run_qec_program_camps(program)
+}
+
+#[cfg(not(test))]
+fn run_qec_program_camps_for_auto(program: &QecProgram) -> Result<QecSampleResult> {
+    run_qec_program_camps(program)
+}
+
+fn run_qec_program_auto(program: &QecProgram) -> Result<QecSampleResult> {
+    match run_qec_program_spd_for_auto(program) {
+        Ok(result) if analytical_result_has_no_truncation(&result) => Ok(result),
+        Ok(_) => run_qec_program_auto_after_camps(
+            program,
+            "light-cone SPD exceeded its exact truncation budget".to_string(),
+        ),
+        Err(spd_error) => run_qec_program_auto_after_camps(
+            program,
+            format!("light-cone SPD failed ({spd_error})"),
+        ),
+    }
+}
+
+fn run_qec_program_auto_after_camps(
+    program: &QecProgram,
+    spd_context: String,
+) -> Result<QecSampleResult> {
+    match run_qec_program_camps_for_auto(program) {
+        Ok(result) => Ok(result),
+        Err(camps_error) => {
+            run_qec_program_tensor_network_observable(program).map_err(|tn_error| {
+                PrismError::IncompatibleBackend {
+                    backend: "QEC auto T-strategy".to_string(),
+                    reason: format!(
+                        "{spd_context} and CAMPS fallback failed ({camps_error}); \
+                         tensor-network scalar fallback failed: {tn_error}"
+                    ),
+                }
+            })
+        }
+    }
+}
+
+/// Discarded-mass variance at or below this is treated as numerically exact.
+/// SPD reports `variance = total_discarded²`, and a handful of legitimate
+/// sub-`QEC_SPD_EPSILON` terms can leave a tiny nonzero residue that must not
+/// force the costlier CAMPS / tensor-network fallback. A discarded amplitude of
+/// `1e-6` (variance `1e-12`) is far below the statistical noise of any shot
+/// count the QEC paths target.
+const QEC_SPD_NEGLIGIBLE_VARIANCE: f64 = 1e-12;
+
+fn analytical_result_has_no_truncation(result: &QecSampleResult) -> bool {
+    result
+        .observable_expectations
+        .as_ref()
+        .map(|estimates| {
+            estimates
+                .iter()
+                .all(|estimate| estimate.variance <= QEC_SPD_NEGLIGIBLE_VARIANCE)
+        })
+        .unwrap_or(true)
+}
+
+/// Default truncation tolerance for SPD on QEC programs.
+const QEC_SPD_EPSILON: f64 = 1e-10;
+/// Default term-count cap for SPD on QEC programs. Sub-percent error is
+/// expected for `t ≤ 20`; larger T-counts may exceed this and report a
+/// non-zero `total_discarded`.
+const QEC_SPD_MAX_TERMS: usize = 16_384;
+
+/// Lower a QEC program into a unitary Circuit plus per-record qubit map
+/// for the joint-Pauli SPD / CAMPS analytical paths.
+///
+/// Delegates to the deferred-lowering machinery in `qec/noise.rs`
+/// (`lower_qec_program_to_deferred_circuit_allowing_non_clifford`),
+/// which handles Reset (fresh qubit alias), MPP (scratch qubit + CNOT
+/// chain), basis-rotated measurements (`H` / `S†H` prefix), and the
+/// trailing measurement record bookkeeping. The trailing
+/// `Instruction::Measure` ops appended by the deferred lowering are
+/// stripped from the returned Circuit so the strategies can evaluate
+/// `⟨0^n| U† P U |0^n⟩` against the pure unitary.
+///
+/// **Still rejected:**
+/// - Active `Noise` channels: SPD / CAMPS do not have an
+///   `apply_noise_to_measurements`-style hook.
+/// - `ExpectationValue`: unmodified rejection.
+/// - `Detector`: analytical strategies do not emit detector rows yet.
+fn lower_qec_program_for_pauli_observable(program: &QecProgram) -> Result<(Circuit, Vec<usize>)> {
+    for op in program.ops() {
+        match op {
+            QecOp::Noise { channel, .. } if channel.probability() > 0.0 => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC SPD / CAMPS".to_string(),
+                    reason: format!(
+                        "analytical strategies evaluate pure-state expectations and \
+                         cannot absorb Pauli noise channels (got `{channel:?}`); \
+                         route noisy QEC programs through `run_qec_program_reference` \
+                         (statevector per shot with stochastic noise) or extend \
+                         CAMPS to an `MPDO` density-matrix path"
+                    ),
+                });
+            }
+            QecOp::ExpectationValue { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC SPD / CAMPS".to_string(),
+                    reason: "EXP_VAL op is reserved for the dedicated \
+                             expectation runner"
+                        .to_string(),
+                });
+            }
+            QecOp::Detector { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC SPD / CAMPS".to_string(),
+                    reason: "analytical strategies do not emit detector records yet".to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let deferred =
+        super::noise::lower_qec_program_to_deferred_circuit_allowing_non_clifford(program)?;
+    let mut circuit = Circuit::new(
+        deferred.circuit.num_qubits,
+        deferred.circuit.num_classical_bits,
+    );
+    for inst in &deferred.circuit.instructions {
+        if matches!(inst, crate::circuit::Instruction::Gate { .. }) {
+            circuit.instructions.push(inst.clone());
+        }
+    }
+    Ok((circuit, deferred.measurement_qubits))
+}
+
+/// Convert an observable-row record list into a joint Pauli observable.
+/// Each record contributes a single Z factor on the measured qubit; an
+/// even number of factors on the same qubit cancels (Z² = I).
+fn observable_row_to_pauli_terms(
+    row: &[usize],
+    record_to_qubit: &[usize],
+) -> Result<Vec<PauliTerm>> {
+    let mut parity: SmallVec<[(usize, bool); 8]> = SmallVec::new();
+    for &record in row {
+        let qubit = *record_to_qubit
+            .get(record)
+            .ok_or_else(|| PrismError::InvalidParameter {
+                message: format!(
+                    "observable references record {record} but only {} records exist",
+                    record_to_qubit.len()
+                ),
+            })?;
+        if let Some(entry) = parity.iter_mut().find(|(q, _)| *q == qubit) {
+            entry.1 = !entry.1;
+        } else {
+            parity.push((qubit, true));
+        }
+    }
+    let mut terms: Vec<PauliTerm> = parity
+        .into_iter()
+        .filter(|(_, odd)| *odd)
+        .map(|(qubit, _)| PauliTerm::z(qubit))
+        .collect();
+    terms.sort_by_key(|t| t.qubit);
+    Ok(terms)
+}
+
+/// Max number of postselection rows allowed for the analytical
+/// conditional-expectation path. Each additional row doubles the
+/// number of Pauli evaluations; 12 caps the inner sum at 4,096 terms
+/// per observable.
+const MAX_POSTSEL_FOR_CONDITIONAL_EXPECTATION: usize = 12;
+
+/// Resolve postselection rows into (qubit-set, sign) pairs ready for
+/// the conditional-expectation expansion. Returns
+/// `(Vec<(Vec<usize>, bool)>, Vec<f64>)`: per-row qubit list and per-row
+/// `ε_i ∈ {+1, -1}` based on the `expected` outcome bit.
+fn lower_postselection_rows(
+    rows: &[(Vec<usize>, bool)],
+    record_to_qubit: &[usize],
+) -> Result<Vec<(Vec<usize>, f64)>> {
+    if rows.len() > MAX_POSTSEL_FOR_CONDITIONAL_EXPECTATION {
+        return Err(PrismError::BackendUnsupported {
+            backend: "QEC analytical conditional expectation".to_string(),
+            operation: format!(
+                "{} postselection rows exceeds the cap ({}); use the \
+                 reference runner for large-postsel circuits",
+                rows.len(),
+                MAX_POSTSEL_FOR_CONDITIONAL_EXPECTATION
+            ),
+        });
+    }
+    let mut out = Vec::with_capacity(rows.len());
+    for (records, expected) in rows {
+        let mut qubits = Vec::with_capacity(records.len());
+        for &record in records {
+            let qubit =
+                *record_to_qubit
+                    .get(record)
+                    .ok_or_else(|| PrismError::InvalidParameter {
+                        message: format!(
+                            "postselection references record {record} but only {} records exist",
+                            record_to_qubit.len()
+                        ),
+                    })?;
+            qubits.push(qubit);
+        }
+        let sign = if *expected { -1.0 } else { 1.0 };
+        out.push((qubits, sign));
+    }
+    Ok(out)
+}
+
+/// XOR-merge a sequence of qubit lists into a sorted, deduplicated
+/// `Vec<PauliTerm>` of `Z` factors (each qubit appears with parity 1).
+fn merge_qubit_groups_into_z_terms<'a, I>(groups: I) -> Vec<PauliTerm>
+where
+    I: IntoIterator<Item = &'a [usize]>,
+{
+    use std::collections::BTreeMap;
+    let mut counts: BTreeMap<usize, usize> = BTreeMap::new();
+    for group in groups {
+        for &q in group {
+            *counts.entry(q).or_insert(0) += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter(|(_, c)| c % 2 == 1)
+        .map(|(q, _)| PauliTerm::z(q))
+        .collect()
+}
+
+fn validate_z_stabilizers(stabilizers: &[Vec<usize>], num_qubits: usize) -> Result<()> {
+    for stabilizer in stabilizers {
+        for &qubit in stabilizer {
+            if qubit >= num_qubits {
+                return Err(PrismError::InvalidQubit {
+                    index: qubit,
+                    register_size: num_qubits,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Per-Pauli-string evaluation outcome. `discarded_sq` carries the
+/// squared truncation weight (zero for exact strategies like CAMPS and
+/// tensor-network); the analytical SPD strategy reports its light-cone
+/// truncation error here so it can be attributed to the right observable.
+struct ConditionalEval {
+    mean: f64,
+    discarded_sq: f64,
+}
+
+/// Generic conditional-expectation evaluator for the analytical
+/// strategies. Implements `⟨O⟩_post = ⟨O·Π⟩ / ⟨Π⟩` where
+/// `Π = ∏_j (I + ε_j Z(S_j))/2`. Expands the product into a sum over
+/// `2^J` subsets `T ⊆ {1..J}` and evaluates each Pauli-string
+/// expectation via the supplied closure. Returns
+/// `(post_means, per_observable_discarded_sq, accept_rate)`, where the
+/// discarded-weight vector is aligned with `observable_terms_list` so each
+/// observable's truncation error is tracked independently.
+fn evaluate_conditional_expectations<F>(
+    observable_terms_list: &[Vec<PauliTerm>],
+    postsel: &[(Vec<usize>, f64)],
+    mut eval: F,
+) -> Result<(Vec<f64>, Vec<f64>, f64)>
+where
+    F: FnMut(&[PauliTerm]) -> Result<ConditionalEval>,
+{
+    let j = postsel.len();
+    let subset_count = 1usize << j;
+    let scale = 1.0 / (1usize << j) as f64;
+
+    let mut pi_sum = 0.0;
+    let mut obs_pi_sums = vec![0.0; observable_terms_list.len()];
+    let mut obs_discarded = vec![0.0; observable_terms_list.len()];
+
+    let obs_qubits: Vec<Vec<usize>> = observable_terms_list
+        .iter()
+        .map(|terms| terms.iter().map(|t| t.qubit).collect())
+        .collect();
+
+    for mask in 0..subset_count {
+        let mut sign = 1.0;
+        let mut qubit_groups: Vec<&[usize]> = Vec::with_capacity(j + 1);
+        for (j_idx, (qubits, eps)) in postsel.iter().enumerate() {
+            if (mask >> j_idx) & 1 == 1 {
+                sign *= *eps;
+                qubit_groups.push(qubits.as_slice());
+            }
+        }
+        let pi_pauli = merge_qubit_groups_into_z_terms(qubit_groups.iter().copied());
+        let pi_value = eval(&pi_pauli)?;
+        pi_sum += sign * pi_value.mean;
+
+        for (obs_idx, obs_q) in obs_qubits.iter().enumerate() {
+            qubit_groups.push(obs_q.as_slice());
+            let combined_pauli = merge_qubit_groups_into_z_terms(qubit_groups.iter().copied());
+            qubit_groups.pop();
+            let outcome = eval(&combined_pauli)?;
+            obs_pi_sums[obs_idx] += sign * outcome.mean;
+            obs_discarded[obs_idx] += outcome.discarded_sq;
+        }
+    }
+
+    let accept_rate = (pi_sum * scale).clamp(0.0, 1.0);
+    if accept_rate <= 1e-12 {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC postselection has acceptance rate {accept_rate:.2e}; cannot \
+                 condition an expectation on a zero-measure event"
+            ),
+        });
+    }
+    let post_means: Vec<f64> = obs_pi_sums
+        .iter()
+        .map(|s| (s * scale) / accept_rate)
+        .collect();
+    Ok((post_means, obs_discarded, accept_rate))
+}
+
+fn build_qec_result_from_observable_means(
+    program: &QecProgram,
+    means: Vec<f64>,
+    estimates: Vec<QecObservableEstimate>,
+) -> Result<QecSampleResult> {
+    build_qec_result_with_acceptance(program, means, estimates, 1.0)
+}
+
+fn accepted_shots_for_rate(total_shots: usize, accept_rate: f64) -> usize {
+    (((total_shots as f64) * accept_rate).round() as usize).min(total_shots)
+}
+
+fn build_qec_result_with_acceptance(
+    program: &QecProgram,
+    means: Vec<f64>,
+    estimates: Vec<QecObservableEstimate>,
+    accept_rate: f64,
+) -> Result<QecSampleResult> {
+    if program.num_detectors() > 0 {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC analytical result".to_string(),
+            reason: "analytical QEC T strategies do not emit detector records yet".to_string(),
+        });
+    }
+
+    let total_shots = program.options().shots;
+    let accepted_shots = accepted_shots_for_rate(total_shots, accept_rate);
+    let discarded_shots = total_shots - accepted_shots;
+    let num_observables = program.num_observables();
+    let num_detectors = program.num_detectors();
+    let num_measurements = program.num_measurements();
+    let measurements = PackedShots::from_meas_major(Vec::new(), 0, num_measurements);
+    // Detector records are empty because analytical strategies reject
+    // detectors. Observable records are synthesized so their popcount
+    // marginals equal `logical_errors`, but the analytical path has no
+    // per-shot accept mask: the `count` one-bits occupy positions
+    // `[0, accepted_shots)` and the rest is inert padding up to
+    // `total_shots`. Consumers must therefore divide by `accepted_shots`
+    // (e.g. via [`QecSampleResult::logical_error_rates`]), not
+    // `total_shots`, and must not align observable rows shot-for-shot with
+    // detector rows. Exact expectations live in `observable_expectations`.
+    let detector_words = total_shots.div_ceil(64) * num_detectors;
+    let detectors =
+        PackedShots::from_meas_major(vec![0u64; detector_words], total_shots, num_detectors);
+
+    let mut logical_errors = Vec::with_capacity(num_observables);
+    for &mean in &means {
+        let rate = ((1.0 - mean) * 0.5).clamp(0.0, 1.0);
+        let count = if accepted_shots == 0 {
+            0
+        } else {
+            (rate * accepted_shots as f64).round() as u64
+        };
+        logical_errors.push(count);
+    }
+    let observables = packed_observable_records_from_logical_errors(total_shots, &logical_errors);
+
+    let result = QecSampleResult::new_with_total_shots(
+        total_shots,
+        measurements,
+        detectors,
+        observables,
+        accepted_shots,
+        discarded_shots,
+        logical_errors,
+    )?;
+    result.with_observable_expectations(estimates)
+}
+
+fn packed_observable_records_from_logical_errors(
+    total_shots: usize,
+    logical_errors: &[u64],
+) -> PackedShots {
+    let num_observables = logical_errors.len();
+    let s_words = total_shots.div_ceil(64);
+    let mut data = vec![0u64; num_observables * s_words];
+    for (observable, &count) in logical_errors.iter().enumerate() {
+        let mut remaining = (count as usize).min(total_shots);
+        for word in 0..s_words {
+            let bits = remaining.min(64);
+            data[observable * s_words + word] = match bits {
+                0 => 0,
+                64 => u64::MAX,
+                n => (1u64 << n) - 1,
+            };
+            remaining -= bits;
+            if remaining == 0 {
+                break;
+            }
+        }
+    }
+    PackedShots::from_meas_major(data, total_shots, num_observables)
+}
+
+/// Default MPS bond-dimension cap for CAMPS. Matches the
+/// auto-dispatch ceiling used elsewhere in PRISM-Q (`MPS(256)` in
+/// `sim/dispatch.rs`).
+const QEC_CAMPS_MAX_BOND_DIM: usize = 256;
+
+/// CAMPS analytical path for QEC observables.
+///
+/// Tracks the Clifford prefix separately from the MPS, applies T/Tdg through
+/// the CAMPS disentangler update, and evaluates Z-string observables directly
+/// from the MPS plus prefix. The path shares SPD's restricted lowering and
+/// Z-only observable scope.
+fn run_qec_program_camps(program: &QecProgram) -> Result<QecSampleResult> {
+    use super::camps_prefix::{
+        apply_t_via_camps, evaluate_z_observable_camps, SignedCliffordPrefix,
+    };
+    use crate::circuit::Instruction;
+
+    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let observable_rows = program.observable_rows()?;
+    let postsel_rows = program.postselection_rows()?;
+
+    let mut backend = MpsBackend::new(program.options().seed, QEC_CAMPS_MAX_BOND_DIM);
+    backend.init(circuit.num_qubits, 0)?;
+
+    let mut prefix = SignedCliffordPrefix::identity(circuit.num_qubits);
+    for inst in &circuit.instructions {
+        let Instruction::Gate { gate, targets } = inst else {
+            continue;
+        };
+        match gate {
+            Gate::T => {
+                apply_t_via_camps(&mut prefix, &mut backend, targets[0], false, 1e-10)?;
+            }
+            Gate::Tdg => {
+                apply_t_via_camps(&mut prefix, &mut backend, targets[0], true, 1e-10)?;
+            }
+            _ => {
+                prefix.apply_state_gate(gate, targets).map_err(|_| {
+                    PrismError::InvalidParameter {
+                        message: format!(
+                            "CAMPS dispatcher: gate {gate:?} is neither Clifford nor T/Tdg; \
+                             extend `lower_qec_program_for_pauli_observable` or add a CAMPS \
+                             fallback to handle this instruction"
+                        ),
+                    }
+                })?;
+            }
+        }
+    }
+
+    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
+    for row in observable_rows.iter() {
+        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
+    }
+
+    // Clifford gates are absorbed into a [`SignedCliffordPrefix`]; T/Tdg
+    // gates dispatch through [`apply_t_via_camps`] (Liu & Clark
+    // Algorithm 1 OFD). The observable `⟨ψ|Π Z_q|ψ⟩` is evaluated as
+    // `⟨ϕ| C†(Π Z_q) C |ϕ⟩` by composing twisted Pauli rows and calling
+    // [`crate::backend::mps::MpsBackend::pauli_expectation`].
+    let eval = |terms: &[PauliTerm]| -> Result<f64> {
+        let qubits: Vec<usize> = terms.iter().map(|t| t.qubit).collect();
+        evaluate_z_observable_camps(&prefix, &backend, &qubits)
+    };
+
+    if postsel_rows.is_empty() {
+        let mut means = Vec::with_capacity(observable_terms_list.len());
+        let mut estimates = Vec::with_capacity(observable_terms_list.len());
+        for terms in &observable_terms_list {
+            let mean = eval(terms)?;
+            means.push(mean);
+            estimates.push(QecObservableEstimate {
+                mean,
+                variance: 0.0,
+                num_shots: program.options().shots,
+            });
+        }
+        return build_qec_result_from_observable_means(program, means, estimates);
+    }
+
+    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
+    let (means, _obs_discarded, accept_rate) =
+        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
+            Ok(ConditionalEval {
+                mean: eval(terms)?,
+                discarded_sq: 0.0,
+            })
+        })?;
+    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
+    let estimates: Vec<_> = means
+        .iter()
+        .map(|&m| QecObservableEstimate {
+            mean: m,
+            variance: 0.0,
+            num_shots: estimate_shots,
+        })
+        .collect();
+    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+}
+
+// Private exact fallback for Auto. Contracts each scalar observable directly
+// as <0| U^dagger P U |0> and does not materialize a dense statevector.
+fn run_qec_program_tensor_network_observable(program: &QecProgram) -> Result<QecSampleResult> {
+    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let observable_rows = program.observable_rows()?;
+    let postsel_rows = program.postselection_rows()?;
+
+    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
+    for row in observable_rows.iter() {
+        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
+    }
+
+    let eval = |terms: &[PauliTerm]| -> Result<f64> {
+        crate::backend::tensornetwork::expectation_zero_state(&circuit, terms)
+    };
+
+    if postsel_rows.is_empty() {
+        let mut means = Vec::with_capacity(observable_terms_list.len());
+        let mut estimates = Vec::with_capacity(observable_terms_list.len());
+        for terms in &observable_terms_list {
+            let mean = eval(terms)?;
+            means.push(mean);
+            estimates.push(QecObservableEstimate {
+                mean,
+                variance: 0.0,
+                num_shots: program.options().shots,
+            });
+        }
+        return build_qec_result_from_observable_means(program, means, estimates);
+    }
+
+    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
+    let (means, _obs_discarded, accept_rate) =
+        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
+            Ok(ConditionalEval {
+                mean: eval(terms)?,
+                discarded_sq: 0.0,
+            })
+        })?;
+    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
+    let estimates: Vec<_> = means
+        .iter()
+        .map(|&mean| QecObservableEstimate {
+            mean,
+            variance: 0.0,
+            num_shots: estimate_shots,
+        })
+        .collect();
+    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+}
+
+/// Tolerance on `⟨ψ|S|ψ⟩ = +1` for a rerouting stabilizer.
+const REROUTE_STABILIZER_TOL: f64 = 1e-6;
+
+/// Verify that the Z-string distinguishing the original observable support from
+/// the rerouted support is a genuine `+1` stabilizer of the evaluated state.
+///
+/// Rerouting replaces observable `O` with `O' = O · S`, which preserves the
+/// expectation only when `S |ψ⟩ = +|ψ⟩`. The reroute module documents this as a
+/// caller obligation but cannot check it (it has no state). Here the state is
+/// available cheaply via SPD on `S` alone, so validate it rather than silently
+/// evaluate a different operator. `S = supp(original) ⊕ supp(rerouted)`; an
+/// empty support means no reroute happened and is trivially valid.
+fn verify_reroute_is_state_stabilizer(
+    circuit: &Circuit,
+    original_support: &[usize],
+    rerouted_support: &[usize],
+) -> Result<()> {
+    let stab_support = xor_z_support(original_support, rerouted_support);
+    if stab_support.is_empty() {
+        return Ok(());
+    }
+    let stab_terms: Vec<PauliTerm> = stab_support.iter().copied().map(PauliTerm::z).collect();
+    let stab =
+        run_spd_observable_light_cone(circuit, &stab_terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
+    if (stab.mean - 1.0).abs() > REROUTE_STABILIZER_TOL {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "reroute stabilizer on qubits {stab_support:?} is not a +1 stabilizer of the \
+                 state (⟨S⟩ = {:.6}); rerouting would evaluate a different operator",
+                stab.mean
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn run_qec_program_spd_rerouted(
+    program: &QecProgram,
+    reroutes: &[QecObservableReroute],
+) -> Result<QecSampleResult> {
+    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let observable_rows = program.observable_rows()?;
+    let postsel_rows = program.postselection_rows()?;
+    if !postsel_rows.is_empty() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC SPD rerouted".to_string(),
+            reason: "rerouted analytical SPD does not yet combine stabilizer rerouting with postselection projectors".to_string(),
+        });
+    }
+
+    // Reroute stabilizers and the observable support must live in the same
+    // qubit space. Observable support comes from `record_to_qubit`, which
+    // resolves to lowered circuit qubits; a `Reset` reassigns a logical
+    // qubit to a fresh higher index, so a stabilizer expressed in original
+    // logical-qubit indices would silently land on the wrong physical qubit.
+    // Reject such programs rather than evaluate a different operator.
+    if program
+        .ops()
+        .iter()
+        .any(|op| matches!(op, QecOp::Reset { .. }))
+    {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC SPD rerouted".to_string(),
+            reason: "stabilizer rerouting is not supported for programs containing RESET; \
+                     resets relabel logical qubits, making stabilizer qubit indices ambiguous"
+                .to_string(),
+        });
+    }
+
+    let mut reroute_by_observable: Vec<Option<&QecObservableReroute>> =
+        vec![None; observable_rows.len()];
+    for reroute in reroutes {
+        let slot = reroute_by_observable
+            .get_mut(reroute.observable)
+            .ok_or_else(|| PrismError::InvalidParameter {
+                message: format!(
+                    "reroute references observable {} but program has {} observables",
+                    reroute.observable,
+                    observable_rows.len()
+                ),
+            })?;
+        if slot.is_some() {
+            return Err(PrismError::InvalidParameter {
+                message: format!("duplicate reroute for observable {}", reroute.observable),
+            });
+        }
+        validate_z_stabilizers(&reroute.stabilizers, program.num_qubits())?;
+        *slot = Some(reroute);
+    }
+
+    let mut means = Vec::with_capacity(observable_rows.len());
+    let mut estimates = Vec::with_capacity(observable_rows.len());
+    for (observable, row) in observable_rows.iter().enumerate() {
+        let mut terms = observable_row_to_pauli_terms(row, &record_to_qubit)?;
+        if let Some(reroute) = reroute_by_observable[observable] {
+            let support: Vec<usize> = terms.iter().map(|term| term.qubit).collect();
+            let route = min_cone_z_representative(&circuit, &support, &reroute.stabilizers)?;
+            verify_reroute_is_state_stabilizer(&circuit, &support, &route.rerouted_support)?;
+            terms = route
+                .rerouted_support
+                .iter()
+                .copied()
+                .map(PauliTerm::z)
+                .collect();
+        }
+        let result =
+            run_spd_observable_light_cone(&circuit, &terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
+        means.push(result.mean);
+        estimates.push(QecObservableEstimate {
+            mean: result.mean,
+            variance: result.total_discarded * result.total_discarded,
+            num_shots: program.options().shots,
+        });
+    }
+
+    build_qec_result_from_observable_means(program, means, estimates)
+}
+
+/// SPD analytical path for QEC observables.
+///
+/// Backward-propagates the observable through its inverse light cone, branching each
+/// T into two weighted Pauli terms, truncating terms below
+/// `QEC_SPD_EPSILON` when the sum exceeds `QEC_SPD_MAX_TERMS`. Returns
+/// the diagonal sum on `|0^n⟩` per observable. Truncation error is
+/// reported via `QecObservableEstimate::variance = total_discarded²`.
+fn run_qec_program_spd(program: &QecProgram) -> Result<QecSampleResult> {
+    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let observable_rows = program.observable_rows()?;
+    let postsel_rows = program.postselection_rows()?;
+    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
+    for row in observable_rows.iter() {
+        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
+    }
+
+    if postsel_rows.is_empty() {
+        let mut means = Vec::with_capacity(observable_terms_list.len());
+        let mut estimates = Vec::with_capacity(observable_terms_list.len());
+        for terms in &observable_terms_list {
+            let result =
+                run_spd_observable_light_cone(&circuit, terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
+            means.push(result.mean);
+            estimates.push(QecObservableEstimate {
+                mean: result.mean,
+                variance: result.total_discarded * result.total_discarded,
+                num_shots: program.options().shots,
+            });
+        }
+        return build_qec_result_from_observable_means(program, means, estimates);
+    }
+
+    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
+    let (means, obs_discarded, accept_rate) =
+        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
+            let result =
+                run_spd_observable_light_cone(&circuit, terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
+            Ok(ConditionalEval {
+                mean: result.mean,
+                discarded_sq: result.total_discarded * result.total_discarded,
+            })
+        })?;
+    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
+    let estimates: Vec<_> = means
+        .iter()
+        .zip(obs_discarded.iter())
+        .map(|(&m, &discarded_sq)| QecObservableEstimate {
+            mean: m,
+            variance: discarded_sq,
+            num_shots: estimate_shots,
+        })
+        .collect();
+    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SEED: u64 = 0xDEAD_BEEF;
+
+    struct AutoHookGuard;
+
+    impl AutoHookGuard {
+        fn force_spd_nonexact_and_camps_failure() -> Self {
+            super::auto_test_hooks::set_force_spd_nonexact(true);
+            super::auto_test_hooks::set_force_camps_failure(true);
+            Self
+        }
+    }
+
+    impl Drop for AutoHookGuard {
+        fn drop(&mut self) {
+            super::auto_test_hooks::set_force_spd_nonexact(false);
+            super::auto_test_hooks::set_force_camps_failure(false);
+        }
+    }
+
+    fn options(shots: usize) -> QecOptions {
+        QecOptions {
+            shots,
+            seed: TEST_SEED,
+            chunk_size: Some(128),
+            keep_measurements: false,
+        }
+    }
+
+    fn h_t_h_program(shots: usize) -> QecProgram {
+        let mut program = QecProgram::with_options(1, options(shots));
+        program.push_gate(Gate::H, &[0]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        program.push_gate(Gate::H, &[0]).unwrap();
+        let m0 = program.measure_z(0).unwrap();
+        program
+            .observable_include(0, &[QecRecordRef::absolute(m0)])
+            .unwrap();
+        program
+    }
+
+    fn entangled_xor_program(shots: usize) -> QecProgram {
+        let mut program = QecProgram::with_options(3, options(shots));
+        program.push_gate(Gate::H, &[0]).unwrap();
+        program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+        program.push_gate(Gate::Cx, &[1, 2]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        for qubit in 0..3 {
+            program.push_gate(Gate::H, &[qubit]).unwrap();
+        }
+        let mut records = Vec::new();
+        for qubit in 0..3 {
+            records.push(QecRecordRef::absolute(program.measure_z(qubit).unwrap()));
+        }
+        program.observable_include(0, &records).unwrap();
+        program
+    }
+
+    fn postselected_program(shots: usize) -> QecProgram {
+        let mut program = QecProgram::with_options(1, options(shots));
+        program.push_gate(Gate::H, &[0]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        let m0 = program.measure_z(0).unwrap();
+        program.reset(QecBasis::Z, 0).unwrap();
+        program.push_gate(Gate::H, &[0]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        let m1 = program.measure_z(0).unwrap();
+        program
+            .postselect(&[QecRecordRef::absolute(m0)], false)
+            .unwrap();
+        program
+            .observable_include(0, &[QecRecordRef::absolute(m1)])
+            .unwrap();
+        program
+    }
+
+    fn deterministic_t_zero_program(shots: usize) -> QecProgram {
+        let mut program = QecProgram::with_options(1, options(shots));
+        program.push_gate(Gate::T, &[0]).unwrap();
+        let m0 = program.measure_z(0).unwrap();
+        program
+            .observable_include(0, &[QecRecordRef::absolute(m0)])
+            .unwrap();
+        program
+    }
+
+    fn deterministic_t_one_program(shots: usize) -> QecProgram {
+        let mut program = QecProgram::with_options(1, options(shots));
+        program.push_gate(Gate::X, &[0]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        let m0 = program.measure_z(0).unwrap();
+        program
+            .observable_include(0, &[QecRecordRef::absolute(m0)])
+            .unwrap();
+        program
+    }
+
+    fn estimates(result: &QecSampleResult) -> &[QecObservableEstimate] {
+        result
+            .observable_expectations
+            .as_ref()
+            .expect("analytical result must populate observable expectations")
+    }
+
+    fn assert_estimates_close(actual: &QecSampleResult, expected: &QecSampleResult) {
+        let actual_estimates = estimates(actual);
+        let expected_estimates = estimates(expected);
+        assert_eq!(actual_estimates.len(), expected_estimates.len());
+        for (idx, (actual, expected)) in actual_estimates
+            .iter()
+            .zip(expected_estimates.iter())
+            .enumerate()
+        {
+            assert!(
+                (actual.mean - expected.mean).abs() < 1e-10,
+                "observable {idx}: tensor-network mean {} differs from expected {}",
+                actual.mean,
+                expected.mean
+            );
+            assert_eq!(actual.variance, 0.0);
+        }
+        assert_eq!(actual.accepted_shots, expected.accepted_shots);
+        assert_eq!(actual.discarded_shots, expected.discarded_shots);
+        assert_eq!(actual.logical_errors, expected.logical_errors);
+    }
+
+    #[test]
+    fn tensor_network_observable_matches_spd_on_small_non_truncated_programs() {
+        let fixtures = vec![
+            h_t_h_program(512),
+            entangled_xor_program(512),
+            postselected_program(512),
+        ];
+        for program in fixtures {
+            let spd = run_qec_program_spd(&program).unwrap();
+            assert!(analytical_result_has_no_truncation(&spd));
+            let tensor_network = run_qec_program_tensor_network_observable(&program).unwrap();
+            assert_estimates_close(&tensor_network, &spd);
+        }
+    }
+
+    #[test]
+    fn tensor_network_observable_matches_reference_on_deterministic_t_fixtures() {
+        let fixtures = vec![
+            deterministic_t_zero_program(128),
+            deterministic_t_one_program(128),
+        ];
+        for program in fixtures {
+            let reference = run_qec_program_reference(&program).unwrap();
+            let tensor_network = run_qec_program_tensor_network_observable(&program).unwrap();
+            assert_eq!(tensor_network.accepted_shots, reference.accepted_shots);
+            assert_eq!(tensor_network.discarded_shots, reference.discarded_shots);
+            assert_eq!(tensor_network.logical_errors, reference.logical_errors);
+        }
+    }
+
+    #[test]
+    fn auto_uses_tensor_network_when_spd_nonexact_and_camps_fails() {
+        let program = h_t_h_program(256);
+        let expected = run_qec_program_tensor_network_observable(&program).unwrap();
+        let _guard = AutoHookGuard::force_spd_nonexact_and_camps_failure();
+        let actual = run_qec_program_auto(&program).unwrap();
+        assert_estimates_close(&actual, &expected);
+    }
+}

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -319,6 +319,7 @@ fn run_with_internal(
     if matches!(kind, BackendKind::Auto)
         && circuit.is_clifford_plus_t()
         && circuit.has_t_gates()
+        && !has_nonunitary_or_classical_ops(circuit)
         && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
     {
         let t = circuit.t_count();
@@ -741,6 +742,22 @@ pub(crate) fn run_shots_with(
             shots,
             num_classical_bits: circuit.num_classical_bits,
         });
+    }
+
+    if matches!(kind, BackendKind::StabilizerRank) && circuit.has_t_gates() {
+        return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+    }
+    if matches!(kind, BackendKind::Auto)
+        && circuit.has_terminal_measurements_only()
+        && circuit.is_clifford_plus_t()
+        && circuit.has_t_gates()
+        && circuit.num_qubits > MAX_STABILIZER_RANK_QUBITS
+    {
+        let t = circuit.t_count();
+        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
+        if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
+            return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+        }
     }
 
     if circuit.has_terminal_measurements_only() {

--- a/src/sim/stabilizer_rank.rs
+++ b/src/sim/stabilizer_rank.rs
@@ -1,14 +1,23 @@
 //! Stabilizer rank simulation for Clifford+T circuits.
 //!
-//! Maintains a weighted sum of stabilizer states: |ψ⟩ = Σ_k c_k |φ_k⟩.
-//! Clifford gates are applied to all terms (O(n²) per term). Each T gate
-//! expands every term into two via T = α·I + β·Z, doubling the term count.
+//! Pauli-offset representation: every branch of the T = αI + βZ expansion is
+//! written as `branch_k = w_k · P_k · |ψ_0⟩`, where `|ψ_0⟩` is the result of
+//! running every Clifford in the circuit on `|0…0⟩` with no Z insertions, and
+//! `P_k` is a signed Pauli string accumulating the Zs that earlier T-positions
+//! chose, each conjugated through the Cliffords that followed it
+//! (Heisenberg picture: `U Z_q U†` is a signed Pauli for any Clifford `U`).
+//!
+//! A single shared [`StabilizerBackend`] evolves `|ψ_0⟩`; each branch is a
+//! `(weight, SignedPauli)` pair. Accumulation reconstructs the statevector once
+//! and routes amplitudes through each branch's Pauli, sidestepping the global
+//! phase ambiguity inherent in per-branch tableau export.
 //!
 //! Two modes:
-//! - **Exact probabilities** (n ≤ 25): export statevectors per term, accumulate
-//!   weighted amplitudes, compute |amplitude|² for each basis state.
-//! - **Measurement sampling** (any n): compute Born probabilities via pairwise
-//!   stabilizer inner products O(χ² · n³), sample outcomes.
+//! - **Exact probabilities** (n ≤ 25): reconstruct `|ψ_0⟩`, sum weighted
+//!   Pauli-shifted amplitudes, compute |amplitude|² for each basis state.
+//! - **Measurement sampling** (any n): keep coherent weighted MPS branches,
+//!   project requested measurement outcomes, and contract pairwise branch
+//!   overlaps without materializing a dense statevector.
 
 use num_complex::Complex64;
 use rand::Rng;
@@ -16,14 +25,268 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use std::f64::consts::FRAC_PI_4;
 
+use crate::backend::mps::MpsBackend;
 use crate::backend::stabilizer::StabilizerBackend;
 use crate::backend::Backend;
 use crate::circuit::{Circuit, Instruction, SmallVec};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
+/// Letter-level signed Pauli string. Each qubit's `(x, z)` bit pair encodes
+/// the Pauli letter directly: (0,0)=I, (1,0)=X, (0,1)=Z, (1,1)=Y. `phase4` is
+/// the extra `i^{phase4}` global factor multiplying the product, so `Y_q` is
+/// stored as `x=1,z=1,phase4=0` (the `i` in `Y=iXZ` is baked into the letter
+/// convention, not the global phase).
+///
+/// This shares its letter and `phase4` convention with
+/// [`crate::qec::camps_prefix`]'s `SignedPauli`, but the two are kept
+/// separate on purpose: this type tracks a single observable string with
+/// dense `Vec<bool>` storage and forward `G·P·G†` conjugation, while the
+/// CAMPS variant maintains a full inverse Clifford tableau with packed
+/// `Vec<u64>` rows and `rowmul`. Any change to the (x,z)->letter or
+/// `phase4` convention must be mirrored in both.
+#[derive(Clone, Debug)]
+struct SignedPauli {
+    x: Vec<bool>,
+    z: Vec<bool>,
+    phase4: u8,
+}
+
+impl SignedPauli {
+    fn identity(n: usize) -> Self {
+        Self {
+            x: vec![false; n],
+            z: vec![false; n],
+            phase4: 0,
+        }
+    }
+
+    /// `P ← Z_q · P`. Letter table for (Z) · (letter): Z·I=Z, Z·X=iY,
+    /// Z·Y=-iX, Z·Z=I.
+    fn mul_z_on_left(&mut self, q: usize) {
+        let xb = self.x[q];
+        let zb = self.z[q];
+        match (xb, zb) {
+            (false, false) => {
+                self.z[q] = true;
+            }
+            (true, false) => {
+                self.z[q] = true;
+                self.phase4 = (self.phase4 + 1) & 3;
+            }
+            (true, true) => {
+                self.z[q] = false;
+                self.phase4 = (self.phase4 + 3) & 3;
+            }
+            (false, true) => {
+                self.z[q] = false;
+            }
+        }
+    }
+
+    /// `P ← G · P · G†` for supported Clifford gates.
+    fn conjugate_by(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        match gate {
+            Gate::Id => Ok(()),
+            Gate::H => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                self.x[q] = zb;
+                self.z[q] = xb;
+                if xb && zb {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::S => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                match (xb, zb) {
+                    (true, false) => {
+                        self.z[q] = true;
+                    }
+                    (true, true) => {
+                        self.z[q] = false;
+                        self.phase4 = (self.phase4 + 2) & 3;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+            Gate::Sdg => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                match (xb, zb) {
+                    (true, false) => {
+                        self.z[q] = true;
+                        self.phase4 = (self.phase4 + 2) & 3;
+                    }
+                    (true, true) => {
+                        self.z[q] = false;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+            Gate::SX => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                match (xb, zb) {
+                    (true, true) => {
+                        self.x[q] = false;
+                    }
+                    (false, true) => {
+                        self.x[q] = true;
+                        self.phase4 = (self.phase4 + 2) & 3;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+            Gate::SXdg => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                match (xb, zb) {
+                    (true, true) => {
+                        self.x[q] = false;
+                        self.phase4 = (self.phase4 + 2) & 3;
+                    }
+                    (false, true) => {
+                        self.x[q] = true;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+            Gate::X => {
+                let q = targets[0];
+                if self.z[q] {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::Y => {
+                let q = targets[0];
+                let (xb, zb) = (self.x[q], self.z[q]);
+                if xb != zb {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::Z => {
+                let q = targets[0];
+                if self.x[q] {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::Cx => {
+                let c = targets[0];
+                let t = targets[1];
+                let (xc, zc, xt, zt) = (self.x[c], self.z[c], self.x[t], self.z[t]);
+                self.x[t] = xt ^ xc;
+                self.z[c] = zc ^ zt;
+                if xc && zt && (xt == zc) {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::Cz => {
+                let a = targets[0];
+                let b = targets[1];
+                let (xa, za, xb_, zb_) = (self.x[a], self.z[a], self.x[b], self.z[b]);
+                self.z[a] = za ^ xb_;
+                self.z[b] = zb_ ^ xa;
+                if xa && xb_ && (za != zb_) {
+                    self.phase4 = (self.phase4 + 2) & 3;
+                }
+                Ok(())
+            }
+            Gate::Swap => {
+                let a = targets[0];
+                let b = targets[1];
+                self.x.swap(a, b);
+                self.z.swap(a, b);
+                Ok(())
+            }
+            _ => Err(PrismError::BackendUnsupported {
+                backend: "stabilizer_rank".into(),
+                operation: format!("Pauli conjugation by non-Clifford gate `{}`", gate.name()),
+            }),
+        }
+    }
+
+    /// `P|input⟩ = phase · |x_out⟩`. Returns `(phase, x_out)`.
+    fn act_on_basis(&self, input: usize) -> (Complex64, usize) {
+        let mut x_out = input;
+        let mut phase4 = self.phase4 as u32;
+        for q in 0..self.x.len() {
+            let xq = self.x[q];
+            let zq = self.z[q];
+            let bit = (input >> q) & 1 == 1;
+            match (xq, zq) {
+                (false, false) => {}
+                (true, false) => {
+                    x_out ^= 1 << q;
+                }
+                (false, true) => {
+                    if bit {
+                        phase4 += 2;
+                    }
+                }
+                (true, true) => {
+                    // Y|0⟩ = i|1⟩, Y|1⟩ = -i|0⟩.
+                    x_out ^= 1 << q;
+                    phase4 += if bit { 3 } else { 1 };
+                }
+            }
+        }
+        let phase = match (phase4 & 3) as u8 {
+            0 => Complex64::new(1.0, 0.0),
+            1 => Complex64::new(0.0, 1.0),
+            2 => Complex64::new(-1.0, 0.0),
+            3 => Complex64::new(0.0, -1.0),
+            _ => unreachable!(),
+        };
+        (phase, x_out)
+    }
+}
+
 const MAX_STATEVECTOR_QUBITS: usize = 25;
 const MAX_TERMS: usize = 1 << 20; // 1M terms safety limit
+
+fn validate_stabilizer_rank_circuit(circuit: &Circuit) -> Result<()> {
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate { gate, .. } => {
+                if !(gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)) {
+                    return Err(PrismError::BackendUnsupported {
+                        backend: "stabilizer_rank".into(),
+                        operation: format!("non-Clifford+T gate `{}`", gate.name()),
+                    });
+                }
+            }
+            Instruction::Measure { .. } | Instruction::Reset { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "stabilizer_rank".into(),
+                    reason:
+                        "stabilizer-rank probabilities require a unitary circuit without measurements or resets"
+                            .to_string(),
+                });
+            }
+            Instruction::Conditional { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "stabilizer_rank".into(),
+                    reason:
+                        "stabilizer-rank probabilities require a unitary circuit without conditionals"
+                            .to_string(),
+                });
+            }
+            Instruction::Barrier { .. } => {}
+        }
+    }
+    Ok(())
+}
 
 fn t_coefficients() -> (Complex64, Complex64) {
     let exp_i_pi_4 = Complex64::new(FRAC_PI_4.cos(), FRAC_PI_4.sin());
@@ -37,10 +300,18 @@ fn tdg_coefficients() -> (Complex64, Complex64) {
     (alpha.conj(), beta.conj())
 }
 
-/// A weighted stabilizer state: coefficient × stabilizer tableau.
-struct WeightedStabilizer {
+/// A weighted Pauli-offset branch: `weight · offset · |ψ_0⟩`.
+struct WeightedBranch {
     weight: Complex64,
-    backend: StabilizerBackend,
+    offset: SignedPauli,
+}
+
+/// A coherent branch for shot sampling. MPS storage keeps branch phases
+/// explicit and avoids dense statevector materialization.
+#[derive(Clone)]
+struct WeightedMpsBranch {
+    weight: Complex64,
+    state: MpsBackend,
 }
 
 /// Result of stabilizer rank probability computation.
@@ -77,12 +348,15 @@ pub fn run_stabilizer_rank(circuit: &Circuit, seed: u64) -> Result<StabRankResul
             ),
         });
     }
+    validate_stabilizer_rank_circuit(circuit)?;
 
-    let mut terms: Vec<WeightedStabilizer> = vec![WeightedStabilizer {
+    let mut backend = StabilizerBackend::new(seed);
+    backend.init(n, nc)?;
+
+    let mut branches: Vec<WeightedBranch> = vec![WeightedBranch {
         weight: Complex64::new(1.0, 0.0),
-        backend: StabilizerBackend::new(seed),
+        offset: SignedPauli::identity(n),
     }];
-    terms[0].backend.init(n, nc)?;
 
     let mut t_count = 0usize;
 
@@ -91,58 +365,68 @@ pub fn run_stabilizer_rank(circuit: &Circuit, seed: u64) -> Result<StabRankResul
             Instruction::Gate { gate, targets } => match gate {
                 Gate::T => {
                     t_count += 1;
-                    expand_t(&mut terms, targets[0], false)?;
+                    expand_t(&mut branches, targets[0], false)?;
                 }
                 Gate::Tdg => {
                     t_count += 1;
-                    expand_t(&mut terms, targets[0], true)?;
+                    expand_t(&mut branches, targets[0], true)?;
                 }
-                _ => apply_to_all_terms(&mut terms, inst)?,
+                _ => {
+                    backend.apply(inst)?;
+                    conjugate_all(&mut branches, gate, targets)?;
+                }
             },
-            _ => apply_to_all_terms(&mut terms, inst)?,
+            _ => {
+                backend.apply(inst)?;
+            }
         }
     }
 
-    accumulate_probabilities(&terms, n).map(|probabilities| StabRankResult {
+    accumulate_probabilities(&backend, &branches, n).map(|probabilities| StabRankResult {
         probabilities,
-        num_terms: terms.len(),
+        num_terms: branches.len(),
         t_count,
         pruned_count: 0,
     })
 }
 
-/// Apply an instruction to all terms, parallelized when term count is large.
-fn apply_to_all_terms(terms: &mut [WeightedStabilizer], inst: &Instruction) -> Result<()> {
+fn conjugate_all(branches: &mut [WeightedBranch], gate: &Gate, targets: &[usize]) -> Result<()> {
     #[cfg(feature = "parallel")]
-    if terms.len() >= MIN_TERMS_FOR_PAR {
+    if branches.len() >= MIN_TERMS_FOR_PAR {
         use rayon::prelude::*;
-        terms
+        branches
             .par_iter_mut()
-            .try_for_each(|term| term.backend.apply(inst))?;
+            .try_for_each(|b| b.offset.conjugate_by(gate, targets))?;
         return Ok(());
     }
-
-    for term in terms.iter_mut() {
-        term.backend.apply(inst)?;
+    for b in branches.iter_mut() {
+        b.offset.conjugate_by(gate, targets)?;
     }
     Ok(())
 }
 
-/// Accumulate weighted amplitudes across all terms and compute probabilities.
-fn accumulate_probabilities(terms: &[WeightedStabilizer], n: usize) -> Result<Vec<f64>> {
+/// Reconstruct `|ψ_0⟩` once, then route each branch's contribution through
+/// its Pauli offset. The global phase of `|ψ_0⟩` is a common factor across
+/// every branch and cancels in `|·|²`.
+fn accumulate_probabilities(
+    backend: &StabilizerBackend,
+    branches: &[WeightedBranch],
+    n: usize,
+) -> Result<Vec<f64>> {
     let dim = 1usize << n;
     let zero = Complex64::new(0.0, 0.0);
+    let psi0 = backend.export_statevector()?;
 
     #[cfg(feature = "parallel")]
-    if terms.len() >= MIN_TERMS_FOR_PAR {
+    if branches.len() >= MIN_TERMS_FOR_PAR {
         use rayon::prelude::*;
-        let total_amps = terms
+        let total_amps = branches
             .par_iter()
-            .map(|term| {
-                let amps = term.backend.export_statevector().unwrap();
+            .map(|b| {
                 let mut partial = vec![zero; dim];
-                for (i, amp) in amps.iter().enumerate() {
-                    partial[i] = term.weight * amp;
+                for (y, amp) in psi0.iter().enumerate() {
+                    let (phase, x_out) = b.offset.act_on_basis(y);
+                    partial[x_out] += b.weight * phase * amp;
                 }
                 partial
             })
@@ -159,24 +443,27 @@ fn accumulate_probabilities(terms: &[WeightedStabilizer], n: usize) -> Result<Ve
     }
 
     let mut total_amps = vec![zero; dim];
-    for term in terms {
-        let amps = term.backend.export_statevector()?;
-        for (i, amp) in amps.iter().enumerate() {
-            total_amps[i] += term.weight * amp;
+    for b in branches {
+        for (y, amp) in psi0.iter().enumerate() {
+            let (phase, x_out) = b.offset.act_on_basis(y);
+            total_amps[x_out] += b.weight * phase * amp;
         }
     }
     Ok(total_amps.iter().map(|a| a.norm_sqr()).collect())
 }
 
-/// Expand each term by T = α·I + β·Z decomposition on target qubit.
-fn expand_t(terms: &mut Vec<WeightedStabilizer>, qubit: usize, is_dagger: bool) -> Result<()> {
-    let new_count = terms
-        .len()
-        .checked_mul(2)
-        .ok_or_else(|| PrismError::BackendUnsupported {
-            backend: "stabilizer_rank".into(),
-            operation: "term count overflow".into(),
-        })?;
+/// Split each branch by T = α·I + β·Z on `qubit`. The β branch left-multiplies
+/// the offset by `Z_qubit` (since the T expansion inserts Z to the left of the
+/// existing accumulated Pauli, in the order the gates have been processed).
+fn expand_t(branches: &mut Vec<WeightedBranch>, qubit: usize, is_dagger: bool) -> Result<()> {
+    let new_count =
+        branches
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| PrismError::BackendUnsupported {
+                backend: "stabilizer_rank".into(),
+                operation: "term count overflow".into(),
+            })?;
     if new_count > MAX_TERMS {
         return Err(PrismError::BackendUnsupported {
             backend: "stabilizer_rank".into(),
@@ -190,25 +477,20 @@ fn expand_t(terms: &mut Vec<WeightedStabilizer>, qubit: usize, is_dagger: bool) 
         t_coefficients()
     };
 
-    let orig_len = terms.len();
-    let mut new_terms = Vec::with_capacity(orig_len);
+    let orig_len = branches.len();
+    let mut new_branches = Vec::with_capacity(orig_len);
 
-    for term in terms.iter_mut() {
-        let mut z_backend = term.backend.clone();
-        let z_inst = Instruction::Gate {
-            gate: Gate::Z,
-            targets: SmallVec::from_slice(&[qubit]),
-        };
-        z_backend.apply(&z_inst)?;
-        new_terms.push(WeightedStabilizer {
-            weight: term.weight * beta,
-            backend: z_backend,
+    for b in branches.iter_mut() {
+        let mut z_offset = b.offset.clone();
+        z_offset.mul_z_on_left(qubit);
+        new_branches.push(WeightedBranch {
+            weight: b.weight * beta,
+            offset: z_offset,
         });
-
-        term.weight *= alpha;
+        b.weight *= alpha;
     }
 
-    terms.extend(new_terms);
+    branches.extend(new_branches);
     Ok(())
 }
 
@@ -234,15 +516,18 @@ pub fn run_stabilizer_rank_approx(
             ),
         });
     }
+    validate_stabilizer_rank_circuit(circuit)?;
 
     let max_terms = max_terms.max(2);
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
-    let mut terms: Vec<WeightedStabilizer> = vec![WeightedStabilizer {
+    let mut backend = StabilizerBackend::new(seed);
+    backend.init(n, nc)?;
+
+    let mut branches: Vec<WeightedBranch> = vec![WeightedBranch {
         weight: Complex64::new(1.0, 0.0),
-        backend: StabilizerBackend::new(seed),
+        offset: SignedPauli::identity(n),
     }];
-    terms[0].backend.init(n, nc)?;
 
     let mut t_count = 0usize;
     let mut pruned_total = 0usize;
@@ -252,83 +537,75 @@ pub fn run_stabilizer_rank_approx(
             Instruction::Gate { gate, targets } => match gate {
                 Gate::T => {
                     t_count += 1;
-                    expand_t_unbounded(&mut terms, targets[0], false)?;
-                    pruned_total += prune_terms(&mut terms, max_terms, &mut rng);
+                    expand_t_unbounded(&mut branches, targets[0], false);
+                    pruned_total += prune_terms(&mut branches, max_terms, &mut rng);
                 }
                 Gate::Tdg => {
                     t_count += 1;
-                    expand_t_unbounded(&mut terms, targets[0], true)?;
-                    pruned_total += prune_terms(&mut terms, max_terms, &mut rng);
+                    expand_t_unbounded(&mut branches, targets[0], true);
+                    pruned_total += prune_terms(&mut branches, max_terms, &mut rng);
                 }
-                _ => apply_to_all_terms(&mut terms, inst)?,
+                _ => {
+                    backend.apply(inst)?;
+                    conjugate_all(&mut branches, gate, targets)?;
+                }
             },
-            _ => apply_to_all_terms(&mut terms, inst)?,
+            _ => {
+                backend.apply(inst)?;
+            }
         }
     }
 
-    accumulate_probabilities(&terms, n).map(|probabilities| StabRankResult {
+    accumulate_probabilities(&backend, &branches, n).map(|probabilities| StabRankResult {
         probabilities,
-        num_terms: terms.len(),
+        num_terms: branches.len(),
         t_count,
         pruned_count: pruned_total,
     })
 }
 
-/// Expand terms without the MAX_TERMS safety check (for approximate mode).
-fn expand_t_unbounded(
-    terms: &mut Vec<WeightedStabilizer>,
-    qubit: usize,
-    is_dagger: bool,
-) -> Result<()> {
+fn expand_t_unbounded(branches: &mut Vec<WeightedBranch>, qubit: usize, is_dagger: bool) {
     let (alpha, beta) = if is_dagger {
         tdg_coefficients()
     } else {
         t_coefficients()
     };
 
-    let orig_len = terms.len();
-    let mut new_terms = Vec::with_capacity(orig_len);
+    let orig_len = branches.len();
+    let mut new_branches = Vec::with_capacity(orig_len);
 
-    for term in terms.iter_mut() {
-        let mut z_backend = term.backend.clone();
-        let z_inst = Instruction::Gate {
-            gate: Gate::Z,
-            targets: SmallVec::from_slice(&[qubit]),
-        };
-        z_backend.apply(&z_inst)?;
-        new_terms.push(WeightedStabilizer {
-            weight: term.weight * beta,
-            backend: z_backend,
+    for b in branches.iter_mut() {
+        let mut z_offset = b.offset.clone();
+        z_offset.mul_z_on_left(qubit);
+        new_branches.push(WeightedBranch {
+            weight: b.weight * beta,
+            offset: z_offset,
         });
-        term.weight *= alpha;
+        b.weight *= alpha;
     }
 
-    terms.extend(new_terms);
-    Ok(())
+    branches.extend(new_branches);
 }
 
-/// Prune terms to at most `max_terms` by discarding lowest-weight terms.
-///
-/// Sorts by descending weight magnitude, keeps the top `max_terms`.
-/// Returns the number of pruned terms.
+/// Prune branches by descending weight magnitude.
 fn prune_terms(
-    terms: &mut Vec<WeightedStabilizer>,
+    branches: &mut Vec<WeightedBranch>,
     max_terms: usize,
     _rng: &mut ChaCha8Rng,
 ) -> usize {
-    if terms.len() <= max_terms {
+    if branches.len() <= max_terms {
         return 0;
     }
 
-    terms.sort_by(|a, b| {
+    branches.sort_by(|a, b| {
         b.weight
             .norm_sqr()
             .partial_cmp(&a.weight.norm_sqr())
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let pruned = terms.len() - max_terms;
-    terms.truncate(max_terms);
+    let pruned = branches.len() - max_terms;
+    branches.truncate(max_terms);
     pruned
 }
 
@@ -455,135 +732,370 @@ pub fn stabilizer_overlap_sq(s1: &StabilizerBackend, s2: &StabilizerBackend, n: 
     2.0_f64.powi(n as i32 - rank as i32)
 }
 
-struct TGateLocation {
-    instruction_index: usize,
-    qubit: usize,
+/// Phase-sensitive stabilizer inner product for small validation fixtures.
+///
+/// Dense export is intentionally limited to the same size as probability
+/// extraction. Large-qubit shot sampling uses MPS branch contraction below.
+pub fn stabilizer_inner_product(
+    s1: &StabilizerBackend,
+    s2: &StabilizerBackend,
+    n: usize,
+) -> Result<Complex64> {
+    if n > MAX_STATEVECTOR_QUBITS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!(
+                "dense stabilizer inner product validation for {} qubits (max {})",
+                n, MAX_STATEVECTOR_QUBITS
+            ),
+        });
+    }
+    let v1 = s1.export_statevector()?;
+    let v2 = s2.export_statevector()?;
+    Ok(v1.iter().zip(v2.iter()).map(|(a, b)| a.conj() * b).sum())
 }
 
-fn find_t_gates(circuit: &Circuit) -> Vec<TGateLocation> {
-    circuit
-        .instructions
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, inst)| match inst {
-            Instruction::Gate {
-                gate: Gate::T | Gate::Tdg,
-                targets,
-            } if targets.len() == 1 => Some(TGateLocation {
-                instruction_index: idx,
-                qubit: targets[0],
-            }),
-            _ => None,
-        })
-        .collect()
-}
-
-fn build_clifford_branch(
-    circuit: &Circuit,
-    t_locations: &[TGateLocation],
-    branch_bits: u64,
-) -> Circuit {
-    let mut out = Circuit::new(circuit.num_qubits, circuit.num_classical_bits);
-    out.instructions.reserve(circuit.instructions.len());
-
-    let mut t_idx = 0;
-
-    for (instr_idx, inst) in circuit.instructions.iter().enumerate() {
-        if t_idx < t_locations.len() && t_locations[t_idx].instruction_index == instr_idx {
-            let loc = &t_locations[t_idx];
-            if (branch_bits >> t_idx) & 1 == 1 {
-                out.instructions.push(Instruction::Gate {
-                    gate: Gate::Z,
-                    targets: SmallVec::from_slice(&[loc.qubit]),
-                });
+fn validate_stabilizer_rank_shot_circuit(circuit: &Circuit) -> Result<()> {
+    for inst in &circuit.instructions {
+        let gate = match inst {
+            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => gate,
+            Instruction::Measure { .. }
+            | Instruction::Reset { .. }
+            | Instruction::Barrier { .. } => {
+                continue;
             }
-            t_idx += 1;
-        } else {
-            out.instructions.push(inst.clone());
+        };
+        if !(gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)) {
+            return Err(PrismError::BackendUnsupported {
+                backend: "stabilizer_rank".into(),
+                operation: format!("non-Clifford+T gate `{}`", gate.name()),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn initial_mps_branches(circuit: &Circuit, seed: u64) -> Result<Vec<WeightedMpsBranch>> {
+    validate_stabilizer_rank_shot_circuit(circuit)?;
+    let mut state = MpsBackend::new_exact(seed);
+    state.init(circuit.num_qubits, circuit.num_classical_bits)?;
+    Ok(vec![WeightedMpsBranch {
+        weight: Complex64::new(1.0, 0.0),
+        state,
+    }])
+}
+
+fn apply_mps_gate(
+    branches: &mut Vec<WeightedMpsBranch>,
+    gate: &Gate,
+    targets: &[usize],
+) -> Result<()> {
+    match gate {
+        Gate::T => expand_t_mps(branches, targets[0], false),
+        Gate::Tdg => expand_t_mps(branches, targets[0], true),
+        _ if gate.is_clifford() => {
+            let inst = Instruction::Gate {
+                gate: gate.clone(),
+                targets: SmallVec::from_slice(targets),
+            };
+            for branch in branches {
+                branch.state.apply(&inst)?;
+            }
+            Ok(())
+        }
+        _ => Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!("non-Clifford+T gate `{}`", gate.name()),
+        }),
+    }
+}
+
+fn expand_t_mps(
+    branches: &mut Vec<WeightedMpsBranch>,
+    qubit: usize,
+    is_dagger: bool,
+) -> Result<()> {
+    let new_count =
+        branches
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| PrismError::BackendUnsupported {
+                backend: "stabilizer_rank".into(),
+                operation: "term count overflow".into(),
+            })?;
+    if new_count > MAX_TERMS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!("too many terms ({} > {})", new_count, MAX_TERMS),
+        });
+    }
+
+    let (alpha, beta) = if is_dagger {
+        tdg_coefficients()
+    } else {
+        t_coefficients()
+    };
+    let z_inst = Instruction::Gate {
+        gate: Gate::Z,
+        targets: SmallVec::from_slice(&[qubit]),
+    };
+
+    let orig_len = branches.len();
+    let mut new_branches = Vec::with_capacity(orig_len);
+    for branch in branches.iter_mut() {
+        let mut z_branch = branch.clone();
+        z_branch.weight *= beta;
+        z_branch.state.apply(&z_inst)?;
+        new_branches.push(z_branch);
+        branch.weight *= alpha;
+    }
+    branches.extend(new_branches);
+    Ok(())
+}
+
+fn weighted_mps_norm_sq(branches: &[WeightedMpsBranch]) -> Result<f64> {
+    if branches.is_empty() {
+        return Ok(0.0);
+    }
+
+    let mut total = Complex64::new(0.0, 0.0);
+    for left in branches {
+        let left_weight = left.weight.conj();
+        for right in branches {
+            let overlap = left.state.inner_product(&right.state)?;
+            total += left_weight * right.weight * overlap;
         }
     }
 
-    out
-}
-
-fn run_branch(
-    circuit: &Circuit,
-    t_locations: &[TGateLocation],
-    branch_bits: u64,
-    seed: u64,
-) -> Result<Vec<bool>> {
-    let branch_circuit = build_clifford_branch(circuit, t_locations, branch_bits);
-    let mut backend = StabilizerBackend::new(seed);
-    backend.init(branch_circuit.num_qubits, branch_circuit.num_classical_bits)?;
-    for inst in &branch_circuit.instructions {
-        backend.apply(inst)?;
+    if !total.re.is_finite() || !total.im.is_finite() {
+        return Err(PrismError::InvalidParameter {
+            message: "stabilizer-rank MPS branch norm is not finite".to_string(),
+        });
     }
-    Ok(backend.classical_results().to_vec())
+    if total.re < -1e-8 || total.im.abs() > 1e-7 {
+        return Err(PrismError::InvalidParameter {
+            message: format!("invalid stabilizer-rank MPS branch norm {total:?}"),
+        });
+    }
+    Ok(total.re.max(0.0))
 }
 
-/// Shot sampling on a Clifford+T circuit via stochastic branch selection.
-///
-/// Each shot randomly replaces T→I or T→Z weighted by |α|/|β|, producing a
-/// Clifford circuit that is simulated on the stabilizer backend. Uses
-/// antithetic pairing (complement branch) for variance reduction.
-pub fn run_stabilizer_rank_shots(
+fn project_mps_branches(
+    branches: &[WeightedMpsBranch],
+    qubit: usize,
+    outcome: bool,
+) -> Vec<WeightedMpsBranch> {
+    let mut projected = Vec::with_capacity(branches.len());
+    for branch in branches {
+        let mut next = branch.clone();
+        let prob = next.state.project_z_outcome(qubit, outcome);
+        if prob <= crate::backend::NORM_CLAMP_MIN {
+            continue;
+        }
+        next.weight *= prob.sqrt();
+        projected.push(next);
+    }
+    projected
+}
+
+fn normalize_mps_branches(branches: &mut [WeightedMpsBranch], norm_sq: f64) -> Result<()> {
+    if norm_sq <= crate::backend::NORM_CLAMP_MIN {
+        return Err(PrismError::InvalidParameter {
+            message: "stabilizer-rank projection eliminated every branch".to_string(),
+        });
+    }
+    let scale = 1.0 / norm_sq.sqrt();
+    for branch in branches {
+        branch.weight *= scale;
+    }
+    Ok(())
+}
+
+fn sample_mps_measurement(
+    branches: &mut Vec<WeightedMpsBranch>,
+    qubit: usize,
+    rng: &mut ChaCha8Rng,
+) -> Result<bool> {
+    let mut zero = project_mps_branches(branches, qubit, false);
+    let mut one = project_mps_branches(branches, qubit, true);
+    let norm_zero = weighted_mps_norm_sq(&zero)?;
+    let norm_one = weighted_mps_norm_sq(&one)?;
+    let denom = norm_zero + norm_one;
+    if denom <= crate::backend::NORM_CLAMP_MIN {
+        return Err(PrismError::InvalidParameter {
+            message: "stabilizer-rank measurement has zero total probability".to_string(),
+        });
+    }
+
+    let outcome = if norm_zero <= crate::backend::NORM_CLAMP_MIN {
+        true
+    } else if norm_one <= crate::backend::NORM_CLAMP_MIN {
+        false
+    } else {
+        rng.random::<f64>() < (norm_one / denom).clamp(0.0, 1.0)
+    };
+
+    if outcome {
+        normalize_mps_branches(&mut one, norm_one)?;
+        *branches = one;
+    } else {
+        normalize_mps_branches(&mut zero, norm_zero)?;
+        *branches = zero;
+    }
+    Ok(outcome)
+}
+
+fn apply_reset_mps(
+    branches: &mut Vec<WeightedMpsBranch>,
+    qubit: usize,
+    rng: &mut ChaCha8Rng,
+) -> Result<()> {
+    let measured_one = sample_mps_measurement(branches, qubit, rng)?;
+    if measured_one {
+        apply_mps_gate(branches, &Gate::X, &[qubit])?;
+    }
+    Ok(())
+}
+
+fn process_mps_instruction(
+    branches: &mut Vec<WeightedMpsBranch>,
+    inst: &Instruction,
+    classical_bits: &mut [bool],
+    rng: &mut ChaCha8Rng,
+) -> Result<()> {
+    match inst {
+        Instruction::Gate { gate, targets } => apply_mps_gate(branches, gate, targets),
+        Instruction::Measure {
+            qubit,
+            classical_bit,
+        } => {
+            let outcome = sample_mps_measurement(branches, *qubit, rng)?;
+            classical_bits[*classical_bit] = outcome;
+            Ok(())
+        }
+        Instruction::Reset { qubit } => apply_reset_mps(branches, *qubit, rng),
+        Instruction::Barrier { .. } => Ok(()),
+        Instruction::Conditional {
+            condition,
+            gate,
+            targets,
+        } => {
+            if condition.evaluate(classical_bits) {
+                apply_mps_gate(branches, gate, targets)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn build_mps_branches_for_unitary(circuit: &Circuit, seed: u64) -> Result<Vec<WeightedMpsBranch>> {
+    let mut branches = initial_mps_branches(circuit, seed)?;
+    let mut classical_bits = vec![false; circuit.num_classical_bits];
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate { .. } | Instruction::Barrier { .. } => {
+                process_mps_instruction(&mut branches, inst, &mut classical_bits, &mut rng)?;
+            }
+            Instruction::Measure { .. }
+            | Instruction::Reset { .. }
+            | Instruction::Conditional { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "stabilizer_rank".into(),
+                    reason: "unitary branch preparation cannot include measurements, resets, or conditionals"
+                        .to_string(),
+                });
+            }
+        }
+    }
+    Ok(branches)
+}
+
+fn sample_terminal_mps_branches(
+    base_branches: &[WeightedMpsBranch],
     circuit: &Circuit,
     num_shots: usize,
     seed: u64,
 ) -> Result<super::ShotsResult> {
-    let t_locations = find_t_gates(circuit);
-    let t_count = t_locations.len();
-
-    if t_count == 0 {
-        return super::run_shots_with(super::BackendKind::Stabilizer, circuit, num_shots, seed);
-    }
-    if t_count > 64 {
-        return Err(PrismError::BackendUnsupported {
-            backend: "stabilizer_rank".into(),
-            operation: format!("shot sampling for {} T-gates (max 64)", t_count),
-        });
-    }
-
-    let (alpha, beta) = t_coefficients();
-    let p_alpha = alpha.norm() / (alpha.norm() + beta.norm());
-    let t_mask = if t_count >= 64 {
-        u64::MAX
-    } else {
-        (1u64 << t_count) - 1
-    };
-
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut shots = Vec::with_capacity(num_shots);
-
-    while shots.len() < num_shots {
-        let mut branch_bits = 0u64;
-        for i in 0..t_count {
-            if rng.random::<f64>() >= p_alpha {
-                branch_bits |= 1u64 << i;
+    for _ in 0..num_shots {
+        let mut branches = base_branches.to_vec();
+        let mut classical_bits = vec![false; circuit.num_classical_bits];
+        for inst in &circuit.instructions {
+            if matches!(
+                inst,
+                Instruction::Measure { .. } | Instruction::Barrier { .. }
+            ) {
+                process_mps_instruction(&mut branches, inst, &mut classical_bits, &mut rng)?;
             }
         }
-
-        let branch_seed = rng.random::<u64>();
-        shots.push(run_branch(circuit, &t_locations, branch_bits, branch_seed)?);
-
-        if shots.len() < num_shots {
-            let anti_bits = !branch_bits & t_mask;
-            let anti_seed = rng.random::<u64>();
-            shots.push(run_branch(circuit, &t_locations, anti_bits, anti_seed)?);
-        }
+        shots.push(classical_bits);
     }
-
-    shots.truncate(num_shots);
-
     Ok(super::ShotsResult {
         shots,
         num_classical_bits: circuit.num_classical_bits,
     })
 }
 
+fn sample_mps_branches_online(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<super::ShotsResult> {
+    validate_stabilizer_rank_shot_circuit(circuit)?;
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut shots = Vec::with_capacity(num_shots);
+    for _ in 0..num_shots {
+        let mut branches = initial_mps_branches(circuit, seed)?;
+        let mut classical_bits = vec![false; circuit.num_classical_bits];
+        for inst in &circuit.instructions {
+            process_mps_instruction(&mut branches, inst, &mut classical_bits, &mut rng)?;
+        }
+        shots.push(classical_bits);
+    }
+    Ok(super::ShotsResult {
+        shots,
+        num_classical_bits: circuit.num_classical_bits,
+    })
+}
+
+/// Shot sampling on a Clifford+T circuit.
+///
+/// Samples from the coherent output distribution `|⟨x|ψ⟩|²`. The T branches
+/// `T = αI + βZ` must be summed into a single amplitude before squaring;
+/// sampling each branch independently as a classical mixture discards the
+/// interference between branches and produces the wrong outcome distribution
+/// (for example `H·T·H` would collapse to `[0.5, 0.5]` instead of
+/// `[cos²(π/8), sin²(π/8)]`).
+///
+/// Terminal and mid-circuit measurements are sampled by projecting coherent
+/// weighted branches and contracting branch overlaps. This avoids the dense
+/// statevector cap used by probability-vector APIs.
+pub fn run_stabilizer_rank_shots(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<super::ShotsResult> {
+    if !circuit.has_t_gates() {
+        return super::run_shots_with(super::BackendKind::Stabilizer, circuit, num_shots, seed);
+    }
+
+    validate_stabilizer_rank_shot_circuit(circuit)?;
+
+    if circuit.has_terminal_measurements_only() && !circuit.has_resets() {
+        let stripped = circuit.without_measurements();
+        let base_branches = build_mps_branches_for_unitary(&stripped, seed)?;
+        return sample_terminal_mps_branches(&base_branches, circuit, num_shots, seed);
+    }
+
+    sample_mps_branches_online(circuit, num_shots, seed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::circuit::SmallVec;
 
     #[test]
     fn test_pure_clifford() {
@@ -616,6 +1128,282 @@ mod tests {
             result.probabilities[0],
             p0_expected
         );
+    }
+
+    #[test]
+    fn shots_preserve_t_branch_interference() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+
+        let num_shots = 20_000;
+        let result = run_stabilizer_rank_shots(&c, num_shots, 42).unwrap();
+        let zeros = result.shots.iter().filter(|s| !s[0]).count();
+        let p0 = zeros as f64 / num_shots as f64;
+        let expected = (std::f64::consts::FRAC_PI_8).cos().powi(2);
+        assert!(
+            (p0 - expected).abs() < 0.02,
+            "P(0) = {p0}, expected {expected} (a classical T-branch mixture would give 0.5)"
+        );
+    }
+
+    #[test]
+    fn shots_without_t_bypass_statevector_qubit_cap() {
+        let n = MAX_STATEVECTOR_QUBITS + 5;
+        let mut c = Circuit::new(n, n);
+        for q in 0..n {
+            c.add_gate(Gate::H, &[q]);
+            c.add_measure(q, q);
+        }
+
+        let result = run_stabilizer_rank_shots(&c, 16, 42).unwrap();
+        assert_eq!(result.shots.len(), 16);
+        assert!(result.shots.iter().all(|shot| shot.len() == n));
+    }
+
+    #[test]
+    fn shots_with_t_bypass_statevector_qubit_cap_terminal() {
+        let n = MAX_STATEVECTOR_QUBITS + 5;
+        let mut c = Circuit::new(n, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+
+        let result = run_stabilizer_rank_shots(&c, 32, 42).unwrap();
+        assert_eq!(result.shots.len(), 32);
+        assert!(result.shots.iter().all(|shot| shot.len() == 1));
+
+        let public_result =
+            crate::sim::run_shots_with(crate::sim::BackendKind::StabilizerRank, &c, 8, 42).unwrap();
+        assert_eq!(public_result.shots.len(), 8);
+
+        let auto_result =
+            crate::sim::run_shots_with(crate::sim::BackendKind::Auto, &c, 8, 42).unwrap();
+        assert_eq!(auto_result.shots.len(), 8);
+    }
+
+    #[test]
+    fn shots_with_t_bypass_statevector_qubit_cap_mid_circuit() {
+        let n = MAX_STATEVECTOR_QUBITS + 5;
+        let mut c = Circuit::new(n, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_measure(0, 0);
+        c.instructions.push(Instruction::Conditional {
+            condition: crate::circuit::ClassicalCondition::BitIsOne(0),
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[1]),
+        });
+        c.add_reset(0);
+        c.add_measure(1, 1);
+
+        let result = run_stabilizer_rank_shots(&c, 32, 42).unwrap();
+        assert_eq!(result.shots.len(), 32);
+        assert!(result.shots.iter().all(|shot| shot.len() == 2));
+    }
+
+    #[test]
+    fn forced_mps_projection_has_expected_probability() {
+        let mut plus = MpsBackend::new_exact(0);
+        plus.init(1, 0).unwrap();
+        plus.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+
+        let mut zero = plus.clone();
+        let mut one = plus;
+        let p0 = zero.project_z_outcome(0, false);
+        let p1 = one.project_z_outcome(0, true);
+
+        assert!((p0 - 0.5).abs() < 1e-12);
+        assert!((p1 - 0.5).abs() < 1e-12);
+        assert!(zero.inner_product(&one).unwrap().norm() < 1e-12);
+    }
+
+    #[test]
+    fn test_rejects_reset_in_probability_path() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_reset(0);
+
+        assert!(run_stabilizer_rank(&c, 42).is_err());
+        assert!(run_stabilizer_rank_approx(&c, 8, 42).is_err());
+    }
+
+    #[test]
+    fn test_rejects_measurement_in_probability_path() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_measure(0, 0);
+
+        assert!(run_stabilizer_rank(&c, 42).is_err());
+        assert!(run_stabilizer_rank_approx(&c, 8, 42).is_err());
+    }
+
+    #[test]
+    fn test_multi_t_with_separating_clifford() {
+        // Regression: prior to absorbing the deterministic Z-eigenvalue
+        // into the branch weight, this circuit returned [0.5, 0.5]
+        // because the AG tableau dropped the global -1 phase on the
+        // |1⟩ branch. The T-count scaling sweep surfaced the bug.
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        let sv = crate::sim::run_with(crate::sim::BackendKind::Statevector, &c, 42).unwrap();
+        let sv_probs = sv.probabilities.unwrap().to_vec();
+        for (i, (&sr, &sv)) in result.probabilities.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (sr - sv).abs() < 1e-10,
+                "P({i}) mismatch: stab_rank = {sr}, statevector = {sv}"
+            );
+        }
+    }
+
+    /// Regression for prior two-T multi-qubit reconstruction failure.
+    /// Per-branch tableau export picked inconsistent implicit global
+    /// phases when support shifted between branches. The Pauli-offset
+    /// representation should preserve the interference pattern.
+    #[test]
+    fn test_two_t_multi_qubit_bisect_stages() {
+        type Stage<'a> = (&'a str, &'a [(Gate, &'a [usize])]);
+        let stages: &[Stage] = &[
+            ("ghz_only", &[(Gate::H, &[0]), (Gate::Cx, &[0, 1])]),
+            (
+                "ghz_t",
+                &[(Gate::H, &[0]), (Gate::Cx, &[0, 1]), (Gate::T, &[0])],
+            ),
+            (
+                "ghz_t_h",
+                &[
+                    (Gate::H, &[0]),
+                    (Gate::Cx, &[0, 1]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                ],
+            ),
+            (
+                "ghz_t_h_t",
+                &[
+                    (Gate::H, &[0]),
+                    (Gate::Cx, &[0, 1]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                    (Gate::T, &[0]),
+                ],
+            ),
+            (
+                "ghz_t_h_t_h0",
+                &[
+                    (Gate::H, &[0]),
+                    (Gate::Cx, &[0, 1]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                ],
+            ),
+            (
+                "ghz_t_h_t_h0_h1",
+                &[
+                    (Gate::H, &[0]),
+                    (Gate::Cx, &[0, 1]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                    (Gate::T, &[0]),
+                    (Gate::H, &[0]),
+                    (Gate::H, &[1]),
+                ],
+            ),
+        ];
+        let mut failures = Vec::new();
+        for (label, gates) in stages {
+            let mut c = Circuit::new(2, 0);
+            for (gate, targets) in *gates {
+                c.add_gate(gate.clone(), targets);
+            }
+            let result = run_stabilizer_rank(&c, 42).unwrap();
+            let sv = crate::sim::run_with(crate::sim::BackendKind::Statevector, &c, 42).unwrap();
+            let sv_probs = sv.probabilities.unwrap().to_vec();
+            let max_diff = result
+                .probabilities
+                .iter()
+                .zip(sv_probs.iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f64, f64::max);
+            if max_diff > 1e-9 {
+                failures.push(format!(
+                    "{label}: sr={:?} sv={:?}",
+                    result.probabilities, sv_probs
+                ));
+            }
+        }
+        assert!(failures.is_empty(), "fails:\n  {}", failures.join("\n  "));
+    }
+
+    /// Companion to the bisect test: minimal multi-qubit two-T fixture.
+    /// Same root cause: cross-branch phase reconstruction.
+    #[test]
+    fn test_two_t_multi_qubit_entangled_matches_statevector() {
+        // Surface fixture: H_0, CX(0,1), T_0, H_0, T_0, H_0, H_1.
+        // Both stabilizer_rank and statevector should agree on the
+        // full 2q probability vector.
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        let result = run_stabilizer_rank(&c, 42).unwrap();
+        let sv = crate::sim::run_with(crate::sim::BackendKind::Statevector, &c, 42).unwrap();
+        let sv_probs = sv.probabilities.unwrap().to_vec();
+        for (i, (&sr, &sv)) in result.probabilities.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (sr - sv).abs() < 1e-10,
+                "P({i}) mismatch: stab_rank = {sr}, statevector = {sv}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_multi_qubit_multi_t_post_cliffords_matches_statevector() {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::Cx, &[0, 2]);
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        c.add_gate(Gate::T, &[2]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::T, &[1]);
+        c.add_gate(Gate::Cz, &[0, 1]);
+        c.add_gate(Gate::Tdg, &[2]);
+        c.add_gate(Gate::H, &[2]);
+        c.add_gate(Gate::Swap, &[0, 2]);
+
+        let sr = run_stabilizer_rank(&c, 42).unwrap();
+        let sv = crate::sim::run_with(crate::sim::BackendKind::Statevector, &c, 42).unwrap();
+        let sv_probs = sv.probabilities.unwrap().to_vec();
+        for (i, (sr_p, sv_p)) in sr.probabilities.iter().zip(sv_probs.iter()).enumerate() {
+            assert!(
+                (sr_p - sv_p).abs() < 1e-10,
+                "prob[{i}]: stab_rank={sr_p}, statevector={sv_p}"
+            );
+        }
     }
 
     #[test]
@@ -768,6 +1556,50 @@ mod tests {
     }
 
     #[test]
+    fn test_stabilizer_inner_product_matches_dense_export() {
+        let mut b1 = StabilizerBackend::new(42);
+        b1.init(2, 0).unwrap();
+        b1.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        b1.apply(&Instruction::Gate {
+            gate: Gate::Cx,
+            targets: SmallVec::from_slice(&[0, 1]),
+        })
+        .unwrap();
+
+        let mut b2 = StabilizerBackend::new(7);
+        b2.init(2, 0).unwrap();
+        b2.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        b2.apply(&Instruction::Gate {
+            gate: Gate::S,
+            targets: SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        b2.apply(&Instruction::Gate {
+            gate: Gate::Cx,
+            targets: SmallVec::from_slice(&[0, 1]),
+        })
+        .unwrap();
+
+        let b1_vec = b1.export_statevector().unwrap();
+        let b2_vec = b2.export_statevector().unwrap();
+        let expected: Complex64 = b1_vec
+            .iter()
+            .zip(b2_vec.iter())
+            .map(|(a, b)| a.conj() * b)
+            .sum();
+        let actual = stabilizer_inner_product(&b1, &b2, 2).unwrap();
+        assert!((actual - expected).norm() < 1e-12);
+    }
+
+    #[test]
     fn test_too_many_terms() {
         let mut c = Circuit::new(1, 0);
         // 21 T gates would need 2^21 > MAX_TERMS terms
@@ -841,21 +1673,6 @@ mod more_tests {
         let c = Circuit::new(n, 0);
         assert!(run_stabilizer_rank(&c, 0).is_err());
         assert!(run_stabilizer_rank_approx(&c, 0, 16).is_err());
-    }
-
-    #[test]
-    fn find_t_gates_locates_correct_positions() {
-        let mut c = Circuit::new(2, 0);
-        c.add_gate(Gate::H, &[0]);
-        c.add_gate(Gate::T, &[1]);
-        c.add_gate(Gate::Cx, &[0, 1]);
-        c.add_gate(Gate::T, &[0]);
-        let locs = find_t_gates(&c);
-        assert_eq!(locs.len(), 2);
-        assert_eq!(locs[0].instruction_index, 1);
-        assert_eq!(locs[0].qubit, 1);
-        assert_eq!(locs[1].instruction_index, 3);
-        assert_eq!(locs[1].qubit, 0);
     }
 
     #[test]

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -4,185 +4,58 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
 use crate::circuit::{Circuit, Instruction, SmallVec};
-use crate::error::Result;
+use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 use crate::sim::compiled::{flip_bit, propagate_backward, PauliVec};
 
 const SQRT_2: f64 = std::f64::consts::SQRT_2;
-const MIN_CLIFF_GATES_FOR_COALESCE: usize = 16;
 
-// ---------------------------------------------------------------------------
-// Clifford Map: pre-compiled symplectic transformation over GF(2)
-// ---------------------------------------------------------------------------
+/// Absolute ceiling on the weighted-Pauli term count, enforced even in exact
+/// mode (`max_terms == 0`). Without a per-step truncation budget the term set
+/// grows as `2^(in-cone T count)`; this caps transient memory the same way the
+/// stabilizer-rank backend does. Exceeding it is an error, not a silent
+/// truncation: callers wanting bounded approximate evaluation pass a nonzero
+/// `max_terms` instead.
+const SPD_MAX_TERMS_CEILING: usize = 1 << 20;
 
-struct CliffordMap {
-    num_words: usize,
-    col_xx: Vec<u64>,
-    col_xz: Vec<u64>,
-    col_zx: Vec<u64>,
-    col_zz: Vec<u64>,
+#[inline]
+fn check_spd_term_ceiling(len: usize) -> Result<()> {
+    if len > SPD_MAX_TERMS_CEILING {
+        return Err(PrismError::BackendUnsupported {
+            backend: "SPD".into(),
+            operation: format!(
+                "weighted-Pauli sum exceeded {SPD_MAX_TERMS_CEILING} terms; pass a nonzero \
+                 max_terms for bounded approximate truncation"
+            ),
+        });
+    }
+    Ok(())
 }
 
-impl CliffordMap {
-    fn identity(n: usize) -> Self {
-        let num_words = n.div_ceil(64);
-        let mut col_xx = vec![0u64; n * num_words];
-        let mut col_zz = vec![0u64; n * num_words];
-        for q in 0..n {
-            col_xx[q * num_words + q / 64] = 1u64 << (q % 64);
-            col_zz[q * num_words + q / 64] = 1u64 << (q % 64);
-        }
-        Self {
-            num_words,
-            col_xx,
-            col_xz: vec![0u64; n * num_words],
-            col_zx: vec![0u64; n * num_words],
-            col_zz,
-        }
-    }
-
-    #[inline(always)]
-    fn col_range(&self, q: usize) -> std::ops::Range<usize> {
-        q * self.num_words..(q + 1) * self.num_words
-    }
-
-    fn apply_h(&mut self, q: usize) {
-        let r = self.col_range(q);
-        for i in r {
-            std::mem::swap(&mut self.col_xx[i], &mut self.col_xz[i]);
-            std::mem::swap(&mut self.col_zx[i], &mut self.col_zz[i]);
-        }
-    }
-
-    fn apply_s(&mut self, q: usize) {
-        let r = self.col_range(q);
-        for i in r {
-            self.col_xz[i] ^= self.col_xx[i];
-            self.col_zz[i] ^= self.col_zx[i];
-        }
-    }
-
-    fn apply_sx(&mut self, q: usize) {
-        let r = self.col_range(q);
-        for i in r {
-            self.col_xx[i] ^= self.col_xz[i];
-            self.col_zx[i] ^= self.col_zz[i];
-        }
-    }
-
-    fn apply_cx(&mut self, ctrl: usize, tgt: usize) {
-        let nw = self.num_words;
-        for w in 0..nw {
-            self.col_xx[tgt * nw + w] ^= self.col_xx[ctrl * nw + w];
-            self.col_xz[tgt * nw + w] ^= self.col_xz[ctrl * nw + w];
-            self.col_zx[ctrl * nw + w] ^= self.col_zx[tgt * nw + w];
-            self.col_zz[ctrl * nw + w] ^= self.col_zz[tgt * nw + w];
-        }
-    }
-
-    fn apply_cz(&mut self, q0: usize, q1: usize) {
-        let nw = self.num_words;
-        for w in 0..nw {
-            self.col_xz[q0 * nw + w] ^= self.col_xx[q1 * nw + w];
-            self.col_xz[q1 * nw + w] ^= self.col_xx[q0 * nw + w];
-            self.col_zz[q0 * nw + w] ^= self.col_zx[q1 * nw + w];
-            self.col_zz[q1 * nw + w] ^= self.col_zx[q0 * nw + w];
-        }
-    }
-
-    fn apply_swap(&mut self, q0: usize, q1: usize) {
-        let nw = self.num_words;
-        for w in 0..nw {
-            let r0 = q0 * nw + w;
-            let r1 = q1 * nw + w;
-            self.col_xx.swap(r0, r1);
-            self.col_xz.swap(r0, r1);
-            self.col_zx.swap(r0, r1);
-            self.col_zz.swap(r0, r1);
-        }
-    }
-
-    fn apply_gate(&mut self, gate: &Gate, targets: &[usize]) {
-        match gate {
-            Gate::H => self.apply_h(targets[0]),
-            Gate::S | Gate::Sdg => self.apply_s(targets[0]),
-            Gate::SX | Gate::SXdg => self.apply_sx(targets[0]),
-            Gate::X | Gate::Y | Gate::Z | Gate::Id => {}
-            Gate::Cx => self.apply_cx(targets[0], targets[1]),
-            Gate::Cz => self.apply_cz(targets[0], targets[1]),
-            Gate::Swap => self.apply_swap(targets[0], targets[1]),
-            _ => {}
-        }
-    }
-
-    fn apply(&self, pauli: &mut PauliVec) {
-        let nw = self.num_words;
-
-        let mut scratch = [0u64; 32];
-        if nw <= 16 {
-            scratch[..nw].copy_from_slice(&pauli.x);
-            scratch[16..16 + nw].copy_from_slice(&pauli.z);
-            pauli.x.fill(0);
-            pauli.z.fill(0);
-
-            for word in 0..nw {
-                let mut xw = scratch[word];
-                while xw != 0 {
-                    let bit = xw.trailing_zeros() as usize;
-                    let q = word * 64 + bit;
-                    let base = q * nw;
-                    for w in 0..nw {
-                        pauli.x[w] ^= self.col_xx[base + w];
-                        pauli.z[w] ^= self.col_xz[base + w];
-                    }
-                    xw &= xw - 1;
-                }
-
-                let mut zw = scratch[16 + word];
-                while zw != 0 {
-                    let bit = zw.trailing_zeros() as usize;
-                    let q = word * 64 + bit;
-                    let base = q * nw;
-                    for w in 0..nw {
-                        pauli.x[w] ^= self.col_zx[base + w];
-                        pauli.z[w] ^= self.col_zz[base + w];
-                    }
-                    zw &= zw - 1;
+fn validate_clifford_t_unitary(circuit: &Circuit, backend: &'static str) -> Result<()> {
+    for inst in &circuit.instructions {
+        match inst {
+            Instruction::Gate { gate, .. } => {
+                if !(gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)) {
+                    return Err(PrismError::BackendUnsupported {
+                        backend: backend.to_string(),
+                        operation: format!("non-Clifford+T gate `{}`", gate.name()),
+                    });
                 }
             }
-        } else {
-            let old_x = pauli.x.clone();
-            let old_z = pauli.z.clone();
-            pauli.x.fill(0);
-            pauli.z.fill(0);
-
-            for word in 0..nw {
-                let mut xw = old_x[word];
-                while xw != 0 {
-                    let bit = xw.trailing_zeros() as usize;
-                    let q = word * 64 + bit;
-                    let base = q * nw;
-                    for w in 0..nw {
-                        pauli.x[w] ^= self.col_xx[base + w];
-                        pauli.z[w] ^= self.col_xz[base + w];
-                    }
-                    xw &= xw - 1;
-                }
-
-                let mut zw = old_z[word];
-                while zw != 0 {
-                    let bit = zw.trailing_zeros() as usize;
-                    let q = word * 64 + bit;
-                    let base = q * nw;
-                    for w in 0..nw {
-                        pauli.x[w] ^= self.col_zx[base + w];
-                        pauli.z[w] ^= self.col_zz[base + w];
-                    }
-                    zw &= zw - 1;
-                }
+            Instruction::Barrier { .. } => {}
+            Instruction::Measure { .. }
+            | Instruction::Reset { .. }
+            | Instruction::Conditional { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: backend.to_string(),
+                    reason: "Pauli propagation requires a unitary Clifford+T circuit without measurements, resets, or conditionals"
+                        .to_string(),
+                });
             }
         }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -190,13 +63,11 @@ impl CliffordMap {
 // ---------------------------------------------------------------------------
 
 enum CoalescedOp {
-    Map(CliffordMap),
     SmallCliff(Vec<(Gate, SmallVec<[usize; 4]>)>),
     T { qubit: usize, is_dagger: bool },
 }
 
 fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
-    let n = circuit.num_qubits;
     let mut ops = Vec::new();
     let mut cliff_buf: Vec<(Gate, SmallVec<[usize; 4]>)> = Vec::new();
 
@@ -204,14 +75,14 @@ fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
         if let Instruction::Gate { gate, targets } = inst {
             match gate {
                 Gate::T => {
-                    flush_cliff_buf(n, &mut cliff_buf, &mut ops);
+                    flush_cliff_buf(&mut cliff_buf, &mut ops);
                     ops.push(CoalescedOp::T {
                         qubit: targets[0],
                         is_dagger: false,
                     });
                 }
                 Gate::Tdg => {
-                    flush_cliff_buf(n, &mut cliff_buf, &mut ops);
+                    flush_cliff_buf(&mut cliff_buf, &mut ops);
                     ops.push(CoalescedOp::T {
                         qubit: targets[0],
                         is_dagger: true,
@@ -222,30 +93,18 @@ fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
                 }
             }
         } else {
-            flush_cliff_buf(n, &mut cliff_buf, &mut ops);
+            flush_cliff_buf(&mut cliff_buf, &mut ops);
         }
     }
-    flush_cliff_buf(n, &mut cliff_buf, &mut ops);
+    flush_cliff_buf(&mut cliff_buf, &mut ops);
     ops
 }
 
-fn flush_cliff_buf(
-    n: usize,
-    buf: &mut Vec<(Gate, SmallVec<[usize; 4]>)>,
-    ops: &mut Vec<CoalescedOp>,
-) {
+fn flush_cliff_buf(buf: &mut Vec<(Gate, SmallVec<[usize; 4]>)>, ops: &mut Vec<CoalescedOp>) {
     if buf.is_empty() {
         return;
     }
-    if buf.len() < MIN_CLIFF_GATES_FOR_COALESCE {
-        ops.push(CoalescedOp::SmallCliff(std::mem::take(buf)));
-    } else {
-        let mut map = CliffordMap::identity(n);
-        for (gate, targets) in buf.drain(..) {
-            map.apply_gate(&gate, &targets);
-        }
-        ops.push(CoalescedOp::Map(map));
-    }
+    ops.push(CoalescedOp::SmallCliff(std::mem::take(buf)));
 }
 
 // ---------------------------------------------------------------------------
@@ -259,28 +118,26 @@ fn branch_t_gate(
     is_dagger: bool,
     rng: &mut impl Rng,
 ) -> Complex64 {
+    // PauliVec stores the Y letter as the ordered product XZ. Since
+    // actual Y = i XZ, the T flip branch is imaginary in this basis:
+    // T contributes -i/sqrt(2), and Tdg contributes +i/sqrt(2).
+    // SPP samples one branch with probability 1/2, so the per-shot
+    // flip weight is +/-i*sqrt(2).
     if !pauli.has_x_or_y(qubit) {
         return Complex64::new(1.0, 0.0);
     }
 
-    let has_z = (pauli.z[qubit / 64] >> (qubit % 64)) & 1 != 0;
-    let is_y = has_z;
-
     let keep = rng.random_bool(0.5);
-    if !keep {
-        flip_bit(&mut pauli.z, qubit);
+    if keep {
+        return Complex64::new(SQRT_2, 0.0);
     }
 
-    let sign = match (is_y, keep, is_dagger) {
-        (false, _, false) => 1.0,
-        (false, true, true) => 1.0,
-        (false, false, true) => -1.0,
-        (true, true, false) => 1.0,
-        (true, false, false) => -1.0,
-        (true, _, true) => 1.0,
-    };
-
-    Complex64::new(sign * SQRT_2, 0.0)
+    flip_bit(&mut pauli.z, qubit);
+    if is_dagger {
+        Complex64::new(0.0, SQRT_2)
+    } else {
+        Complex64::new(0.0, -SQRT_2)
+    }
 }
 
 fn backward_propagate_coalesced(
@@ -296,11 +153,13 @@ fn backward_propagate_coalesced(
 
     for op in ops.iter().rev() {
         match op {
-            CoalescedOp::Map(map) => {
-                map.apply(&mut pauli);
-            }
             CoalescedOp::SmallCliff(gates) => {
                 for (gate, targets) in gates.iter().rev() {
+                    // Phase track Clifford conjugation, mirroring the
+                    // SPD path (`conjugate_all_backward_phased`); the
+                    // bare `propagate_backward` is Pauli-frame only
+                    // and drops the `-1` from e.g. `HYH = -Y`.
+                    weight *= clifford_conjugation_phase(gate, targets, &pauli);
                     propagate_backward(&mut pauli, gate, targets);
                 }
             }
@@ -375,7 +234,160 @@ fn estimate_qubit_expectation(
     (mean, std_error, nonzero)
 }
 
+/// Pauli axis for a joint-observable term. Identity factors are omitted
+/// from the term list and contribute trivially.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PauliAxis {
+    X,
+    Y,
+    Z,
+}
+
+/// One non-identity factor of a joint Pauli observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PauliTerm {
+    pub qubit: usize,
+    pub axis: PauliAxis,
+}
+
+impl PauliTerm {
+    pub fn new(qubit: usize, axis: PauliAxis) -> Self {
+        Self { qubit, axis }
+    }
+
+    pub fn x(qubit: usize) -> Self {
+        Self::new(qubit, PauliAxis::X)
+    }
+
+    pub fn y(qubit: usize) -> Self {
+        Self::new(qubit, PauliAxis::Y)
+    }
+
+    pub fn z(qubit: usize) -> Self {
+        Self::new(qubit, PauliAxis::Z)
+    }
+}
+
+/// Result of running SPP on a joint Pauli observable.
+#[derive(Debug, Clone)]
+pub struct SppObservableResult {
+    pub mean: f64,
+    pub std_error: f64,
+    pub variance: f64,
+    pub num_samples: usize,
+    pub nonzero_fraction: f64,
+    pub t_count: usize,
+}
+
+/// Result of running SPD on a joint Pauli observable.
+#[derive(Debug, Clone)]
+pub struct SpdObservableResult {
+    pub mean: f64,
+    pub t_count: usize,
+    pub peak_terms: usize,
+    pub total_discarded: f64,
+}
+
+fn pauli_vec_from_terms(
+    num_qubits: usize,
+    terms: &[PauliTerm],
+) -> std::result::Result<(PauliVec, Complex64), crate::error::PrismError> {
+    let num_words = num_qubits.div_ceil(64);
+    let mut pv = PauliVec::new(num_words);
+    let mut coeff = Complex64::new(1.0, 0.0);
+    let mut seen = vec![false; num_qubits];
+    for term in terms {
+        if term.qubit >= num_qubits {
+            return Err(crate::error::PrismError::InvalidQubit {
+                index: term.qubit,
+                register_size: num_qubits,
+            });
+        }
+        if seen[term.qubit] {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: format!(
+                    "joint Pauli observable has duplicate factor on qubit {}",
+                    term.qubit
+                ),
+            });
+        }
+        seen[term.qubit] = true;
+        match term.axis {
+            PauliAxis::X => {
+                pv.x[term.qubit / 64] |= 1u64 << (term.qubit % 64);
+            }
+            PauliAxis::Z => {
+                pv.z[term.qubit / 64] |= 1u64 << (term.qubit % 64);
+            }
+            PauliAxis::Y => {
+                pv.x[term.qubit / 64] |= 1u64 << (term.qubit % 64);
+                pv.z[term.qubit / 64] |= 1u64 << (term.qubit % 64);
+                coeff *= Complex64::new(0.0, 1.0);
+            }
+        }
+    }
+    Ok((pv, coeff))
+}
+
+/// Estimate `⟨0^n| U† P U |0^n⟩` for joint Pauli observable `P` on a
+/// Clifford+T circuit `U` via stochastic Pauli propagation.
+///
+/// Each sample backward-propagates the observable through the circuit
+/// (Clifford segments as coalesced gate runs, T gates via a stochastic
+/// Pauli branch that records a complex weight). The
+/// contribution is `Re(weight)` when the final Pauli is diagonal in
+/// `{I, Z}` (i.e. evaluates trivially on `|0^n⟩`), else zero.
+pub fn run_spp_observable(
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    num_samples: usize,
+    seed: u64,
+) -> Result<SppObservableResult> {
+    validate_clifford_t_unitary(circuit, "SPP observable")?;
+    let n = circuit.num_qubits;
+    let t_count = count_t_gates(circuit);
+    let ops = coalesce_cliffords(circuit);
+    let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut mean = 0.0f64;
+    let mut m2 = 0.0f64;
+    let mut nonzero = 0usize;
+
+    for i in 0..num_samples {
+        let (pauli, weight) = backward_propagate_coalesced(&ops, &obs, &mut rng);
+        let val = if pauli.is_diagonal() {
+            nonzero += 1;
+            (obs_coeff * weight).re
+        } else {
+            0.0
+        };
+        let delta = val - mean;
+        mean += delta / (i + 1) as f64;
+        let delta2 = val - mean;
+        m2 += delta * delta2;
+    }
+
+    let variance = if num_samples > 1 {
+        m2 / (num_samples - 1) as f64
+    } else {
+        0.0
+    };
+    let std_error = (variance / num_samples.max(1) as f64).sqrt();
+    let nonzero_fraction = nonzero as f64 / num_samples.max(1) as f64;
+
+    Ok(SppObservableResult {
+        mean,
+        std_error,
+        variance,
+        num_samples,
+        nonzero_fraction,
+        t_count,
+    })
+}
+
 pub fn run_spp(circuit: &Circuit, num_samples: usize, seed: u64) -> Result<SppResult> {
+    validate_clifford_t_unitary(circuit, "SPP")?;
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
     let t_count = count_t_gates(circuit);
@@ -533,12 +545,14 @@ fn clifford_conjugation_phase(gate: &Gate, targets: &[usize], pauli: &PauliVec) 
 
 struct WeightedPauliSum {
     terms: HashMap<PauliVec, Complex64>,
+    scratch: Vec<(PauliVec, Complex64)>,
 }
 
 impl WeightedPauliSum {
     fn new() -> Self {
         Self {
             terms: HashMap::new(),
+            scratch: Vec::new(),
         }
     }
 
@@ -548,11 +562,18 @@ impl WeightedPauliSum {
     }
 
     fn conjugate_all_backward_phased(&mut self, gate: &Gate, targets: &[usize]) {
-        let old_terms: Vec<(PauliVec, Complex64)> = self.terms.drain().collect();
-        for (mut pauli, coeff) in old_terms {
+        // Clifford conjugation is a bijection on Pauli strings: the symplectic
+        // action on the (x, z) bits is invertible, so distinct keys map to
+        // distinct keys and no coefficient merging occurs. Reuse `scratch` to
+        // avoid a per-gate heap allocation, drain into it (which keeps the
+        // map's bucket capacity), then re-insert directly without the
+        // accumulate path.
+        self.scratch.clear();
+        self.scratch.extend(self.terms.drain());
+        for (mut pauli, coeff) in self.scratch.drain(..) {
             let phase = clifford_conjugation_phase(gate, targets, &pauli);
             propagate_backward(&mut pauli, gate, targets);
-            self.insert(pauli, coeff * phase);
+            self.terms.insert(pauli, coeff * phase);
         }
     }
 
@@ -612,7 +633,61 @@ pub struct SpdResult {
     pub total_discarded: f64,
 }
 
+/// Deterministic SPD on a joint Pauli observable.
+///
+/// Starts with the single weighted term `(observable, 1.0)`, backward-
+/// propagates through every gate, branches each T into two terms with
+/// `α / β` coefficients, and truncates terms whose magnitude falls below
+/// `epsilon` whenever the sum exceeds `max_terms`. Returns
+/// `⟨0^n| U† P U |0^n⟩` as the sum of remaining diagonal-term
+/// coefficients.
+pub fn run_spd_observable(
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    epsilon: f64,
+    max_terms: usize,
+) -> Result<SpdObservableResult> {
+    validate_clifford_t_unitary(circuit, "SPD observable")?;
+    let n = circuit.num_qubits;
+    let t_count = count_t_gates(circuit);
+    let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
+
+    let mut sum = WeightedPauliSum::new();
+    sum.insert(obs, obs_coeff);
+    let mut peak_terms = sum.terms.len();
+    let mut total_discarded = 0.0;
+
+    for inst in circuit.instructions.iter().rev() {
+        if let Instruction::Gate { gate, targets } = inst {
+            match gate {
+                Gate::T => sum.branch_t_deterministic(targets[0], false),
+                Gate::Tdg => sum.branch_t_deterministic(targets[0], true),
+                _ => sum.conjugate_all_backward_phased(gate, targets),
+            }
+        }
+        if max_terms > 0 && sum.terms.len() > max_terms {
+            total_discarded += sum.truncate(epsilon);
+        }
+        check_spd_term_ceiling(sum.terms.len())?;
+        if sum.terms.len() > peak_terms {
+            peak_terms = sum.terms.len();
+        }
+    }
+
+    if epsilon > 0.0 {
+        total_discarded += sum.truncate(epsilon);
+    }
+
+    Ok(SpdObservableResult {
+        mean: sum.diagonal_expectation(),
+        t_count,
+        peak_terms,
+        total_discarded,
+    })
+}
+
 pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdResult> {
+    validate_clifford_t_unitary(circuit, "SPD")?;
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
     let t_count = count_t_gates(circuit);
@@ -637,6 +712,7 @@ pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdR
             if max_terms > 0 && sum.terms.len() > max_terms {
                 total_discarded += sum.truncate(epsilon);
             }
+            check_spd_term_ceiling(sum.terms.len())?;
 
             if sum.terms.len() > peak_terms {
                 peak_terms = sum.terms.len();
@@ -654,6 +730,96 @@ pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdR
         expectations,
         t_count,
         max_terms: peak_terms,
+        total_discarded,
+    })
+}
+
+/// Inverse light cone of a Pauli observable under a circuit, computed
+/// conservatively by gate-graph reachability.
+///
+/// Returns, for each instruction index in `circuit.instructions`, whether the
+/// gate at that index can affect the backward-propagated observable. A gate is
+/// in the cone if its support intersects the current cone-qubit set when the
+/// circuit is traversed in reverse from the observable.
+///
+/// Exactness: a gate whose target set is disjoint from the cone-qubit set at
+/// its backward-traversal depth conjugates the propagated observable trivially
+/// (`U_k^dag P_k U_k = P_k` because the support of `P_k` is contained in the
+/// cone set at depth `k`, and `U_k` acts as identity outside its targets).
+/// Removing those gates from the backward pass is therefore exact.
+pub fn inverse_light_cone(circuit: &Circuit, observable: &[PauliTerm]) -> Vec<bool> {
+    let mut cone: std::collections::HashSet<usize> = observable.iter().map(|t| t.qubit).collect();
+    let n_inst = circuit.instructions.len();
+    let mut keep = vec![false; n_inst];
+
+    for (idx, inst) in circuit.instructions.iter().enumerate().rev() {
+        let targets: &[usize] = match inst {
+            Instruction::Gate { targets, .. } => targets,
+            _ => continue,
+        };
+        let touches = targets.iter().any(|q| cone.contains(q));
+        if touches {
+            keep[idx] = true;
+            for &q in targets {
+                cone.insert(q);
+            }
+        }
+    }
+    keep
+}
+
+/// SPD on a joint Pauli observable, restricted to the inverse light cone.
+///
+/// Identical in result to `run_spd_observable` for any Clifford+T circuit, but
+/// skips gates whose support is disjoint from the propagated observable's
+/// causal cone. For QEC syndrome and detector observables with bounded
+/// spatial support, this turns the SPD cliff from a function of total T-count
+/// into a function of in-cone T-count.
+pub fn run_spd_observable_light_cone(
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    epsilon: f64,
+    max_terms: usize,
+) -> Result<SpdObservableResult> {
+    validate_clifford_t_unitary(circuit, "light-cone SPD observable")?;
+    let n = circuit.num_qubits;
+    let t_count = count_t_gates(circuit);
+    let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
+    let keep = inverse_light_cone(circuit, observable);
+
+    let mut sum = WeightedPauliSum::new();
+    sum.insert(obs, obs_coeff);
+    let mut peak_terms = sum.terms.len();
+    let mut total_discarded = 0.0;
+
+    for (idx, inst) in circuit.instructions.iter().enumerate().rev() {
+        if !keep[idx] {
+            continue;
+        }
+        if let Instruction::Gate { gate, targets } = inst {
+            match gate {
+                Gate::T => sum.branch_t_deterministic(targets[0], false),
+                Gate::Tdg => sum.branch_t_deterministic(targets[0], true),
+                _ => sum.conjugate_all_backward_phased(gate, targets),
+            }
+        }
+        if max_terms > 0 && sum.terms.len() > max_terms {
+            total_discarded += sum.truncate(epsilon);
+        }
+        check_spd_term_ceiling(sum.terms.len())?;
+        if sum.terms.len() > peak_terms {
+            peak_terms = sum.terms.len();
+        }
+    }
+
+    if epsilon > 0.0 {
+        total_discarded += sum.truncate(epsilon);
+    }
+
+    Ok(SpdObservableResult {
+        mean: sum.diagonal_expectation(),
+        t_count,
+        peak_terms,
         total_discarded,
     })
 }
@@ -1060,19 +1226,12 @@ mod tests {
     }
 
     #[test]
-    fn clifford_map_identity_and_apply_all() {
-        let mut m = CliffordMap::identity(5);
-        m.apply_h(0);
-        m.apply_s(1);
-        m.apply_sx(2);
-        m.apply_cx(0, 1);
-        m.apply_cz(2, 3);
-        assert_eq!(m.num_words, 1);
-        assert_eq!(m.col_xx.len(), 5);
-    }
-
-    #[test]
-    fn coalesce_cliffords_triggers_map_path() {
+    fn coalesce_cliffords_long_clifford_run_stays_phase_correct() {
+        // Regression: the SmallCliff path threads
+        // `clifford_conjugation_phase` through every gate so global
+        // signs from `HYH = -Y`, `SYS† = -X`, etc. are preserved.
+        // Confirm SPP matches the analytical SPD on a long Clifford
+        // run.
         let mut circuit = Circuit::new(4, 0);
         for _ in 0..20 {
             for q in 0..4 {
@@ -1082,12 +1241,16 @@ mod tests {
             circuit.add_gate(Gate::Cx, &[0, 1]);
             circuit.add_gate(Gate::Cz, &[2, 3]);
         }
-        let ops = coalesce_cliffords(&circuit);
-        assert!(!ops.is_empty());
-        let result = run_spp(&circuit, 32, 42).unwrap();
-        assert_eq!(result.expectations.len(), 4);
-        let probs = spp_to_probabilities(&result);
-        assert_eq!(probs.len(), 8);
+        let spp = run_spp(&circuit, 4_000, 42).unwrap();
+        let spd = run_spd(&circuit, 1e-10, 16_384).unwrap();
+        for q in 0..4 {
+            assert!(
+                (spp.expectations[q] - spd.expectations[q]).abs() < 0.08,
+                "qubit {q}: spp={}, spd={}",
+                spp.expectations[q],
+                spd.expectations[q]
+            );
+        }
     }
 
     #[test]
@@ -1110,5 +1273,103 @@ mod tests {
         assert_eq!(probs.len(), 4);
         let sum: f64 = probs.iter().sum();
         assert!((sum - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn light_cone_excludes_disjoint_gates() {
+        let mut circuit = Circuit::new(4, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::T, &[0]);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::H, &[3]);
+        circuit.add_gate(Gate::T, &[3]);
+        circuit.add_gate(Gate::H, &[3]);
+
+        let obs = [PauliTerm::z(0)];
+        let keep = inverse_light_cone(&circuit, &obs);
+        assert_eq!(keep, vec![true, true, true, false, false, false]);
+    }
+
+    #[test]
+    fn light_cone_follows_entangling_gates() {
+        let mut circuit = Circuit::new(3, 0);
+        circuit.add_gate(Gate::T, &[1]);
+        circuit.add_gate(Gate::Cx, &[1, 2]);
+        circuit.add_gate(Gate::H, &[2]);
+        circuit.add_gate(Gate::H, &[0]);
+
+        let obs = [PauliTerm::z(2)];
+        let keep = inverse_light_cone(&circuit, &obs);
+        assert_eq!(keep, vec![true, true, true, false]);
+    }
+
+    #[test]
+    fn light_cone_spd_matches_unrestricted_spd() {
+        let mut circuit = Circuit::new(5, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::T, &[0]);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::H, &[4]);
+        circuit.add_gate(Gate::T, &[4]);
+        circuit.add_gate(Gate::Cx, &[3, 4]);
+        circuit.add_gate(Gate::T, &[3]);
+
+        let obs = [PauliTerm::z(0)];
+        let full = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+        let cone = run_spd_observable_light_cone(&circuit, &obs, 0.0, 0).unwrap();
+        assert!(
+            (full.mean - cone.mean).abs() < 1e-12,
+            "full={} cone={}",
+            full.mean,
+            cone.mean
+        );
+        assert!(cone.peak_terms <= full.peak_terms);
+    }
+
+    #[test]
+    fn light_cone_skips_most_gates_on_disjoint_t_block() {
+        let mut circuit = Circuit::new(6, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::T, &[0]);
+        circuit.add_gate(Gate::H, &[0]);
+        for _ in 0..6 {
+            circuit.add_gate(Gate::H, &[3]);
+            circuit.add_gate(Gate::T, &[3]);
+            circuit.add_gate(Gate::Cx, &[3, 4]);
+            circuit.add_gate(Gate::T, &[4]);
+            circuit.add_gate(Gate::Cx, &[4, 5]);
+            circuit.add_gate(Gate::T, &[5]);
+        }
+
+        let obs = [PauliTerm::z(0)];
+        let keep = inverse_light_cone(&circuit, &obs);
+        let kept = keep.iter().filter(|b| **b).count();
+        assert_eq!(kept, 3, "only the H-T-H block on q0 should be kept");
+
+        let full = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+        let cone = run_spd_observable_light_cone(&circuit, &obs, 0.0, 0).unwrap();
+        assert!((full.mean - cone.mean).abs() < 1e-12);
+    }
+
+    #[test]
+    fn light_cone_spd_matches_on_entangled_observable() {
+        let mut circuit = Circuit::new(4, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_gate(Gate::T, &[1]);
+        circuit.add_gate(Gate::Cx, &[1, 2]);
+        circuit.add_gate(Gate::T, &[2]);
+        circuit.add_gate(Gate::H, &[3]);
+        circuit.add_gate(Gate::T, &[3]);
+
+        let obs = [PauliTerm::z(0), PauliTerm::z(2)];
+        let full = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+        let cone = run_spd_observable_light_cone(&circuit, &obs, 0.0, 0).unwrap();
+        assert!(
+            (full.mean - cone.mean).abs() < 1e-12,
+            "full={} cone={}",
+            full.mean,
+            cone.mean
+        );
     }
 }

--- a/tests/pauli_joint_observable.rs
+++ b/tests/pauli_joint_observable.rs
@@ -1,0 +1,168 @@
+//! Direct-circuit tests for the joint-observable SPP/SPD API.
+
+use prism_q::circuit::Circuit;
+use prism_q::gates::Gate;
+use prism_q::{run_spd_observable, run_spp_observable, PauliAxis, PauliTerm};
+
+const SEED: u64 = 0xDEAD_BEEF;
+
+#[test]
+fn spp_recovers_single_qubit_z_expectation_on_h_t_h_circuit() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::T, &[0]);
+    circuit.add_gate(Gate::H, &[0]);
+
+    let observable = [PauliTerm::z(0)];
+    let result = run_spp_observable(&circuit, &observable, 8_000, SEED).unwrap();
+    // ⟨0|H T H Z H T† H|0⟩ = ⟨0| (HTH)† Z (HTH) |0⟩ = cos(π/4) = 1/√2
+    let expected = 1.0 / std::f64::consts::SQRT_2;
+    assert!(
+        (result.mean - expected).abs() < 0.05,
+        "SPP mean {:.4} diverged from expected {expected:.4}",
+        result.mean
+    );
+}
+
+#[test]
+fn spd_matches_spp_on_two_qubit_zz_observable() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::T, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::H, &[0]);
+
+    let observable = [PauliTerm::z(0), PauliTerm::z(1)];
+    let spd = run_spd_observable(&circuit, &observable, 1e-10, 1024).unwrap();
+    let spp = run_spp_observable(&circuit, &observable, 16_000, SEED).unwrap();
+    assert!(
+        (spd.mean - spp.mean).abs() < 0.05,
+        "SPD mean {:.4} diverged from SPP mean {:.4}",
+        spd.mean,
+        spp.mean
+    );
+}
+
+#[test]
+fn spp_handles_x_and_y_pauli_factors() {
+    // Pure Clifford: ⟨+|X|+⟩ = +1. Use Y to verify mixed PauliVec layout.
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+
+    let x_result = run_spp_observable(&circuit, &[PauliTerm::x(0)], 1_000, SEED).unwrap();
+    assert!(
+        (x_result.mean - 1.0).abs() < 0.05,
+        "⟨X⟩ on |+⟩ should be +1, got {:.4}",
+        x_result.mean
+    );
+
+    // ⟨+|Y|+⟩ = 0.
+    let y_result = run_spp_observable(&circuit, &[PauliTerm::y(0)], 2_000, SEED).unwrap();
+    assert!(
+        y_result.mean.abs() < 0.05,
+        "⟨Y⟩ on |+⟩ should be 0, got {:.4}",
+        y_result.mean
+    );
+}
+
+#[test]
+fn y_observable_uses_physical_pauli_phase() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::S, &[0]);
+
+    let spd = run_spd_observable(&circuit, &[PauliTerm::y(0)], 0.0, 0).unwrap();
+    let spp = run_spp_observable(&circuit, &[PauliTerm::y(0)], 2_000, SEED).unwrap();
+
+    assert!(
+        (spd.mean - 1.0).abs() < 1e-12,
+        "<Y> on S H |0> should be +1, got {:.4}",
+        spd.mean
+    );
+    assert!(
+        (spp.mean - 1.0).abs() < 0.05,
+        "SPP <Y> on S H |0> should be +1, got {:.4}",
+        spp.mean
+    );
+}
+
+#[test]
+fn stochastic_t_branch_preserves_y_expectation() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::T, &[0]);
+
+    let expected = 1.0 / std::f64::consts::SQRT_2;
+    let spd = run_spd_observable(&circuit, &[PauliTerm::y(0)], 0.0, 0).unwrap();
+    let spp = run_spp_observable(&circuit, &[PauliTerm::y(0)], 12_000, SEED).unwrap();
+
+    assert!(
+        (spd.mean - expected).abs() < 1e-12,
+        "SPD <Y> on T H |0> should be {expected:.4}, got {:.4}",
+        spd.mean
+    );
+    assert!(
+        (spp.mean - expected).abs() < 0.05,
+        "SPP <Y> on T H |0> should be {expected:.4}, got {:.4}",
+        spp.mean
+    );
+}
+
+#[test]
+fn pauli_term_constructor_helpers_match_axis_enum() {
+    assert_eq!(PauliTerm::x(0).axis, PauliAxis::X);
+    assert_eq!(PauliTerm::y(3).axis, PauliAxis::Y);
+    assert_eq!(PauliTerm::z(7).axis, PauliAxis::Z);
+    assert_eq!(PauliTerm::z(7).qubit, 7);
+}
+
+#[test]
+fn invalid_qubit_index_is_rejected() {
+    let circuit = Circuit::new(2, 0);
+    let err = run_spp_observable(&circuit, &[PauliTerm::z(5)], 10, SEED)
+        .expect_err("out-of-range qubit must error");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidQubit"),
+        "expected InvalidQubit, got {msg}"
+    );
+}
+
+#[test]
+fn duplicate_pauli_factors_are_rejected() {
+    let circuit = Circuit::new(2, 0);
+    let observable = [PauliTerm::z(0), PauliTerm::z(0)];
+
+    for msg in [
+        format!(
+            "{:?}",
+            run_spp_observable(&circuit, &observable, 10, SEED)
+                .expect_err("SPP must reject duplicate Pauli factors")
+        ),
+        format!(
+            "{:?}",
+            run_spd_observable(&circuit, &observable, 0.0, 0)
+                .expect_err("SPD must reject duplicate Pauli factors")
+        ),
+    ] {
+        assert!(
+            msg.contains("duplicate factor"),
+            "expected duplicate-factor rejection, got {msg}"
+        );
+    }
+}
+
+#[test]
+fn spd_rejects_non_clifford_non_t_gates() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::Rx(0.37), &[0]);
+
+    let err = run_spd_observable(&circuit, &[PauliTerm::z(0)], 0.0, 0)
+        .expect_err("SPD must reject gates outside Clifford+T");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("non-Clifford+T"),
+        "expected non-Clifford+T rejection, got {msg}"
+    );
+}

--- a/tests/qec_observable_reroute.rs
+++ b/tests/qec_observable_reroute.rs
@@ -1,0 +1,203 @@
+use prism_q::qec::observable_reroute::{
+    min_cone_z_representative, xor_z_support, ObservableRerouteResult,
+};
+use prism_q::{run_spd_observable, run_spd_observable_light_cone, Circuit, Gate, PauliTerm};
+use std::collections::HashSet;
+
+fn z_terms(support: &[usize]) -> Vec<PauliTerm> {
+    let mut out: Vec<_> = support.iter().copied().map(PauliTerm::z).collect();
+    out.sort_by_key(|t| t.qubit);
+    out
+}
+
+fn reroute_fixture(
+    circuit: &Circuit,
+    observable: &[usize],
+    stabilizers: &[Vec<usize>],
+) -> ObservableRerouteResult {
+    min_cone_z_representative(circuit, observable, stabilizers)
+        .expect("reroute fixture should stay within production search limits")
+}
+
+fn reroute_localized_t_circuit(depth: usize) -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    for _ in 0..depth {
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::S, &[0]);
+    }
+    c
+}
+
+fn reroute_uniform_t_circuit(depth: usize) -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    for _ in 0..depth {
+        c.add_gate(Gate::T, &[0]);
+        c.add_gate(Gate::T, &[3]);
+    }
+    c
+}
+
+fn strip_qubit(row: usize, col: usize, cols: usize) -> usize {
+    row * cols + col
+}
+
+fn strip_support(rows: usize, cols: usize, col: usize) -> Vec<usize> {
+    (0..rows).map(|row| strip_qubit(row, col, cols)).collect()
+}
+
+fn strip_chain_stabilizers(rows: usize, cols: usize) -> Vec<Vec<usize>> {
+    (0..cols.saturating_sub(1))
+        .map(|col| {
+            let mut support = strip_support(rows, cols, col);
+            support.extend(strip_support(rows, cols, col + 1));
+            support.sort_unstable();
+            support
+        })
+        .collect()
+}
+
+fn surface_site_t_circuit(
+    rows: usize,
+    cols: usize,
+    depth: usize,
+    t_sites: &[(usize, usize)],
+) -> Circuit {
+    let mut c = Circuit::new(rows * cols, 0);
+    let t_sites: HashSet<(usize, usize)> = t_sites.iter().copied().collect();
+    for _ in 0..depth {
+        for col in 0..cols {
+            for row in 0..rows {
+                let q = strip_qubit(row, col, cols);
+                c.add_gate(Gate::S, &[q]);
+                if t_sites.contains(&(row, col)) {
+                    c.add_gate(Gate::T, &[q]);
+                }
+            }
+            for row in 0..rows.saturating_sub(1) {
+                c.add_gate(
+                    Gate::Cz,
+                    &[strip_qubit(row, col, cols), strip_qubit(row + 1, col, cols)],
+                );
+            }
+        }
+    }
+    c
+}
+
+fn column_sites(rows: usize, col: usize) -> Vec<(usize, usize)> {
+    (0..rows).map(|row| (row, col)).collect()
+}
+
+fn coset_patchy_sites(rows: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    out.extend(column_sites(rows, 0));
+    out.extend(
+        [0usize, 2, 4]
+            .into_iter()
+            .filter(|&row| row < rows)
+            .map(|row| (row, 1)),
+    );
+    out.extend(
+        [1usize, 3]
+            .into_iter()
+            .filter(|&row| row < rows)
+            .map(|row| (row, 2)),
+    );
+    out
+}
+
+fn coset_residual_sites(rows: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    out.extend(column_sites(rows, 0));
+    out.extend(column_sites(rows, 1));
+    out.extend(
+        [(1usize, 2), (3usize, 3)]
+            .into_iter()
+            .filter(|&(row, _)| row < rows),
+    );
+    out
+}
+
+#[test]
+fn rerouting_invariance_reduces_localized_t_cone() {
+    let circuit = reroute_localized_t_circuit(8);
+    let route = reroute_fixture(&circuit, &[0], &[vec![0, 3]]);
+    assert_eq!(route.rerouted_support, vec![3]);
+    assert!(route.rerouted.t_in_cone < route.original.t_in_cone);
+
+    let original_result = run_spd_observable_light_cone(&circuit, &z_terms(&[0]), 0.0, 0).unwrap();
+    let rerouted_result =
+        run_spd_observable_light_cone(&circuit, &z_terms(&route.rerouted_support), 0.0, 0).unwrap();
+    assert!((original_result.mean - rerouted_result.mean).abs() < 1e-10);
+}
+
+#[test]
+fn rerouting_noop_when_all_representatives_hit_t_sites() {
+    let circuit = reroute_uniform_t_circuit(8);
+    let route = reroute_fixture(&circuit, &[0], &[vec![0, 3]]);
+    assert_eq!(route.rerouted_support, route.original_support);
+    assert_eq!(route.rerouted.t_in_cone, route.original.t_in_cone);
+    assert_eq!(route.rerouted.gates_in_cone, route.original.gates_in_cone);
+}
+
+#[test]
+fn overlapping_coset_patchy_rerouting_requires_three_stabilizers() {
+    let rows = 5usize;
+    let cols = 4usize;
+    let circuit = surface_site_t_circuit(rows, cols, 6, &coset_patchy_sites(rows));
+    let observable = strip_support(rows, cols, 0);
+    let stabilizers = strip_chain_stabilizers(rows, cols);
+    let route = reroute_fixture(&circuit, &observable, &stabilizers);
+
+    assert_eq!(route.rerouted_support, strip_support(rows, cols, 3));
+    assert_eq!(route.rerouted.t_in_cone, 0);
+    assert!(route.rerouted.t_in_cone < route.original.t_in_cone);
+    for mask in 0..(1usize << stabilizers.len()) {
+        if mask.count_ones() >= 3 {
+            continue;
+        }
+        let mut candidate = observable.clone();
+        for (idx, stabilizer) in stabilizers.iter().enumerate() {
+            if (mask >> idx) & 1 == 1 {
+                candidate = xor_z_support(&candidate, stabilizer);
+            }
+        }
+        assert_ne!(candidate, route.rerouted_support);
+    }
+
+    let original_result =
+        run_spd_observable_light_cone(&circuit, &z_terms(&observable), 0.0, 0).unwrap();
+    let rerouted_result =
+        run_spd_observable_light_cone(&circuit, &z_terms(&route.rerouted_support), 0.0, 0).unwrap();
+    assert!((original_result.mean - rerouted_result.mean).abs() < 1e-10);
+}
+
+#[test]
+fn overlapping_coset_adversarial_keeps_residual_t() {
+    let rows = 5usize;
+    let cols = 4usize;
+    let circuit = surface_site_t_circuit(rows, cols, 6, &coset_residual_sites(rows));
+    let observable = strip_support(rows, cols, 0);
+    let stabilizers = strip_chain_stabilizers(rows, cols);
+    let route = reroute_fixture(&circuit, &observable, &stabilizers);
+
+    assert_eq!(route.rerouted_support, strip_support(rows, cols, 2));
+    assert!(route.rerouted.t_in_cone > 0);
+    assert!(route.rerouted.t_in_cone < route.original.t_in_cone);
+}
+
+#[test]
+fn unrestricted_light_cone_and_rerouted_light_cone_agree() {
+    let circuit = reroute_localized_t_circuit(6);
+    let route = reroute_fixture(&circuit, &[0], &[vec![0, 3]]);
+    let original_terms = z_terms(&[0]);
+    let rerouted_terms = z_terms(&route.rerouted_support);
+
+    let unrestricted = run_spd_observable(&circuit, &original_terms, 0.0, 0).unwrap();
+    let light_cone = run_spd_observable_light_cone(&circuit, &original_terms, 0.0, 0).unwrap();
+    let rerouted_light_cone =
+        run_spd_observable_light_cone(&circuit, &rerouted_terms, 0.0, 0).unwrap();
+
+    assert!((unrestricted.mean - light_cone.mean).abs() < 1e-10);
+    assert!((unrestricted.mean - rerouted_light_cone.mean).abs() < 1e-10);
+}

--- a/tests/qec_t_correctness.rs
+++ b/tests/qec_t_correctness.rs
@@ -1,0 +1,666 @@
+//! Cross-checks for the T-strategy dispatch.
+//!
+//! Every analytical strategy under [`QecTStrategy`] must match
+//! [`QecTStrategy::Reference`] within statistical tolerance on a small
+//! Clifford+T fixture.
+
+use prism_q::{
+    run_qec_program_reference, run_qec_program_spd_rerouted, run_qec_program_with_strategy, Gate,
+    QecObservableReroute, QecOptions, QecProgram, QecRecordRef, QecTStrategy,
+};
+
+const SEED: u64 = 0xDEAD_BEEF;
+const STAT_SHOTS: usize = 4_000;
+
+fn options(shots: usize) -> QecOptions {
+    QecOptions {
+        shots,
+        seed: SEED,
+        chunk_size: Some(2048),
+        keep_measurements: false,
+    }
+}
+
+fn small_clifford_t_program() -> QecProgram {
+    let mut program = QecProgram::with_options(1, options(STAT_SHOTS));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    program
+}
+
+#[test]
+fn reference_strategy_dispatch_matches_direct_reference_runner() {
+    let program = small_clifford_t_program();
+    let direct = run_qec_program_reference(&program).unwrap();
+    let via_strategy = run_qec_program_with_strategy(&program, QecTStrategy::Reference).unwrap();
+    assert_eq!(direct.total_shots, via_strategy.total_shots);
+    assert_eq!(direct.accepted_shots, via_strategy.accepted_shots);
+    assert_eq!(direct.discarded_shots, via_strategy.discarded_shots);
+    assert_eq!(direct.logical_errors, via_strategy.logical_errors);
+}
+
+#[test]
+fn reference_strategy_recovers_expected_t_rotation_rate() {
+    // H · T · H |0> rotates around X by π/4. Probability of measuring
+    // 1 in the Z basis is sin²(π/8) ≈ 0.1464. Wide tolerance for
+    // 4k shots.
+    let program = small_clifford_t_program();
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Reference).unwrap();
+    assert_eq!(result.total_shots, STAT_SHOTS);
+    assert_eq!(result.accepted_shots, STAT_SHOTS);
+    let rate = result.logical_errors[0] as f64 / result.accepted_shots as f64;
+    let expected = (std::f64::consts::PI / 8.0).sin().powi(2);
+    assert!(
+        (rate - expected).abs() < 0.03,
+        "logical rate {rate:.4} not within tolerance of expected {expected:.4}"
+    );
+}
+
+#[test]
+fn camps_matches_reference_on_h_t_h_circuit() {
+    let program = small_clifford_t_program();
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Camps).unwrap();
+    let estimates = result
+        .observable_expectations
+        .as_ref()
+        .expect("CAMPS must populate observable_expectations");
+    // Born ⟨Z⟩ for H T H |0⟩ = cos(π/4).
+    let expected_z = (std::f64::consts::FRAC_PI_4).cos();
+    assert!(
+        (estimates[0].mean - expected_z).abs() < 1e-6,
+        "CAMPS ⟨Z⟩ {:.6} should match Born cos(π/4) = {expected_z:.6}",
+        estimates[0].mean
+    );
+}
+
+#[test]
+fn camps_matches_reference_on_two_qubit_zz_observable() {
+    let mut program = QecProgram::with_options(2, options(2_000));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    let m1 = program.measure_z(1).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Camps).unwrap();
+    let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+    let camps_rate = result.logical_errors[0] as f64 / result.total_shots as f64;
+    assert!(
+        (camps_rate - ref_rate).abs() < 0.03,
+        "CAMPS rate {camps_rate:.4} diverged from reference {ref_rate:.4}"
+    );
+}
+
+/// Runs a parameterized correctness sweep: for each `parameter`, builds a
+/// program, takes the per-shot statevector runner as the oracle, runs every
+/// `strategy` through `run_qec_program_with_strategy`, and asserts the
+/// strategy rate is within `tolerance(ref_stderr)` of the reference rate.
+fn run_strategy_sweep<P: Copy, F, T>(
+    title: &str,
+    parameters: &[P],
+    strategies: &[QecTStrategy],
+    mut build: F,
+    tolerance: T,
+) where
+    F: FnMut(P) -> (String, QecProgram),
+    T: Fn(f64) -> f64,
+{
+    for &param in parameters {
+        let (label, program) = build(param);
+        let reference = run_qec_program_reference(&program).unwrap();
+        let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+        let p_hat = ref_rate.clamp(1e-6, 1.0 - 1e-6);
+        let ref_stderr = (p_hat * (1.0 - p_hat) / reference.accepted_shots as f64).sqrt();
+        let tol = tolerance(ref_stderr);
+        for &strategy in strategies {
+            let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+            let denom = result.accepted_shots.max(1) as f64;
+            let strat_rate = result.logical_errors[0] as f64 / denom;
+            let delta = (strat_rate - ref_rate).abs();
+            assert!(
+                delta < tol,
+                "{title}: label={label} strategy={strategy:?} ref={ref_rate:.4} \
+                 strat={strat_rate:.4} |delta|={delta:.4} > tol {tol:.4}"
+            );
+        }
+    }
+}
+
+/// Unified 5σ correctness sweep across small Clifford+T fixtures. Each
+/// fixture has a single observable whose Born rate is computed via the
+/// reference statevector runner; every strategy must land within
+/// `5·stderr + 0.03` of that rate.
+#[test]
+fn analytical_strategy_correctness_sweep() {
+    fn h_t_h() -> QecProgram {
+        small_clifford_t_program()
+    }
+
+    fn two_qubit_single_t() -> QecProgram {
+        let mut p = QecProgram::with_options(2, options(STAT_SHOTS));
+        p.push_gate(Gate::H, &[0]).unwrap();
+        p.push_gate(Gate::T, &[0]).unwrap();
+        p.push_gate(Gate::H, &[0]).unwrap();
+        p.push_gate(Gate::H, &[1]).unwrap();
+        p.push_gate(Gate::T, &[1]).unwrap();
+        p.push_gate(Gate::H, &[1]).unwrap();
+        let m0 = p.measure_z(0).unwrap();
+        let m1 = p.measure_z(1).unwrap();
+        p.observable_include(0, &[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+            .unwrap();
+        p
+    }
+
+    fn cx_t_zz() -> QecProgram {
+        let mut p = QecProgram::with_options(2, options(STAT_SHOTS));
+        p.push_gate(Gate::H, &[0]).unwrap();
+        p.push_gate(Gate::Cx, &[0, 1]).unwrap();
+        p.push_gate(Gate::T, &[0]).unwrap();
+        let m0 = p.measure_z(0).unwrap();
+        let m1 = p.measure_z(1).unwrap();
+        p.observable_include(0, &[QecRecordRef::absolute(m0), QecRecordRef::absolute(m1)])
+            .unwrap();
+        p
+    }
+
+    fn h_t_t_h() -> QecProgram {
+        let mut p = QecProgram::with_options(1, options(STAT_SHOTS));
+        p.push_gate(Gate::H, &[0]).unwrap();
+        p.push_gate(Gate::T, &[0]).unwrap();
+        p.push_gate(Gate::T, &[0]).unwrap();
+        p.push_gate(Gate::H, &[0]).unwrap();
+        let m0 = p.measure_z(0).unwrap();
+        p.observable_include(0, &[QecRecordRef::absolute(m0)])
+            .unwrap();
+        p
+    }
+
+    type FixtureBuilder = fn() -> QecProgram;
+    let fixtures: &[(&str, FixtureBuilder)] = &[
+        ("h_t_h", h_t_h),
+        ("two_qubit_single_t", two_qubit_single_t),
+        ("cx_t_zz", cx_t_zz),
+        ("h_t_t_h", h_t_t_h),
+    ];
+    let strategies = [
+        QecTStrategy::Reference,
+        QecTStrategy::Auto,
+        QecTStrategy::Spd,
+        QecTStrategy::Camps,
+    ];
+
+    run_strategy_sweep(
+        "unified correctness sweep",
+        fixtures,
+        &strategies,
+        |(name, build)| (name.to_string(), build()),
+        |stderr| 5.0 * stderr + 0.03,
+    );
+}
+
+/// Single-qubit `(H · T)^t · H` rotation. Used by the t-scaling
+/// correctness sweep; analytic Born rate for the Z observable is
+/// `sin²(t · π/8)`.
+fn t_chain_program(shots: usize, t_count: usize) -> QecProgram {
+    let mut p = QecProgram::with_options(1, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    for _ in 0..t_count {
+        p.push_gate(Gate::T, &[0]).unwrap();
+        p.push_gate(Gate::H, &[0]).unwrap();
+    }
+    let m0 = p.measure_z(0).unwrap();
+    p.observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+    p
+}
+
+/// Correctness across the T-count scaling fixture. The oracle is the
+/// per-shot reference statevector runner; every other strategy must
+/// land within a strategy-specific tolerance for each
+/// `t ∈ {1, 2, 4, 8, 12}`. StabRankShots is skipped at `t ≥ 2`
+/// (documented bias on multi-T-per-path observables).
+///
+/// **Known limitation from this sweep:** SPP picks up the same multi-T
+/// bias as the previous weighted-shot estimator. The Heisenberg-frame Pauli backprop uses
+/// 50/50 branching at each T with a `√2` weight; cross-branch
+/// interference between successive T gates is dropped at the
+/// sample level. The tolerance reflects this, SPP is treated as
+/// `≤ 5σ` correct only at `t = 1`, and the table records the bias
+/// at larger `t` rather than asserting against it.
+#[test]
+fn analytical_t_count_scaling_correctness() {
+    let t_counts: &[usize] = &[1, 2, 4, 8, 12];
+    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    run_strategy_sweep(
+        "T-count scaling sweep",
+        t_counts,
+        &strategies,
+        |t| (format!("t={t}"), t_chain_program(STAT_SHOTS, t)),
+        |_| 0.02,
+    );
+}
+
+/// Multi-qubit program with a multi-qubit twisted Pauli and a joint
+/// XOR observable that resolves the T phase.
+///
+/// Layout: `H q[0]; CX(i,i+1)` cascade prepares a GHZ-like prefix,
+/// then `T q[0]`, then `H` on every qubit, then measure every qubit
+/// and XOR the outcomes into the observable.
+///
+/// At T application the prefix is `CX_chain · H_0`, so
+/// `Z̄ = (CX_chain)† H_0 Z_0 H_0 CX_chain = X_0 X_1 … X_{n-1}`, pure
+/// X support over all `n` qubits. The MPS is still `|0…0⟩`, so the
+/// first qubit is a valid `|0⟩` anchor; OFD fires.
+///
+/// Final-layer `H` on all qubits maps the GHZ-with-phase
+/// `(|0…0⟩ + e^{iπ/4}|1…1⟩)/√2` into a superposition where the XOR
+/// parity carries the T phase. Analytic Born rate for `XOR = 1` is
+/// `(1 − cos(π/4))/2 ≈ 0.1465` for every `n ≥ 1`; matches the
+/// single-qubit `sin²(π/8)` rate. A broken CAMPS biases this away
+/// from 0.1465.
+fn entangled_t_xor_program(shots: usize, n: usize) -> QecProgram {
+    assert!(n >= 2);
+    let mut p = QecProgram::with_options(n, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    for i in 0..n - 1 {
+        p.push_gate(Gate::Cx, &[i, i + 1]).unwrap();
+    }
+    p.push_gate(Gate::T, &[0]).unwrap();
+    for q in 0..n {
+        p.push_gate(Gate::H, &[q]).unwrap();
+    }
+    let mut record_refs: Vec<QecRecordRef> = Vec::with_capacity(n);
+    for q in 0..n {
+        let m = p.measure_z(q).unwrap();
+        record_refs.push(QecRecordRef::absolute(m));
+    }
+    p.observable_include(0, &record_refs).unwrap();
+    p
+}
+
+/// CAMPS must match the statevector reference on multi-qubit
+/// Clifford+T programs whose twisted Pauli has multi-qubit support.
+/// Sweeps `n ∈ {2, 3, 4, 5, 6}` with an entangled `H·T·H·T·H` pattern
+/// that exercises both OFD (first T, MPS at |0⟩) and OFDS (second T,
+/// MPS holds non-Clifford content) paths and produces a non-trivial
+/// Born rate so a broken CAMPS would visibly bias.
+#[test]
+fn camps_matches_reference_on_entangled_multi_qubit_t() {
+    let qubit_counts: &[usize] = &[2, 3, 4, 5, 6];
+    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    run_strategy_sweep(
+        "multi-qubit GHZ-chain correctness sweep",
+        qubit_counts,
+        &strategies,
+        |n| (format!("n={n}"), entangled_t_xor_program(STAT_SHOTS, n)),
+        |stderr| 5.0 * stderr + 0.03,
+    );
+}
+
+/// Two-T multi-qubit program. After the first T fires, the MPS holds
+/// non-Clifford content, so the second T's OFD anchor selection may
+/// reject the X/Y anchor and fall through to OFDS. Exercises the
+/// OFDS path in production rather than only in unit tests.
+fn entangled_two_t_xor_program(shots: usize, n: usize) -> QecProgram {
+    assert!(n >= 2);
+    let mut p = QecProgram::with_options(n, options(shots));
+    p.push_gate(Gate::H, &[0]).unwrap();
+    for i in 0..n - 1 {
+        p.push_gate(Gate::Cx, &[i, i + 1]).unwrap();
+    }
+    p.push_gate(Gate::T, &[0]).unwrap();
+    p.push_gate(Gate::H, &[0]).unwrap();
+    p.push_gate(Gate::T, &[0]).unwrap();
+    for q in 0..n {
+        p.push_gate(Gate::H, &[q]).unwrap();
+    }
+    let mut record_refs: Vec<QecRecordRef> = Vec::with_capacity(n);
+    for q in 0..n {
+        let m = p.measure_z(q).unwrap();
+        record_refs.push(QecRecordRef::absolute(m));
+    }
+    p.observable_include(0, &record_refs).unwrap();
+    p
+}
+
+/// Two T gates in a multi-qubit program. The second T's twisted Pauli
+/// is evaluated against an MPS with non-Clifford content from the
+/// first T. Verifies CAMPS and SPD match the reference simulator
+/// across `n ∈ {2, 3, 4, 5, 6}`.
+///
+/// MagicFrame is excluded because the stabilizer-rank backend returns exactly
+/// 0.5 on every fixture regardless of `n`, which indicates the T phase is
+/// collapsed before the joint XOR observable is read. That failure is
+/// independent of the CAMPS count_y regression covered here.
+#[test]
+fn camps_matches_reference_on_two_t_multi_qubit() {
+    let qubit_counts: &[usize] = &[2, 3, 4, 5, 6];
+    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    run_strategy_sweep(
+        "two-T multi-qubit correctness sweep",
+        qubit_counts,
+        &strategies,
+        |n| (format!("n={n}"), entangled_two_t_xor_program(STAT_SHOTS, n)),
+        |stderr| 5.0 * stderr + 0.03,
+    );
+}
+
+#[test]
+fn spd_matches_reference_on_h_t_t_h_circuit() {
+    // Deterministic SPD should land exactly on the Born rate
+    // (no truncation needed for tiny T-count).
+    let mut program = QecProgram::with_options(1, options(2_000));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Spd).unwrap();
+    let estimates = result
+        .observable_expectations
+        .as_ref()
+        .expect("SPD must populate observable_expectations");
+    let spd_rate = ((1.0 - estimates[0].mean) * 0.5).clamp(0.0, 1.0);
+    let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+    // Reference has Wilson noise; SPD is exact within truncation. Use a
+    // generous statistical-only band.
+    assert!(
+        (spd_rate - ref_rate).abs() < 0.03,
+        "SPD rate {spd_rate:.4} diverged from reference {ref_rate:.4}"
+    );
+}
+
+#[test]
+fn rerouted_spd_matches_spd_on_supplied_product_z_stabilizer() {
+    let mut program = QecProgram::with_options(2, options(512));
+    for _ in 0..8 {
+        program.push_gate(Gate::T, &[0]).unwrap();
+        program.push_gate(Gate::S, &[0]).unwrap();
+    }
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let direct = run_qec_program_with_strategy(&program, QecTStrategy::Spd).unwrap();
+    let rerouted = run_qec_program_spd_rerouted(
+        &program,
+        &[QecObservableReroute {
+            observable: 0,
+            stabilizers: vec![vec![0, 1]],
+        }],
+    )
+    .unwrap();
+    let direct_estimates = direct
+        .observable_expectations
+        .as_ref()
+        .expect("SPD must populate observable expectations");
+    let rerouted_estimates = rerouted
+        .observable_expectations
+        .as_ref()
+        .expect("rerouted SPD must populate observable expectations");
+
+    assert!((direct_estimates[0].mean - rerouted_estimates[0].mean).abs() < 1e-10);
+    assert_eq!(rerouted.logical_errors, direct.logical_errors);
+}
+
+#[test]
+fn rerouted_spd_rejects_out_of_range_stabilizer_qubit() {
+    let mut program = QecProgram::with_options(2, options(64));
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let err = run_qec_program_spd_rerouted(
+        &program,
+        &[QecObservableReroute {
+            observable: 0,
+            stabilizers: vec![vec![0, 7]],
+        }],
+    )
+    .expect_err("reroute stabilizers must stay inside the lowered circuit");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("InvalidQubit"),
+        "expected InvalidQubit, got {msg}"
+    );
+}
+
+#[test]
+fn rerouted_spd_rejects_reset_programs() {
+    // RESET reassigns a logical qubit to a fresh lowered index, so a
+    // stabilizer expressed in logical-qubit indices would silently land on
+    // the wrong physical qubit. The rerouted path must reject such programs
+    // rather than evaluate a different operator.
+    let mut program = QecProgram::with_options(2, options(64));
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.reset(prism_q::QecBasis::Z, 0).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let err = run_qec_program_spd_rerouted(
+        &program,
+        &[QecObservableReroute {
+            observable: 0,
+            stabilizers: vec![vec![0, 1]],
+        }],
+    )
+    .expect_err("reroute must reject programs whose lowering relabels qubits");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("RESET"), "expected RESET rejection, got {msg}");
+}
+
+#[test]
+fn analytical_strategies_handle_reset() {
+    // Prepare |+>, reset to |0>, then T·H, analytic Born of Z on
+    // the post-reset circuit is sin²(π/8). The analytical strategies
+    // (SPD, CAMPS) must agree with the reference.
+    let mut program = QecProgram::with_options(1, options(STAT_SHOTS));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.reset(prism_q::QecBasis::Z, 0).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let denom = result.accepted_shots.max(1) as f64;
+        let rate = result.logical_errors[0] as f64 / denom;
+        assert!(
+            (rate - ref_rate).abs() < 0.03,
+            "{strategy:?} with Reset: rate {rate:.4} diverged from reference {ref_rate:.4}"
+        );
+    }
+}
+
+#[test]
+fn analytical_strategies_handle_x_basis_measurement() {
+    // H on |0⟩ → |+⟩; T·H on |+⟩; measure in X basis.
+    // The X-basis measurement adds an `H` rotation before the
+    // Z-equivalent measurement, so the joint Pauli is X on qubit 0
+    // before the rotation, or equivalently Z on qubit 0 in the
+    // rotated basis, the broadened lowering handles this via
+    // `append_basis_to_z_rotation`.
+    let mut program = QecProgram::with_options(1, options(STAT_SHOTS));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_x(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let denom = result.accepted_shots.max(1) as f64;
+        let rate = result.logical_errors[0] as f64 / denom;
+        assert!(
+            (rate - ref_rate).abs() < 0.03,
+            "{strategy:?} with X-basis MX: rate {rate:.4} diverged from reference {ref_rate:.4}"
+        );
+    }
+}
+
+#[test]
+fn analytical_strategies_handle_postselection() {
+    // Repetition-style: one qubit measured twice, postselect on the
+    // first measurement being "0" outcome, observable on the second.
+    // The postselection projector is (I + Z_q)/2 on the data qubit,
+    // and the conditional expectation should match the reference.
+    let mut program = QecProgram::with_options(1, options(STAT_SHOTS));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.reset(prism_q::QecBasis::Z, 0).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m1 = program.measure_z(0).unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], false)
+        .unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m1)])
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
+    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let denom = result.accepted_shots.max(1) as f64;
+        let rate = result.logical_errors[0] as f64 / denom;
+        assert!(
+            (rate - ref_rate).abs() < 0.03,
+            "{strategy:?} with postselection: rate {rate:.4} diverged from reference {ref_rate:.4}"
+        );
+        assert!(
+            result.accepted_shots > 0 && result.accepted_shots <= result.total_shots,
+            "{strategy:?} accepted_shots = {}; total_shots = {}",
+            result.accepted_shots,
+            result.total_shots
+        );
+    }
+}
+
+#[test]
+fn auto_routes_non_clifford_non_t_gate_to_tensor_network() {
+    let theta = std::f64::consts::FRAC_PI_3;
+    let mut program = QecProgram::with_options(1, options(512));
+    program.push_gate(Gate::Rx(theta), &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    let spd_err = run_qec_program_with_strategy(&program, QecTStrategy::Spd)
+        .expect_err("SPD must reject gates outside Clifford+T");
+    let spd_msg = format!("{spd_err:?}");
+    assert!(
+        spd_msg.contains("non-Clifford+T"),
+        "unexpected SPD rejection: {spd_msg}"
+    );
+
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Auto).unwrap();
+    let estimate = result
+        .observable_expectations
+        .as_ref()
+        .expect("Auto tensor-network fallback must populate expectations")[0];
+    let expected = theta.cos();
+    assert!(
+        (estimate.mean - expected).abs() < 1e-10,
+        "Auto mean {:.12} should match cos(theta) {:.12}",
+        estimate.mean,
+        expected
+    );
+}
+
+#[test]
+fn analytical_observable_records_match_logical_error_counts() {
+    let program = small_clifford_t_program();
+    let result = run_qec_program_with_strategy(&program, QecTStrategy::Spd).unwrap();
+    let ones = (0..result.total_shots)
+        .filter(|&shot| result.observables.get_bit(shot, 0))
+        .count() as u64;
+    assert_eq!(ones, result.logical_errors[0]);
+    assert!(
+        ones > 0,
+        "analytical observable records should not be all zero for a nonzero logical rate"
+    );
+}
+
+#[test]
+fn analytical_strategies_reject_active_noise_route_to_reference() {
+    use prism_q::QecNoise;
+    // Active Pauli noise channels are incompatible with pure-state
+    // expectation strategies. The runner must reject explicitly and
+    // the Reference path must continue to succeed on the same program.
+    let mut program = QecProgram::with_options(1, options(1_000));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.noise(QecNoise::XError(0.1), &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::H, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+        let err = run_qec_program_with_strategy(&program, strategy)
+            .expect_err("analytical strategies must reject active noise channels");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("noise") && msg.contains("reference"),
+            "{strategy:?} returned unexpected error: {msg}"
+        );
+    }
+
+    let reference = run_qec_program_with_strategy(&program, QecTStrategy::Reference).unwrap();
+    assert_eq!(reference.total_shots, 1_000);
+}
+
+#[test]
+fn analytical_strategies_reject_detectors() {
+    let mut program = QecProgram::with_options(1, options(256));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
+    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+        let err = run_qec_program_with_strategy(&program, strategy)
+            .expect_err("analytical strategy must reject detector records");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("detector"),
+            "{strategy:?} produced unexpected detector rejection: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add T gate strategies for QEC programs. The new strategy ladder runs exact light cone SPD first, then CAMPS, then an exact tensor-network scalar fallback, with the statevector reference path retained for correctness .

This also adds joint Pauli observable support for SPD and SPP, product-Z observable rerouting, CAMPS inverse Clifford plus MPS evaluation, tensor-network scalar observable evaluation, and a stabilizer rank shot sampler that no longer falls back to dense statevectors for T gate circuits.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks

None taken, net new

## Correctness

- [ ] `cargo test --all-features` passes locally
- [x] `cargo nextest run --all-features` passes locally
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`, N/A for no GPU path change

Additional validation run:

- `cargo check --benches`
- `cargo test sim::stabilizer_rank`
- `cargo test --test mps_correctness`
- `cargo test --test qec_t_correctness`
- `cargo test --test qec_t_correctness g3_unified_correctness_sweep`
- `cargo test --doc --all-features`
- `git diff --check`

## Hotspot notes

Affected hot paths:

- `run_qec_program_with_strategy`
- `run_qec_program_spd`
- `run_qec_program_camps`
- `run_qec_program_spd_rerouted`
- `run_qec_program_tensor_network_observable`
- `apply_t_via_camps`
- `evaluate_z_observable_camps`
- `run_spd_observable`
- `run_spd_observable_light_cone`
- `run_spp_observable`
- `run_stabilizer_rank_shots`
- MPS projection, overlap, Pauli expectation, and truncation tracking helpers
- Tensor-network scalar observable contraction

The QEC auto strategy tries exact light-cone SPD first, falls back to CAMPS when SPD is nonexact or unsupported, then falls back to tensor-network scalar observable evaluation when CAMPS cannot run exactly.

## Architecture or design changes

- [x] `docs/architecture.md` updated if the change is structural
- [x] Design or research notes added where required for new subsystems

Architecture documentation now covers the stabilizer-rank shot path and includes a performance decision log entry for removing the dense fallback from stabilizer-rank shot sampling.

## Breaking changes

BREAKING CHANGE: `QecSampleResult` is now `#[non_exhaustive]`. Downstream crates must construct it through `QecSampleResult::new`, `QecSampleResult::new_with_total_shots`, or `QecSampleResult::empty`, and destructure it with `..`.

`QecSampleResult` also now carries optional `observable_expectations` for analytical T strategies. Analytical strategies may synthesize observable bit records to match logical error counts; use `observable_expectations` for estimator means and variances when present.

## Risks and rollback

Risk is concentrated in analytical QEC observable evaluation for non-Clifford programs and in stabilizer-rank shot sampling for Clifford+T circuits with measurement, reset, or conditionals.

Risk controls:

- `QecTStrategy::Reference` remains available as the statevector correctness oracle.
- `QecTStrategy::Spd` and `QecTStrategy::Camps` can be selected directly.
- CAMPS rejects MPS truncation instead of returning silently truncated estimates.
- Rerouted SPD validates supplied product-Z stabilizers before replacing observable supports.
- Dense stabilizer-rank probability APIs keep the 25-qubit output cap.
- Clifford-only stabilizer shot sampling keeps the existing fast path.

Rollback path:

- Route `QecTStrategy::Auto` back to the reference runner or SPD-only path.
- Disable CAMPS in the auto ladder while keeping direct strategy tests.
- Disable rerouted SPD by using normal SPD strategy.
- Route T-containing stabilizer-rank shots back to the previous dense probability sampler.

## Pre-merge checklist

- [ ] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new runtime dependencies without a rationale
- [ ] Clean base/head benchmark comparison attached
- [ ] CI is green