### PR TITLE
fix(kernel): add kernel checks across CPU arch and GPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,15 +245,16 @@ jobs:
       - name: Cross-backend correctness matrix
         run: cross test --target aarch64-unknown-linux-gnu --features "$CI_FEATURES" --test backend_matrix
 
-  # Compile-check the GPU paths without a device: cudarc dynamic-linking builds with
-  # the toolkit but needs no GPU at runtime. Enforces the exhaustive GPU dispatch
-  # matches and golden_gpu registry, and runs the device-free KERNEL_NAMES test.
+  # Compile-check the GPU paths with the CUDA toolkit but no device. The job only
+  # compiles and runs the device-free KERNEL_NAMES test (nothing opens a device),
+  # enforcing the exhaustive GPU dispatch matches and the golden_gpu registry at
+  # compile time. Pinned to ubuntu-22.04: CUDA 12.4 (matching cudarc's cuda-12040
+  # bindings) has no package for the ubuntu2404 repo on ubuntu-latest.
   gpu-check:
     name: GPU compile-check (no device)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      # Provides nvrtc/driver headers for the build. No GPU is present or needed.
       - uses: Jimver/cuda-toolkit@v0.2.18
         with:
           cuda: '12.4.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,60 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
+  # Execute the NEON fallbacks under emulation. check-aarch64 above only compiles,
+  # so without this the NEON kernels are never run against their scalar reference on
+  # Linux. Scoped to the SIMD-relevant tests to bound QEMU wall-clock.
+  test-aarch64-qemu:
+    name: Test aarch64 (QEMU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: SIMD kernel unit tests (NEON vs scalar)
+        run: cross test --target aarch64-unknown-linux-gnu --features "$CI_FEATURES" --lib backend::simd::tests
+      - name: word_ops unit tests (NEON vs scalar)
+        run: cross test --target aarch64-unknown-linux-gnu --features "$CI_FEATURES" --lib backend::word_ops::tests
+      - name: Batched diagonal phase reference (NEON path)
+        run: cross test --target aarch64-unknown-linux-gnu --features "$CI_FEATURES" --lib backend::statevector::tests::batch_phase_matches_independent_reference
+      - name: Cross-backend correctness matrix
+        run: cross test --target aarch64-unknown-linux-gnu --features "$CI_FEATURES" --test backend_matrix
+
+  # Compile-check the GPU paths without a device: cudarc dynamic-linking builds with
+  # the toolkit but needs no GPU at runtime. Enforces the exhaustive GPU dispatch
+  # matches and golden_gpu registry, and runs the device-free KERNEL_NAMES test.
+  gpu-check:
+    name: GPU compile-check (no device)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Provides nvrtc/driver headers for the build. No GPU is present or needed.
+      - uses: Jimver/cuda-toolkit@v0.2.18
+        with:
+          cuda: '12.4.0'
+          method: network
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - uses: taiki-e/install-action@cargo-nextest
+      - name: Compile-check GPU dispatch + golden_gpu coverage
+        run: cargo check --all-targets --features "parallel gpu"
+      - name: Clippy GPU paths
+        run: cargo clippy --all-targets --features "parallel gpu" -- -D warnings -D clippy::undocumented_unsafe_blocks
+      - name: KERNEL_NAMES consistency (device-free)
+        run: cargo nextest run --features "parallel gpu" -E 'test(kernel_names_match_source_entry_points)'
+
   test-macos-arm:
     name: Test macOS ARM64
     runs-on: macos-14

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -2473,4 +2473,163 @@ mod tests {
             );
         }
     }
