### PR TITLE
docs: add github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'llms.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'llms.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+      - name: Build book
+        run: mdbook build docs
+      - name: Copy llms.txt to site root
+        run: cp llms.txt docs/book/llms.txt
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build
 /target/
 
+# Rendered documentation site (built in CI)
+docs/book/
+
 # Profiling & benchmarks
 bench_results/
 benchmark_internal/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,20 @@ cargo llvm-cov --all-features                     # terminal summary
 cargo llvm-cov --all-features --html --open       # browseable HTML report
 ```
 
+## Documentation site
+
+The architecture guide and glossary in `docs/` publish as an mdBook site to GitHub Pages
+via `.github/workflows/docs.yml`. Preview locally:
+
+```bash
+cargo install mdbook   # once
+mdbook serve docs      # serves at http://localhost:3000
+```
+
+The book is rooted at `docs/` (`docs/book.toml`); `docs/SUMMARY.md` lists the pages and
+rendered output lands in `docs/book/` (gitignored). Publishing requires the repository
+Pages source set to "GitHub Actions" once under Settings > Pages.
+
 ## Benchmarks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ and BMI2 SIMD kernels in the inner loop. CPU kernels are the default path, with
 optional CUDA support for statevector and experimental stabilizer workloads. Input is
 OpenQASM 3.0 with backward compatible 2.0 syntax.
 
+## Documentation
+
+Full documentation is published at <https://abecoull.github.io/prism-q/>. The generated
+API reference is on [docs.rs](https://docs.rs/prism-q).
+
 ## Installation
 
 Add PRISM-Q to a Rust project:

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,5 @@
+# Summary
+
+- [Overview](./overview.md)
+- [Architecture](./architecture.md)
+- [Glossary](./glossary.md)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "PRISM-Q"
+description = "A Rust quantum circuit simulator built for speed."
+authors = ["A. Coull"]
+language = "en"
+src = "."
+
+[output.html]
+git-repository-url = "https://github.com/AbeCoull/prism-q"
+default-theme = "rust"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,21 @@
+# PRISM-Q
+
+PRISM-Q is a Rust quantum circuit simulator built for speed. It dispatches across
+multiple specialized backends, runs a multi pass fusion pipeline, and uses AVX2, FMA,
+and BMI2 SIMD kernels in the inner loop. CPU kernels are the default path, with
+optional CUDA support for statevector and experimental stabilizer workloads. Input is
+OpenQASM 3.0 with backward compatible 2.0 syntax.
+
+## Where to go next
+
+- [Architecture](./architecture.md): backends, dispatch tree, fusion pipeline, and SIMD strategy.
+- [Glossary](./glossary.md): terminology used across the documentation.
+- [API reference](https://docs.rs/prism-q): generated Rust API documentation.
+- [Source and issues](https://github.com/AbeCoull/prism-q): repository on GitHub.
+
+## Install
+
+```bash
+cargo add prism-q                     # core
+cargo add prism-q --features parallel # Rayon parallelism for larger circuits
+```

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,18 @@
+# PRISM-Q
+
+> PRISM-Q is a Rust quantum circuit simulator built for speed. It dispatches across
+> multiple specialized backends, runs a multi pass fusion pipeline, and uses AVX2, FMA,
+> and BMI2 SIMD kernels in the inner loop. CPU kernels are the default path, with
+> optional CUDA support for statevector and experimental stabilizer workloads. Input is
+> OpenQASM 3.0 with backward compatible 2.0 syntax.
+
+## Documentation
+
+- [Architecture](https://abecoull.github.io/prism-q/architecture.html): backends, dispatch tree, fusion pipeline, SIMD strategy
+- [Glossary](https://abecoull.github.io/prism-q/glossary.html): terminology
+- [API reference](https://docs.rs/prism-q): generated Rust API documentation
+
+## Install
+
+- crates.io: https://crates.io/crates/prism-q
+- `cargo add prism-q`


### PR DESCRIPTION
This is a docs update to publish to GH pages. skipping the formal write-up for this informal description.

Enabling pages for better documentation. This will be part of a multiphase documentation update.