### PR TITLE
feat(dist): add MPI base for the state vector backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "build-probe-mpi"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78ace2bb02fc18ad937f1599a853fcf3da2327bc1eb3c8e62b1f2fe4573bfd6"
+dependencies = [
+ "pkg-config",
+ "shell-words",
+]
 
 [[package]]
 name = "bumpalo"
@@ -74,6 +104,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +156,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +196,15 @@ name = "coe-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8f1e641542c07631228b1e0dc04b69ae3c1d58ef65d5691a439711d805c698"
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
 
 [[package]]
 name = "criterion"
@@ -210,8 +279,14 @@ version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "dbgf"
@@ -341,6 +416,12 @@ dependencies = [
  "pulp 0.18.22",
  "reborrow",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "gemm"
@@ -480,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,10 +628,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libffi"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0498fe5655f857803e156523e644dcdcdc3b3c7edda42ea2afdae2e09b2db87b"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d4f1d4ce15091955144350b75db16a96d4a63728500122706fb4d29a26afbb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libloading"
@@ -583,6 +711,38 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mpi"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41457b69d35846af2fec1877a4f3b866a72b6ab2c9500218f115e65e10993b21"
+dependencies = [
+ "build-probe-mpi",
+ "conv",
+ "libffi",
+ "mpi-sys",
+ "once_cell",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "mpi-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f655543f54b263cbc3d2456bf714bd807d66a33eff8f70136687f0776d34f76"
+dependencies = [
+ "bindgen",
+ "build-probe-mpi",
+ "cc",
+]
 
 [[package]]
 name = "nano-gemm"
@@ -655,6 +815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +922,7 @@ dependencies = [
  "criterion",
  "cudarc",
  "faer",
+ "mpi",
  "num-complex",
  "num_cpus",
  "rand",
@@ -754,7 +931,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -901,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1148,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,7 +1192,7 @@ dependencies = [
  "byteorder",
  "enum-as-inner",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
@@ -1001,7 +1202,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1009,6 +1219,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 faer = { version = "0.20", optional = true, default-features = false, features = ["std", "rayon", "linalg"] }
 cudarc = { version = "0.19", optional = true, default-features = false, features = ["cuda-12040", "dynamic-linking", "driver", "nvrtc", "std"] }
+mpi = { version = "0.8", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -34,6 +35,8 @@ default = ["parallel"]
 parallel = ["rayon", "num_cpus", "faer"]
 serialization = ["serde", "serde_json"]
 gpu = ["dep:cudarc"]
+distributed = []
+distributed-mpi = ["distributed", "dep:mpi"]
 bench-fast = []
 bench-internal = []
 
@@ -80,6 +83,10 @@ harness = false
 name = "bench_gpu"
 harness = false
 required-features = ["gpu"]
+
+[[example]]
+name = "dist_mpi_check"
+required-features = ["distributed-mpi"]
 
 [[bench]]
 name = "qec_t_strategies"

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,8 @@ all-features = true
 ignore = [
     # paste: unmaintained, transitive dep from faer/gemm. Revisit when upstream moves to pastey.
     { id = "RUSTSEC-2024-0436", reason = "transitive dep from faer, revisit when deps migrate to pastey" },
+    # custom_derive: unmaintained, transitive dep from optional mpi via conv.
+    { id = "RUSTSEC-2025-0058", reason = "transitive dep from optional mpi, revisit when mpi removes conv/custom_derive" },
 ]
 
 [licenses]
@@ -13,6 +15,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
+    "BSD-3-Clause",
     "ISC",
     "Zlib",
     "Unicode-3.0",

--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -1,0 +1,97 @@
+//! MPI correctness check for the distributed state vector backend.
+//!
+//! Run under an MPI launcher; rank 0 compares the gathered distributed result
+//! against a single process [`StatevectorBackend`] reference and exits nonzero on
+//! mismatch so a test script can gate on the process exit code:
+//!
+//! ```text
+//! . scripts\mpi-env.ps1
+//! cargo build --example dist_mpi_check --features distributed-mpi
+//! mpiexec -n 4 target\debug\examples\dist_mpi_check.exe
+//! ```
+//!
+//! Requires the `distributed-mpi` feature. Without it the binary prints a note
+//! and exits 0 so a plain `cargo build --examples` stays green.
+//!
+//! The worker thread uses a larger stack because debug SIMD kernels can exceed
+//! the default MSVC main thread stack.
+
+#[cfg(not(feature = "distributed-mpi"))]
+fn main() {
+    eprintln!("dist_mpi_check requires --features distributed-mpi; nothing to do.");
+}
+
+#[cfg(feature = "distributed-mpi")]
+fn main() {
+    let handle = std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(run)
+        .expect("spawn worker thread");
+    handle.join().expect("worker thread panicked");
+}
+
+#[cfg(feature = "distributed-mpi")]
+fn run() {
+    use prism_q::backend::distributed_statevector::DistributedStatevectorBackend;
+    use prism_q::backend::statevector::StatevectorBackend;
+    use prism_q::circuit::builder::CircuitBuilder;
+    use prism_q::circuit::Circuit;
+    use prism_q::distributed::DistributedContext;
+    use prism_q::sim::run_on;
+
+    const SEED: u64 = 42;
+    const TOL: f64 = 1e-10;
+
+    // Cover local entanglement and global one qubit gates.
+    fn build_circuit(num_qubits: usize, _local_qubits: usize) -> Circuit {
+        let mut b = CircuitBuilder::new(num_qubits);
+        // Local entanglement on the bottom qubits.
+        b.h(0).cx(0, 1).cx(1, 2);
+        // Include global targets.
+        for q in 0..num_qubits {
+            b.h(q);
+        }
+        b.rx(0.37, num_qubits - 1)
+            .t(num_qubits - 1)
+            .rz(-0.6, num_qubits - 2);
+        b.build()
+    }
+
+    let ctx = DistributedContext::world().expect("MPI world init");
+    let rank = ctx.rank();
+    let size = ctx.size();
+    assert!(size.is_power_of_two(), "rank count must be a power of two");
+    let p = size.trailing_zeros() as usize;
+
+    let num_qubits = 6;
+    let local_qubits = num_qubits - p;
+    let circuit = build_circuit(num_qubits, local_qubits);
+
+    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+    let probs = run_on(&mut backend, &circuit)
+        .expect("distributed run")
+        .probabilities
+        .expect("probabilities")
+        .to_vec();
+
+    if rank == 0 {
+        let mut reference = StatevectorBackend::new(SEED);
+        let expected = run_on(&mut reference, &circuit)
+            .expect("reference run")
+            .probabilities
+            .expect("probabilities")
+            .to_vec();
+
+        assert_eq!(expected.len(), probs.len(), "length mismatch");
+        let mut max_err = 0.0_f64;
+        for (e, a) in expected.iter().zip(probs.iter()) {
+            max_err = max_err.max((e - a).abs());
+        }
+        if max_err < TOL {
+            println!("OK: {size} ranks, {num_qubits} qubits, max_err={max_err:.2e}");
+        } else {
+            eprintln!("FAIL: max_err={max_err:.3e} exceeds tol {TOL:.1e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/scripts/mpi-env.ps1
+++ b/scripts/mpi-env.ps1
@@ -1,0 +1,55 @@
+# Set up the environment for building and running the `distributed-mpi` feature.
+#
+# rsmpi (the `mpi` crate) needs three things that are not on PATH by default:
+#   1. The MSVC developer environment (INCLUDE/LIB/Windows SDK) for bindgen and linking.
+#   2. The MS-MPI SDK (MSMPI_INC / MSMPI_LIB64), installed via `winget install Microsoft.msmpisdk`.
+#   3. libclang, for bindgen. VS 2022 bundles one under VC\Tools\Llvm.
+#
+# Dot-source this script before cargo:  . scripts\mpi-env.ps1
+# Then:  cargo test --features distributed-mpi
+# And to launch ranks:  mpiexec -n 4 target\debug\examples\dist_mpi_check.exe
+
+$ErrorActionPreference = 'Stop'
+
+function Find-VsInstall {
+    $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $p = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath -nologo 2>$null
+        if ($p) { return $p.Trim() }
+    }
+    foreach ($c in @(
+        "C:\Program Files\Microsoft Visual Studio\2022\Community",
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community"
+    )) { if (Test-Path $c) { return $c } }
+    throw "No Visual Studio with C++ tools found."
+}
+
+$vsRoot = Find-VsInstall
+$vcvars = Join-Path $vsRoot "VC\Auxiliary\Build\vcvars64.bat"
+if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found under $vsRoot" }
+
+# Import the MSVC developer environment (INCLUDE, LIB, WindowsSdkDir, PATH additions).
+cmd /c "`"$vcvars`" >nul 2>&1 && set" | ForEach-Object {
+    if ($_ -match '^(.*?)=(.*)$') { Set-Item -Path "Env:$($matches[1])" -Value $matches[2] }
+}
+
+# MS-MPI SDK (machine-scope vars set by the installer).
+$env:MSMPI_INC = [Environment]::GetEnvironmentVariable('MSMPI_INC', 'Machine')
+$env:MSMPI_LIB64 = [Environment]::GetEnvironmentVariable('MSMPI_LIB64', 'Machine')
+if (-not $env:MSMPI_INC -or -not (Test-Path (Join-Path $env:MSMPI_INC 'mpi.h'))) {
+    throw "MS-MPI SDK not found. Install with: winget install --id Microsoft.msmpisdk"
+}
+
+# libclang for bindgen, bundled with VS.
+$llvm = Join-Path $vsRoot "VC\Tools\Llvm\x64\bin"
+if (Test-Path (Join-Path $llvm 'libclang.dll')) {
+    $env:LIBCLANG_PATH = $llvm
+}
+
+Write-Host "MPI build environment ready:"
+Write-Host "  VS:           $vsRoot"
+Write-Host "  MSMPI_INC:    $env:MSMPI_INC"
+Write-Host "  MSMPI_LIB64:  $env:MSMPI_LIB64"
+Write-Host "  LIBCLANG_PATH:$env:LIBCLANG_PATH"

--- a/scripts/test-mpi.ps1
+++ b/scripts/test-mpi.ps1
@@ -1,0 +1,42 @@
+# Build and run the distributed backend's multi-rank correctness check.
+#
+# Usage:   powershell -ExecutionPolicy Bypass -File scripts\test-mpi.ps1 [-Ranks 4]
+#
+# Sets up the MPI build environment, builds the lib tests and the mpiexec check
+# binary, then launches it across N ranks. Rank 0 asserts the gathered result
+# matches the single-node statevector reference and exits non-zero on mismatch.
+
+param(
+    [int[]] $RankCounts = @(1, 2, 4)
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+. (Join-Path $scriptDir 'mpi-env.ps1')
+
+Write-Host "`n== Building lib tests (distributed-mpi) =="
+cargo test --features distributed-mpi --lib distributed --no-run
+if ($LASTEXITCODE -ne 0) { throw "lib test build failed" }
+
+Write-Host "`n== Running SerialComm lib tests =="
+cargo test --features distributed-mpi --lib distributed
+if ($LASTEXITCODE -ne 0) { throw "lib tests failed" }
+
+Write-Host "`n== Building mpiexec check binary =="
+cargo build --example dist_mpi_check --features distributed-mpi
+if ($LASTEXITCODE -ne 0) { throw "example build failed" }
+
+$exe = Join-Path $scriptDir '..\target\debug\examples\dist_mpi_check.exe'
+$mpiexec = "C:\Program Files\Microsoft MPI\Bin\mpiexec.exe"
+if (-not (Test-Path $mpiexec)) { $mpiexec = "mpiexec" }
+
+# The check circuit is small, so relax the local-qubit floor to let it
+# distribute across ranks on a single host.
+foreach ($n in $RankCounts) {
+    Write-Host "`n== mpiexec -n $n dist_mpi_check =="
+    & $mpiexec -n $n -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe
+    if ($LASTEXITCODE -ne 0) { throw "multi-rank check failed at -n $n" }
+}
+
+Write-Host "`nAll distributed MPI checks passed."

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1,0 +1,233 @@
+//! Distributed state vector backend.
+//!
+//! Partitions the `2^n` amplitude vector across `P = 2^p` ranks. The low
+//! `n - p` qubits are *local* (indexing each rank's contiguous slice); the top
+//! `p` qubits are *global* (selecting the rank id). Each rank holds a local
+//! slice of length `2^(n-p)` inside an inner [`StatevectorBackend`]. Gates on
+//! local qubits reuse the existing SIMD kernels.
+//!
+//! # Memory layout
+//!
+//! The global amplitude index is `rank * 2^(n-p) + local_index`. Qubit `q` with
+//! `q < n - p` is bit `q` of `local_index`; qubit `q >= n - p` is bit
+//! `q - (n - p)` of the rank id. Qubit 0 remains the least significant bit, so
+//! `|0...0>` lives at `local_index = 0` on rank 0.
+//!
+//! # Status
+//!
+//! Implemented: local gates, one qubit gates on rank bits, global diagonal
+//! scaling, and gathers for `probabilities` and `export_statevector`. With a
+//! single rank ([`SerialComm`]), every qubit is local.
+//!
+//! Not implemented yet: gates over multiple qubits that span rank bits,
+//! measurement, reset, conditionals, and sampling.
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use num_complex::Complex64;
+
+use crate::backend::simd;
+use crate::backend::statevector::StatevectorBackend;
+use crate::backend::{dense_probability_len, dense_statevector_len, Backend};
+use crate::circuit::Instruction;
+use crate::distributed::DistributedContext;
+use crate::error::{PrismError, Result};
+
+const BACKEND_NAME: &str = "distributed_statevector";
+
+/// Distributed state vector backend over an [`Arc<DistributedContext>`].
+pub struct DistributedStatevectorBackend {
+    context: Arc<DistributedContext>,
+    inner: StatevectorBackend,
+    num_qubits: usize,
+    global_qubits: usize,
+    recv: Vec<Complex64>,
+}
+
+impl DistributedStatevectorBackend {
+    /// Create a backend bound to the given rank context and RNG seed.
+    pub fn new(context: Arc<DistributedContext>, seed: u64) -> Self {
+        Self {
+            context,
+            inner: StatevectorBackend::new(seed),
+            num_qubits: 0,
+            global_qubits: 0,
+            recv: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn local_qubits(&self) -> usize {
+        self.num_qubits - self.global_qubits
+    }
+
+    #[inline]
+    fn is_single_rank(&self) -> bool {
+        self.context.size() == 1
+    }
+
+    #[inline]
+    fn targets_are_local(&self, targets: &[usize]) -> bool {
+        let local = self.local_qubits();
+        targets.iter().all(|&q| q < local)
+    }
+
+    /// Bit position within the rank id for global qubit `q` (`q >= local`).
+    #[inline]
+    fn global_bit(&self, q: usize) -> usize {
+        q - self.local_qubits()
+    }
+
+    /// Whether this rank holds the `|1>` half of global qubit `q`.
+    #[inline]
+    fn rank_bit_set(&self, q: usize) -> bool {
+        (self.context.rank() >> self.global_bit(q)) & 1 == 1
+    }
+
+    /// Apply a one qubit gate whose target is stored in the rank id.
+    ///
+    /// Exchange with the partner rank, then write this rank's half of the 2x2
+    /// result.
+    fn apply_global_1q(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
+        let partner = self.context.rank() ^ (1usize << self.global_bit(target));
+        let len = self.inner.state.len();
+        if self.recv.len() != len {
+            self.recv.resize(len, Complex64::new(0.0, 0.0));
+        }
+        self.context
+            .comm()
+            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+
+        let (c_self, c_remote) = if self.rank_bit_set(target) {
+            (mat[1][1], mat[1][0])
+        } else {
+            (mat[0][0], mat[0][1])
+        };
+        simd::combine_global_half(&mut self.inner.state, &self.recv, c_self, c_remote);
+    }
+
+    /// Apply a diagonal one qubit gate whose target is stored in the rank id.
+    ///
+    /// The rank bit is constant across the local slice, so this only scales the
+    /// slice by `d0` or `d1`.
+    fn apply_global_diagonal_1q(&mut self, target: usize, d0: Complex64, d1: Complex64) {
+        let factor = if self.rank_bit_set(target) { d1 } else { d0 };
+        simd::scale_complex_slice(&mut self.inner.state, factor);
+    }
+
+    fn unsupported(&self, operation: &str) -> PrismError {
+        PrismError::BackendUnsupported {
+            backend: BACKEND_NAME.to_string(),
+            operation: operation.to_string(),
+        }
+    }
+}
+
+impl Backend for DistributedStatevectorBackend {
+    fn name(&self) -> &'static str {
+        BACKEND_NAME
+    }
+
+    fn supports_fused_gates(&self) -> bool {
+        // Fusion assumes every target indexes the local slice.
+        self.is_single_rank()
+    }
+
+    fn supports_qft_block(&self) -> bool {
+        self.is_single_rank() && self.inner.supports_qft_block()
+    }
+
+    fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        let size = self.context.size();
+        if !size.is_power_of_two() {
+            return Err(PrismError::BackendUnsupported {
+                backend: BACKEND_NAME.to_string(),
+                operation: format!("rank count {size} is not a power of two"),
+            });
+        }
+        let p = size.trailing_zeros() as usize;
+        let min_local = crate::distributed::min_local_qubits();
+        if size > 1 && num_qubits < p + min_local {
+            return Err(PrismError::BackendUnsupported {
+                backend: BACKEND_NAME.to_string(),
+                operation: format!(
+                    "{num_qubits} qubits across {size} ranks leaves fewer than \
+                     {min_local} local qubits per rank"
+                ),
+            });
+        }
+
+        self.num_qubits = num_qubits;
+        self.global_qubits = p;
+        let local_qubits = num_qubits - p;
+        self.inner.init(local_qubits, num_classical_bits)?;
+
+        // inner.init seeds index 0 on every rank; only rank 0 owns |0...0>.
+        if self.context.rank() != 0 {
+            if let Some(amp) = self.inner.state.get_mut(0) {
+                *amp = Complex64::new(0.0, 0.0);
+            }
+        }
+        Ok(())
+    }
+
+    fn apply(&mut self, instruction: &Instruction) -> Result<()> {
+        if self.global_qubits == 0 {
+            return self.inner.apply(instruction);
+        }
+        match instruction {
+            Instruction::Gate { gate, targets } => {
+                if self.targets_are_local(targets) {
+                    return self.inner.apply(instruction);
+                }
+                if gate.num_qubits() == 1 {
+                    let target = targets[0];
+                    let mat = gate.matrix_2x2();
+                    if gate.is_diagonal_1q() {
+                        self.apply_global_diagonal_1q(target, mat[0][0], mat[1][1]);
+                    } else {
+                        self.apply_global_1q(target, mat);
+                    }
+                    Ok(())
+                } else {
+                    Err(self.unsupported("multi-qubit gate spanning a global qubit"))
+                }
+            }
+            Instruction::Barrier { .. } => Ok(()),
+            Instruction::Measure { .. } => Err(self.unsupported("distributed measurement")),
+            Instruction::Reset { .. } => Err(self.unsupported("distributed reset")),
+            Instruction::Conditional { .. } => {
+                Err(self.unsupported("distributed classical conditional"))
+            }
+        }
+    }
+
+    fn classical_results(&self) -> &[bool] {
+        self.inner.classical_results()
+    }
+
+    fn probabilities(&self) -> Result<Vec<f64>> {
+        let local = self.inner.probabilities()?;
+        if self.global_qubits == 0 {
+            return Ok(local);
+        }
+        dense_probability_len(BACKEND_NAME, self.num_qubits)?;
+        Ok(self.context.comm().allgather_f64(&local))
+    }
+
+    fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    fn export_statevector(&self) -> Result<Vec<Complex64>> {
+        let local = self.inner.export_statevector()?;
+        if self.global_qubits == 0 {
+            return Ok(local);
+        }
+        dense_statevector_len(BACKEND_NAME, "statevector export", self.num_qubits)?;
+        Ok(self.context.comm().allgather_c64(&local))
+    }
+}

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -1,0 +1,325 @@
+use super::DistributedStatevectorBackend;
+use crate::backend::statevector::StatevectorBackend;
+use crate::backend::Backend;
+use crate::circuit::builder::CircuitBuilder;
+use crate::circuit::Circuit;
+use crate::distributed::{DistributedContext, RankComm};
+use crate::sim::run_on;
+use num_complex::Complex64;
+use std::sync::{Arc, Condvar, Mutex};
+
+const SEED: u64 = 42;
+const TOL: f64 = 1e-10;
+
+/// Test transport that simulates ranks with threads.
+///
+/// This covers global gate exchange without an MPI launcher. Each rank runs the
+/// same circuit and reaches collectives in the same order.
+struct LoopbackShared {
+    size: usize,
+    state: Mutex<LoopbackState>,
+    cv: Condvar,
+}
+
+struct LoopbackState {
+    generation: u64,
+    arrived: usize,
+    cslots: Vec<Vec<Complex64>>,
+    fslots: Vec<f64>,
+}
+
+impl LoopbackShared {
+    fn new(size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            size,
+            state: Mutex::new(LoopbackState {
+                generation: 0,
+                arrived: 0,
+                cslots: vec![Vec::new(); size],
+                fslots: vec![0.0; size],
+            }),
+            cv: Condvar::new(),
+        })
+    }
+
+    fn barrier(&self) {
+        let mut st = self.state.lock().unwrap();
+        let gen = st.generation;
+        st.arrived += 1;
+        if st.arrived == self.size {
+            st.arrived = 0;
+            st.generation = st.generation.wrapping_add(1);
+            self.cv.notify_all();
+        } else {
+            while st.generation == gen {
+                st = self.cv.wait(st).unwrap();
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LoopbackComm {
+    shared: Arc<LoopbackShared>,
+    rank: usize,
+}
+
+impl std::fmt::Debug for LoopbackComm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoopbackComm")
+            .field("rank", &self.rank)
+            .field("size", &self.shared.size)
+            .finish()
+    }
+}
+
+impl RankComm for LoopbackComm {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn size(&self) -> usize {
+        self.shared.size
+    }
+
+    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            st.cslots[self.rank] = local.to_vec();
+        }
+        self.shared.barrier();
+        let out = {
+            let st = self.shared.state.lock().unwrap();
+            st.cslots.iter().flat_map(|s| s.iter().copied()).collect()
+        };
+        self.shared.barrier();
+        out
+    }
+
+    fn allgather_f64(&self, local: &[f64]) -> Vec<f64> {
+        let as_c: Vec<Complex64> = local.iter().map(|&v| Complex64::new(v, 0.0)).collect();
+        self.allgather_c64(&as_c).iter().map(|c| c.re).collect()
+    }
+
+    fn allreduce_sum_f64(&self, value: f64) -> f64 {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            st.fslots[self.rank] = value;
+        }
+        self.shared.barrier();
+        let sum = {
+            let st = self.shared.state.lock().unwrap();
+            st.fslots.iter().sum()
+        };
+        self.shared.barrier();
+        sum
+    }
+
+    fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
+        debug_assert_eq!(send.len(), recv.len());
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            st.cslots[self.rank] = send.to_vec();
+        }
+        self.shared.barrier();
+        {
+            let st = self.shared.state.lock().unwrap();
+            recv.copy_from_slice(&st.cslots[partner]);
+        }
+        self.shared.barrier();
+    }
+
+    fn barrier(&self) {
+        self.shared.barrier();
+    }
+}
+
+/// Run `circuit` across simulated ranks and return rank 0's probabilities.
+fn loopback_probs(circuit: &Circuit, size: usize) -> Vec<f64> {
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    run_on(&mut backend, &circuit)
+                        .expect("distributed run")
+                        .probabilities
+                        .expect("probabilities")
+                        .to_vec()
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let mut results: Vec<Vec<f64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    // Every rank holds the same gathered vector.
+    let first = results.swap_remove(0);
+    results.clear();
+    first
+}
+
+fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
+    let expected = reference_probs(circuit);
+    for &size in sizes {
+        let actual = loopback_probs(circuit, size);
+        assert_eq!(
+            expected.len(),
+            actual.len(),
+            "length mismatch at size {size}"
+        );
+        for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+            assert!(
+                (e - a).abs() < TOL,
+                "size {size}: prob[{i}] expected {e}, got {a}"
+            );
+        }
+    }
+}
+
+fn reference_probs(circuit: &Circuit) -> Vec<f64> {
+    let mut backend = StatevectorBackend::new(SEED);
+    run_on(&mut backend, circuit)
+        .expect("statevector run")
+        .probabilities
+        .expect("probabilities")
+        .to_vec()
+}
+
+fn distributed_serial_probs(circuit: &Circuit) -> Vec<f64> {
+    let ctx = DistributedContext::serial();
+    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+    run_on(&mut backend, circuit)
+        .expect("distributed run")
+        .probabilities
+        .expect("probabilities")
+        .to_vec()
+}
+
+fn assert_probs_match(circuit: &Circuit) {
+    let expected = reference_probs(circuit);
+    let actual = distributed_serial_probs(circuit);
+    assert_eq!(expected.len(), actual.len(), "length mismatch");
+    for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+        assert!(
+            (e - a).abs() < TOL,
+            "prob[{i}] mismatch: expected {e}, got {a}"
+        );
+    }
+}
+
+#[test]
+fn serial_matches_statevector_bell() {
+    let mut b = CircuitBuilder::new(2);
+    b.h(0).cx(0, 1);
+    assert_probs_match(&b.build());
+}
+
+#[test]
+fn serial_matches_statevector_rotations_and_entanglers() {
+    let mut b = CircuitBuilder::new(4);
+    b.h(0)
+        .rx(0.37, 1)
+        .ry(1.1, 2)
+        .rz(-0.6, 3)
+        .cx(0, 1)
+        .cz(1, 2)
+        .swap(2, 3)
+        .t(0)
+        .s(1);
+    assert_probs_match(&b.build());
+}
+
+#[test]
+fn serial_matches_statevector_ghz() {
+    let n = 6;
+    let mut b = CircuitBuilder::new(n);
+    b.h(0);
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    assert_probs_match(&b.build());
+}
+
+#[test]
+fn serial_export_statevector_matches() {
+    let mut b = CircuitBuilder::new(3);
+    b.h(0).cx(0, 1).ry(0.9, 2).cz(0, 2);
+    let circuit = b.build();
+
+    let mut sv = StatevectorBackend::new(SEED);
+    sv.init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    sv.apply_instructions(&circuit.instructions).unwrap();
+    let expected = sv.export_statevector().unwrap();
+
+    let ctx = DistributedContext::serial();
+    let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
+    dist.init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    dist.apply_instructions(&circuit.instructions).unwrap();
+    let actual = dist.export_statevector().unwrap();
+
+    assert_eq!(expected.len(), actual.len());
+    for (e, a) in expected.iter().zip(actual.iter()) {
+        assert!((e - a).norm() < TOL);
+    }
+}
+
+/// Relax the local qubit floor before constructing any distributed backend.
+fn relax_min_local_qubits() {
+    std::env::set_var("PRISM_DIST_MIN_LOCAL_QUBITS", "1");
+    assert_eq!(crate::distributed::min_local_qubits(), 1);
+}
+
+#[test]
+fn loopback_global_hadamard_wall() {
+    relax_min_local_qubits();
+    // H on every qubit covers global exchange and combine.
+    let mut b = CircuitBuilder::new(4);
+    for q in 0..4 {
+        b.h(q);
+    }
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_global_rotations_and_diagonals() {
+    relax_min_local_qubits();
+    let mut b = CircuitBuilder::new(4);
+    b.h(0)
+        .rx(0.7, 3)
+        .ry(1.3, 2)
+        .rz(-0.4, 3)
+        .t(2)
+        .s(3)
+        .x(1)
+        .h(2)
+        .h(3);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_local_only_matches_across_ranks() {
+    relax_min_local_qubits();
+    // Entangling chain confined to local qubits.
+    let mut b = CircuitBuilder::new(5);
+    b.h(0).cx(0, 1).cx(1, 2);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn reports_global_qubit_count_for_single_rank() {
+    let ctx = DistributedContext::serial();
+    let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
+    dist.init(5, 0).unwrap();
+    assert_eq!(dist.num_qubits(), 5);
+    // Single rank: every qubit is local.
+    assert!(dist.supports_fused_gates());
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,6 +21,8 @@
 //!
 //! See `docs/architecture.md` § "Add a new backend" for the full playbook.
 
+#[cfg(feature = "distributed")]
+pub mod distributed_statevector;
 pub mod factored;
 pub mod factored_stabilizer;
 pub(crate) mod memory;

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1344,7 +1344,7 @@ pub(crate) fn scale_complex_slice(slice: &mut [Complex64], factor: Complex64) {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", any(feature = "distributed", test)))]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn combine_global_half_avx2fma(
     dst: &mut [Complex64],
@@ -1375,7 +1375,7 @@ unsafe fn combine_global_half_avx2fma(
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", any(feature = "distributed", test)))]
 #[target_feature(enable = "fma")]
 unsafe fn combine_global_half_fma(
     dst: &mut [Complex64],
@@ -1400,7 +1400,7 @@ unsafe fn combine_global_half_fma(
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", any(feature = "distributed", test)))]
 unsafe fn combine_global_half_neon(
     dst: &mut [Complex64],
     remote: &[Complex64],
@@ -1425,6 +1425,7 @@ unsafe fn combine_global_half_neon(
 }
 
 #[allow(dead_code)]
+#[cfg(any(feature = "distributed", test))]
 #[inline(always)]
 fn combine_global_half_scalar(
     dst: &mut [Complex64],
@@ -1441,6 +1442,7 @@ fn combine_global_half_scalar(
 /// `dst[i] = c_self * dst[i] + c_remote * remote[i]`.
 ///
 /// Used after a distributed rank exchange for a global one qubit gate.
+#[cfg(any(feature = "distributed", test))]
 pub(crate) fn combine_global_half(
     dst: &mut [Complex64],
     remote: &[Complex64],

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1344,7 +1344,7 @@ pub(crate) fn scale_complex_slice(slice: &mut [Complex64], factor: Complex64) {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", any(feature = "distributed", test)))]
+#[cfg(all(target_arch = "x86_64", feature = "distributed"))]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn combine_global_half_avx2fma(
     dst: &mut [Complex64],
@@ -1375,7 +1375,7 @@ unsafe fn combine_global_half_avx2fma(
     }
 }
 
-#[cfg(all(target_arch = "x86_64", any(feature = "distributed", test)))]
+#[cfg(all(target_arch = "x86_64", feature = "distributed"))]
 #[target_feature(enable = "fma")]
 unsafe fn combine_global_half_fma(
     dst: &mut [Complex64],
@@ -1400,7 +1400,7 @@ unsafe fn combine_global_half_fma(
     }
 }
 
-#[cfg(all(target_arch = "aarch64", any(feature = "distributed", test)))]
+#[cfg(all(target_arch = "aarch64", feature = "distributed"))]
 unsafe fn combine_global_half_neon(
     dst: &mut [Complex64],
     remote: &[Complex64],
@@ -1424,8 +1424,7 @@ unsafe fn combine_global_half_neon(
     }
 }
 
-#[allow(dead_code)]
-#[cfg(any(feature = "distributed", test))]
+#[cfg(feature = "distributed")]
 #[inline(always)]
 fn combine_global_half_scalar(
     dst: &mut [Complex64],
@@ -1442,7 +1441,7 @@ fn combine_global_half_scalar(
 /// `dst[i] = c_self * dst[i] + c_remote * remote[i]`.
 ///
 /// Used after a distributed rank exchange for a global one qubit gate.
-#[cfg(any(feature = "distributed", test))]
+#[cfg(feature = "distributed")]
 pub(crate) fn combine_global_half(
     dst: &mut [Complex64],
     remote: &[Complex64],
@@ -2401,7 +2400,7 @@ mod tests {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "distributed"))]
     #[test]
     fn combine_global_half_x86_tiers_match_scalar() {
         let c_self = c(0.3, -0.4);

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -2399,6 +2399,41 @@ mod tests {
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn combine_global_half_x86_tiers_match_scalar() {
+        let c_self = c(0.3, -0.4);
+        let c_remote = c(-0.2, 0.7);
+        for len in [1usize, 2, 3, 4, 5, 7, 16, 17, 33] {
+            let dst0: Vec<Complex64> = (0..len)
+                .map(|i| c((i as f64) * 0.13 - 0.4, 0.2 - (i as f64) * 0.07))
+                .collect();
+            let remote: Vec<Complex64> = (0..len)
+                .map(|i| c(0.5 - (i as f64) * 0.11, (i as f64) * 0.03 + 0.1))
+                .collect();
+            let mut expected = dst0.clone();
+            combine_global_half_scalar(&mut expected, &remote, c_self, c_remote);
+
+            if has_fma() {
+                let mut actual = dst0.clone();
+                // SAFETY: FMA support is checked above, and the slices have equal length.
+                unsafe { combine_global_half_fma(&mut actual, &remote, c_self, c_remote) };
+                assert_state_close(&actual, &expected, &format!("fma len={len}"));
+            }
+
+            if has_avx2_fma() {
+                let mut actual = dst0.clone();
+                // SAFETY: AVX2 and FMA support are checked above, and the slices have equal length.
+                unsafe { combine_global_half_avx2fma(&mut actual, &remote, c_self, c_remote) };
+                assert_state_close(&actual, &expected, &format!("avx2fma len={len}"));
+            }
+
+            let mut actual = dst0.clone();
+            combine_global_half(&mut actual, &remote, c_self, c_remote);
+            assert_state_close(&actual, &expected, &format!("dispatch len={len}"));
+        }
+    }
+
     fn identity_4x4() -> [[Complex64; 4]; 4] {
         let z = c(0.0, 0.0);
         let o = c(1.0, 0.0);
@@ -2740,7 +2775,7 @@ mod tests {
         let root = env!("CARGO_MANIFEST_DIR");
         // Per-file expected counts; the breakdown makes a drift easy to localise.
         let expected: [(&str, usize); 4] = [
-            ("src/backend/simd.rs", 27),
+            ("src/backend/simd.rs", 29),
             ("src/backend/word_ops.rs", 2),
             ("src/backend/stabilizer/kernels/simd.rs", 3),
             ("src/backend/statevector/kernels.rs", 10),

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1346,6 +1346,132 @@ pub(crate) fn scale_complex_slice(slice: &mut [Complex64], factor: Complex64) {
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
+unsafe fn combine_global_half_avx2fma(
+    dst: &mut [Complex64],
+    remote: &[Complex64],
+    c_self: Complex64,
+    c_remote: Complex64,
+) {
+    let s_rr = _mm256_set1_pd(c_self.re);
+    let s_ii = _mm256_set1_pd(c_self.im);
+    let r_rr = _mm256_set1_pd(c_remote.re);
+    let r_ii = _mm256_set1_pd(c_remote.im);
+    let dp = dst.as_mut_ptr() as *mut f64;
+    let rp = remote.as_ptr() as *const f64;
+    let pairs = dst.len() / 2;
+    for i in 0..pairs {
+        let off = i * 4;
+        let d = _mm256_loadu_pd(dp.add(off));
+        let r = _mm256_loadu_pd(rp.add(off));
+        let acc = _mm256_add_pd(
+            complex_mul_avx2fma(s_rr, s_ii, d),
+            complex_mul_avx2fma(r_rr, r_ii, r),
+        );
+        _mm256_storeu_pd(dp.add(off), acc);
+    }
+    if dst.len() % 2 != 0 {
+        let last = dst.len() - 1;
+        dst[last] = c_self * dst[last] + c_remote * remote[last];
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "fma")]
+unsafe fn combine_global_half_fma(
+    dst: &mut [Complex64],
+    remote: &[Complex64],
+    c_self: Complex64,
+    c_remote: Complex64,
+) {
+    let s_rr = _mm_set1_pd(c_self.re);
+    let s_ii = _mm_set1_pd(c_self.im);
+    let r_rr = _mm_set1_pd(c_remote.re);
+    let r_ii = _mm_set1_pd(c_remote.im);
+    let dp = dst.as_mut_ptr() as *mut f64;
+    let rp = remote.as_ptr() as *const f64;
+    for i in 0..dst.len() {
+        let d = _mm_loadu_pd(dp.add(i * 2));
+        let r = _mm_loadu_pd(rp.add(i * 2));
+        let acc = _mm_add_pd(
+            complex_mul_fma(s_rr, s_ii, d),
+            complex_mul_fma(r_rr, r_ii, r),
+        );
+        _mm_storeu_pd(dp.add(i * 2), acc);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn combine_global_half_neon(
+    dst: &mut [Complex64],
+    remote: &[Complex64],
+    c_self: Complex64,
+    c_remote: Complex64,
+) {
+    let s_rr = vdupq_n_f64(c_self.re);
+    let s_ii_as = vcombine_f64(vdup_n_f64(-c_self.im), vdup_n_f64(c_self.im));
+    let r_rr = vdupq_n_f64(c_remote.re);
+    let r_ii_as = vcombine_f64(vdup_n_f64(-c_remote.im), vdup_n_f64(c_remote.im));
+    let dp = dst.as_mut_ptr() as *mut f64;
+    let rp = remote.as_ptr() as *const f64;
+    for i in 0..dst.len() {
+        let d = vld1q_f64(dp.add(i * 2));
+        let r = vld1q_f64(rp.add(i * 2));
+        let acc = vaddq_f64(
+            complex_mul_neon(s_rr, s_ii_as, d),
+            complex_mul_neon(r_rr, r_ii_as, r),
+        );
+        vst1q_f64(dp.add(i * 2), acc);
+    }
+}
+
+#[allow(dead_code)]
+#[inline(always)]
+fn combine_global_half_scalar(
+    dst: &mut [Complex64],
+    remote: &[Complex64],
+    c_self: Complex64,
+    c_remote: Complex64,
+) {
+    for (d, &r) in dst.iter_mut().zip(remote.iter()) {
+        *d = c_self * *d + c_remote * r;
+    }
+}
+
+/// Combine two equal-length amplitude slices in place:
+/// `dst[i] = c_self * dst[i] + c_remote * remote[i]`.
+///
+/// Used after a distributed rank exchange for a global one qubit gate.
+pub(crate) fn combine_global_half(
+    dst: &mut [Complex64],
+    remote: &[Complex64],
+    c_self: Complex64,
+    c_remote: Complex64,
+) {
+    debug_assert_eq!(dst.len(), remote.len());
+    #[cfg(target_arch = "x86_64")]
+    {
+        if dst.len() >= MIN_SIMD_SLICE && has_avx2_fma() {
+            // SAFETY: AVX2 and FMA are available; slices have equal length.
+            unsafe { combine_global_half_avx2fma(dst, remote, c_self, c_remote) };
+            return;
+        }
+        if dst.len() >= 2 && has_fma() {
+            // SAFETY: FMA is available; slices have equal length.
+            unsafe { combine_global_half_fma(dst, remote, c_self, c_remote) };
+            return;
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    if dst.len() >= MIN_SIMD_SLICE {
+        // SAFETY: NEON is available; slices have equal length.
+        unsafe { combine_global_half_neon(dst, remote, c_self, c_remote) };
+        return;
+    }
+    combine_global_half_scalar(dst, remote, c_self, c_remote);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
 unsafe fn scale_complex_to_slice_avx2fma(
     dst: &mut [Complex64],
     src: &[Complex64],

--- a/src/distributed/comm.rs
+++ b/src/distributed/comm.rs
@@ -1,0 +1,190 @@
+//! Rank transport for distributed simulation.
+//!
+//! [`RankComm`] abstracts the collective and peer operations used by distributed
+//! backends. It is independent of state representation.
+//!
+//! [`SerialComm`] is the single rank implementation used by tests. `MpiComm`
+//! uses `rsmpi` behind the `distributed-mpi` feature and requires `mpiexec`.
+
+use num_complex::Complex64;
+
+/// Collective and peer operations across a rank set.
+///
+/// The amplitude exchange routines treat `Complex64` as two contiguous `f64`
+/// values, matching the `#[repr(C)]` layout of `num_complex::Complex`.
+pub trait RankComm: std::fmt::Debug + Send + Sync {
+    /// Index of the calling rank, in `0..size()`.
+    fn rank(&self) -> usize;
+
+    /// Total number of ranks. Always a power of two for the distributed backend.
+    fn size(&self) -> usize;
+
+    /// Concatenate every rank's `local` block in ascending rank order.
+    ///
+    /// The returned vector has length `size() * local.len()` and is identical
+    /// on every rank.
+    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64>;
+
+    /// `f64` version of [`allgather_c64`](RankComm::allgather_c64).
+    fn allgather_f64(&self, local: &[f64]) -> Vec<f64>;
+
+    /// Sum a scalar across all ranks; every rank receives the total.
+    fn allreduce_sum_f64(&self, value: f64) -> f64;
+
+    /// Exchange equal length amplitude blocks with `partner`.
+    ///
+    /// On return, `recv` holds `partner`'s `send` block. `send` and `recv` must
+    /// have the same length.
+    fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]);
+
+    /// Block until all ranks reach this point.
+    fn barrier(&self);
+}
+
+/// Single rank. All collectives are identity operations.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SerialComm;
+
+impl RankComm for SerialComm {
+    #[inline]
+    fn rank(&self) -> usize {
+        0
+    }
+
+    #[inline]
+    fn size(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
+        local.to_vec()
+    }
+
+    #[inline]
+    fn allgather_f64(&self, local: &[f64]) -> Vec<f64> {
+        local.to_vec()
+    }
+
+    #[inline]
+    fn allreduce_sum_f64(&self, value: f64) -> f64 {
+        value
+    }
+
+    #[inline]
+    fn sendrecv_c64(&self, _partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
+        debug_assert_eq!(send.len(), recv.len());
+        recv.copy_from_slice(send);
+    }
+
+    #[inline]
+    fn barrier(&self) {}
+}
+
+/// `Complex64` is two adjacent `f64` values. Assert the layout used by MPI.
+#[cfg(feature = "distributed-mpi")]
+const _: () = assert!(std::mem::size_of::<Complex64>() == 2 * std::mem::size_of::<f64>());
+
+/// Reinterpret `Complex64` as flat `f64` values for MPI calls.
+#[cfg(feature = "distributed-mpi")]
+#[inline]
+fn as_f64(slice: &[Complex64]) -> &[f64] {
+    // SAFETY: Complex64 is repr(C) over two f64 values with no padding.
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const f64, slice.len() * 2) }
+}
+
+#[cfg(feature = "distributed-mpi")]
+#[inline]
+fn as_f64_mut(slice: &mut [Complex64]) -> &mut [f64] {
+    // SAFETY: same layout as `as_f64`; the mutable borrow is exclusive.
+    unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut f64, slice.len() * 2) }
+}
+
+/// MPI transport over `rsmpi`.
+///
+/// Requires the `distributed-mpi` feature, a system MPI install, and an MPI
+/// launcher.
+#[cfg(feature = "distributed-mpi")]
+pub struct MpiComm {
+    _universe: mpi::environment::Universe,
+    world: mpi::topology::SimpleCommunicator,
+    rank: usize,
+    size: usize,
+}
+
+#[cfg(feature = "distributed-mpi")]
+impl std::fmt::Debug for MpiComm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MpiComm")
+            .field("rank", &self.rank)
+            .field("size", &self.size)
+            .finish()
+    }
+}
+
+#[cfg(feature = "distributed-mpi")]
+impl MpiComm {
+    /// Initialize MPI and capture the world communicator.
+    ///
+    /// Returns `None` when MPI initialization fails.
+    pub fn world() -> Option<Self> {
+        use mpi::traits::Communicator;
+        let universe = mpi::initialize()?;
+        let world = universe.world();
+        let rank = world.rank() as usize;
+        let size = world.size() as usize;
+        Some(Self {
+            _universe: universe,
+            world,
+            rank,
+            size,
+        })
+    }
+}
+
+#[cfg(feature = "distributed-mpi")]
+impl RankComm for MpiComm {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
+        use mpi::traits::CommunicatorCollectives;
+        let mut out = vec![Complex64::new(0.0, 0.0); local.len() * self.size];
+        self.world
+            .all_gather_into(as_f64(local), as_f64_mut(&mut out));
+        out
+    }
+
+    fn allgather_f64(&self, local: &[f64]) -> Vec<f64> {
+        use mpi::traits::CommunicatorCollectives;
+        let mut out = vec![0.0_f64; local.len() * self.size];
+        self.world.all_gather_into(local, &mut out);
+        out
+    }
+
+    fn allreduce_sum_f64(&self, value: f64) -> f64 {
+        use mpi::traits::CommunicatorCollectives;
+        let mut out = 0.0_f64;
+        self.world
+            .all_reduce_into(&value, &mut out, mpi::collective::SystemOperation::sum());
+        out
+    }
+
+    fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
+        use mpi::point_to_point as p2p;
+        use mpi::traits::Communicator;
+        debug_assert_eq!(send.len(), recv.len());
+        let peer = self.world.process_at_rank(partner as i32);
+        p2p::send_receive_into(as_f64(send), &peer, as_f64_mut(recv), &peer);
+    }
+
+    fn barrier(&self) {
+        use mpi::traits::CommunicatorCollectives;
+        self.world.barrier();
+    }
+}

--- a/src/distributed/mod.rs
+++ b/src/distributed/mod.rs
@@ -1,0 +1,89 @@
+//! Distributed context, transport, and thresholds.
+//!
+//! [`DistributedContext`] wraps a shared [`RankComm`] transport. Backend modules
+//! define their own state partitioning and use this module for rank access.
+//!
+//! Available contexts:
+//! - [`DistributedContext::serial`]: a single rank for tests and non-MPI runs.
+//! - [`DistributedContext::world`]: the MPI world communicator (requires the
+//!   `distributed-mpi` feature and an MPI launcher).
+//!
+//! Tuning thresholds are cached after the first environment variable read.
+
+pub mod comm;
+
+use std::sync::Arc;
+
+pub use comm::{RankComm, SerialComm};
+
+#[cfg(feature = "distributed-mpi")]
+pub use comm::MpiComm;
+
+/// Default minimum local qubit count below which distribution is not worthwhile.
+///
+/// Small slices per rank spend more time in communication than computation.
+pub const MIN_LOCAL_QUBITS_DEFAULT: usize = 10;
+
+/// Minimum local qubits per rank, tunable via `PRISM_DIST_MIN_LOCAL_QUBITS`.
+pub fn min_local_qubits() -> usize {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_MIN_LOCAL_QUBITS", MIN_LOCAL_QUBITS_DEFAULT, 1))
+}
+
+#[inline]
+fn env_usize_or(var: &str, default: usize, min: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|n| n.max(min))
+        .unwrap_or(default)
+}
+
+/// Shared handle to a rank transport for distributed simulation.
+pub struct DistributedContext {
+    comm: Arc<dyn RankComm>,
+}
+
+impl std::fmt::Debug for DistributedContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DistributedContext")
+            .field("rank", &self.rank())
+            .field("size", &self.size())
+            .finish()
+    }
+}
+
+impl DistributedContext {
+    /// Build a context from any [`RankComm`] implementation.
+    pub fn from_comm(comm: Arc<dyn RankComm>) -> Arc<Self> {
+        Arc::new(Self { comm })
+    }
+
+    /// Single rank. Used by tests and by non-MPI runs.
+    pub fn serial() -> Arc<Self> {
+        Self::from_comm(Arc::new(SerialComm))
+    }
+
+    /// Initialize MPI and capture the world communicator.
+    ///
+    /// Returns `None` when MPI cannot be initialized.
+    #[cfg(feature = "distributed-mpi")]
+    pub fn world() -> Option<Arc<Self>> {
+        MpiComm::world().map(|c| Self::from_comm(Arc::new(c)))
+    }
+
+    /// Index of the calling rank.
+    pub fn rank(&self) -> usize {
+        self.comm.rank()
+    }
+
+    /// Total number of ranks.
+    pub fn size(&self) -> usize {
+        self.comm.size()
+    }
+
+    pub(crate) fn comm(&self) -> &Arc<dyn RankComm> {
+        &self.comm
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 pub mod backend;
 pub mod circuit;
 pub mod circuits;
+#[cfg(feature = "distributed")]
+pub mod distributed;
 pub mod error;
 pub mod gates;
 #[cfg(feature = "gpu")]
@@ -55,6 +57,8 @@ pub mod gpu;
 pub mod qec;
 pub mod sim;
 
+#[cfg(feature = "distributed")]
+pub use backend::distributed_statevector::DistributedStatevectorBackend;
 pub use backend::factored::FactoredBackend;
 pub use backend::factored_stabilizer::FactoredStabilizerBackend;
 pub use backend::mps::MpsBackend;
@@ -65,6 +69,10 @@ pub use backend::statevector::StatevectorBackend;
 pub use backend::tensornetwork::TensorNetworkBackend;
 pub use circuit::builder::CircuitBuilder;
 pub use circuit::{Circuit, ClassicalCondition, Instruction, SvgOptions, TextOptions};
+#[cfg(feature = "distributed-mpi")]
+pub use distributed::MpiComm;
+#[cfg(feature = "distributed")]
+pub use distributed::{DistributedContext, RankComm, SerialComm};
 pub use error::{PrismError, Result};
 pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
 #[cfg(feature = "bench-internal")]

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -8,11 +8,16 @@ use crate::backend::{max_statevector_qubits, Backend};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "distributed"))]
 use std::sync::Arc;
 
 #[cfg(feature = "gpu")]
 use crate::gpu::GpuContext;
+
+#[cfg(feature = "distributed")]
+use crate::backend::distributed_statevector::DistributedStatevectorBackend;
+#[cfg(feature = "distributed")]
+use crate::distributed::DistributedContext;
 
 use super::{try_backend_probabilities, RunOutcome};
 
@@ -123,6 +128,16 @@ pub enum BackendKind {
     StabilizerGpu {
         context: Arc<GpuContext>,
     },
+    /// Exact state vector distributed across `2^p` ranks via a
+    /// [`DistributedContext`]. The low `n - p` qubits are simulated locally with
+    /// the standard SIMD kernels; the top `p` qubits select the rank.
+    ///
+    /// Results are independent of the rank count. With a single rank the path is
+    /// identical to [`BackendKind::Statevector`].
+    #[cfg(feature = "distributed")]
+    StatevectorDistributed {
+        context: Arc<DistributedContext>,
+    },
 }
 
 impl BackendKind {
@@ -211,6 +226,8 @@ pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> 
         | BackendKind::DeterministicPauli { .. } => false,
         #[cfg(feature = "gpu")]
         BackendKind::StabilizerGpu { .. } => false,
+        #[cfg(feature = "distributed")]
+        BackendKind::StatevectorDistributed { context } => context.size() == 1,
         BackendKind::Auto => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
         _ => true,
     }
@@ -354,6 +371,10 @@ pub(super) fn select_dispatch(
         #[cfg(feature = "gpu")]
         BackendKind::StabilizerGpu { context } => DispatchAction::Backend(Box::new(
             stabilizer_gpu_with_crossover(context, circuit, seed),
+        )),
+        #[cfg(feature = "distributed")]
+        BackendKind::StatevectorDistributed { context } => DispatchAction::Backend(Box::new(
+            DistributedStatevectorBackend::new(context.clone(), seed),
         )),
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -136,6 +136,18 @@ impl<'c, SeedState> Simulate<'c, SeedState> {
     pub fn gpu(self, context: std::sync::Arc<crate::gpu::GpuContext>) -> Self {
         self.backend(BackendKind::StatevectorGpu { context })
     }
+
+    /// Distribute the exact state vector across the ranks of `context`.
+    ///
+    /// With a single rank this behaves like [`Simulate::backend`] with
+    /// [`BackendKind::Statevector`].
+    #[cfg(feature = "distributed")]
+    pub fn distributed(
+        self,
+        context: std::sync::Arc<crate::distributed::DistributedContext>,
+    ) -> Self {
+        self.backend(BackendKind::StatevectorDistributed { context })
+    }
 }
 
 impl<'c> Simulate<'c, Unseeded> {
@@ -288,6 +300,17 @@ fn run_with_internal(
 ) -> Result<RunOutcome> {
     if !matches!(kind, BackendKind::Auto) {
         validate_explicit_backend(&kind, circuit)?;
+    }
+    // The distributed backend runs the whole circuit across ranks in lockstep.
+    // Subsystem decomposition, Clifford+T, and temporal-Clifford shortcuts all
+    // reshape execution per sub-block, which would desynchronize the collective
+    // calls every rank must issue in the same order. Dispatch directly.
+    #[cfg(feature = "distributed")]
+    if matches!(kind, BackendKind::StatevectorDistributed { .. }) {
+        return match select_dispatch(&kind, circuit, seed, false) {
+            DispatchAction::Backend(mut backend) => execute(&mut *backend, circuit, &opts),
+            _ => unreachable!("StatevectorDistributed always dispatches to a backend"),
+        };
     }
     let mut has_partial_independence = false;
     if circuit.num_qubits >= MIN_DECOMPOSITION_QUBITS {


### PR DESCRIPTION

## Summary

Add a feature gated MPI foundation for the state vector backend. The implementation should let the state vector amplitudes be partitioned across power of two MPI ranks while preserving the existing single rank statevector behavior.

## Performance Impact

Affected workload:

- Statevector simulations that exceed single process memory capacity.
- Local gate application in distributed statevector mode.
- Global one qubit gates that require rank pair exchange.

Expected tradeoff:

- Local gates should stay close to existing statevector throughput on each rank.
- Global gates add communication cost proportional to local slice length.
- No heap allocation should be introduced inside gate application inner loops.

Measurement plan:

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| statevector local gate baseline | TBD | TBD | TBD | TBD |
| distributed local gate, 1 rank | TBD | TBD | TBD | TBD |
| distributed global 1q gate, MPI ranks | N/A | TBD | N/A | N/A |

Regression verdict: TBD

## Correctness Plan

- Compare distributed statevector output against the existing statevector backend for small circuits.
- Use fixed RNG seed `42` for tests.
- Use deterministic circuits for MPI smoke coverage.
- Validate probability sums remain within numerical tolerance.
- Validate exported statevector ordering against dense statevector indexing.

## Documentation Impact

- Document distributed statevector memory layout in the module docstring.
- Document the `distributed-mpi` feature flag and MPI runtime requirement.
- Update architecture docs if the distributed backend becomes part of public backend selection.

## Risks And Rollback

Risk is contained by the `distributed-mpi` feature flag and explicit backend selection. If MPI support fails in CI or on unsupported systems, disable the feature or remove the distributed backend from dispatch without changing the existing statevector backend.