+
+    // Drive every SIMD tier the host supports against the scalar reference. The
+    // dispatcher runs only the best tier, so SSE2/FMA never execute on an AVX2 host
+    // without forcing them here.
+
+    #[cfg(target_arch = "x86_64")]
+    fn available_tiers() -> Vec<SimdTier> {
+        let mut tiers = vec![SimdTier::Sse2];
+        if has_fma() {
+            tiers.push(SimdTier::Fma);
+        }
+        if has_avx2_fma() {
+            tiers.push(SimdTier::Avx2Fma);
+        }
+        tiers
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn tier_name(tier: &SimdTier) -> &'static str {
+        match tier {
+            SimdTier::Avx2Fma => "avx2fma",
+            SimdTier::Fma => "fma",
+            SimdTier::Sse2 => "sse2",
+        }
+    }
+
+    /// All four entries distinct, so an indexing or sign bug cannot cancel out.
+    #[cfg(target_arch = "x86_64")]
+    fn asymmetric_gate() -> [[Complex64; 2]; 2] {
+        [[c(0.3, 0.1), c(-0.2, 0.4)], [c(0.5, -0.3), c(0.1, 0.2)]]
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn apply_slices_every_tier_matches_scalar() {
+        let mat = asymmetric_gate();
+        // Length deliberately not a multiple of the widest tier's stride so the
+        // scalar remainder loop is exercised too.
+        let lo0: Vec<Complex64> = (0..37)
+            .map(|i| c(0.11 * i as f64, -0.07 * i as f64))
+            .collect();
+        let hi0: Vec<Complex64> = (0..37)
+            .map(|i| c(-0.05 * i as f64, 0.09 * i as f64))
+            .collect();
+
+        let mut lo_ref = lo0.clone();
+        let mut hi_ref = hi0.clone();
+        apply_slices_scalar(&mut lo_ref, &mut hi_ref, &mat);
+
+        for tier in available_tiers() {
+            let mut prepared = PreparedGate1q::new(&mat);
+            let name = tier_name(&tier);
+            prepared.tier = tier;
+            let mut lo = lo0.clone();
+            let mut hi = hi0.clone();
+            prepared.apply(&mut lo, &mut hi);
+            for i in 0..lo.len() {
+                assert!(
+                    (lo[i] - lo_ref[i]).norm() < EPS && (hi[i] - hi_ref[i]).norm() < EPS,
+                    "tier {name} diverged from scalar at index {i}"
+                );
+            }
+        }
+    }
+
+    /// Scalar reference for a full-state single-qubit apply.
+    #[cfg(target_arch = "x86_64")]
+    fn scalar_full_apply(state: &mut [Complex64], target: usize, mat: &[[Complex64; 2]; 2]) {
+        let half = 1usize << target;
+        let mut base = 0usize;
+        while base < state.len() {
+            for k in base..base + half {
+                let v0 = state[k];
+                let v1 = state[k + half];
+                state[k] = mat[0][0] * v0 + mat[0][1] * v1;
+                state[k + half] = mat[1][0] * v0 + mat[1][1] * v1;
+            }
+            base += half * 2;
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn apply_full_sequential_every_tier_matches_scalar() {
+        let mat = asymmetric_gate();
+        // Cover the AVX2 size/target guard boundary (target >= 2 and small state
+        // takes the 256-bit path; otherwise the 128-bit fallback).
+        for nq in [3usize, 5, 8] {
+            let dim = 1usize << nq;
+            let state0: Vec<Complex64> = (0..dim)
+                .map(|i| c(0.013 * i as f64 + 0.1, -0.017 * i as f64))
+                .collect();
+            for target in 0..nq {
+                let mut reference = state0.clone();
+                scalar_full_apply(&mut reference, target, &mat);
+
+                for tier in available_tiers() {
+                    let mut prepared = PreparedGate1q::new(&mat);
+                    let name = tier_name(&tier);
+                    prepared.tier = tier;
+                    let mut state = state0.clone();
+                    prepared.apply_full_sequential(&mut state, target);
+                    for i in 0..dim {
+                        assert!(
+                            (state[i] - reference[i]).norm() < EPS,
+                            "tier {name} nq={nq} target={target} diverged at index {i}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn norm_sqr_sum_avx2fma_matches_scalar() {
+        if !has_avx2_fma() {
+            return;
+        }
+        let slice: Vec<Complex64> = (0..101)
+            .map(|i| c(0.07 * i as f64 - 1.0, 0.03 * i as f64 + 0.2))
+            .collect();
+        let scalar: f64 = slice.iter().map(|z| z.norm_sqr()).sum();
+        // SAFETY: guarded by has_avx2_fma() above.
+        let simd = unsafe { norm_sqr_sum_avx2fma(&slice) };
+        assert!(
+            (simd - scalar).abs() < 1e-9,
+            "avx2fma norm_sqr_sum={simd} vs scalar={scalar}"
+        );
+    }
+
+    // Completeness tripwire: pin the count of `#[target_feature]` kernels so adding
+    // one without a paired per-tier test fails here. Reads source text only, so it
+    // runs on every arch.
+    #[test]
+    fn target_feature_kernel_count_is_pinned() {
+        // Split the needle so this test's own source does not self-count.
+        let needle = concat!("target_feature", "(enable");
+        let root = env!("CARGO_MANIFEST_DIR");
+        // Per-file expected counts; the breakdown makes a drift easy to localise.
+        let expected: [(&str, usize); 4] = [
+            ("src/backend/simd.rs", 27),
+            ("src/backend/word_ops.rs", 2),
+            ("src/backend/stabilizer/kernels/simd.rs", 3),
+            ("src/backend/statevector/kernels.rs", 10),
+        ];
+        for (file, want) in expected {
+            let path = format!("{root}/{file}");
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("cannot read {path}: {e}"));
+            let got = text.matches(needle).count();
+            assert_eq!(
+                got, want,
+                "{file} has {got} `#[target_feature]` kernels, pinned at {want}. \
+                 If you added or removed a tiered kernel, add/adjust its per-tier \
+                 equivalence test and update this pin."
+            );
+        }
+    }
 }

--- a/src/backend/stabilizer/kernels/mod.rs
+++ b/src/backend/stabilizer/kernels/mod.rs
@@ -667,7 +667,23 @@ impl StabilizerBackend {
             Gate::Cx => self.sgi_apply_cx(targets[0], targets[1]),
             Gate::Cz => self.sgi_apply_cz(targets[0], targets[1]),
             Gate::Swap => self.sgi_apply_swap(targets[0], targets[1]),
-            _ => {
+            Gate::T
+            | Gate::Tdg
+            | Gate::Rx(_)
+            | Gate::Ry(_)
+            | Gate::Rz(_)
+            | Gate::P(_)
+            | Gate::Rzz(_)
+            | Gate::Cu(_)
+            | Gate::Mcu(_)
+            | Gate::Fused(_)
+            | Gate::BatchPhase(_)
+            | Gate::BatchRzz(_)
+            | Gate::DiagonalBatch(_)
+            | Gate::MultiFused(_)
+            | Gate::Fused2q(_)
+            | Gate::Multi2q(_)
+            | Gate::QftBlock { .. } => {
                 return Err(PrismError::BackendUnsupported {
                     backend: self.name().to_string(),
                     operation: format!(
@@ -1002,7 +1018,23 @@ impl StabilizerBackend {
             Gate::Cx => self.apply_cx(targets[0], targets[1]),
             Gate::Cz => self.apply_cz(targets[0], targets[1]),
             Gate::Swap => self.apply_swap(targets[0], targets[1]),
-            _ => {
+            Gate::T
+            | Gate::Tdg
+            | Gate::Rx(_)
+            | Gate::Ry(_)
+            | Gate::Rz(_)
+            | Gate::P(_)
+            | Gate::Rzz(_)
+            | Gate::Cu(_)
+            | Gate::Mcu(_)
+            | Gate::Fused(_)
+            | Gate::BatchPhase(_)
+            | Gate::BatchRzz(_)
+            | Gate::DiagonalBatch(_)
+            | Gate::MultiFused(_)
+            | Gate::Fused2q(_)
+            | Gate::Multi2q(_)
+            | Gate::QftBlock { .. } => {
                 return Err(PrismError::BackendUnsupported {
                     backend: self.name().to_string(),
                     operation: format!(

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -459,7 +459,23 @@ impl StabilizerBackend {
                 self.queue_2q_gpu(op::SWAP, targets[0], targets[1]);
                 Ok(())
             }
-            _ => Err(PrismError::BackendUnsupported {
+            Gate::T
+            | Gate::Tdg
+            | Gate::Rx(_)
+            | Gate::Ry(_)
+            | Gate::Rz(_)
+            | Gate::P(_)
+            | Gate::Rzz(_)
+            | Gate::Cu(_)
+            | Gate::Mcu(_)
+            | Gate::Fused(_)
+            | Gate::BatchPhase(_)
+            | Gate::BatchRzz(_)
+            | Gate::DiagonalBatch(_)
+            | Gate::MultiFused(_)
+            | Gate::Fused2q(_)
+            | Gate::Multi2q(_)
+            | Gate::QftBlock { .. } => Err(PrismError::BackendUnsupported {
                 backend: self.name().to_string(),
                 operation: format!(
                     "non-Clifford gate `{}` (stabilizer backend supports Clifford gates only)",

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -299,7 +299,22 @@ impl StatevectorBackend {
                 }
                 Ok(())
             }
-            _ => {
+            Gate::Id
+            | Gate::X
+            | Gate::Y
+            | Gate::Z
+            | Gate::H
+            | Gate::S
+            | Gate::Sdg
+            | Gate::T
+            | Gate::Tdg
+            | Gate::SX
+            | Gate::SXdg
+            | Gate::Rx(_)
+            | Gate::Ry(_)
+            | Gate::Rz(_)
+            | Gate::P(_)
+            | Gate::Fused(_) => {
                 let mat = gate.matrix_2x2();
                 if gate.is_diagonal_1q() {
                     k::launch_apply_diagonal_1q(&ctx, gpu, targets[0], mat[0][0], mat[1][1])
@@ -473,7 +488,22 @@ impl StatevectorBackend {
             Gate::Multi2q(data) => {
                 self.apply_multi_2q(&data.gates);
             }
-            _ => {
+            Gate::Id
+            | Gate::X
+            | Gate::Y
+            | Gate::Z
+            | Gate::H
+            | Gate::S
+            | Gate::Sdg
+            | Gate::T
+            | Gate::Tdg
+            | Gate::SX
+            | Gate::SXdg
+            | Gate::Rx(_)
+            | Gate::Ry(_)
+            | Gate::Rz(_)
+            | Gate::P(_)
+            | Gate::Fused(_) => {
                 let mat = gate.matrix_2x2();
                 if gate.is_diagonal_1q() {
                     self.apply_diagonal_gate(targets[0], mat[0][0], mat[1][1]);

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1348,6 +1348,61 @@ fn test_deferred_norm_export_statevector() {
     );
 }
 
+/// `apply_batch_phase` vs an independent reference. At 6 qubits the sequential path
+/// runs, so a BMI2+FMA host exercises `apply_batch_phase_bmi2` and others the scalar
+/// fallback.
+#[test]
+fn batch_phase_matches_independent_reference() {
+    use crate::circuit::{smallvec, Instruction, SmallVec};
+    use crate::gates::{BatchPhaseData, Gate};
+
+    let n = 6usize;
+    let control = 1usize;
+    let entries: [(usize, Complex64); 3] = [
+        (0, Complex64::from_polar(1.0, 0.37)),
+        (2, Complex64::from_polar(1.0, -0.91)),
+        (4, Complex64::from_polar(1.0, 1.25)),
+    ];
+
+    let mut backend = StatevectorBackend::new(42);
+    backend.init(n, 0).unwrap();
+    for q in 0..n {
+        let targets: SmallVec<[usize; 4]> = smallvec![q];
+        backend
+            .apply(&Instruction::Gate {
+                gate: Gate::H,
+                targets,
+            })
+            .unwrap();
+    }
+    let mut phases: SmallVec<[(usize, Complex64); 8]> = smallvec![];
+    for &(tq, ph) in &entries {
+        phases.push((tq, ph));
+    }
+    let ctrl_targets: SmallVec<[usize; 4]> = smallvec![control];
+    backend
+        .apply(&Instruction::Gate {
+            gate: Gate::BatchPhase(Box::new(BatchPhaseData { phases })),
+            targets: ctrl_targets,
+        })
+        .unwrap();
+    let got = backend.export_statevector().unwrap();
+
+    let amp0 = Complex64::new((1.0 / (1u64 << n) as f64).sqrt(), 0.0);
+    let dim = 1usize << n;
+    let mut expected = vec![amp0; dim];
+    for (i, e) in expected.iter_mut().enumerate() {
+        if (i >> control) & 1 == 1 {
+            for &(tq, ph) in &entries {
+                if (i >> tq) & 1 == 1 {
+                    *e *= ph;
+                }
+            }
+        }
+    }
+    assert_state_close(&got, &expected, 1e-12);
+}
+
 #[cfg(feature = "gpu")]
 mod gpu_scaffold {
     use super::*;

--- a/src/backend/word_ops.rs
+++ b/src/backend/word_ops.rs
@@ -103,3 +103,33 @@ pub(crate) fn has_avx2() -> bool {
 pub(crate) fn has_avx2() -> bool {
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Dispatcher and the AVX2 kernel must both equal a plain scalar XOR. The
+    /// length is not a multiple of the SIMD stride, so the remainder loop runs too.
+    #[test]
+    fn xor_words_matches_scalar_reference() {
+        let src: Vec<u64> = (0..37)
+            .map(|i| 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(i + 1))
+            .collect();
+        let dst0: Vec<u64> = (0..37)
+            .map(|i| 0xD1B5_4A32_D192_ED03u64.wrapping_add(i))
+            .collect();
+        let expected: Vec<u64> = dst0.iter().zip(&src).map(|(d, s)| d ^ s).collect();
+
+        let mut dst = dst0.clone();
+        xor_words(&mut dst, &src);
+        assert_eq!(dst, expected, "xor_words dispatcher");
+
+        #[cfg(target_arch = "x86_64")]
+        if has_avx2() {
+            let mut dst = dst0.clone();
+            // SAFETY: equal lengths; avx2 verified above.
+            unsafe { xor_words_avx2(dst.as_mut_ptr(), src.as_ptr(), src.len()) };
+            assert_eq!(dst, expected, "xor_words_avx2 kernel");
+        }
+    }
+}

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -170,3 +170,50 @@ pub(crate) const KERNEL_NAMES: &[&str] = &[
     "bts_apply_noise_masks_meas_major",
     "bts_generate_and_apply_noise_meas_major_by_row",
 ];
+
+#[cfg(test)]
+mod sync_tests {
+    use super::{kernel_source, KERNEL_NAMES};
+    use std::collections::BTreeSet;
+
+    /// Names following each `__global__ void` marker in the PTX source.
+    fn source_entry_points(src: &str) -> BTreeSet<String> {
+        const MARKER: &str = "__global__ void ";
+        let mut names = BTreeSet::new();
+        let mut rest = src;
+        while let Some(pos) = rest.find(MARKER) {
+            rest = &rest[pos + MARKER.len()..];
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                names.insert(name);
+            }
+        }
+        names
+    }
+
+    /// `KERNEL_NAMES` must match the kernels in the CUDA source exactly: a missing
+    /// name is never pre-resolved by `GpuDevice::new`, an orphan name is dead drift.
+    /// Inspects the source string only, so it needs no GPU device.
+    #[test]
+    fn kernel_names_match_source_entry_points() {
+        let src = kernel_source();
+        let in_source = source_entry_points(&src);
+        let declared: BTreeSet<String> = KERNEL_NAMES.iter().map(|s| s.to_string()).collect();
+
+        let missing: Vec<&String> = in_source.difference(&declared).collect();
+        let orphan: Vec<&String> = declared.difference(&in_source).collect();
+
+        assert!(
+            missing.is_empty(),
+            "kernels defined in source but absent from KERNEL_NAMES \
+             (GpuDevice::new would not pre-resolve them): {missing:?}"
+        );
+        assert!(
+            orphan.is_empty(),
+            "KERNEL_NAMES entries with no matching kernel in source: {orphan:?}"
+        );
+    }
+}

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -12,7 +12,10 @@ use num_complex::Complex64;
 
 use prism_q::backend::Backend;
 use prism_q::circuit::{smallvec, Instruction, SmallVec};
-use prism_q::gates::{DiagEntry, DiagonalBatchData, Gate, McuData, MultiFusedData};
+use prism_q::gates::{
+    BatchPhaseData, BatchRzzData, DiagEntry, DiagonalBatchData, Gate, McuData, Multi2qData,
+    MultiFusedData,
+};
 use prism_q::gpu::GpuContext;
 use prism_q::StatevectorBackend;
 
@@ -59,6 +62,141 @@ fn g(gate: Gate, targets: &[usize]) -> Instruction {
     let mut tv: SmallVec<[usize; 4]> = smallvec![];
     tv.extend_from_slice(targets);
     Instruction::Gate { gate, targets: tv }
+}
+
+// One constructed instance per `Gate` variant, fed through the exhaustive
+// `representative` match so a new variant cannot be added without a GPU
+// differential case.
+
+fn sample_2x2() -> [[Complex64; 2]; 2] {
+    [
+        [Complex64::new(0.6, -0.1), Complex64::new(-0.3, 0.2)],
+        [Complex64::new(0.2, 0.4), Complex64::new(0.7, -0.2)],
+    ]
+}
+
+fn sample_4x4() -> [[Complex64; 4]; 4] {
+    let mut mat = [[Complex64::new(0.0, 0.0); 4]; 4];
+    for (r, row) in mat.iter_mut().enumerate() {
+        for (c, entry) in row.iter_mut().enumerate() {
+            *entry = Complex64::new(0.1 * (r as f64 + 1.0), 0.07 * (c as f64 + 1.0));
+        }
+    }
+    mat
+}
+
+fn gate_samples() -> Vec<Gate> {
+    let m2 = sample_2x2();
+    let m4 = sample_4x4();
+    vec![
+        Gate::Id,
+        Gate::X,
+        Gate::Y,
+        Gate::Z,
+        Gate::H,
+        Gate::S,
+        Gate::Sdg,
+        Gate::T,
+        Gate::Tdg,
+        Gate::SX,
+        Gate::SXdg,
+        Gate::Rx(0.37),
+        Gate::Ry(1.11),
+        Gate::Rz(-0.62),
+        Gate::P(0.44),
+        Gate::Fused(Box::new(m2)),
+        Gate::Rzz(0.3),
+        Gate::Cx,
+        Gate::Cz,
+        Gate::Swap,
+        Gate::Cu(Box::new(m2)),
+        Gate::Mcu(Box::new(McuData {
+            mat: m2,
+            num_controls: 2,
+        })),
+        Gate::BatchPhase(Box::new(BatchPhaseData {
+            phases: smallvec![(1usize, Complex64::from_polar(1.0, 0.5))],
+        })),
+        Gate::BatchRzz(Box::new(BatchRzzData {
+            edges: vec![(0, 1, 0.3), (1, 2, 0.5)],
+        })),
+        Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+            entries: vec![
+                DiagEntry::Phase1q {
+                    qubit: 0,
+                    d0: Complex64::from_polar(1.0, 0.2),
+                    d1: Complex64::from_polar(1.0, -0.3),
+                },
+                DiagEntry::Phase2q {
+                    q0: 1,
+                    q1: 2,
+                    phase: Complex64::from_polar(1.0, 0.5),
+                },
+                DiagEntry::Parity2q {
+                    q0: 0,
+                    q1: 3,
+                    same: Complex64::from_polar(1.0, 0.1),
+                    diff: Complex64::from_polar(1.0, -0.4),
+                },
+            ],
+        })),
+        Gate::MultiFused(Box::new(MultiFusedData {
+            gates: vec![(0, m2), (1, m2)],
+            all_diagonal: false,
+        })),
+        Gate::Fused2q(Box::new(m4)),
+        Gate::Multi2q(Box::new(Multi2qData {
+            gates: vec![(0, 1, m4)],
+        })),
+        Gate::QftBlock { start: 0, num: 4 },
+    ]
+}
+
+/// Maps each `Gate` variant to a target layout. Exhaustive by design.
+fn representative(gate: &Gate) -> (usize, Vec<Instruction>) {
+    const N: usize = 5;
+    let targets: Vec<usize> = match gate {
+        Gate::Id
+        | Gate::X
+        | Gate::Y
+        | Gate::Z
+        | Gate::H
+        | Gate::S
+        | Gate::Sdg
+        | Gate::T
+        | Gate::Tdg
+        | Gate::SX
+        | Gate::SXdg
+        | Gate::Rx(_)
+        | Gate::Ry(_)
+        | Gate::Rz(_)
+        | Gate::P(_)
+        | Gate::Fused(_) => vec![0],
+        Gate::Cx | Gate::Cz | Gate::Swap | Gate::Rzz(_) => vec![0, 1],
+        Gate::Cu(_) => vec![0, 2],
+        Gate::Mcu(data) => (0..=data.num_controls as usize).collect(),
+        Gate::BatchPhase(_) => vec![0],
+        Gate::BatchRzz(_) => vec![0, 1, 2],
+        Gate::DiagonalBatch(_) => vec![0, 1, 2, 3],
+        Gate::MultiFused(_) => (0..N).collect(),
+        Gate::Fused2q(_) => vec![0, 1],
+        Gate::Multi2q(_) => vec![0, 1],
+        Gate::QftBlock { start, num } => {
+            (*start as usize..*start as usize + *num as usize).collect()
+        }
+    };
+    let mut insts: Vec<Instruction> = (0..N).map(|q| g(Gate::H, &[q])).collect();
+    insts.push(g(gate.clone(), &targets));
+    (N, insts)
+}
+
+#[test]
+fn every_gate_variant_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    for sample in gate_samples() {
+        let (n, insts) = representative(&sample);
+        f.compare(n, &insts);
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
# Keeping CPU and GPU kernels in sync programmatically

## The issue: I forget to update all the paths when making kernel updates and (embarassingly) there are still testing gaps that miss this.

```
                          Gate::H  (one logical operation)
                                 │
        ┌────────────────────────┼─────────────────────────┐
        ▼                        ▼                          ▼
  CPU x86 kernels          CPU ARM kernel             GPU kernel
  ┌───────────────┐        ┌──────────────┐          ┌──────────────┐
  │ AVX2  ─┐      │        │              │          │  CUDA C      │
  │ FMA   ─┼─tiers│        │  NEON        │          │  __global__  │
  │ SSE2  ─┘      │        │  (fallback)  │          │  apply_gate  │
  └───────────────┘        └──────────────┘          └──────────────┘
        │                        │                          │
        └──── must all produce IDENTICAL amplitudes ────────┘

   Nothing forced them to agree so there is hidden drift until someone hits it.
```

Two independent axes:

```
   AXIS 1: CPU architectures            AXIS 2: CPU vs GPU
   x86 SIMD ⇄ NEON ⇄ scalar             Rust dispatch ⇄ CUDA dispatch
```

## What "drift" looks like and the `_ =>` trap

Every dispatch was a `match` ending in a catch-all:

```rust
match gate {
    Gate::Cx  => apply_cx(...),
    Gate::Cz  => apply_cz(...),
    // ...
    _ => { /* assume it's a 1-qubit gate */ }   // ⚠️ silently eats anything new
}
```

```
   BEFORE                                AFTER (exhaustive)
   ┌──────────────────────┐             ┌──────────────────────┐
   │ Cx → ...             │             │ Cx → ...             │
   │ Cz → ...             │             │ Cz → ...             │
   │  _ → 1q path  ◄──────┼─ new gate   │ H|X|Rz|... → 1q path │
   └──────────────────────┘   falls     │  (no wildcard)       │
                               here     └──────────┬───────────┘
                               SILENTLY            │ new gate has
                               (wrong result)      ▼ no arm
                                              ┌──────────────┐
                                              │ COMPILE ERROR│ ✅
                                              └──────────────┘
```

## Worked example: an eager contributor (always welcome) adds a two-qubit `Rzx(θ)` gate

They add one line to the enum:

```rust
pub enum Gate {
    // ...
    Rzx(f64),   // ← new two-qubit rotation
}
```

Watch each guard fire, in order:

```
STEP 1 — cargo build (no GPU needed)
─────────────────────────────────────────────────────────────
 error[E0004]: non-exhaustive patterns: `&Rzx(_)` not covered
   src/backend/statevector/mod.rs          (CPU dispatch)     ✗
   src/backend/stabilizer/kernels/mod.rs   (CPU + SGI)        ✗   ← 5 sites,
   src/backend/stabilizer/mod.rs           (GPU dispatch)     ✗      one error
                                                                     each
 ➜ Contributed is asked to decide: real 2q kernel? or reject?
   They cannot "forget" the GPU or the stabilizer path. Alternatively, I can
   work with them in a PR to help shape up the branch.
```

Say they wire up the CPU kernel and a CUDA kernel. Next:

```
STEP 2 — cargo test  (the differential + structural nets)
─────────────────────────────────────────────────────────────
 representative() in golden_gpu.rs is exhaustive too:
   error: `Rzx(_)` not covered          ✗  ← forces a GPU vs CPU
                                              comparison case to exist

 kernel_names_match_source test:
   if they named the CUDA kernel "apply_rzx" but forgot KERNEL_NAMES:
   assert failed: kernels in source but absent from KERNEL_NAMES:
                  ["apply_rzx"]          ✗
```

```
STEP 3 — they hand write/vibecode an AVX2 kernel but skip the NEON twin
─────────────────────────────────────────────────────────────
 target_feature count tripwire:
   src/backend/simd.rs has 28 #[target_feature] kernels,
   pinned at 27.                         ✗
   "added a tiered kernel — add its per-tier test and bump the pin"

 CI 'test-aarch64-qemu' job (runs NEON under emulation):
   if the NEON kernel is wrong, the differential test       ✗
   (NEON result ≠ scalar result) fails on real ARM execution
```

```
STEP 4 — CI 'gpu-check' job (CUDA toolkit, NO GPU device)
─────────────────────────────────────────────────────────────
 cargo check --features gpu   → compiles the GPU dispatch arms ✓/✗
 KERNEL_NAMES test            → device-free, runs here         ✓/✗
```

Therefore the same gate, every layer it must touch:

```
                      ┌─────────── added Gate::Rzx ───────────┐
                      ▼            ▼            ▼              ▼
  guard:        compiler      compiler     test(golden)   test(count)
  catches:      CPU dispatch  GPU dispatch CPU≠GPU         missing NEON
                                                            + CI QEMU/gpu
  result:       can't build until ALL are handled → no silent drift
```

## The mechanics

```
 enforcement        mechanism                runs in
 ─────────────────  ───────────────────────  ─────────────────────────
 exhaustive match   rustc (compile error)    every build (CPU + gpu-check)
 representative()   rustc (compile error)    gpu-check job
 KERNEL_NAMES test  string parse, no device  gpu-check job
 per-tier SIMD      run each x86 tier         every x86 build/CI
 target_feature pin reads source, counts      every build, any arch
 NEON execution     QEMU differential         test-aarch64-qemu job
```

## Before and AFter

```
  Adding Gate::Rzx ...

  WITHOUT these guards            WITH these guards
  ───────────────────            ─────────────────
  builds fine ✓                  build FAILS until handled
  CPU works ✓                    compiler lists every site
  GPU silently wrong ✗           differential test demands a case
  NEON silently wrong ✗          QEMU job runs the NEON path
  ships → bug found in           caught on the PR, before merge
  production months later
```