### PR TITLE
feat(dist): support global multi-qubit gates

### DIFF
--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -42,18 +42,27 @@ fn run() {
     const SEED: u64 = 42;
     const TOL: f64 = 1e-10;
 
-    // Cover local entanglement and global one qubit gates.
+    // Cover local entanglement, global one qubit gates, and two-qubit and
+    // controlled gates whose operands span local and global qubits.
     fn build_circuit(num_qubits: usize, _local_qubits: usize) -> Circuit {
-        let mut b = CircuitBuilder::new(num_qubits);
+        let n = num_qubits;
+        let hi = n - 1; // global on multi-rank runs
+        let mid = n - 2; // global on 4+ ranks
+        let mut b = CircuitBuilder::new(n);
         // Local entanglement on the bottom qubits.
         b.h(0).cx(0, 1).cx(1, 2);
-        // Include global targets.
-        for q in 0..num_qubits {
+        // One qubit gates on every qubit, including global targets.
+        for q in 0..n {
             b.h(q);
         }
-        b.rx(0.37, num_qubits - 1)
-            .t(num_qubits - 1)
-            .rz(-0.6, num_qubits - 2);
+        b.rx(0.37, hi).t(hi).rz(-0.6, mid);
+        // Two-qubit and controlled gates spanning the local/global boundary.
+        b.cx(0, hi) // control local, target global
+            .cx(hi, 0) // control global, target local
+            .cz(1, mid) // diagonal across the boundary
+            .rzz(0.4, 2, hi) // parity diagonal across the boundary
+            .swap(0, hi) // swap across the boundary
+            .cphase(0.5, mid, hi); // controlled phase, both global on 4 ranks
         b.build()
     }
 

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -15,12 +15,17 @@
 //!
 //! # Status
 //!
-//! Implemented: local gates, one qubit gates on rank bits, global diagonal
-//! scaling, and gathers for `probabilities` and `export_statevector`. With a
-//! single rank ([`SerialComm`]), every qubit is local.
+//! Implemented: local gates, one qubit gates on rank bits (exchange plus the
+//! `combine_global_half` SIMD kernel; diagonals scale in place), and two-qubit
+//! and controlled gates spanning rank bits (Cx, Cz, Swap, Rzz, Cu, Mcu). A
+//! global control is constant per rank, so it gates the whole slice with no
+//! communication; controlled diagonals (Cz, controlled phase, Rzz) never
+//! communicate. Plus gathers for `probabilities` and `export_statevector`. With
+//! a single rank ([`SerialComm`]), every qubit is local.
 //!
-//! Not implemented yet: gates over multiple qubits that span rank bits,
-//! measurement, reset, conditionals, and sampling.
+//! Not implemented yet: measurement, reset, conditionals, and sampling. Fused
+//! and batched gates are not applied across rank bits (fusion is disabled on
+//! multi-rank runs).
 
 #[cfg(test)]
 mod tests;
@@ -32,9 +37,10 @@ use num_complex::Complex64;
 use crate::backend::simd;
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::{dense_probability_len, dense_statevector_len, Backend};
-use crate::circuit::Instruction;
+use crate::circuit::{smallvec, Instruction};
 use crate::distributed::DistributedContext;
 use crate::error::{PrismError, Result};
+use crate::gates::Gate;
 
 const BACKEND_NAME: &str = "distributed_statevector";
 
@@ -118,6 +124,279 @@ impl DistributedStatevectorBackend {
         simd::scale_complex_slice(&mut self.inner.state, factor);
     }
 
+    /// True if every global control qubit has its rank bit set on this rank.
+    ///
+    /// A global control is constant across a rank's slice (it equals the rank
+    /// id bit), so a controlled gate is either fully active or fully inactive on
+    /// a given rank. Every rank evaluates this identically for its own id, and
+    /// exchange partners share the same global control bits (they differ only in
+    /// the target bit), so collectives stay in lockstep.
+    #[inline]
+    fn global_controls_satisfied(&self, global_controls: &[usize]) -> bool {
+        global_controls.iter().all(|&c| self.rank_bit_set(c))
+    }
+
+    /// Apply a 2x2 matrix to a local target qubit, gated by a set of local
+    /// control qubits (all must be 1). With no controls this is a plain 1q gate.
+    fn apply_local_controlled_1q(
+        &mut self,
+        local_controls: &[usize],
+        target: usize,
+        mat: [[Complex64; 2]; 2],
+    ) {
+        if local_controls.is_empty() {
+            self.inner
+                .apply_1q_matrix(target, &mat)
+                .expect("local 1q matrix");
+            return;
+        }
+        let ctrl_mask: usize = local_controls.iter().map(|&c| 1usize << c).sum();
+        let half = 1usize << target;
+        let state = &mut self.inner.state;
+        let pairs = state.len() >> 1;
+        for k in 0..pairs {
+            let i0 = (k & !(half - 1)) << 1 | (k & (half - 1));
+            if i0 & ctrl_mask != ctrl_mask {
+                continue;
+            }
+            let i1 = i0 | half;
+            let a = state[i0];
+            let b = state[i1];
+            state[i0] = mat[0][0] * a + mat[0][1] * b;
+            state[i1] = mat[1][0] * a + mat[1][1] * b;
+        }
+    }
+
+    /// Apply a 2x2 matrix to a global target qubit, gated by local control
+    /// qubits (all must be 1). Exchanges with the partner rank, then combines
+    /// only the controlled indices; uncontrolled indices keep their own value.
+    fn apply_global_controlled_1q(
+        &mut self,
+        local_controls: &[usize],
+        target: usize,
+        mat: [[Complex64; 2]; 2],
+    ) {
+        let partner = self.context.rank() ^ (1usize << self.global_bit(target));
+        let len = self.inner.state.len();
+        if self.recv.len() != len {
+            self.recv.resize(len, Complex64::new(0.0, 0.0));
+        }
+        self.context
+            .comm()
+            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+
+        let (c_self, c_remote) = if self.rank_bit_set(target) {
+            (mat[1][1], mat[1][0])
+        } else {
+            (mat[0][0], mat[0][1])
+        };
+
+        if local_controls.is_empty() {
+            simd::combine_global_half(&mut self.inner.state, &self.recv, c_self, c_remote);
+            return;
+        }
+        let ctrl_mask: usize = local_controls.iter().map(|&c| 1usize << c).sum();
+        for (i, amp) in self.inner.state.iter_mut().enumerate() {
+            if i & ctrl_mask == ctrl_mask {
+                *amp = c_self * *amp + c_remote * self.recv[i];
+            }
+        }
+    }
+
+    /// Apply a controlled gate (one target, zero or more controls) whose qubit
+    /// set may span local and global qubits. Covers Cx, Cu, and Mcu uniformly.
+    fn apply_controlled_dist(
+        &mut self,
+        controls: &[usize],
+        target: usize,
+        mat: [[Complex64; 2]; 2],
+    ) {
+        let local = self.local_qubits();
+        let (local_controls, global_controls): (Vec<usize>, Vec<usize>) =
+            controls.iter().partition(|&&c| c < local);
+
+        // A global control that is 0 on this rank deactivates the whole gate.
+        if !self.global_controls_satisfied(&global_controls) {
+            return;
+        }
+
+        if target < local {
+            self.apply_local_controlled_1q(&local_controls, target, mat);
+        } else {
+            self.apply_global_controlled_1q(&local_controls, target, mat);
+        }
+    }
+
+    /// Apply a controlled diagonal gate `diag(1, phase)` on the all-ones corner
+    /// of its qubit set. Covers Cz, controlled phase, and diagonal Mcu with no
+    /// communication: a global qubit contributes a constant rank-bit factor, and
+    /// local qubits restrict which slice indices receive the phase.
+    fn apply_controlled_phase_dist(&mut self, qubits: &[usize], phase: Complex64) {
+        let local = self.local_qubits();
+        let (local_qubits, global_qubits): (Vec<usize>, Vec<usize>) =
+            qubits.iter().partition(|&&q| q < local);
+
+        // Every global qubit in the corner must have its rank bit set.
+        if !global_qubits.iter().all(|&q| self.rank_bit_set(q)) {
+            return;
+        }
+
+        if local_qubits.is_empty() {
+            simd::scale_complex_slice(&mut self.inner.state, phase);
+            return;
+        }
+        let mask: usize = local_qubits.iter().map(|&q| 1usize << q).sum();
+        for (i, amp) in self.inner.state.iter_mut().enumerate() {
+            if i & mask == mask {
+                *amp *= phase;
+            }
+        }
+    }
+
+    /// Apply `Rzz(theta)` across any local/global split. Rzz is fully diagonal,
+    /// `phase = exp(-i theta/2)` when the two qubit bits agree and
+    /// `exp(i theta/2)` when they differ, so no communication is needed: a
+    /// global qubit contributes a constant rank bit to the parity.
+    fn apply_rzz_dist(&mut self, q0: usize, q1: usize, theta: f64) {
+        let local = self.local_qubits();
+        let phase_same = Complex64::from_polar(1.0, -theta / 2.0);
+        let phase_diff = Complex64::from_polar(1.0, theta / 2.0);
+        let phases = [phase_same, phase_diff];
+
+        match (q0 < local, q1 < local) {
+            (true, true) => {
+                for (i, amp) in self.inner.state.iter_mut().enumerate() {
+                    let parity = ((i >> q0) ^ (i >> q1)) & 1;
+                    *amp *= phases[parity];
+                }
+            }
+            (false, false) => {
+                let parity =
+                    ((self.rank_bit_set(q0) as usize) ^ (self.rank_bit_set(q1) as usize)) & 1;
+                simd::scale_complex_slice(&mut self.inner.state, phases[parity]);
+            }
+            (true, false) | (false, true) => {
+                let (local_q, global_q) = if q0 < local { (q0, q1) } else { (q1, q0) };
+                let global_bit = self.rank_bit_set(global_q) as usize;
+                for (i, amp) in self.inner.state.iter_mut().enumerate() {
+                    let parity = (((i >> local_q) & 1) ^ global_bit) & 1;
+                    *amp *= phases[parity];
+                }
+            }
+        }
+    }
+
+    /// Apply `SWAP(a, b)` across any local/global split.
+    ///
+    /// Local-local delegates to the inner kernel. When a global qubit is
+    /// involved, SWAP exchanges the `|01>` and `|10>` amplitudes of the pair:
+    /// only indices where the two qubit bits differ move.
+    fn apply_swap_dist(&mut self, a: usize, b: usize) {
+        let local = self.local_qubits();
+        match (a < local, b < local) {
+            (true, true) => {
+                self.inner
+                    .apply(&Instruction::Gate {
+                        gate: Gate::Swap,
+                        targets: smallvec![a, b],
+                    })
+                    .expect("local swap");
+            }
+            (false, false) => {
+                // Both global: ranks differing in exactly these two bits and with
+                // opposite values swap their entire slices. Equal-bit ranks are
+                // unaffected (|00>, |11> map to themselves).
+                if self.rank_bit_set(a) == self.rank_bit_set(b) {
+                    return;
+                }
+                let partner = self.context.rank()
+                    ^ (1usize << self.global_bit(a))
+                    ^ (1usize << self.global_bit(b));
+                let len = self.inner.state.len();
+                if self.recv.len() != len {
+                    self.recv.resize(len, Complex64::new(0.0, 0.0));
+                }
+                self.context
+                    .comm()
+                    .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+                self.inner.state.copy_from_slice(&self.recv);
+            }
+            (true, false) | (false, true) => {
+                let (local_q, global_q) = if a < local { (a, b) } else { (b, a) };
+                let partner = self.context.rank() ^ (1usize << self.global_bit(global_q));
+                let len = self.inner.state.len();
+                if self.recv.len() != len {
+                    self.recv.resize(len, Complex64::new(0.0, 0.0));
+                }
+                self.context
+                    .comm()
+                    .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+                // This rank's global bit is fixed. Amplitudes whose local bit
+                // differs from the global bit belong to the |01>/|10> subspace
+                // and take the partner's value at the local-bit-flipped index.
+                let global_bit = self.rank_bit_set(global_q);
+                let half = 1usize << local_q;
+                let len = self.inner.state.len();
+                for i in 0..len {
+                    let local_bit = (i >> local_q) & 1 == 1;
+                    if local_bit != global_bit {
+                        let partner_idx = i ^ half;
+                        self.inner.state[i] = self.recv[partner_idx];
+                    }
+                }
+            }
+        }
+    }
+
+    /// Dispatch a multi-qubit gate whose qubit set spans at least one global
+    /// qubit. Fusion is disabled in multi-rank mode, so gates arrive as raw
+    /// primitives (Cx, Cz, Swap, Cu, Mcu, Rzz).
+    fn apply_global_multi_qubit(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        match gate {
+            Gate::Cx => {
+                self.apply_controlled_dist(&targets[..1], targets[1], Gate::X.matrix_2x2());
+                Ok(())
+            }
+            Gate::Cz => {
+                self.apply_controlled_phase_dist(
+                    &[targets[0], targets[1]],
+                    -Complex64::new(1.0, 0.0),
+                );
+                Ok(())
+            }
+            Gate::Swap => {
+                self.apply_swap_dist(targets[0], targets[1]);
+                Ok(())
+            }
+            Gate::Rzz(theta) => {
+                self.apply_rzz_dist(targets[0], targets[1], *theta);
+                Ok(())
+            }
+            Gate::Cu(mat) => {
+                if let Some(phase) = gate.controlled_phase() {
+                    self.apply_controlled_phase_dist(&[targets[0], targets[1]], phase);
+                } else {
+                    self.apply_controlled_dist(&targets[..1], targets[1], **mat);
+                }
+                Ok(())
+            }
+            Gate::Mcu(data) => {
+                let num_ctrl = data.num_controls as usize;
+                let controls = &targets[..num_ctrl];
+                let target = targets[num_ctrl];
+                if let Some(phase) = gate.controlled_phase() {
+                    let mut corner: Vec<usize> = controls.to_vec();
+                    corner.push(target);
+                    self.apply_controlled_phase_dist(&corner, phase);
+                } else {
+                    self.apply_controlled_dist(controls, target, data.mat);
+                }
+                Ok(())
+            }
+            _ => Err(self.unsupported("fused or batched gate spanning a global qubit")),
+        }
+    }
+
     fn unsupported(&self, operation: &str) -> PrismError {
         PrismError::BackendUnsupported {
             backend: BACKEND_NAME.to_string(),
@@ -191,10 +470,9 @@ impl Backend for DistributedStatevectorBackend {
                     } else {
                         self.apply_global_1q(target, mat);
                     }
-                    Ok(())
-                } else {
-                    Err(self.unsupported("multi-qubit gate spanning a global qubit"))
+                    return Ok(());
                 }
+                self.apply_global_multi_qubit(gate, targets)
             }
             Instruction::Barrier { .. } => Ok(()),
             Instruction::Measure { .. } => Err(self.unsupported("distributed measurement")),

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -6,6 +6,7 @@ use crate::circuit::Circuit;
 use crate::distributed::{DistributedContext, RankComm};
 use crate::sim::run_on;
 use num_complex::Complex64;
+use std::collections::VecDeque;
 use std::sync::{Arc, Condvar, Mutex};
 
 const SEED: u64 = 42;
@@ -26,6 +27,11 @@ struct LoopbackState {
     arrived: usize,
     cslots: Vec<Vec<Complex64>>,
     fslots: Vec<f64>,
+    // Pairwise mailboxes indexed by `sender * size + receiver`. Each holds a
+    // FIFO queue of messages so repeated exchanges between the same pair stay
+    // ordered. This models MPI point-to-point, which is independent of the
+    // global barrier used by the collectives.
+    mailbox: Vec<VecDeque<Vec<Complex64>>>,
 }
 
 impl LoopbackShared {
@@ -37,6 +43,7 @@ impl LoopbackShared {
                 arrived: 0,
                 cslots: vec![Vec::new(); size],
                 fslots: vec![0.0; size],
+                mailbox: (0..size * size).map(|_| VecDeque::new()).collect(),
             }),
             cv: Condvar::new(),
         })
