### PR TITLE
chore: make parallel feature opt-out instead of opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,28 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  check-no-default-features:
+    name: Lint & Test (no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - uses: taiki-e/install-action@cargo-nextest
+
+      - name: Clippy
+        run: cargo clippy --all-targets --no-default-features -- -D warnings -D clippy::undocumented_unsafe_blocks
+
+      - name: Tests
+        run: cargo nextest run --no-default-features
+
+      - name: Doc tests
+        run: cargo test --doc --no-default-features
+
   benchmark-regression:
     name: Benchmark Regression
     runs-on: ubuntu-latest
@@ -187,8 +209,8 @@ jobs:
           cache-bin: false
       - name: Install cross-compilation toolchain
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-      - name: Check (no features)
-        run: cargo check --target aarch64-unknown-linux-gnu
+      - name: Check (no default features)
+        run: cargo check --target aarch64-unknown-linux-gnu --no-default-features
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       - name: Check (CI features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cudarc = { version = "0.19", optional = true, default-features = false, features
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [features]
-default = []
+default = ["parallel"]
 parallel = ["rayon", "num_cpus", "faer"]
 serialization = ["serde", "serde_json"]
 gpu = ["dep:cudarc"]

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Add PRISM-Q to a Rust project:
 cargo add prism-q
 ```
 
-Enable Rayon parallelism for larger circuits:
+Rayon parallelism and the faer SVD path are on by default. For a single-threaded,
+minimal-dependency build, opt out:
 
 ```bash
-cargo add prism-q --features parallel
+cargo add prism-q --no-default-features
 ```
 
 For CUDA support, install CUDA Toolkit 12.x or newer, then build with:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -476,31 +476,6 @@ Backward-propagates as a weighted sum of Pauli strings stored in a HashMap. T ga
 
 `run_spd(circuit, epsilon, max_terms) → SpdResult`
 
-## Performance decision log
-
-### 2026-05-28 Remove dense fallback from stabilizer-rank shots
-- **Context**: T-containing stabilizer-rank shot sampling rejected circuits
-  above 25 qubits because it reused the dense probability-vector path. Large
-  low-T circuits should be sampleable when branch count and MPS bond growth
-  remain within budget.
-- **Options considered**: Keep the statevector fallback and document the limit,
-  use dense probability extraction only for terminal measurements, or sample
-  online from coherent weighted branches. The first two options kept the
-  25-qubit cap for user-facing sampling.
-- **Decision**: Use coherent weighted MPS branches for
-  `run_stabilizer_rank_shots`. Keep the 25-qubit limit only on APIs that
-  explicitly return dense probability vectors.
-- **Measurement**: `cargo bench --bench circuits --features bench-fast --
-  "stabilizer_rank/shots_(terminal|mid_circuit)"` on Windows, rustc 1.93.0,
-  8 logical processors. Criterion mean estimates for 64 shots: 32q chi2
-  terminal 21.380 ms, mid-circuit 28.531 ms; 128q chi16 terminal 4.0263 s,
-  mid-circuit 3.2277 s; 1000q chi2 terminal 838.02 ms, mid-circuit 1.1196 s.
-  Old implementation was unsupported above 25 qubits for T-containing shot
-  circuits.
-- **Revisit trigger**: Optimize branch overlap and projection if 1000q chi2
-  exceeds 2 seconds for 64 shots on the release benchmark runner, or if chi16
-  terminal sampling regresses by more than 5 percent against the saved Criterion
-  baseline.
 
 ## Memory layout
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,6 +16,6 @@ OpenQASM 3.0 with backward compatible 2.0 syntax.
 ## Install
 
 ```bash
-cargo add prism-q                     # core
-cargo add prism-q --features parallel # Rayon parallelism for larger circuits
+cargo add prism-q                         # Rayon parallelism + faer SVD (default)
+cargo add prism-q --no-default-features    # single-threaded, minimal dependencies
 ```


### PR DESCRIPTION
Moving the parallel feature to be installed by default to avoid performance confusion.