@@ -117,16 +124,21 @@ impl RankComm for LoopbackComm {
 
     fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
         debug_assert_eq!(send.len(), recv.len());
-        {
-            let mut st = self.shared.state.lock().unwrap();
-            st.cslots[self.rank] = send.to_vec();
+        let size = self.shared.size;
+        let mut st = self.shared.state.lock().unwrap();
+        // Deposit into self -> partner, then wait for partner -> self. Pairwise
+        // and barrier-independent, so ranks that skip an exchange (a 0 control)
+        // never block a partner: their partner skips the same exchange.
+        st.mailbox[self.rank * size + partner].push_back(send.to_vec());
+        self.shared.cv.notify_all();
+        let inbox = partner * size + self.rank;
+        loop {
+            if let Some(msg) = st.mailbox[inbox].pop_front() {
+                recv.copy_from_slice(&msg);
+                return;
+            }
+            st = self.shared.cv.wait(st).unwrap();
         }
-        self.shared.barrier();
-        {
-            let st = self.shared.state.lock().unwrap();
-            recv.copy_from_slice(&st.cslots[partner]);
-        }
-        self.shared.barrier();
     }
 
     fn barrier(&self) {
@@ -311,6 +323,119 @@ fn loopback_local_only_matches_across_ranks() {
     // Entangling chain confined to local qubits.
     let mut b = CircuitBuilder::new(5);
     b.h(0).cx(0, 1).cx(1, 2);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+// --- P2: two-qubit / controlled gates spanning global qubits ---
+//
+// With 4 qubits across 4 ranks, qubits 0,1 are local and 2,3 are global, so a
+// two-qubit gate can place its operands in every local/global combination. A
+// leading Hadamard wall spreads amplitude so every branch carries weight.
+
+fn spread_4q() -> CircuitBuilder {
+    let mut b = CircuitBuilder::new(4);
+    b.h(0).h(1).h(2).h(3);
+    b
+}
+
+#[test]
+fn loopback_cx_all_qubit_splits() {
+    relax_min_local_qubits();
+    // (local,local), (local,global), (global,local), (global,global).
+    for &(c, t) in &[(0usize, 1usize), (1, 2), (2, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.cx(c, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_cz_all_qubit_splits() {
+    relax_min_local_qubits();
+    for &(a, t) in &[(0usize, 1usize), (1, 3), (3, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.cz(a, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_swap_all_qubit_splits() {
+    relax_min_local_qubits();
+    for &(a, t) in &[(0usize, 1usize), (1, 2), (3, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.swap(a, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_rzz_all_qubit_splits() {
+    relax_min_local_qubits();
+    for &(a, t) in &[(0usize, 1usize), (1, 2), (2, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.rzz(0.85, a, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_cphase_all_qubit_splits() {
+    relax_min_local_qubits();
+    for &(c, t) in &[(0usize, 1usize), (1, 2), (2, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.cphase(0.6, c, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_controlled_unitary_global_target() {
+    relax_min_local_qubits();
+    // A non-phase controlled unitary (Ry(0.9) on the target) with control and
+    // target in mixed local/global positions.
+    let ry = |theta: f64| {
+        let (s, c) = (theta / 2.0).sin_cos();
+        [
+            [Complex64::new(c, 0.0), Complex64::new(-s, 0.0)],
+            [Complex64::new(s, 0.0), Complex64::new(c, 0.0)],
+        ]
+    };
+    for &(c, t) in &[(1usize, 2usize), (2, 0), (2, 3)] {
+        let mut b = spread_4q();
+        b.cu(ry(0.9), c, t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_toffoli_mixed_splits() {
+    relax_min_local_qubits();
+    let x = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    // Two controls + target across local/global boundaries.
+    for &(c0, c1, t) in &[(0usize, 1usize, 2usize), (0, 2, 3), (2, 3, 0), (1, 2, 3)] {
+        let mut b = spread_4q();
+        b.mcu(x, &[c0, c1], t);
+        assert_loopback_matches(&b.build(), &[1, 2, 4]);
+    }
+}
+
+#[test]
+fn loopback_mixed_circuit_qft_like() {
+    relax_min_local_qubits();
+    // H walls interleaved with controlled phases spanning all splits, plus an
+    // entangling tail. Exercises the full P2 path end to end.
+    let mut b = CircuitBuilder::new(4);
+    b.h(0).h(1).h(2).h(3);
+    b.cphase(0.5, 0, 2)
+        .cphase(0.25, 1, 3)
+        .cx(2, 1)
+        .rzz(0.4, 0, 3)
+        .swap(1, 2)
+        .cz(0, 3);
     assert_loopback_matches(&b.build(), &[1, 2, 4]);
 }
 


### PR DESCRIPTION
## Summary

Add distributed statevector support for multi qubit and controlled gates that span local and global qubits. This enables Cx, Cz, Swap, Rzz, Cu, and Mcu paths across rank boundaries, with communication avoided for diagonal cases where rank bits provide the needed state.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| distributed_statevector global Cx/Cz/Swap/Rzz/Cu/Mcu | TODO | TODO | TODO | TODO |

Regression verdict: FAIL until benchmark data is supplied.

Benchmark data is required before merge because this change touches distributed gate dispatch and gate paths.

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`


## Hotspot notes

Affected functions: `DistributedStatevectorBackend::apply`, `apply_global_multi_qubit`, `apply_controlled_dist`, `apply_global_controlled_1q`, `apply_controlled_phase_dist`, `apply_rzz_dist`, and `apply_swap_dist`.


## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems


## Breaking changes

None.

## Risks and rollback

Primary risks are incorrect amplitude movement for cross rank gates and communication deadlock if ranks diverge on exchange participation. Rollback is a revert of the distributed multi qubit dispatch path, restoring the previous unsupported behavior for gates spanning global qubits.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green