### PR TITLE
Feat/distributed p3 fusion batches

### DIFF
--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -63,6 +63,18 @@ fn run() {
             .rzz(0.4, 2, hi) // parity diagonal across the boundary
             .swap(0, hi) // swap across the boundary
             .cphase(0.5, mid, hi); // controlled phase, both global on 4 ranks
+                                   // Fusion-triggering tail: rotation layers + a CX ladder fuse into
+                                   // MultiFused / Fused2q, and the cphase ladder into BatchPhase, all
+                                   // reaching the global qubits at the top of the register.
+        for q in 0..n {
+            b.ry(0.2 + 0.01 * q as f64, q).rz(0.1, q);
+        }
+        for q in 0..n - 1 {
+            b.cx(q, q + 1);
+        }
+        for q in 0..n - 1 {
+            b.cphase(0.3, q, n - 1);
+        }
         b.build()
     }
 
@@ -72,7 +84,9 @@ fn run() {
     assert!(size.is_power_of_two(), "rank count must be a power of two");
     let p = size.trailing_zeros() as usize;
 
-    let num_qubits = 6;
+    // 16 qubits crosses every fusion threshold (1q/2q/multi/diagonal-batch), so
+    // the run exercises fused and batched gates spanning the global qubits.
+    let num_qubits = 16;
     let local_qubits = num_qubits - p;
     let circuit = build_circuit(num_qubits, local_qubits);
 

--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -1,7 +1,7 @@
 //! MPI correctness check for the distributed state vector backend.
 //!
 //! Run under an MPI launcher; rank 0 compares the gathered distributed result
-//! against a single process [`StatevectorBackend`] reference and exits nonzero on
+//! against a one process [`StatevectorBackend`] reference and exits nonzero on
 //! mismatch so a test script can gate on the process exit code:
 //!
 //! ```text
@@ -42,11 +42,11 @@ fn run() {
     const SEED: u64 = 42;
     const TOL: f64 = 1e-10;
 
-    // Cover local entanglement, global one qubit gates, and two-qubit and
+    // Cover local entanglement, global one qubit gates, and two qubit and
     // controlled gates whose operands span local and global qubits.
     fn build_circuit(num_qubits: usize, _local_qubits: usize) -> Circuit {
         let n = num_qubits;
-        let hi = n - 1; // global on multi-rank runs
+        let hi = n - 1; // global with more than one rank
         let mid = n - 2; // global on 4+ ranks
         let mut b = CircuitBuilder::new(n);
         // Local entanglement on the bottom qubits.
@@ -56,16 +56,15 @@ fn run() {
             b.h(q);
         }
         b.rx(0.37, hi).t(hi).rz(-0.6, mid);
-        // Two-qubit and controlled gates spanning the local/global boundary.
+        // Two qubit and controlled gates spanning the local/global boundary.
         b.cx(0, hi) // control local, target global
             .cx(hi, 0) // control global, target local
             .cz(1, mid) // diagonal across the boundary
             .rzz(0.4, 2, hi) // parity diagonal across the boundary
             .swap(0, hi) // swap across the boundary
             .cphase(0.5, mid, hi); // controlled phase, both global on 4 ranks
-                                   // Fusion-triggering tail: rotation layers + a CX ladder fuse into
-                                   // MultiFused / Fused2q, and the cphase ladder into BatchPhase, all
-                                   // reaching the global qubits at the top of the register.
+                                   // Fusion tail: rotations and CX form MultiFused
+                                   // and Fused2q; cphase forms BatchPhase.
         for q in 0..n {
             b.ry(0.2 + 0.01 * q as f64, q).rz(0.1, q);
         }
@@ -84,13 +83,13 @@ fn run() {
     assert!(size.is_power_of_two(), "rank count must be a power of two");
     let p = size.trailing_zeros() as usize;
 
-    // 16 qubits crosses every fusion threshold (1q/2q/multi/diagonal-batch), so
+    // 16 qubits crosses every fusion threshold (1q, 2q, multi, diagonal batch), so
     // the run exercises fused and batched gates spanning the global qubits.
     let num_qubits = 16;
     let local_qubits = num_qubits - p;
     let circuit = build_circuit(num_qubits, local_qubits);
 
-    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+    let mut backend = DistributedStatevectorBackend::new(ctx.clone(), SEED);
     let probs = run_on(&mut backend, &circuit)
         .expect("distributed run")
         .probabilities
@@ -116,5 +115,58 @@ fn run() {
             eprintln!("FAIL: max_err={max_err:.3e} exceeds tol {TOL:.1e}");
             std::process::exit(1);
         }
+    }
+
+    // Measurement determinism: with a fixed seed every rank count must produce
+    // the same classical outcomes. The script compares the printed signature
+    // across `-n 1/2/4`. Reuse the existing context (MPI initializes only once).
+    measurement_check(ctx, num_qubits);
+}
+
+#[cfg(feature = "distributed-mpi")]
+fn measurement_check(
+    ctx: std::sync::Arc<prism_q::distributed::DistributedContext>,
+    num_qubits: usize,
+) {
+    use prism_q::backend::distributed_statevector::DistributedStatevectorBackend;
+    use prism_q::circuit::builder::CircuitBuilder;
+    use prism_q::sim::run_on;
+
+    const SEED: u64 = 42;
+
+    let n = num_qubits;
+    let mut b = CircuitBuilder::new_with_classical(n, n);
+    // Superposition + entanglement, then measure every qubit (local and global).
+    for q in 0..n {
+        b.h(q);
+    }
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    for q in 0..n {
+        b.measure(q, q);
+    }
+    let circuit = b.build();
+
+    let rank = ctx.rank();
+    let size = ctx.size();
+    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+    let out = run_on(&mut backend, &circuit).expect("distributed measurement run");
+
+    if rank == 0 {
+        // Pack the outcome bits into a signature for rank count comparison.
+        let mut sig: u64 = 0;
+        for (i, &bit) in out.classical_bits.iter().enumerate() {
+            if bit {
+                sig ^= 1u64 << (i % 64);
+            }
+        }
+        println!("MEAS: {size} ranks, outcome_sig=0x{sig:016x}");
+        // Communication cost proxy: messages and amplitudes exchanged by rank 0.
+        println!(
+            "COMM: {size} ranks, messages={}, amplitudes={}",
+            backend.exchange_messages(),
+            backend.exchange_amplitudes()
+        );
     }
 }

--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -150,8 +150,17 @@ fn measurement_check(
 
     let rank = ctx.rank();
     let size = ctx.size();
-    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+    let mut backend = DistributedStatevectorBackend::new(ctx.clone(), SEED);
     let out = run_on(&mut backend, &circuit).expect("distributed measurement run");
+
+    // Same circuit with qubit relabeling disabled, for the cost comparison.
+    let mut direct = DistributedStatevectorBackend::new(ctx, SEED);
+    direct.set_relabel(false);
+    let direct_out = run_on(&mut direct, &circuit).expect("direct measurement run");
+    assert_eq!(
+        out.classical_bits, direct_out.classical_bits,
+        "relabel and direct runs must measure identical outcomes"
+    );
 
     if rank == 0 {
         // Pack the outcome bits into a signature for rank count comparison.
@@ -162,11 +171,17 @@ fn measurement_check(
             }
         }
         println!("MEAS: {size} ranks, outcome_sig=0x{sig:016x}");
-        // Communication cost proxy: messages and amplitudes exchanged by rank 0.
+        // Communication cost proxy: messages and amplitudes exchanged by rank 0,
+        // with qubit relabeling (default) and with direct per-gate exchange.
         println!(
             "COMM: {size} ranks, messages={}, amplitudes={}",
             backend.exchange_messages(),
             backend.exchange_amplitudes()
+        );
+        println!(
+            "COMM-DIRECT: {size} ranks, messages={}, amplitudes={}",
+            direct.exchange_messages(),
+            direct.exchange_amplitudes()
         );
     }
 }

--- a/scripts/test-mpi.ps1
+++ b/scripts/test-mpi.ps1
@@ -1,10 +1,10 @@
-# Build and run the distributed backend's multi-rank correctness check.
+# Build and run the distributed backend rank correctness check.
 #
 # Usage:   powershell -ExecutionPolicy Bypass -File scripts\test-mpi.ps1 [-Ranks 4]
 #
 # Sets up the MPI build environment, builds the lib tests and the mpiexec check
 # binary, then launches it across N ranks. Rank 0 asserts the gathered result
-# matches the single-node statevector reference and exits non-zero on mismatch.
+# matches the one process statevector reference and exits nonzero on mismatch.
 
 param(
     [int[]] $RankCounts = @(1, 2, 4)
@@ -31,12 +31,26 @@ $exe = Join-Path $scriptDir '..\target\debug\examples\dist_mpi_check.exe'
 $mpiexec = "C:\Program Files\Microsoft MPI\Bin\mpiexec.exe"
 if (-not (Test-Path $mpiexec)) { $mpiexec = "mpiexec" }
 
-# The check circuit is small, so relax the local-qubit floor to let it
+# The check circuit is small, so relax the local qubit floor to let it
 # distribute across ranks on a single host.
+$measSigs = @{}
 foreach ($n in $RankCounts) {
     Write-Host "`n== mpiexec -n $n dist_mpi_check =="
-    & $mpiexec -n $n -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe
-    if ($LASTEXITCODE -ne 0) { throw "multi-rank check failed at -n $n" }
+    $out = & $mpiexec -n $n -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe
+    if ($LASTEXITCODE -ne 0) { throw "rank check failed at -n $n" }
+    $out | ForEach-Object { Write-Host $_ }
+    # Capture the measurement signature to confirm it matches across rank counts.
+    $match = $out | Select-String -Pattern 'outcome_sig=(\S+)' | Select-Object -First 1
+    if (-not $match) {
+        throw "measurement signature missing at -n $n"
+    }
+    $measSigs[$n] = $match.Matches[0].Groups[1].Value
 }
+
+$unique = $measSigs.Values | Select-Object -Unique
+if ($unique.Count -gt 1) {
+    throw "measurement outcomes differ across rank counts: $($measSigs | Out-String)"
+}
+Write-Host "`nMeasurement determinism: signature $($unique) identical across ranks."
 
 Write-Host "`nAll distributed MPI checks passed."

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -23,9 +23,14 @@
 //! communicate. Plus gathers for `probabilities` and `export_statevector`. With
 //! a single rank ([`SerialComm`]), every qubit is local.
 //!
-//! Not implemented yet: measurement, reset, conditionals, and sampling. Fused
-//! and batched gates are not applied across rank bits (fusion is disabled on
-//! multi-rank runs).
+//! Fusion runs in every mode: fully local fused gates dispatch to the inner
+//! backend's tiled SIMD kernels, while fused or batched gates that span a rank
+//! bit (MultiFused, Fused2q, Multi2q, BatchPhase, BatchRzz, DiagonalBatch) are
+//! decomposed into the primitive paths above. A general two-qubit gate over one
+//! global qubit needs a single pairwise exchange; over two global qubits it
+//! gathers the four-rank group.
+//!
+//! Not implemented yet: measurement, reset, conditionals, and sampling.
 
 #[cfg(test)]
 mod tests;
@@ -43,6 +48,12 @@ use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
 const BACKEND_NAME: &str = "distributed_statevector";
+
+/// Whether a 2x2 matrix is diagonal (off-diagonal entries effectively zero).
+#[inline]
+fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
+    mat[0][1].norm() < 1e-12 && mat[1][0].norm() < 1e-12
+}
 
 /// Distributed state vector backend over an [`Arc<DistributedContext>`].
 pub struct DistributedStatevectorBackend {
@@ -258,9 +269,22 @@ impl DistributedStatevectorBackend {
     /// `exp(i theta/2)` when they differ, so no communication is needed: a
     /// global qubit contributes a constant rank bit to the parity.
     fn apply_rzz_dist(&mut self, q0: usize, q1: usize, theta: f64) {
-        let local = self.local_qubits();
         let phase_same = Complex64::from_polar(1.0, -theta / 2.0);
         let phase_diff = Complex64::from_polar(1.0, theta / 2.0);
+        self.apply_rzz_phases_dist(q0, q1, phase_same, phase_diff);
+    }
+
+    /// Apply a parity-diagonal two-qubit phase: `phase_same` when the two qubit
+    /// bits agree, `phase_diff` when they differ. Shared by `Rzz` and the
+    /// `Parity2q` diagonal-batch entry. Communication-free.
+    fn apply_rzz_phases_dist(
+        &mut self,
+        q0: usize,
+        q1: usize,
+        phase_same: Complex64,
+        phase_diff: Complex64,
+    ) {
+        let local = self.local_qubits();
         let phases = [phase_same, phase_diff];
 
         match (q0 < local, q1 < local) {
@@ -348,6 +372,113 @@ impl DistributedStatevectorBackend {
         }
     }
 
+    /// Apply a general 4x4 two-qubit unitary across any local/global split.
+    ///
+    /// `mat` follows the backend convention where row/column index `2*b0 + b1`
+    /// orders the `(q0, q1)` bits with `q0` most significant. Local-local
+    /// delegates to the inner tiled kernel. One global qubit needs a single
+    /// pairwise exchange; two global qubits need a four-way gather across the
+    /// rank group that shares the two rank bits.
+    fn apply_2q_dist(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        let local = self.local_qubits();
+        match (q0 < local, q1 < local) {
+            (true, true) => self.apply_local_fused_2q(q0, q1, mat),
+            (true, false) | (false, true) => self.apply_2q_one_global(q0, q1, mat),
+            (false, false) => self.apply_2q_two_global(q0, q1, mat),
+        }
+    }
+
+    /// Apply a fully local 4x4 gate through the inner backend's tiled kernel.
+    fn apply_local_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        self.inner
+            .apply(&Instruction::Gate {
+                gate: Gate::Fused2q(Box::new(*mat)),
+                targets: smallvec![q0, q1],
+            })
+            .expect("local fused 2q");
+    }
+
+    /// One qubit local, one global. Exchange with the partner that differs in
+    /// the global bit, then recompute each amplitude from the four inputs of the
+    /// 2x2 block: the two local-bit values on this rank (global bit `g`) and the
+    /// two on the partner (global bit `1 - g`).
+    fn apply_2q_one_global(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        let local = self.local_qubits();
+        let (local_q, global_q, global_is_q0) = if q0 < local {
+            (q0, q1, false)
+        } else {
+            (q1, q0, true)
+        };
+        let partner = self.context.rank() ^ (1usize << self.global_bit(global_q));
+        let len = self.inner.state.len();
+        if self.recv.len() != len {
+            self.recv.resize(len, Complex64::new(0.0, 0.0));
+        }
+        self.context
+            .comm()
+            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+
+        let g = self.rank_bit_set(global_q) as usize;
+        let half = 1usize << local_q;
+        // Basis index in `mat` is `2*b_q0 + b_q1`.
+        let basis = |gbit: usize, lbit: usize| -> usize {
+            if global_is_q0 {
+                (gbit << 1) | lbit
+            } else {
+                (lbit << 1) | gbit
+            }
+        };
+        // Output depends on both local-bit siblings, so snapshot first.
+        let local_snapshot = self.inner.state.clone();
+        for i in 0..len {
+            let l = (i >> local_q) & 1;
+            let row = basis(g, l);
+            let sib0 = i & !half; // local bit 0 sibling index
+            let sib1 = i | half; // local bit 1 sibling index
+            let mut acc = mat[row][basis(g, 0)] * local_snapshot[sib0];
+            acc += mat[row][basis(g, 1)] * local_snapshot[sib1];
+            acc += mat[row][basis(1 - g, 0)] * self.recv[sib0];
+            acc += mat[row][basis(1 - g, 1)] * self.recv[sib1];
+            self.inner.state[i] = acc;
+        }
+    }
+
+    /// Both qubits global. The four `(q0, q1)` combinations live on four ranks
+    /// that share every other rank bit. Gather the other three slices, then each
+    /// rank computes its output row of `mat` from the four gathered slices.
+    fn apply_2q_two_global(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+        let b0 = self.global_bit(q0);
+        let b1 = self.global_bit(q1);
+        let rank = self.context.rank();
+        let g0 = (rank >> b0) & 1;
+        let g1 = (rank >> b1) & 1;
+        let my_basis = (g0 << 1) | g1;
+
+        let len = self.inner.state.len();
+        let mut slices: [Vec<Complex64>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+        for (c, slot) in slices.iter_mut().enumerate() {
+            if c == my_basis {
+                *slot = self.inner.state.clone();
+                continue;
+            }
+            let c0 = (c >> 1) & 1;
+            let c1 = c & 1;
+            let partner = (rank & !(1 << b0) & !(1 << b1)) | (c0 << b0) | (c1 << b1);
+            let mut buf = vec![Complex64::new(0.0, 0.0); len];
+            self.context
+                .comm()
+                .sendrecv_c64(partner, &self.inner.state, &mut buf);
+            *slot = buf;
+        }
+        for i in 0..len {
+            let mut acc = Complex64::new(0.0, 0.0);
+            for (c, slice) in slices.iter().enumerate() {
+                acc += mat[my_basis][c] * slice[i];
+            }
+            self.inner.state[i] = acc;
+        }
+    }
+
     /// Dispatch a multi-qubit gate whose qubit set spans at least one global
     /// qubit. Fusion is disabled in multi-rank mode, so gates arrive as raw
     /// primitives (Cx, Cz, Swap, Cu, Mcu, Rzz).
@@ -393,7 +524,81 @@ impl DistributedStatevectorBackend {
                 }
                 Ok(())
             }
-            _ => Err(self.unsupported("fused or batched gate spanning a global qubit")),
+            Gate::Fused2q(mat) => {
+                self.apply_2q_dist(targets[0], targets[1], mat);
+                Ok(())
+            }
+            Gate::Multi2q(data) => {
+                for &(q0, q1, ref mat) in &data.gates {
+                    self.apply_2q_dist(q0, q1, mat);
+                }
+                Ok(())
+            }
+            Gate::MultiFused(data) => {
+                for &(q, ref mat) in &data.gates {
+                    if q < self.local_qubits() {
+                        self.inner.apply_1q_matrix(q, mat).expect("local 1q matrix");
+                    } else if is_diagonal_2x2(mat) {
+                        self.apply_global_diagonal_1q(q, mat[0][0], mat[1][1]);
+                    } else {
+                        self.apply_global_1q(q, *mat);
+                    }
+                }
+                Ok(())
+            }
+            Gate::BatchPhase(data) => {
+                let control = targets[0];
+                for &(target, phase) in &data.phases {
+                    self.apply_controlled_phase_dist(&[control, target], phase);
+                }
+                Ok(())
+            }
+            Gate::BatchRzz(data) => {
+                for &(q0, q1, theta) in &data.edges {
+                    self.apply_rzz_dist(q0, q1, theta);
+                }
+                Ok(())
+            }
+            Gate::DiagonalBatch(data) => {
+                for entry in &data.entries {
+                    self.apply_diag_entry_dist(entry);
+                }
+                Ok(())
+            }
+            _ => Err(self.unsupported("gate spanning a global qubit")),
+        }
+    }
+
+    /// Apply a single [`DiagEntry`] across any local/global split. All diagonal
+    /// entries are communication-free.
+    fn apply_diag_entry_dist(&mut self, entry: &crate::gates::DiagEntry) {
+        use crate::gates::DiagEntry;
+        match *entry {
+            DiagEntry::Phase1q { qubit, d0, d1 } => {
+                if qubit < self.local_qubits() {
+                    self.inner
+                        .apply_1q_matrix(
+                            qubit,
+                            &[
+                                [d0, Complex64::new(0.0, 0.0)],
+                                [Complex64::new(0.0, 0.0), d1],
+                            ],
+                        )
+                        .expect("local diagonal 1q");
+                } else {
+                    self.apply_global_diagonal_1q(qubit, d0, d1);
+                }
+            }
+            DiagEntry::Phase2q { q0, q1, phase } => {
+                self.apply_controlled_phase_dist(&[q0, q1], phase);
+            }
+            DiagEntry::Parity2q {
+                q0, q1, same, diff, ..
+            } => {
+                // same = exp(-i theta/2), diff = exp(i theta/2) for Rzz(theta).
+                // Recover the parity phases directly without the angle.
+                self.apply_rzz_phases_dist(q0, q1, same, diff);
+            }
         }
     }
 
@@ -411,8 +616,10 @@ impl Backend for DistributedStatevectorBackend {
     }
 
     fn supports_fused_gates(&self) -> bool {
-        // Fusion assumes every target indexes the local slice.
-        self.is_single_rank()
+        // Fusion runs in every mode. Fully local fused gates dispatch to the
+        // inner backend's tiled SIMD kernels; fused or batched gates that span a
+        // rank bit are decomposed into primitives at apply time.
+        true
     }
 
     fn supports_qft_block(&self) -> bool {

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1,36 +1,53 @@
 //! Distributed state vector backend.
 //!
-//! Partitions the `2^n` amplitude vector across `P = 2^p` ranks. The low
-//! `n - p` qubits are *local* (indexing each rank's contiguous slice); the top
-//! `p` qubits are *global* (selecting the rank id). Each rank holds a local
-//! slice of length `2^(n-p)` inside an inner [`StatevectorBackend`]. Gates on
-//! local qubits reuse the existing SIMD kernels.
+//! Splits the `2^n` amplitude vector across `P = 2^p` ranks. The low `n - p`
+//! qubits index the local slice. The top `p` qubits select the rank. Each rank
+//! stores `2^(n - p)` amplitudes in an inner [`StatevectorBackend`].
 //!
 //! # Memory layout
 //!
-//! The global amplitude index is `rank * 2^(n-p) + local_index`. Qubit `q` with
-//! `q < n - p` is bit `q` of `local_index`; qubit `q >= n - p` is bit
-//! `q - (n - p)` of the rank id. Qubit 0 remains the least significant bit, so
-//! `|0...0>` lives at `local_index = 0` on rank 0.
+//! Global index: `rank * 2^(n - p) + local_index`. If `q < n - p`, qubit `q` is
+//! bit `q` of `local_index`; otherwise it is bit `q - (n - p)` of the rank id.
+//! Qubit 0 is the least significant bit. `|0...0>` is index 0 on rank 0.
 //!
 //! # Status
 //!
-//! Implemented: local gates, one qubit gates on rank bits (exchange plus the
-//! `combine_global_half` SIMD kernel; diagonals scale in place), and two-qubit
-//! and controlled gates spanning rank bits (Cx, Cz, Swap, Rzz, Cu, Mcu). A
-//! global control is constant per rank, so it gates the whole slice with no
-//! communication; controlled diagonals (Cz, controlled phase, Rzz) never
-//! communicate. Plus gathers for `probabilities` and `export_statevector`. With
-//! a single rank ([`SerialComm`]), every qubit is local.
+//! Implemented: local gates, rank bit one qubit gates, two qubit gates, controlled
+//! gates across rank bits, `probabilities`, and `export_statevector`. A global
+//! control is constant on a rank, so it gates the whole slice with no
+//! communication. Diagonal controlled gates never communicate. With one rank
+//! ([`SerialComm`]), every qubit is local.
 //!
-//! Fusion runs in every mode: fully local fused gates dispatch to the inner
-//! backend's tiled SIMD kernels, while fused or batched gates that span a rank
-//! bit (MultiFused, Fused2q, Multi2q, BatchPhase, BatchRzz, DiagonalBatch) are
-//! decomposed into the primitive paths above. A general two-qubit gate over one
-//! global qubit needs a single pairwise exchange; over two global qubits it
-//! gathers the four-rank group.
+//! Fusion runs in every mode. Local fused gates dispatch to the inner SIMD
+//! kernels. Fused or batched gates that span rank bits are decomposed into the
+//! paths above. A general two qubit gate over one global qubit needs one
+//! pairwise exchange; over two global qubits it gathers a group of four ranks.
 //!
-//! Not implemented yet: measurement, reset, conditionals, and sampling.
+//! Once a rank resolves its global qubit bits, the remaining gate is local and
+//! dispatches to the inner backend. The only manual amplitude loops combine the
+//! received buffers after communication.
+//!
+//! Measurement, reset, and classical conditionals are supported. Measurement
+//! probabilities are summed with `Allreduce`. Each rank uses the same seeded RNG,
+//! so ranks agree without exchanging the draw. Reset follows the statevector
+//! convention: project onto `|0>`, renormalize, and reinitialize to `|0...0>`
+//! when the zero branch is empty.
+//!
+//! # Communication cost
+//!
+//! Only gates that are not diagonal and touch a global target communicate. A
+//! global one qubit gate, or a two qubit gate over one global qubit, costs one
+//! pairwise exchange of the local slice. A two qubit gate over two global qubits
+//! gathers four ranks. Global one qubit exchange is tiled by
+//! [`crate::distributed::exchange_chunk`], which bounds the receive buffer.
+//!
+//! [`DistributedStatevectorBackend::exchange_messages`] and
+//! [`DistributedStatevectorBackend::exchange_amplitudes`] expose rank local
+//! communication volume. Use these counters to evaluate qubit reordering and
+//! routing, since one host cannot measure real network latency.
+//!
+//! Not implemented yet: distributed shot sampling, and automatic qubit reorder
+//! to keep busy qubits local.
 
 #[cfg(test)]
 mod tests;
@@ -38,18 +55,20 @@ mod tests;
 use std::sync::Arc;
 
 use num_complex::Complex64;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 use crate::backend::simd;
 use crate::backend::statevector::StatevectorBackend;
-use crate::backend::{dense_probability_len, dense_statevector_len, Backend};
-use crate::circuit::{smallvec, Instruction};
+use crate::backend::{dense_probability_len, dense_statevector_len, measurement_inv_norm, Backend};
+use crate::circuit::{smallvec, Instruction, SmallVec};
 use crate::distributed::DistributedContext;
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
 const BACKEND_NAME: &str = "distributed_statevector";
 
-/// Whether a 2x2 matrix is diagonal (off-diagonal entries effectively zero).
+/// Whether a 2x2 matrix is diagonal.
 #[inline]
 fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
     mat[0][1].norm() < 1e-12 && mat[1][0].norm() < 1e-12
@@ -62,6 +81,19 @@ pub struct DistributedStatevectorBackend {
     num_qubits: usize,
     global_qubits: usize,
     recv: Vec<Complex64>,
+    seed: u64,
+    /// Max amplitudes exchanged per message for a global one qubit gate.
+    /// Tiling the exchange bounds the receive buffer to `exchange_chunk`.
+    exchange_chunk: usize,
+    /// Count of `sendrecv` messages issued by this rank, and the total
+    /// amplitudes exchanged. Reorder and routing passes should minimize these
+    /// counters.
+    exchange_messages: u64,
+    exchange_amplitudes: u64,
+    /// RNG for measurement decisions, seeded identically on every rank and
+    /// advanced in lockstep. Outcomes are derived from `Allreduce`d global
+    /// probabilities, so all ranks agree without exchanging the draw.
+    meas_rng: ChaCha8Rng,
 }
 
 impl DistributedStatevectorBackend {
@@ -73,7 +105,39 @@ impl DistributedStatevectorBackend {
             num_qubits: 0,
             global_qubits: 0,
             recv: Vec::new(),
+            seed,
+            exchange_chunk: crate::distributed::exchange_chunk(),
+            exchange_messages: 0,
+            exchange_amplitudes: 0,
+            meas_rng: ChaCha8Rng::seed_from_u64(seed),
         }
+    }
+
+    /// Override the exchange chunk size in amplitudes. Tests use this to cover
+    /// the tiled path without using the process environment.
+    #[cfg(test)]
+    pub(crate) fn set_exchange_chunk(&mut self, chunk: usize) {
+        self.exchange_chunk = chunk.max(1);
+    }
+
+    /// Number of `sendrecv` messages this rank has issued since `init`.
+    ///
+    /// Cost proxy for this backend. One host cannot measure real network
+    /// latency, so routing changes are evaluated against this count.
+    pub fn exchange_messages(&self) -> u64 {
+        self.exchange_messages
+    }
+
+    /// Total amplitudes this rank has sent across all exchanges since `init`.
+    pub fn exchange_amplitudes(&self) -> u64 {
+        self.exchange_amplitudes
+    }
+
+    /// Record a pairwise exchange of `amplitudes` for the cost counters.
+    #[inline]
+    fn count_exchange(&mut self, amplitudes: usize) {
+        self.exchange_messages += 1;
+        self.exchange_amplitudes += amplitudes as u64;
     }
 
     #[inline]
@@ -107,23 +171,33 @@ impl DistributedStatevectorBackend {
     /// Apply a one qubit gate whose target is stored in the rank id.
     ///
     /// Exchange with the partner rank, then write this rank's half of the 2x2
-    /// result.
+    /// result. The combine is elementwise, so the exchange is tiled in chunks of
+    /// [`crate::distributed::exchange_chunk`] amplitudes, bounding the receive
+    /// buffer to `chunk` instead of a full slice copy. The default chunk is
+    /// the whole slice (single message), so behavior is unchanged unless tuned.
     fn apply_global_1q(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
         let partner = self.context.rank() ^ (1usize << self.global_bit(target));
-        let len = self.inner.state.len();
-        if self.recv.len() != len {
-            self.recv.resize(len, Complex64::new(0.0, 0.0));
-        }
-        self.context
-            .comm()
-            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
-
         let (c_self, c_remote) = if self.rank_bit_set(target) {
             (mat[1][1], mat[1][0])
         } else {
             (mat[0][0], mat[0][1])
         };
-        simd::combine_global_half(&mut self.inner.state, &self.recv, c_self, c_remote);
+        let len = self.inner.state.len();
+        let chunk = self.exchange_chunk.min(len).max(1);
+        if self.recv.len() != chunk {
+            self.recv.resize(chunk, Complex64::new(0.0, 0.0));
+        }
+        let mut off = 0;
+        while off < len {
+            let end = (off + chunk).min(len);
+            self.count_exchange(end - off);
+            let recv = &mut self.recv[..end - off];
+            self.context
+                .comm()
+                .sendrecv_c64(partner, &self.inner.state[off..end], recv);
+            simd::combine_global_half(&mut self.inner.state[off..end], recv, c_self, c_remote);
+            off = end;
+        }
     }
 
     /// Apply a diagonal one qubit gate whose target is stored in the rank id.
@@ -135,47 +209,30 @@ impl DistributedStatevectorBackend {
         simd::scale_complex_slice(&mut self.inner.state, factor);
     }
 
-    /// True if every global control qubit has its rank bit set on this rank.
-    ///
-    /// A global control is constant across a rank's slice (it equals the rank
-    /// id bit), so a controlled gate is either fully active or fully inactive on
-    /// a given rank. Every rank evaluates this identically for its own id, and
-    /// exchange partners share the same global control bits (they differ only in
-    /// the target bit), so collectives stay in lockstep.
-    #[inline]
-    fn global_controls_satisfied(&self, global_controls: &[usize]) -> bool {
-        global_controls.iter().all(|&c| self.rank_bit_set(c))
-    }
-
     /// Apply a 2x2 matrix to a local target qubit, gated by a set of local
-    /// control qubits (all must be 1). With no controls this is a plain 1q gate.
+    /// control qubits (all must be 1). The whole operation is local, so it
+    /// dispatches to the inner backend's SIMD and parallel controlled kernels.
     fn apply_local_controlled_1q(
         &mut self,
         local_controls: &[usize],
         target: usize,
         mat: [[Complex64; 2]; 2],
     ) {
-        if local_controls.is_empty() {
-            self.inner
-                .apply_1q_matrix(target, &mat)
-                .expect("local 1q matrix");
-            return;
-        }
-        let ctrl_mask: usize = local_controls.iter().map(|&c| 1usize << c).sum();
-        let half = 1usize << target;
-        let state = &mut self.inner.state;
-        let pairs = state.len() >> 1;
-        for k in 0..pairs {
-            let i0 = (k & !(half - 1)) << 1 | (k & (half - 1));
-            if i0 & ctrl_mask != ctrl_mask {
-                continue;
+        let gate = match local_controls.len() {
+            0 => {
+                self.inner
+                    .apply_1q_matrix(target, &mat)
+                    .expect("local 1q matrix");
+                return;
             }
-            let i1 = i0 | half;
-            let a = state[i0];
-            let b = state[i1];
-            state[i0] = mat[0][0] * a + mat[0][1] * b;
-            state[i1] = mat[1][0] * a + mat[1][1] * b;
-        }
+            1 => Gate::cu(mat),
+            n => Gate::mcu(mat, n as u8),
+        };
+        let mut targets: SmallVec<[usize; 4]> = local_controls.iter().copied().collect();
+        targets.push(target);
+        self.inner
+            .apply(&Instruction::Gate { gate, targets })
+            .expect("local controlled 1q");
     }
 
     /// Apply a 2x2 matrix to a global target qubit, gated by local control
@@ -192,6 +249,7 @@ impl DistributedStatevectorBackend {
         if self.recv.len() != len {
             self.recv.resize(len, Complex64::new(0.0, 0.0));
         }
+        self.count_exchange(len);
         self.context
             .comm()
             .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
@@ -223,12 +281,14 @@ impl DistributedStatevectorBackend {
         mat: [[Complex64; 2]; 2],
     ) {
         let local = self.local_qubits();
-        let (local_controls, global_controls): (Vec<usize>, Vec<usize>) =
-            controls.iter().partition(|&&c| c < local);
-
-        // A global control that is 0 on this rank deactivates the whole gate.
-        if !self.global_controls_satisfied(&global_controls) {
-            return;
+        let mut local_controls: SmallVec<[usize; 4]> = SmallVec::new();
+        for &c in controls {
+            if c < local {
+                local_controls.push(c);
+            } else if !self.rank_bit_set(c) {
+                // A zero global control disables the gate on this rank.
+                return;
+            }
         }
 
         if target < local {
@@ -238,33 +298,55 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Apply a controlled diagonal gate `diag(1, phase)` on the all-ones corner
+    /// Apply a controlled diagonal gate `diag(1, phase)` on the all ones corner
     /// of its qubit set. Covers Cz, controlled phase, and diagonal Mcu with no
-    /// communication: a global qubit contributes a constant rank-bit factor, and
+    /// communication: a global qubit contributes a constant rank bit, and
     /// local qubits restrict which slice indices receive the phase.
+    ///
+    /// The residual on local qubits is another controlled phase gate, so it uses
+    /// the inner backend kernels.
     fn apply_controlled_phase_dist(&mut self, qubits: &[usize], phase: Complex64) {
         let local = self.local_qubits();
-        let (local_qubits, global_qubits): (Vec<usize>, Vec<usize>) =
-            qubits.iter().partition(|&&q| q < local);
-
-        // Every global qubit in the corner must have its rank bit set.
-        if !global_qubits.iter().all(|&q| self.rank_bit_set(q)) {
-            return;
+        let mut local_qubits: SmallVec<[usize; 8]> = SmallVec::new();
+        for &q in qubits {
+            if q < local {
+                local_qubits.push(q);
+            } else if !self.rank_bit_set(q) {
+                // A zero global corner bit makes the gate inactive on this rank.
+                return;
+            }
         }
+        self.apply_local_corner_phase(&local_qubits, phase);
+    }
 
-        if local_qubits.is_empty() {
-            simd::scale_complex_slice(&mut self.inner.state, phase);
-            return;
-        }
-        let mask: usize = local_qubits.iter().map(|&q| 1usize << q).sum();
-        for (i, amp) in self.inner.state.iter_mut().enumerate() {
-            if i & mask == mask {
-                *amp *= phase;
+    /// Apply `phase` on the all ones corner through the inner backend.
+    fn apply_local_corner_phase(&mut self, local_qubits: &[usize], phase: Complex64) {
+        let z = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        match local_qubits.len() {
+            0 => simd::scale_complex_slice(&mut self.inner.state, phase),
+            1 => self
+                .inner
+                .apply_1q_matrix(local_qubits[0], &[[one, z], [z, phase]])
+                .expect("local diagonal phase"),
+            n => {
+                let mat = [[one, z], [z, phase]];
+                let gate = if n == 2 {
+                    Gate::cu(mat)
+                } else {
+                    Gate::mcu(mat, (n - 1) as u8)
+                };
+                self.inner
+                    .apply(&Instruction::Gate {
+                        gate,
+                        targets: local_qubits.iter().copied().collect(),
+                    })
+                    .expect("local controlled phase");
             }
         }
     }
 
-    /// Apply `Rzz(theta)` across any local/global split. Rzz is fully diagonal,
+    /// Apply `Rzz(theta)` across any local or global split. Rzz is diagonal,
     /// `phase = exp(-i theta/2)` when the two qubit bits agree and
     /// `exp(i theta/2)` when they differ, so no communication is needed: a
     /// global qubit contributes a constant rank bit to the parity.
@@ -274,9 +356,8 @@ impl DistributedStatevectorBackend {
         self.apply_rzz_phases_dist(q0, q1, phase_same, phase_diff);
     }
 
-    /// Apply a parity-diagonal two-qubit phase: `phase_same` when the two qubit
-    /// bits agree, `phase_diff` when they differ. Shared by `Rzz` and the
-    /// `Parity2q` diagonal-batch entry. Communication-free.
+    /// Apply a parity diagonal two qubit phase. Shared by `Rzz` and
+    /// `Parity2q`; it needs no communication.
     fn apply_rzz_phases_dist(
         &mut self,
         q0: usize,
@@ -285,36 +366,52 @@ impl DistributedStatevectorBackend {
         phase_diff: Complex64,
     ) {
         let local = self.local_qubits();
-        let phases = [phase_same, phase_diff];
 
         match (q0 < local, q1 < local) {
             (true, true) => {
-                for (i, amp) in self.inner.state.iter_mut().enumerate() {
-                    let parity = ((i >> q0) ^ (i >> q1)) & 1;
-                    *amp *= phases[parity];
-                }
+                // Both qubits are local, so use the inner diagonal batch kernel.
+                use crate::gates::{DiagEntry, DiagonalBatchData};
+                let entry = DiagEntry::Parity2q {
+                    q0,
+                    q1,
+                    same: phase_same,
+                    diff: phase_diff,
+                };
+                self.inner
+                    .apply(&Instruction::Gate {
+                        gate: Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+                            entries: vec![entry],
+                        })),
+                        targets: smallvec![q0, q1],
+                    })
+                    .expect("local parity diagonal");
             }
             (false, false) => {
                 let parity =
                     ((self.rank_bit_set(q0) as usize) ^ (self.rank_bit_set(q1) as usize)) & 1;
-                simd::scale_complex_slice(&mut self.inner.state, phases[parity]);
+                let factor = [phase_same, phase_diff][parity];
+                simd::scale_complex_slice(&mut self.inner.state, factor);
             }
             (true, false) | (false, true) => {
+                // One global qubit is fixed on this rank. The residual is a
+                // diagonal one qubit gate.
                 let (local_q, global_q) = if q0 < local { (q0, q1) } else { (q1, q0) };
-                let global_bit = self.rank_bit_set(global_q) as usize;
-                for (i, amp) in self.inner.state.iter_mut().enumerate() {
-                    let parity = (((i >> local_q) & 1) ^ global_bit) & 1;
-                    *amp *= phases[parity];
-                }
+                let gbit = self.rank_bit_set(global_q) as usize;
+                // Local bit 0 uses parity gbit. Local bit 1 uses gbit ^ 1.
+                let d0 = [phase_same, phase_diff][gbit];
+                let d1 = [phase_same, phase_diff][gbit ^ 1];
+                let z = Complex64::new(0.0, 0.0);
+                self.inner
+                    .apply_1q_matrix(local_q, &[[d0, z], [z, d1]])
+                    .expect("local parity residual");
             }
         }
     }
 
-    /// Apply `SWAP(a, b)` across any local/global split.
+    /// Apply `SWAP(a, b)` across any local or global split.
     ///
-    /// Local-local delegates to the inner kernel. When a global qubit is
-    /// involved, SWAP exchanges the `|01>` and `|10>` amplitudes of the pair:
-    /// only indices where the two qubit bits differ move.
+    /// Local pairs delegate to the inner kernel. With a global qubit, only the
+    /// `|01>` and `|10>` amplitudes move.
     fn apply_swap_dist(&mut self, a: usize, b: usize) {
         let local = self.local_qubits();
         match (a < local, b < local) {
@@ -327,9 +424,8 @@ impl DistributedStatevectorBackend {
                     .expect("local swap");
             }
             (false, false) => {
-                // Both global: ranks differing in exactly these two bits and with
-                // opposite values swap their entire slices. Equal-bit ranks are
-                // unaffected (|00>, |11> map to themselves).
+                // Both are global. Ranks that differ in these two bits swap
+                // slices. Equal bits stay in place.
                 if self.rank_bit_set(a) == self.rank_bit_set(b) {
                     return;
                 }
@@ -340,6 +436,7 @@ impl DistributedStatevectorBackend {
                 if self.recv.len() != len {
                     self.recv.resize(len, Complex64::new(0.0, 0.0));
                 }
+                self.count_exchange(len);
                 self.context
                     .comm()
                     .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
@@ -352,12 +449,12 @@ impl DistributedStatevectorBackend {
                 if self.recv.len() != len {
                     self.recv.resize(len, Complex64::new(0.0, 0.0));
                 }
+                self.count_exchange(len);
                 self.context
                     .comm()
                     .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
-                // This rank's global bit is fixed. Amplitudes whose local bit
-                // differs from the global bit belong to the |01>/|10> subspace
-                // and take the partner's value at the local-bit-flipped index.
+                // The global bit is fixed on this rank. Entries where the local
+                // bit differs take the partner value at the flipped local index.
                 let global_bit = self.rank_bit_set(global_q);
                 let half = 1usize << local_q;
                 let len = self.inner.state.len();
@@ -372,13 +469,11 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Apply a general 4x4 two-qubit unitary across any local/global split.
+    /// Apply a general 4x4 two qubit unitary across any local or global split.
     ///
-    /// `mat` follows the backend convention where row/column index `2*b0 + b1`
-    /// orders the `(q0, q1)` bits with `q0` most significant. Local-local
-    /// delegates to the inner tiled kernel. One global qubit needs a single
-    /// pairwise exchange; two global qubits need a four-way gather across the
-    /// rank group that shares the two rank bits.
+    /// `mat` uses basis index `2*b0 + b1`, with `q0` as the high bit. Local
+    /// pairs delegate to the inner kernel. One global qubit needs one exchange;
+    /// two global qubits gather the rank group that shares both rank bits.
     fn apply_2q_dist(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
         let local = self.local_qubits();
         match (q0 < local, q1 < local) {
@@ -398,10 +493,8 @@ impl DistributedStatevectorBackend {
             .expect("local fused 2q");
     }
 
-    /// One qubit local, one global. Exchange with the partner that differs in
-    /// the global bit, then recompute each amplitude from the four inputs of the
-    /// 2x2 block: the two local-bit values on this rank (global bit `g`) and the
-    /// two on the partner (global bit `1 - g`).
+    /// One qubit is local and one is global. Exchange with the partner rank,
+    /// then recompute each amplitude from the four inputs of the 2x2 block.
     fn apply_2q_one_global(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
         let local = self.local_qubits();
         let (local_q, global_q, global_is_q0) = if q0 < local {
@@ -414,6 +507,7 @@ impl DistributedStatevectorBackend {
         if self.recv.len() != len {
             self.recv.resize(len, Complex64::new(0.0, 0.0));
         }
+        self.count_exchange(len);
         self.context
             .comm()
             .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
@@ -428,7 +522,7 @@ impl DistributedStatevectorBackend {
                 (lbit << 1) | gbit
             }
         };
-        // Output depends on both local-bit siblings, so snapshot first.
+        // Output depends on both local bit siblings, so snapshot first.
         let local_snapshot = self.inner.state.clone();
         for i in 0..len {
             let l = (i >> local_q) & 1;
@@ -452,36 +546,42 @@ impl DistributedStatevectorBackend {
         let rank = self.context.rank();
         let g0 = (rank >> b0) & 1;
         let g1 = (rank >> b1) & 1;
-        let my_basis = (g0 << 1) | g1;
+        let rank_basis = (g0 << 1) | g1;
 
         let len = self.inner.state.len();
-        let mut slices: [Vec<Complex64>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
-        for (c, slot) in slices.iter_mut().enumerate() {
-            if c == my_basis {
-                *slot = self.inner.state.clone();
+        // Gather only partner slices. The local term reads from `inner.state`.
+        let mut partners: [Option<Vec<Complex64>>; 4] = [None, None, None, None];
+        for (c, slot) in partners.iter_mut().enumerate() {
+            if c == rank_basis {
                 continue;
             }
             let c0 = (c >> 1) & 1;
             let c1 = c & 1;
             let partner = (rank & !(1 << b0) & !(1 << b1)) | (c0 << b0) | (c1 << b1);
             let mut buf = vec![Complex64::new(0.0, 0.0); len];
+            self.exchange_messages += 1;
+            self.exchange_amplitudes += len as u64;
             self.context
                 .comm()
                 .sendrecv_c64(partner, &self.inner.state, &mut buf);
-            *slot = buf;
+            *slot = Some(buf);
         }
+        // Write into a fresh buffer so local reads see the old amplitudes.
+        let mut out = vec![Complex64::new(0.0, 0.0); len];
+        let self_coeff = mat[rank_basis][rank_basis];
         for i in 0..len {
-            let mut acc = Complex64::new(0.0, 0.0);
-            for (c, slice) in slices.iter().enumerate() {
-                acc += mat[my_basis][c] * slice[i];
+            let mut acc = self_coeff * self.inner.state[i];
+            for (c, slot) in partners.iter().enumerate() {
+                if let Some(slice) = slot {
+                    acc += mat[rank_basis][c] * slice[i];
+                }
             }
-            self.inner.state[i] = acc;
+            out[i] = acc;
         }
+        self.inner.state = out;
     }
 
-    /// Dispatch a multi-qubit gate whose qubit set spans at least one global
-    /// qubit. Fusion is disabled in multi-rank mode, so gates arrive as raw
-    /// primitives (Cx, Cz, Swap, Cu, Mcu, Rzz).
+    /// Dispatch a gate that spans at least one global qubit.
     fn apply_global_multi_qubit(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         match gate {
             Gate::Cx => {
@@ -569,8 +669,7 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Apply a single [`DiagEntry`] across any local/global split. All diagonal
-    /// entries are communication-free.
+    /// Apply a single [`DiagEntry`] across any local or global split.
     fn apply_diag_entry_dist(&mut self, entry: &crate::gates::DiagEntry) {
         use crate::gates::DiagEntry;
         match *entry {
@@ -595,11 +694,109 @@ impl DistributedStatevectorBackend {
             DiagEntry::Parity2q {
                 q0, q1, same, diff, ..
             } => {
-                // same = exp(-i theta/2), diff = exp(i theta/2) for Rzz(theta).
-                // Recover the parity phases directly without the angle.
+                // These are the parity phases for Rzz(theta).
                 self.apply_rzz_phases_dist(q0, q1, same, diff);
             }
         }
+    }
+
+    /// Total scaled weight of the `qubit == outcome` subspace across ranks.
+    fn prob_outcome_global(&self, qubit: usize, outcome: bool) -> f64 {
+        let norm_sq = self.inner.pending_norm * self.inner.pending_norm;
+        let local_prob = if qubit < self.local_qubits() {
+            let half = 1usize << qubit;
+            let block_size = half << 1;
+            let mut acc = 0.0f64;
+            for block in self.inner.state.chunks(block_size) {
+                let (lo, hi) = block.split_at(half);
+                acc += simd::norm_sqr_sum(if outcome { hi } else { lo });
+            }
+            acc
+        } else if self.rank_bit_set(qubit) == outcome {
+            simd::norm_sqr_sum(&self.inner.state)
+        } else {
+            0.0
+        };
+        self.context.comm().allreduce_sum_f64(local_prob) * norm_sq
+    }
+
+    /// Total weight of the `qubit == 1` subspace across all ranks. Used by
+    /// measurement and as `P(qubit = 1)`.
+    fn prob_one_global(&self, qubit: usize) -> f64 {
+        self.prob_outcome_global(qubit, true)
+    }
+
+    /// Measure `qubit`, collapse the state, and record the bit. Deterministic
+    /// across ranks: the outcome is drawn from the lockstep `meas_rng` against an
+    /// `Allreduce`d probability, so every rank collapses to the same branch.
+    fn measure_dist(&mut self, qubit: usize, classical_bit: usize) {
+        let prob_one = self.prob_one_global(qubit);
+        let outcome = self.meas_rng.random::<f64>() < prob_one;
+        self.inner.classical_bits[classical_bit] = outcome;
+        self.collapse(qubit, outcome);
+        self.inner.pending_norm *= measurement_inv_norm(outcome, prob_one);
+    }
+
+    /// Zero the amplitudes inconsistent with `qubit == outcome`.
+    fn collapse(&mut self, qubit: usize, outcome: bool) {
+        let zero = Complex64::new(0.0, 0.0);
+        if qubit < self.local_qubits() {
+            let half = 1usize << qubit;
+            let block_size = half << 1;
+            for block in self.inner.state.chunks_mut(block_size) {
+                let (lo, hi) = block.split_at_mut(half);
+                if outcome {
+                    simd::zero_slice(lo);
+                } else {
+                    simd::zero_slice(hi);
+                }
+            }
+        } else if self.rank_bit_set(qubit) != outcome {
+            // This rank holds the eliminated branch entirely.
+            for amp in self.inner.state.iter_mut() {
+                *amp = zero;
+            }
+        }
+    }
+
+    /// Reset `qubit` to `|0>` using the statevector backend's projection
+    /// convention.
+    fn reset_dist(&mut self, qubit: usize) {
+        let prob_zero = self.prob_outcome_global(qubit, false);
+        if prob_zero > 0.0 {
+            self.collapse(qubit, false);
+            self.inner.pending_norm *= 1.0 / prob_zero.sqrt();
+        } else {
+            simd::zero_slice(&mut self.inner.state);
+            if self.context.rank() == 0 {
+                if let Some(amp) = self.inner.state.get_mut(0) {
+                    *amp = Complex64::new(1.0, 0.0);
+                }
+            }
+            self.inner.pending_norm = 1.0;
+        }
+    }
+
+    /// Route a gate to the local fast path or the distributed paths by whether
+    /// its qubits span a rank bit.
+    fn apply_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        if self.global_qubits == 0 || self.targets_are_local(targets) {
+            return self.inner.apply(&Instruction::Gate {
+                gate: gate.clone(),
+                targets: targets.into(),
+            });
+        }
+        if gate.num_qubits() == 1 {
+            let target = targets[0];
+            let mat = gate.matrix_2x2();
+            if gate.is_diagonal_1q() {
+                self.apply_global_diagonal_1q(target, mat[0][0], mat[1][1]);
+            } else {
+                self.apply_global_1q(target, mat);
+            }
+            return Ok(());
+        }
+        self.apply_global_multi_qubit(gate, targets)
     }
 
     fn unsupported(&self, operation: &str) -> PrismError {
@@ -648,6 +845,9 @@ impl Backend for DistributedStatevectorBackend {
 
         self.num_qubits = num_qubits;
         self.global_qubits = p;
+        self.meas_rng = ChaCha8Rng::seed_from_u64(self.seed);
+        self.exchange_messages = 0;
+        self.exchange_amplitudes = 0;
         let local_qubits = num_qubits - p;
         self.inner.init(local_qubits, num_classical_bits)?;
 
@@ -661,32 +861,34 @@ impl Backend for DistributedStatevectorBackend {
     }
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
-        if self.global_qubits == 0 {
-            return self.inner.apply(instruction);
-        }
         match instruction {
-            Instruction::Gate { gate, targets } => {
-                if self.targets_are_local(targets) {
-                    return self.inner.apply(instruction);
-                }
-                if gate.num_qubits() == 1 {
-                    let target = targets[0];
-                    let mat = gate.matrix_2x2();
-                    if gate.is_diagonal_1q() {
-                        self.apply_global_diagonal_1q(target, mat[0][0], mat[1][1]);
-                    } else {
-                        self.apply_global_1q(target, mat);
-                    }
-                    return Ok(());
-                }
-                self.apply_global_multi_qubit(gate, targets)
+            // Measurement routes through the distributed path even at a single
+            // rank, so `meas_rng` is the sole measurement RNG and outcomes
+            // match across every rank count for a given seed.
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => {
+                self.measure_dist(*qubit, *classical_bit);
+                Ok(())
+            }
+            Instruction::Reset { qubit } => {
+                self.reset_dist(*qubit);
+                Ok(())
             }
             Instruction::Barrier { .. } => Ok(()),
-            Instruction::Measure { .. } => Err(self.unsupported("distributed measurement")),
-            Instruction::Reset { .. } => Err(self.unsupported("distributed reset")),
-            Instruction::Conditional { .. } => {
-                Err(self.unsupported("distributed classical conditional"))
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => {
+                if condition.evaluate(self.inner.classical_results()) {
+                    self.apply_gate(gate, targets)
+                } else {
+                    Ok(())
+                }
             }
+            Instruction::Gate { gate, targets } => self.apply_gate(gate, targets),
         }
     }
 
@@ -714,5 +916,14 @@ impl Backend for DistributedStatevectorBackend {
         }
         dense_statevector_len(BACKEND_NAME, "statevector export", self.num_qubits)?;
         Ok(self.context.comm().allgather_c64(&local))
+    }
+
+    fn qubit_probability(&self, qubit: usize) -> Result<f64> {
+        Ok(self.prob_one_global(qubit))
+    }
+
+    fn reset(&mut self, qubit: usize) -> Result<()> {
+        self.reset_dist(qubit);
+        Ok(())
     }
 }

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -16,7 +16,7 @@
 //! gates across rank bits, `probabilities`, and `export_statevector`. A global
 //! control is constant on a rank, so it gates the whole slice with no
 //! communication. Diagonal controlled gates never communicate. With one rank
-//! ([`SerialComm`]), every qubit is local.
+//! ([`SerialComm`](crate::distributed::SerialComm)), every qubit is local.
 //!
 //! Fusion runs in every mode. Local fused gates dispatch to the inner SIMD
 //! kernels. Fused or batched gates that span rank bits are decomposed into the
@@ -33,25 +33,58 @@
 //! convention: project onto `|0>`, renormalize, and reinitialize to `|0...0>`
 //! when the zero branch is empty.
 //!
+//! # Qubit relabeling
+//!
+//! At more than one rank the backend keeps a circuit-to-physical qubit map
+//! (on by default, see [`crate::distributed::relabel_enabled`]). SWAP becomes a
+//! map update: no amplitudes move and no rank communicates, at any local or
+//! global split. Before a gate applies non-diagonal action to a qubit in a rank
+//! bit position, the qubit is relabeled into a local position by exchanging the
+//! half slice whose local bit differs from the rank bit, evicting the least
+//! recently used local qubit. The gate and every later gate on that qubit then
+//! run on the inner SIMD kernels with no further communication, until the qubit
+//! is evicted again. Diagonal action and control bits stay free on global
+//! qubits, so they never trigger a relabel.
+//!
+//! Gate targets and the qubit indices inside batched gate data (`MultiFused`,
+//! `Multi2q`, `BatchPhase`, `BatchRzz`, `DiagonalBatch`) are translated through
+//! the map at apply time. `probabilities` and `export_statevector` reorder the
+//! gathered vector back to circuit qubit order; measurement, reset, and
+//! `qubit_probability` translate the qubit index. The direct per-gate exchange
+//! paths remain for relabeling disabled and for instructions whose qubits
+//! cannot all be made local (no eviction victim).
+//!
+//! Relabeling wins whenever gate activity has qubit locality: SWAP networks,
+//! repeated gates on the same qubits, and working sets that fit the local
+//! positions. The known adverse pattern is a cyclic scan, a gate wall over
+//! more hot qubits than local positions repeated layer after layer, which
+//! defeats least recently used eviction and can exceed direct exchange volume.
+//! Lookahead epoch planning addresses that case; until then
+//! `PRISM_DIST_RELABEL=0` restores direct exchange.
+//!
 //! # Communication cost
 //!
-//! Only gates that are not diagonal and touch a global target communicate. A
-//! global one qubit gate, or a two qubit gate over one global qubit, costs one
-//! pairwise exchange of the local slice. A two qubit gate over two global qubits
-//! gathers four ranks. Global one qubit exchange is tiled by
-//! [`crate::distributed::exchange_chunk`], which bounds the receive buffer.
+//! Only gates that are not diagonal and touch a global target communicate. With
+//! relabeling, a global SWAP costs nothing and the first non-diagonal gate on a
+//! global qubit costs a half-slice relabel exchange that also makes later gates
+//! on that qubit local. On the direct paths, a global one qubit gate, or a two
+//! qubit gate over one global qubit, costs one pairwise exchange of the local
+//! slice; a two qubit gate over two global qubits gathers four ranks. Both the
+//! direct one qubit exchange and the relabel exchange are tiled by
+//! [`crate::distributed::exchange_chunk`], which bounds the transfer buffers.
 //!
 //! [`DistributedStatevectorBackend::exchange_messages`] and
 //! [`DistributedStatevectorBackend::exchange_amplitudes`] expose rank local
 //! communication volume. Use these counters to evaluate qubit reordering and
 //! routing, since one host cannot measure real network latency.
 //!
-//! Not implemented yet: distributed shot sampling, and automatic qubit reorder
-//! to keep busy qubits local.
+//! Not implemented yet: distributed shot sampling, and lookahead epoch planning
+//! that batches several relabels into one exchange.
 
 #[cfg(test)]
 mod tests;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use num_complex::Complex64;
@@ -64,7 +97,7 @@ use crate::backend::{dense_probability_len, dense_statevector_len, measurement_i
 use crate::circuit::{smallvec, Instruction, SmallVec};
 use crate::distributed::DistributedContext;
 use crate::error::{PrismError, Result};
-use crate::gates::Gate;
+use crate::gates::{DiagEntry, Gate};
 
 const BACKEND_NAME: &str = "distributed_statevector";
 
@@ -72,6 +105,104 @@ const BACKEND_NAME: &str = "distributed_statevector";
 #[inline]
 fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
     mat[0][1].norm() < 1e-12 && mat[1][0].norm() < 1e-12
+}
+
+/// Visit every circuit qubit an instruction touches: the instruction targets
+/// plus qubit indices stored inside batched gate data. Indices may repeat.
+fn for_each_gate_qubit(gate: &Gate, targets: &[usize], mut f: impl FnMut(usize)) {
+    for &q in targets {
+        f(q);
+    }
+    match gate {
+        Gate::BatchPhase(data) => {
+            for &(target, _) in &data.phases {
+                f(target);
+            }
+        }
+        Gate::BatchRzz(data) => {
+            for &(q0, q1, _) in &data.edges {
+                f(q0);
+                f(q1);
+            }
+        }
+        Gate::MultiFused(data) => {
+            for &(q, _) in &data.gates {
+                f(q);
+            }
+        }
+        Gate::Multi2q(data) => {
+            for &(q0, q1, _) in &data.gates {
+                f(q0);
+                f(q1);
+            }
+        }
+        Gate::DiagonalBatch(data) => {
+            for entry in &data.entries {
+                match *entry {
+                    DiagEntry::Phase1q { qubit, .. } => f(qubit),
+                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                        f(q0);
+                        f(q1);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Circuit qubits that must occupy local positions for the gate to apply
+/// without a per-gate amplitude exchange. Diagonal action and control bits
+/// are free on global qubits, so only non-diagonal application targets count.
+fn required_local_qubits(gate: &Gate, targets: &[usize]) -> SmallVec<[usize; 8]> {
+    let mut req: SmallVec<[usize; 8]> = SmallVec::new();
+    fn push(req: &mut SmallVec<[usize; 8]>, q: usize) {
+        if !req.contains(&q) {
+            req.push(q);
+        }
+    }
+    match gate {
+        Gate::Cx => push(&mut req, targets[1]),
+        Gate::Cz
+        | Gate::Swap
+        | Gate::Rzz(_)
+        | Gate::BatchPhase(_)
+        | Gate::BatchRzz(_)
+        | Gate::DiagonalBatch(_) => {}
+        Gate::Cu(_) | Gate::Mcu(_) => {
+            if gate.controlled_phase().is_none() {
+                let target = match gate {
+                    Gate::Mcu(data) => targets[data.num_controls as usize],
+                    _ => targets[1],
+                };
+                push(&mut req, target);
+            }
+        }
+        Gate::Fused2q(_) => {
+            push(&mut req, targets[0]);
+            push(&mut req, targets[1]);
+        }
+        Gate::Multi2q(data) => {
+            for &(q0, q1, _) in &data.gates {
+                push(&mut req, q0);
+                push(&mut req, q1);
+            }
+        }
+        Gate::MultiFused(data) => {
+            for &(q, ref mat) in &data.gates {
+                if !is_diagonal_2x2(mat) {
+                    push(&mut req, q);
+                }
+            }
+        }
+        g if g.num_qubits() == 1 => {
+            if !g.is_diagonal_1q() {
+                push(&mut req, targets[0]);
+            }
+        }
+        _ => {}
+    }
+    req
 }
 
 /// Distributed state vector backend over an [`Arc<DistributedContext>`].
@@ -94,6 +225,23 @@ pub struct DistributedStatevectorBackend {
     /// advanced in lockstep. Outcomes are derived from `Allreduce`d global
     /// probabilities, so all ranks agree without exchanging the draw.
     meas_rng: ChaCha8Rng,
+    /// Circuit qubit to physical position. Positions below `local_qubits()`
+    /// index the local slice; the rest are rank bits. Identity until a SWAP or
+    /// a relabel exchange moves a qubit.
+    qubit_map: Vec<usize>,
+    /// Physical position to circuit qubit. Inverse of `qubit_map`.
+    phys_map: Vec<usize>,
+    /// Fast path flag: true while `qubit_map` is the identity.
+    map_identity: bool,
+    /// Whether gates relabel global qubits into local positions instead of
+    /// exchanging amplitudes per gate.
+    relabel: bool,
+    /// Instruction tick at which each circuit qubit was last referenced.
+    /// Drives least recently used eviction for relabel victims.
+    last_used: Vec<u64>,
+    tick: u64,
+    /// Send-side packing buffer for the half-slice relabel exchange.
+    pack: Vec<Complex64>,
 }
 
 impl DistributedStatevectorBackend {
@@ -110,6 +258,13 @@ impl DistributedStatevectorBackend {
             exchange_messages: 0,
             exchange_amplitudes: 0,
             meas_rng: ChaCha8Rng::seed_from_u64(seed),
+            qubit_map: Vec::new(),
+            phys_map: Vec::new(),
+            map_identity: true,
+            relabel: crate::distributed::relabel_enabled(),
+            last_used: Vec::new(),
+            tick: 0,
+            pack: Vec::new(),
         }
     }
 
@@ -118,6 +273,13 @@ impl DistributedStatevectorBackend {
     #[cfg(test)]
     pub(crate) fn set_exchange_chunk(&mut self, chunk: usize) {
         self.exchange_chunk = chunk.max(1);
+    }
+
+    /// Enable or disable qubit relabeling for this backend instance, overriding
+    /// the `PRISM_DIST_RELABEL` default. With relabeling off, every gate on a
+    /// global qubit uses the direct per-gate exchange paths.
+    pub fn set_relabel(&mut self, enabled: bool) {
+        self.relabel = enabled;
     }
 
     /// Number of `sendrecv` messages this rank has issued since `init`.
@@ -150,12 +312,6 @@ impl DistributedStatevectorBackend {
         self.context.size() == 1
     }
 
-    #[inline]
-    fn targets_are_local(&self, targets: &[usize]) -> bool {
-        let local = self.local_qubits();
-        targets.iter().all(|&q| q < local)
-    }
-
     /// Bit position within the rank id for global qubit `q` (`q >= local`).
     #[inline]
     fn global_bit(&self, q: usize) -> usize {
@@ -166,6 +322,200 @@ impl DistributedStatevectorBackend {
     #[inline]
     fn rank_bit_set(&self, q: usize) -> bool {
         (self.context.rank() >> self.global_bit(q)) & 1 == 1
+    }
+
+    /// Advance the instruction tick and mark every circuit qubit the
+    /// instruction references. Marked qubits are exempt from eviction until the
+    /// next instruction. Identical on every rank because the instruction stream
+    /// is identical.
+    fn touch_instruction(&mut self, gate: &Gate, targets: &[usize]) {
+        self.tick += 1;
+        let tick = self.tick;
+        for_each_gate_qubit(gate, targets, |q| self.last_used[q] = tick);
+    }
+
+    fn refresh_map_identity(&mut self) {
+        self.map_identity = self.qubit_map.iter().enumerate().all(|(q, &p)| q == p);
+    }
+
+    /// Apply SWAP as a pure relabeling: exchange the two circuit qubits' map
+    /// entries. No amplitudes move and no rank communicates.
+    fn swap_circuit_qubits(&mut self, a: usize, b: usize) {
+        if a == b {
+            return;
+        }
+        let pa = self.qubit_map[a];
+        let pb = self.qubit_map[b];
+        self.qubit_map.swap(a, b);
+        self.phys_map.swap(pa, pb);
+        self.refresh_map_identity();
+    }
+
+    /// Local position holding the least recently used circuit qubit that the
+    /// current instruction does not reference. `None` when every local qubit is
+    /// referenced this tick.
+    fn pick_victim(&self) -> Option<usize> {
+        let local = self.local_qubits();
+        let mut best: Option<(u64, usize)> = None;
+        for pos in 0..local {
+            let used = self.last_used[self.phys_map[pos]];
+            if used == self.tick {
+                continue;
+            }
+            match best {
+                Some((b, _)) if used >= b => {}
+                _ => best = Some((used, pos)),
+            }
+        }
+        best.map(|(_, pos)| pos)
+    }
+
+    /// Bring each requested circuit qubit into a local position. Best effort:
+    /// stops when no eviction victim remains, leaving the rest to the direct
+    /// exchange paths. Each relabel costs one half-slice exchange.
+    fn make_local(&mut self, req: &[usize]) {
+        for &q in req {
+            let pos = self.qubit_map[q];
+            if pos < self.local_qubits() {
+                continue;
+            }
+            let Some(victim) = self.pick_victim() else {
+                return;
+            };
+            self.relabel_swap(victim, pos);
+        }
+    }
+
+    /// Physically swap the qubits at a local and a global position, then update
+    /// the map. Only amplitudes whose local bit differs from this rank's bit of
+    /// the global position move, so each rank exchanges half its slice. Both
+    /// ranks enumerate their moving halves in ascending index order, which the
+    /// single-bit XOR relation between the two sets preserves, so the k-th
+    /// received amplitude lands at the k-th moving index. Tiled by
+    /// `exchange_chunk` like the direct global exchange.
+    fn relabel_swap(&mut self, local_pos: usize, global_pos: usize) {
+        let partner = self.context.rank() ^ (1usize << self.global_bit(global_pos));
+        let gbit = self.rank_bit_set(global_pos);
+        let stride = 1usize << local_pos;
+        let fixed = if gbit { 0 } else { stride };
+        let moving = self.inner.state.len() / 2;
+        let chunk = self.exchange_chunk.min(moving).max(1);
+        if self.pack.len() != chunk {
+            self.pack.resize(chunk, Complex64::new(0.0, 0.0));
+        }
+        if self.recv.len() != chunk {
+            self.recv.resize(chunk, Complex64::new(0.0, 0.0));
+        }
+        let index_of =
+            |flat: usize| ((flat >> local_pos) << (local_pos + 1)) | fixed | (flat & (stride - 1));
+        let mut off = 0;
+        while off < moving {
+            let count = (off + chunk).min(moving) - off;
+            for (k, slot) in self.pack[..count].iter_mut().enumerate() {
+                *slot = self.inner.state[index_of(off + k)];
+            }
+            self.count_exchange(count);
+            self.context
+                .comm()
+                .sendrecv_c64(partner, &self.pack[..count], &mut self.recv[..count]);
+            for (k, &amp) in self.recv[..count].iter().enumerate() {
+                self.inner.state[index_of(off + k)] = amp;
+            }
+            off += count;
+        }
+
+        let local_q = self.phys_map[local_pos];
+        let global_q = self.phys_map[global_pos];
+        self.qubit_map[local_q] = global_pos;
+        self.qubit_map[global_q] = local_pos;
+        self.phys_map.swap(local_pos, global_pos);
+        self.refresh_map_identity();
+    }
+
+    /// Translate an instruction into physical positions: map the targets and
+    /// rewrite qubit indices stored inside batched gate data. Borrows the gate
+    /// unchanged while the map is the identity.
+    fn to_physical<'g>(
+        &self,
+        gate: &'g Gate,
+        targets: &[usize],
+    ) -> (Cow<'g, Gate>, SmallVec<[usize; 4]>) {
+        if self.map_identity {
+            return (Cow::Borrowed(gate), targets.into());
+        }
+        let ptargets: SmallVec<[usize; 4]> = targets.iter().map(|&q| self.qubit_map[q]).collect();
+        let pgate = match gate {
+            Gate::MultiFused(data) => {
+                let mut data = data.clone();
+                for entry in &mut data.gates {
+                    entry.0 = self.qubit_map[entry.0];
+                }
+                Cow::Owned(Gate::MultiFused(data))
+            }
+            Gate::Multi2q(data) => {
+                let mut data = data.clone();
+                for entry in &mut data.gates {
+                    entry.0 = self.qubit_map[entry.0];
+                    entry.1 = self.qubit_map[entry.1];
+                }
+                Cow::Owned(Gate::Multi2q(data))
+            }
+            Gate::BatchPhase(data) => {
+                let mut data = data.clone();
+                for entry in &mut data.phases {
+                    entry.0 = self.qubit_map[entry.0];
+                }
+                Cow::Owned(Gate::BatchPhase(data))
+            }
+            Gate::BatchRzz(data) => {
+                let mut data = data.clone();
+                for entry in &mut data.edges {
+                    entry.0 = self.qubit_map[entry.0];
+                    entry.1 = self.qubit_map[entry.1];
+                }
+                Cow::Owned(Gate::BatchRzz(data))
+            }
+            Gate::DiagonalBatch(data) => {
+                let mut data = data.clone();
+                for entry in &mut data.entries {
+                    match entry {
+                        DiagEntry::Phase1q { qubit, .. } => *qubit = self.qubit_map[*qubit],
+                        DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                            *q0 = self.qubit_map[*q0];
+                            *q1 = self.qubit_map[*q1];
+                        }
+                    }
+                }
+                Cow::Owned(Gate::DiagonalBatch(data))
+            }
+            _ => Cow::Borrowed(gate),
+        };
+        (pgate, ptargets)
+    }
+
+    /// Whether every physical position the translated instruction touches,
+    /// including indices inside batched gate data, is below the local boundary.
+    fn instruction_qubits_local(&self, gate: &Gate, targets: &[usize]) -> bool {
+        let local = self.local_qubits();
+        let mut all = true;
+        for_each_gate_qubit(gate, targets, |q| all &= q < local);
+        all
+    }
+
+    /// Reorder a gathered dense vector from physical to circuit qubit order.
+    fn unpermuted<T: Copy + Default>(&self, phys: Vec<T>) -> Vec<T> {
+        if self.map_identity {
+            return phys;
+        }
+        let mut out = vec![T::default(); phys.len()];
+        for (c, slot) in out.iter_mut().enumerate() {
+            let mut p = 0usize;
+            for (q, &pos) in self.qubit_map.iter().enumerate() {
+                p |= ((c >> q) & 1) << pos;
+            }
+            *slot = phys[p];
+        }
+        out
     }
 
     /// Apply a one qubit gate whose target is stored in the rank id.
@@ -730,11 +1080,23 @@ impl DistributedStatevectorBackend {
     /// across ranks: the outcome is drawn from the lockstep `meas_rng` against an
     /// `Allreduce`d probability, so every rank collapses to the same branch.
     fn measure_dist(&mut self, qubit: usize, classical_bit: usize) {
+        let qubit = self.physical_qubit(qubit);
         let prob_one = self.prob_one_global(qubit);
         let outcome = self.meas_rng.random::<f64>() < prob_one;
         self.inner.classical_bits[classical_bit] = outcome;
         self.collapse(qubit, outcome);
         self.inner.pending_norm *= measurement_inv_norm(outcome, prob_one);
+    }
+
+    /// Physical position of a circuit qubit. Identity before `init` runs the
+    /// map setup or while no relabeling has occurred.
+    #[inline]
+    fn physical_qubit(&self, qubit: usize) -> usize {
+        if self.map_identity {
+            qubit
+        } else {
+            self.qubit_map[qubit]
+        }
     }
 
     /// Zero the amplitudes inconsistent with `qubit == outcome`.
@@ -762,6 +1124,7 @@ impl DistributedStatevectorBackend {
     /// Reset `qubit` to `|0>` using the statevector backend's projection
     /// convention.
     fn reset_dist(&mut self, qubit: usize) {
+        let qubit = self.physical_qubit(qubit);
         let prob_zero = self.prob_outcome_global(qubit, false);
         if prob_zero > 0.0 {
             self.collapse(qubit, false);
@@ -777,26 +1140,52 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Route a gate to the local fast path or the distributed paths by whether
-    /// its qubits span a rank bit.
+    /// Route a gate to the local fast path or the distributed paths.
+    ///
+    /// With relabeling on, SWAP becomes a map update, and qubits that need
+    /// non-diagonal application are moved into local positions first, so the
+    /// per-gate exchange paths below only fire when no eviction victim exists
+    /// or relabeling is disabled.
     fn apply_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
-        if self.global_qubits == 0 || self.targets_are_local(targets) {
+        if self.global_qubits == 0 {
             return self.inner.apply(&Instruction::Gate {
                 gate: gate.clone(),
                 targets: targets.into(),
             });
         }
-        if gate.num_qubits() == 1 {
-            let target = targets[0];
-            let mat = gate.matrix_2x2();
-            if gate.is_diagonal_1q() {
+        if self.relabel {
+            self.touch_instruction(gate, targets);
+            if matches!(gate, Gate::Swap) {
+                self.swap_circuit_qubits(targets[0], targets[1]);
+                return Ok(());
+            }
+            let req = required_local_qubits(gate, targets);
+            if !req.is_empty() {
+                self.make_local(&req);
+            }
+        }
+        if matches!(gate, Gate::QftBlock { .. }) && !self.map_identity {
+            return Err(self.unsupported("QftBlock with a permuted qubit map"));
+        }
+        let (pgate, ptargets) = self.to_physical(gate, targets);
+        if self.instruction_qubits_local(&pgate, &ptargets) {
+            return self.inner.apply(&Instruction::Gate {
+                gate: pgate.into_owned(),
+                targets: ptargets,
+            });
+        }
+        let pgate = pgate.as_ref();
+        if pgate.num_qubits() == 1 {
+            let target = ptargets[0];
+            let mat = pgate.matrix_2x2();
+            if pgate.is_diagonal_1q() {
                 self.apply_global_diagonal_1q(target, mat[0][0], mat[1][1]);
             } else {
                 self.apply_global_1q(target, mat);
             }
             return Ok(());
         }
-        self.apply_global_multi_qubit(gate, targets)
+        self.apply_global_multi_qubit(pgate, &ptargets)
     }
 
     fn unsupported(&self, operation: &str) -> PrismError {
@@ -848,6 +1237,11 @@ impl Backend for DistributedStatevectorBackend {
         self.meas_rng = ChaCha8Rng::seed_from_u64(self.seed);
         self.exchange_messages = 0;
         self.exchange_amplitudes = 0;
+        self.qubit_map = (0..num_qubits).collect();
+        self.phys_map = (0..num_qubits).collect();
+        self.map_identity = true;
+        self.last_used = vec![0; num_qubits];
+        self.tick = 0;
         let local_qubits = num_qubits - p;
         self.inner.init(local_qubits, num_classical_bits)?;
 
@@ -902,7 +1296,8 @@ impl Backend for DistributedStatevectorBackend {
             return Ok(local);
         }
         dense_probability_len(BACKEND_NAME, self.num_qubits)?;
-        Ok(self.context.comm().allgather_f64(&local))
+        let gathered = self.context.comm().allgather_f64(&local);
+        Ok(self.unpermuted(gathered))
     }
 
     fn num_qubits(&self) -> usize {
@@ -915,11 +1310,12 @@ impl Backend for DistributedStatevectorBackend {
             return Ok(local);
         }
         dense_statevector_len(BACKEND_NAME, "statevector export", self.num_qubits)?;
-        Ok(self.context.comm().allgather_c64(&local))
+        let gathered = self.context.comm().allgather_c64(&local);
+        Ok(self.unpermuted(gathered))
     }
 
     fn qubit_probability(&self, qubit: usize) -> Result<f64> {
-        Ok(self.prob_one_global(qubit))
+        Ok(self.prob_one_global(self.physical_qubit(qubit)))
     }
 
     fn reset(&mut self, qubit: usize) -> Result<()> {

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -143,8 +143,9 @@ impl RankComm for LoopbackComm {
     }
 }
 
-/// Run `circuit` across simulated ranks and return rank 0's probabilities.
-fn loopback_probs(circuit: &Circuit, size: usize) -> Vec<f64> {
+/// Run `circuit` across simulated ranks with the given backend configuration
+/// and return rank 0's probabilities.
+fn loopback_probs_with(circuit: &Circuit, size: usize, chunk: usize, relabel: bool) -> Vec<f64> {
     let shared = LoopbackShared::new(size);
     let handles: Vec<_> = (0..size)
         .map(|rank| {
@@ -158,6 +159,8 @@ fn loopback_probs(circuit: &Circuit, size: usize) -> Vec<f64> {
                 .spawn(move || {
                     let ctx = DistributedContext::from_comm(Arc::new(comm));
                     let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_exchange_chunk(chunk);
+                    backend.set_relabel(relabel);
                     run_on(&mut backend, &circuit)
                         .expect("distributed run")
                         .probabilities
@@ -174,58 +177,29 @@ fn loopback_probs(circuit: &Circuit, size: usize) -> Vec<f64> {
     first
 }
 
-/// Like [`loopback_probs`], but uses a fixed exchange chunk.
-fn loopback_probs_chunked(circuit: &Circuit, size: usize, chunk: usize) -> Vec<f64> {
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                    backend.set_exchange_chunk(chunk);
-                    run_on(&mut backend, &circuit)
-                        .expect("distributed run")
-                        .probabilities
-                        .expect("probabilities")
-                        .to_vec()
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let mut results: Vec<Vec<f64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-    let first = results.swap_remove(0);
-    results.clear();
-    first
-}
-
 fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
     let expected = reference_probs(circuit);
-    for &size in sizes {
-        let actual = loopback_probs(circuit, size);
-        assert_eq!(
-            expected.len(),
-            actual.len(),
-            "length mismatch at size {size}"
-        );
-        for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
-            assert!(
-                (e - a).abs() < TOL,
-                "size {size}: prob[{i}] expected {e}, got {a}"
+    for &relabel in &[true, false] {
+        for &size in sizes {
+            let actual = loopback_probs_with(circuit, size, usize::MAX, relabel);
+            assert_eq!(
+                expected.len(),
+                actual.len(),
+                "length mismatch at size {size} relabel {relabel}"
             );
+            for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+                assert!(
+                    (e - a).abs() < TOL,
+                    "size {size} relabel {relabel}: prob[{i}] expected {e}, got {a}"
+                );
+            }
         }
     }
 }
 
 /// Run `circuit` across simulated ranks and return rank 0's probabilities and
 /// classical bits.
-fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
+fn loopback_run_with(circuit: &Circuit, size: usize, relabel: bool) -> (Vec<f64>, Vec<bool>) {
     let shared = LoopbackShared::new(size);
     let handles: Vec<_> = (0..size)
         .map(|rank| {
@@ -239,6 +213,7 @@ fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
                 .spawn(move || {
                     let ctx = DistributedContext::from_comm(Arc::new(comm));
                     let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_relabel(relabel);
                     let out = run_on(&mut backend, &circuit).expect("distributed run");
                     let probs = out.probabilities.expect("probabilities").to_vec();
                     (probs, out.classical_bits)
@@ -253,23 +228,32 @@ fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
     first
 }
 
+fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
+    loopback_run_with(circuit, size, true)
+}
+
 /// Assert that probabilities and classical bits are identical across all rank
 /// counts. This checks measurement determinism across rank counts.
 fn assert_loopback_deterministic(circuit: &Circuit, sizes: &[usize]) {
-    let (ref_probs, ref_bits) = loopback_run(circuit, sizes[0]);
-    for &size in &sizes[1..] {
-        let (probs, bits) = loopback_run(circuit, size);
-        assert_eq!(ref_bits, bits, "classical bits differ at size {size}");
-        assert_eq!(
-            ref_probs.len(),
-            probs.len(),
-            "length differs at size {size}"
-        );
-        for (i, (e, a)) in ref_probs.iter().zip(probs.iter()).enumerate() {
-            assert!(
-                (e - a).abs() < TOL,
-                "size {size}: prob[{i}] {e} vs {a} differ across ranks"
+    for &relabel in &[true, false] {
+        let (ref_probs, ref_bits) = loopback_run_with(circuit, sizes[0], relabel);
+        for &size in &sizes[1..] {
+            let (probs, bits) = loopback_run_with(circuit, size, relabel);
+            assert_eq!(
+                ref_bits, bits,
+                "classical bits differ at size {size} relabel {relabel}"
             );
+            assert_eq!(
+                ref_probs.len(),
+                probs.len(),
+                "length differs at size {size} relabel {relabel}"
+            );
+            for (i, (e, a)) in ref_probs.iter().zip(probs.iter()).enumerate() {
+                assert!(
+                    (e - a).abs() < TOL,
+                    "size {size} relabel {relabel}: prob[{i}] {e} vs {a} differ across ranks"
+                );
+            }
         }
     }
 }
@@ -440,6 +424,134 @@ fn loopback_swap_all_qubit_splits() {
         b.swap(a, t);
         assert_loopback_matches(&b.build(), &[1, 2, 4]);
     }
+}
+
+#[test]
+fn loopback_swap_asymmetric_state() {
+    relax_min_local_qubits();
+    // Distinct rotation per qubit, so every marginal differs and a wrong
+    // readout permutation cannot hide behind symmetric probabilities. A
+    // uniform H wall would mask map bugs.
+    let mut b = CircuitBuilder::new(4);
+    b.rx(0.3, 0).rx(0.7, 1).rx(1.1, 2).rx(1.5, 3);
+    b.swap(0, 3).swap(1, 2).swap(0, 1);
+    b.ry(0.4, 3).cx(3, 0);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_gates_after_relabel_use_moved_qubits() {
+    relax_min_local_qubits();
+    // Repeated non-diagonal gates on global qubits force relabels and
+    // evictions; later gates must follow the moved qubits through the map.
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    b.rx(0.2, 0).rx(0.5, 1).rx(0.9, 2);
+    b.h(3).h(4);
+    b.cx(3, 0).cz(4, 1).rzz(0.6, 2, 3);
+    b.h(0).h(1);
+    b.swap(2, 4).ry(0.8, 4).cx(4, 2);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_export_statevector_after_swap() {
+    relax_min_local_qubits();
+    // Export must reorder the gathered amplitudes back to circuit qubit order
+    // after SWAPs leave the map permuted.
+    let n = 4;
+    let mut b = CircuitBuilder::new(n);
+    b.rx(0.3, 0).ry(0.8, 1).rx(1.2, 2).t(3).h(3);
+    b.swap(0, 3).swap(1, 2);
+    b.rz(0.5, 3).ry(0.2, 0);
+    let circuit = b.build();
+
+    let mut sv = StatevectorBackend::new(SEED);
+    sv.init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    sv.apply_instructions(&circuit.instructions).unwrap();
+    let expected = sv.export_statevector().unwrap();
+
+    let size = 4;
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend
+                        .init(circuit.num_qubits, circuit.num_classical_bits)
+                        .unwrap();
+                    backend.apply_instructions(&circuit.instructions).unwrap();
+                    backend.export_statevector().unwrap()
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let results: Vec<Vec<Complex64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for actual in &results {
+        assert_eq!(expected.len(), actual.len());
+        for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+            assert!((e - a).norm() < TOL, "amp[{i}] expected {e}, got {a}");
+        }
+    }
+}
+
+#[test]
+fn loopback_measure_after_swap_reads_moved_qubit() {
+    relax_min_local_qubits();
+    // |0001> swapped across the boundary becomes |1000>: the top qubit must
+    // read 1 and the bottom 0 through the permuted map.
+    let n = 4;
+    let mut b = CircuitBuilder::new_with_classical(n, 2);
+    b.x(0).swap(0, n - 1);
+    b.measure(n - 1, 0).measure(0, 1);
+    let circuit = b.build();
+    for &size in &[1usize, 2, 4] {
+        let (probs, bits) = loopback_run(&circuit, size);
+        assert!(bits[0], "size {size}: moved excitation must read 1");
+        assert!(!bits[1], "size {size}: vacated qubit must read 0");
+        let expected = 1usize << (n - 1);
+        assert!(
+            (probs[expected] - 1.0).abs() < TOL,
+            "size {size}: state must be |1000>, got p[{expected}]={}",
+            probs[expected]
+        );
+    }
+}
+
+#[test]
+fn loopback_reset_after_swap_clears_moved_qubit() {
+    relax_min_local_qubits();
+    let n = 4;
+    let mut b = CircuitBuilder::new(n);
+    b.rx(0.4, 0).rx(0.9, 1).h(3);
+    b.swap(0, 3);
+    let mut circuit = b.build();
+    circuit.add_reset(3);
+    assert_loopback_matches(&circuit, &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_relabel_victim_starvation_falls_back() {
+    relax_min_local_qubits();
+    // At 4 ranks of a 4 qubit register only two positions are local. An Mcu
+    // referencing every qubit leaves no eviction victim, so the direct global
+    // exchange path must apply the gate.
+    let x = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let mut b = spread_4q();
+    b.mcu(x, &[0, 1, 2], 3);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
 }
 
 #[test]
@@ -749,16 +861,19 @@ fn loopback_tiled_exchange_matches_full() {
     let expected = reference_probs(&circuit);
 
     // The local slice at 4 ranks is 16 amplitudes; these chunks span the tiling
-    // boundaries from one element up to a single whole slice message.
-    for &size in &[1usize, 2, 4] {
-        for &chunk in &[1usize, 3, 16, 1 << 20] {
-            let actual = loopback_probs_chunked(&circuit, size, chunk);
-            assert_eq!(expected.len(), actual.len());
-            for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
-                assert!(
-                    (e - a).abs() < TOL,
-                    "size {size} chunk {chunk}: prob[{i}] expected {e}, got {a}"
-                );
+    // boundaries from one element up to a single whole slice message. Both the
+    // direct exchange and the relabel exchange honor the chunk size.
+    for &relabel in &[true, false] {
+        for &size in &[1usize, 2, 4] {
+            for &chunk in &[1usize, 3, 16, 1 << 20] {
+                let actual = loopback_probs_with(&circuit, size, chunk, relabel);
+                assert_eq!(expected.len(), actual.len());
+                for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+                    assert!(
+                        (e - a).abs() < TOL,
+                        "size {size} chunk {chunk} relabel {relabel}: prob[{i}] expected {e}, got {a}"
+                    );
+                }
             }
         }
     }
@@ -777,17 +892,72 @@ fn exchange_counters_track_communication() {
     dist.apply(&inst_h(3)).unwrap();
     assert_eq!(dist.exchange_messages(), 0, "single rank never exchanges");
 
-    // At 2 ranks qubit 3 is global: the diagonal Z and Rz are free, each H costs
-    // one exchange.
-    let counts = loopback_exchange_counts(
-        &{
-            let mut b = CircuitBuilder::new(4);
-            b.z(3).rz(0.3, 3).h(3).h(3);
-            b.build()
-        },
-        2,
+    // At 2 ranks qubit 3 is global and the local slice is 8 amplitudes. The
+    // diagonal Z and Rz are free. Direct mode exchanges the full slice per H.
+    // Relabel mode pays one half-slice exchange for the first H, after which
+    // qubit 3 is local and the second H is free.
+    let circuit = {
+        let mut b = CircuitBuilder::new(4);
+        b.z(3).rz(0.3, 3).h(3).h(3);
+        b.build()
+    };
+    let direct = loopback_exchange_stats(&circuit, 2, usize::MAX, false);
+    assert_eq!(
+        direct,
+        (2, 16),
+        "two global H gates exchange the slice twice"
     );
-    assert_eq!(counts, 2, "two global H gates cost two exchanges");
+    let relabeled = loopback_exchange_stats(&circuit, 2, usize::MAX, true);
+    assert_eq!(relabeled, (1, 4), "one relabel moves half the slice once");
+}
+
+#[test]
+fn relabel_makes_global_swap_free() {
+    relax_min_local_qubits();
+    let circuit = {
+        let mut b = CircuitBuilder::new(5);
+        b.x(0).swap(0, 4);
+        b.build()
+    };
+    let direct = loopback_exchange_stats(&circuit, 2, usize::MAX, false);
+    let relabeled = loopback_exchange_stats(&circuit, 2, usize::MAX, true);
+    assert_eq!(direct.0, 1, "direct boundary swap exchanges once");
+    assert_eq!(relabeled, (0, 0), "relabel swap is a map update");
+}
+
+#[test]
+fn relabel_reduces_phased_exchange_volume() {
+    relax_min_local_qubits();
+    // Activity shifts from the bottom qubits to the top qubits, as after
+    // fusion passes that concentrate work. Direct exchange pays for every
+    // layer touching the global qubits; relabeling pays two half-slice moves
+    // when the working set shifts and the remaining layers run locally.
+    let n = 6;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..4 {
+        b.ry(0.3 + 0.01 * q as f64, q);
+    }
+    b.cx(0, 1).cx(2, 3);
+    for layer in 0..3 {
+        for q in 2..n {
+            b.ry(0.2 + 0.01 * (layer * n + q) as f64, q);
+        }
+        b.cx(2, 3).cx(3, 4).cx(4, 5);
+    }
+    let circuit = b.build();
+    let direct = loopback_exchange_stats(&circuit, 4, usize::MAX, false);
+    let relabeled = loopback_exchange_stats(&circuit, 4, usize::MAX, true);
+    assert_eq!(
+        relabeled,
+        (2, 16),
+        "two half-slice relabels cover every layer"
+    );
+    assert!(
+        relabeled.1 < direct.1 / 4,
+        "relabel volume {} should be far below direct volume {}",
+        relabeled.1,
+        direct.1
+    );
 }
 
 #[test]
@@ -798,11 +968,24 @@ fn tiled_exchange_splits_messages_not_volume() {
         b.h(4);
         b.build()
     };
-    let full = loopback_exchange_stats(&circuit, 2, 1 << 20);
-    let tiled = loopback_exchange_stats(&circuit, 2, 4);
+    let full = loopback_exchange_stats(&circuit, 2, 1 << 20, false);
+    let tiled = loopback_exchange_stats(&circuit, 2, 4, false);
     assert_eq!(full.0, 1, "full slice is one message");
     assert_eq!(tiled.0, 4, "16 amplitudes in chunks of 4 is four messages");
     assert_eq!(full.1, tiled.1, "total amplitudes exchanged is unchanged");
+
+    let relabel_full = loopback_exchange_stats(&circuit, 2, 1 << 20, true);
+    let relabel_tiled = loopback_exchange_stats(&circuit, 2, 4, true);
+    assert_eq!(
+        relabel_full,
+        (1, 8),
+        "relabel moves the half slice in one message"
+    );
+    assert_eq!(
+        relabel_tiled,
+        (2, 8),
+        "8 amplitudes in chunks of 4 is two messages"
+    );
 }
 
 fn inst_h(q: usize) -> crate::circuit::Instruction {
@@ -812,14 +995,14 @@ fn inst_h(q: usize) -> crate::circuit::Instruction {
     }
 }
 
-/// Run `circuit` across `size` ranks and return rank 0's exchange message count.
-fn loopback_exchange_counts(circuit: &Circuit, size: usize) -> u64 {
-    loopback_exchange_stats(circuit, size, usize::MAX).0
-}
-
-/// Run `circuit` across `size` ranks with the given exchange chunk; return rank
-/// 0's `(message_count, amplitude_count)`.
-fn loopback_exchange_stats(circuit: &Circuit, size: usize, chunk: usize) -> (u64, u64) {
+/// Run `circuit` across `size` ranks with the given exchange chunk and relabel
+/// setting; return rank 0's `(message_count, amplitude_count)`.
+fn loopback_exchange_stats(
+    circuit: &Circuit,
+    size: usize,
+    chunk: usize,
+    relabel: bool,
+) -> (u64, u64) {
     let shared = LoopbackShared::new(size);
     let handles: Vec<_> = (0..size)
         .map(|rank| {
@@ -834,6 +1017,7 @@ fn loopback_exchange_stats(circuit: &Circuit, size: usize, chunk: usize) -> (u64
                     let ctx = DistributedContext::from_comm(Arc::new(comm));
                     let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
                     backend.set_exchange_chunk(chunk);
+                    backend.set_relabel(relabel);
                     backend
                         .init(circuit.num_qubits, circuit.num_classical_bits)
                         .unwrap();

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -439,6 +439,114 @@ fn loopback_mixed_circuit_qft_like() {
     assert_loopback_matches(&b.build(), &[1, 2, 4]);
 }
 
+// --- P3: distributed fusion (fused/batched gates spanning global qubits) ---
+//
+// These circuits are large enough to trigger the fusion pipeline (>= 10 qubits
+// for 1q fusion, >= 12 for 2q, >= 14 for multi-1q, >= 16 for diagonal batch).
+// The reference statevector fuses identically, so a match confirms the
+// distributed backend decomposes each fused/batched variant correctly when its
+// qubit set spans a rank bit. Run at 2 and 4 ranks to put fused gates on the
+// global qubits (the top 1 or 2 of the register).
+
+#[test]
+fn loopback_fused_multifused_and_2q() {
+    relax_min_local_qubits();
+    // HEA-style: layers of 1q rotations (fuse into MultiFused) and CX ladders
+    // (fuse into Fused2q / Multi2q), reaching the global qubits at the top.
+    let n = 14;
+    let mut b = CircuitBuilder::new(n);
+    for layer in 0..3 {
+        for q in 0..n {
+            b.ry(0.3 + 0.01 * (layer * n + q) as f64, q);
+            b.rz(-0.2 + 0.02 * q as f64, q);
+        }
+        for q in 0..n - 1 {
+            b.cx(q, q + 1);
+        }
+    }
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_fused_batchphase_qft() {
+    relax_min_local_qubits();
+    // Textbook QFT produces H walls plus controlled-phase batches (BatchPhase)
+    // and trailing swaps, spanning the full register including global qubits.
+    let n = 12;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+        for (j, target) in (q + 1..n).enumerate() {
+            let angle = std::f64::consts::PI / (1u64 << (j + 1)) as f64;
+            b.cphase(angle, target, q);
+        }
+    }
+    for q in 0..n / 2 {
+        b.swap(q, n - 1 - q);
+    }
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_fused_batchrzz_qaoa() {
+    relax_min_local_qubits();
+    // QAOA-style: Rzz on every edge (fuse into BatchRzz at >= 16q) plus Rx
+    // mixers (MultiFused), spanning global qubits.
+    let n = 16;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    for round in 0..2 {
+        for q in 0..n - 1 {
+            b.rzz(0.7 + 0.01 * round as f64, q, q + 1);
+        }
+        for q in 0..n {
+            b.rx(0.4, q);
+        }
+    }
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_fused_diagonal_batch() {
+    relax_min_local_qubits();
+    // Mixed diagonal run (cphase + rzz + diagonal 1q) at >= 16 qubits triggers
+    // DiagonalBatch fusion; ensure the entries decompose across the boundary.
+    let n = 16;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    for q in 0..n - 1 {
+        b.cphase(0.3, q, q + 1);
+        b.rzz(0.5, q, q + 1);
+    }
+    for q in 0..n {
+        b.t(q);
+        b.rz(0.15, q);
+    }
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_fused_2q_both_global() {
+    relax_min_local_qubits();
+    // Force a fused 2q gate onto the two global qubits at 4 ranks (top two of a
+    // 12q register), exercising the four-way gather path.
+    let n = 12;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    // Adjacent 1q + CX on the top pair fuse into a Fused2q spanning both globals.
+    b.ry(0.6, n - 2)
+        .rz(0.3, n - 1)
+        .cx(n - 2, n - 1)
+        .ry(-0.4, n - 1);
+    assert_loopback_matches(&b.build(), &[1, 2, 4]);
+}
+
 #[test]
 fn reports_global_qubit_count_for_single_rank() {
     let ctx = DistributedContext::serial();

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -27,10 +27,8 @@ struct LoopbackState {
     arrived: usize,
     cslots: Vec<Vec<Complex64>>,
     fslots: Vec<f64>,
-    // Pairwise mailboxes indexed by `sender * size + receiver`. Each holds a
-    // FIFO queue of messages so repeated exchanges between the same pair stay
-    // ordered. This models MPI point-to-point, which is independent of the
-    // global barrier used by the collectives.
+    // Mailboxes indexed by `sender * size + receiver`. FIFO order matches MPI
+    // sendrecv order and stays separate from collective barriers.
     mailbox: Vec<VecDeque<Vec<Complex64>>>,
 }
 
@@ -126,9 +124,8 @@ impl RankComm for LoopbackComm {
         debug_assert_eq!(send.len(), recv.len());
         let size = self.shared.size;
         let mut st = self.shared.state.lock().unwrap();
-        // Deposit into self -> partner, then wait for partner -> self. Pairwise
-        // and barrier-independent, so ranks that skip an exchange (a 0 control)
-        // never block a partner: their partner skips the same exchange.
+        // Send to partner, then wait for partner to send back. Ranks that skip
+        // an exchange do not block because their partner skips it too.
         st.mailbox[self.rank * size + partner].push_back(send.to_vec());
         self.shared.cv.notify_all();
         let inbox = partner * size + self.rank;
@@ -177,6 +174,37 @@ fn loopback_probs(circuit: &Circuit, size: usize) -> Vec<f64> {
     first
 }
 
+/// Like [`loopback_probs`], but uses a fixed exchange chunk.
+fn loopback_probs_chunked(circuit: &Circuit, size: usize, chunk: usize) -> Vec<f64> {
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_exchange_chunk(chunk);
+                    run_on(&mut backend, &circuit)
+                        .expect("distributed run")
+                        .probabilities
+                        .expect("probabilities")
+                        .to_vec()
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let mut results: Vec<Vec<f64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = results.swap_remove(0);
+    results.clear();
+    first
+}
+
 fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
     let expected = reference_probs(circuit);
     for &size in sizes {
@@ -190,6 +218,57 @@ fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
             assert!(
                 (e - a).abs() < TOL,
                 "size {size}: prob[{i}] expected {e}, got {a}"
+            );
+        }
+    }
+}
+
+/// Run `circuit` across simulated ranks and return rank 0's probabilities and
+/// classical bits.
+fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    let out = run_on(&mut backend, &circuit).expect("distributed run");
+                    let probs = out.probabilities.expect("probabilities").to_vec();
+                    (probs, out.classical_bits)
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let mut results: Vec<(Vec<f64>, Vec<bool>)> =
+        handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = results.swap_remove(0);
+    results.clear();
+    first
+}
+
+/// Assert that probabilities and classical bits are identical across all rank
+/// counts. This checks measurement determinism across rank counts.
+fn assert_loopback_deterministic(circuit: &Circuit, sizes: &[usize]) {
+    let (ref_probs, ref_bits) = loopback_run(circuit, sizes[0]);
+    for &size in &sizes[1..] {
+        let (probs, bits) = loopback_run(circuit, size);
+        assert_eq!(ref_bits, bits, "classical bits differ at size {size}");
+        assert_eq!(
+            ref_probs.len(),
+            probs.len(),
+            "length differs at size {size}"
+        );
+        for (i, (e, a)) in ref_probs.iter().zip(probs.iter()).enumerate() {
+            assert!(
+                (e - a).abs() < TOL,
+                "size {size}: prob[{i}] {e} vs {a} differ across ranks"
             );
         }
     }
@@ -293,7 +372,6 @@ fn relax_min_local_qubits() {
 #[test]
 fn loopback_global_hadamard_wall() {
     relax_min_local_qubits();
-    // H on every qubit covers global exchange and combine.
     let mut b = CircuitBuilder::new(4);
     for q in 0..4 {
         b.h(q);
@@ -320,17 +398,13 @@ fn loopback_global_rotations_and_diagonals() {
 #[test]
 fn loopback_local_only_matches_across_ranks() {
     relax_min_local_qubits();
-    // Entangling chain confined to local qubits.
     let mut b = CircuitBuilder::new(5);
     b.h(0).cx(0, 1).cx(1, 2);
     assert_loopback_matches(&b.build(), &[1, 2, 4]);
 }
 
-// --- P2: two-qubit / controlled gates spanning global qubits ---
-//
 // With 4 qubits across 4 ranks, qubits 0,1 are local and 2,3 are global, so a
-// two-qubit gate can place its operands in every local/global combination. A
-// leading Hadamard wall spreads amplitude so every branch carries weight.
+// two qubit gate can place operands in every local and global combination.
 
 fn spread_4q() -> CircuitBuilder {
     let mut b = CircuitBuilder::new(4);
@@ -341,7 +415,6 @@ fn spread_4q() -> CircuitBuilder {
 #[test]
 fn loopback_cx_all_qubit_splits() {
     relax_min_local_qubits();
-    // (local,local), (local,global), (global,local), (global,global).
     for &(c, t) in &[(0usize, 1usize), (1, 2), (2, 0), (2, 3)] {
         let mut b = spread_4q();
         b.cx(c, t);
@@ -392,8 +465,6 @@ fn loopback_cphase_all_qubit_splits() {
 #[test]
 fn loopback_controlled_unitary_global_target() {
     relax_min_local_qubits();
-    // A non-phase controlled unitary (Ry(0.9) on the target) with control and
-    // target in mixed local/global positions.
     let ry = |theta: f64| {
         let (s, c) = (theta / 2.0).sin_cos();
         [
@@ -415,7 +486,6 @@ fn loopback_toffoli_mixed_splits() {
         [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
         [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
     ];
-    // Two controls + target across local/global boundaries.
     for &(c0, c1, t) in &[(0usize, 1usize, 2usize), (0, 2, 3), (2, 3, 0), (1, 2, 3)] {
         let mut b = spread_4q();
         b.mcu(x, &[c0, c1], t);
@@ -427,7 +497,7 @@ fn loopback_toffoli_mixed_splits() {
 fn loopback_mixed_circuit_qft_like() {
     relax_min_local_qubits();
     // H walls interleaved with controlled phases spanning all splits, plus an
-    // entangling tail. Exercises the full P2 path end to end.
+    // entangling tail.
     let mut b = CircuitBuilder::new(4);
     b.h(0).h(1).h(2).h(3);
     b.cphase(0.5, 0, 2)
@@ -439,20 +509,16 @@ fn loopback_mixed_circuit_qft_like() {
     assert_loopback_matches(&b.build(), &[1, 2, 4]);
 }
 
-// --- P3: distributed fusion (fused/batched gates spanning global qubits) ---
-//
 // These circuits are large enough to trigger the fusion pipeline (>= 10 qubits
-// for 1q fusion, >= 12 for 2q, >= 14 for multi-1q, >= 16 for diagonal batch).
+// for 1q fusion, >= 12 for 2q, >= 14 for multi 1q, >= 16 for diagonal batch).
 // The reference statevector fuses identically, so a match confirms the
-// distributed backend decomposes each fused/batched variant correctly when its
-// qubit set spans a rank bit. Run at 2 and 4 ranks to put fused gates on the
-// global qubits (the top 1 or 2 of the register).
+// distributed backend decomposes each fused or batched variant correctly.
 
 #[test]
 fn loopback_fused_multifused_and_2q() {
     relax_min_local_qubits();
-    // HEA-style: layers of 1q rotations (fuse into MultiFused) and CX ladders
-    // (fuse into Fused2q / Multi2q), reaching the global qubits at the top.
+    // HEA pattern: rotation layers fuse into MultiFused, CX ladders into
+    // Fused2q and Multi2q, reaching the global qubits at the top.
     let n = 14;
     let mut b = CircuitBuilder::new(n);
     for layer in 0..3 {
@@ -470,7 +536,7 @@ fn loopback_fused_multifused_and_2q() {
 #[test]
 fn loopback_fused_batchphase_qft() {
     relax_min_local_qubits();
-    // Textbook QFT produces H walls plus controlled-phase batches (BatchPhase)
+    // Textbook QFT produces H walls plus controlled phase batches (BatchPhase)
     // and trailing swaps, spanning the full register including global qubits.
     let n = 12;
     let mut b = CircuitBuilder::new(n);
@@ -490,7 +556,7 @@ fn loopback_fused_batchphase_qft() {
 #[test]
 fn loopback_fused_batchrzz_qaoa() {
     relax_min_local_qubits();
-    // QAOA-style: Rzz on every edge (fuse into BatchRzz at >= 16q) plus Rx
+    // QAOA pattern: Rzz on every edge (fuse into BatchRzz at >= 16q) plus Rx
     // mixers (MultiFused), spanning global qubits.
     let n = 16;
     let mut b = CircuitBuilder::new(n);
@@ -532,14 +598,13 @@ fn loopback_fused_diagonal_batch() {
 #[test]
 fn loopback_fused_2q_both_global() {
     relax_min_local_qubits();
-    // Force a fused 2q gate onto the two global qubits at 4 ranks (top two of a
-    // 12q register), exercising the four-way gather path.
+    // Adjacent 1q gates and a CX on the top pair fuse into a Fused2q spanning
+    // both global qubits at 4 ranks, exercising the four rank gather path.
     let n = 12;
     let mut b = CircuitBuilder::new(n);
     for q in 0..n {
         b.h(q);
     }
-    // Adjacent 1q + CX on the top pair fuse into a Fused2q spanning both globals.
     b.ry(0.6, n - 2)
         .rz(0.3, n - 1)
         .cx(n - 2, n - 1)
@@ -548,11 +613,247 @@ fn loopback_fused_2q_both_global() {
 }
 
 #[test]
+fn loopback_measure_deterministic_basis_state() {
+    relax_min_local_qubits();
+    // X on every qubit yields |1...1>, so every measurement must read 1.
+    let n = 5;
+    let mut b = CircuitBuilder::new_with_classical(n, n);
+    for q in 0..n {
+        b.x(q);
+    }
+    for q in 0..n {
+        b.measure(q, q);
+    }
+    let circuit = b.build();
+    for &size in &[1usize, 2, 4] {
+        let (_probs, bits) = loopback_run(&circuit, size);
+        assert_eq!(bits, vec![true; n], "size {size}: expected all one readout");
+    }
+}
+
+#[test]
+fn loopback_measure_determinism_across_ranks() {
+    relax_min_local_qubits();
+    // With a fixed seed the outcomes and post measurement probabilities must be
+    // identical for every rank count (lockstep meas_rng plus Allreduce).
+    let n = 6;
+    let mut b = CircuitBuilder::new_with_classical(n, n);
+    b.h(0).h(3).h(5);
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    b.measure(0, 0).measure(3, 3).measure(5, 5);
+    assert_loopback_deterministic(&b.build(), &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_ghz_measure_correlated() {
+    relax_min_local_qubits();
+    // A GHZ state collapses to all zeros or all ones, so the measured qubits
+    // must agree at every rank count.
+    let n = 5;
+    let mut b = CircuitBuilder::new_with_classical(n, 2);
+    b.h(0);
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    b.measure(0, 0).measure(n - 1, 1);
+    let circuit = b.build();
+    for &size in &[1usize, 2, 4] {
+        let (_probs, bits) = loopback_run(&circuit, size);
+        assert_eq!(bits[0], bits[1], "size {size}: GHZ qubits must correlate");
+    }
+}
+
+#[test]
+fn loopback_reset_clears_global_qubit() {
+    relax_min_local_qubits();
+    // Resetting every qubit of a full superposition must yield |0...0>.
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    let mut circuit = b.build();
+    for q in 0..n {
+        circuit.add_reset(q);
+    }
+    for &size in &[1usize, 2, 4] {
+        let (probs, _bits) = loopback_run(&circuit, size);
+        assert!(
+            (probs[0] - 1.0).abs() < TOL,
+            "size {size}: reset should yield |0...0>, got p[0]={}",
+            probs[0]
+        );
+    }
+}
+
+#[test]
+fn loopback_reset_empty_zero_branch_matches_statevector() {
+    relax_min_local_qubits();
+    // Statevector reset projects onto the |0> branch. If that branch is empty,
+    // it reinitializes to |0...0>; distributed reset must not preserve other
+    // qubits by flipping the |1> branch.
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    b.x(0).x(n - 1);
+    let mut circuit = b.build();
+    circuit.add_reset(n - 1);
+
+    let expected = reference_probs(&circuit);
+    assert!(
+        (expected[0] - 1.0).abs() < TOL,
+        "statevector reset should reinitialize empty zero branch"
+    );
+    assert_loopback_matches(&circuit, &[1, 2, 4]);
+}
+
+#[test]
+fn loopback_conditional_on_global_measurement() {
+    relax_min_local_qubits();
+    // Measure a |1> qubit into a bit, then conditionally X another qubit. The
+    // conditional must fire identically on every rank.
+    let n = 4;
+    let mut b = CircuitBuilder::new_with_classical(n, 1);
+    b.x(n - 1);
+    b.measure(n - 1, 0);
+    b.conditional(
+        crate::circuit::ClassicalCondition::BitIsOne(0),
+        crate::gates::Gate::X,
+        &[0],
+    );
+    let circuit = b.build();
+    for &size in &[1usize, 2, 4] {
+        let (probs, bits) = loopback_run(&circuit, size);
+        assert!(bits[0], "size {size}: measured bit should be 1");
+        let expected = 1usize | (1usize << (n - 1));
+        assert!(
+            (probs[expected] - 1.0).abs() < TOL,
+            "size {size}: conditional X should set qubit 0"
+        );
+    }
+}
+
+#[test]
+fn loopback_tiled_exchange_matches_full() {
+    relax_min_local_qubits();
+    // Every chunk size must match the statevector reference, so tiling the
+    // exchange preserves correctness.
+    let n = 6;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    b.rx(0.5, n - 1).ry(0.8, n - 2).h(n - 1).h(n - 2);
+    let circuit = b.build();
+    let expected = reference_probs(&circuit);
+
+    // The local slice at 4 ranks is 16 amplitudes; these chunks span the tiling
+    // boundaries from one element up to a single whole slice message.
+    for &size in &[1usize, 2, 4] {
+        for &chunk in &[1usize, 3, 16, 1 << 20] {
+            let actual = loopback_probs_chunked(&circuit, size, chunk);
+            assert_eq!(expected.len(), actual.len());
+            for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+                assert!(
+                    (e - a).abs() < TOL,
+                    "size {size} chunk {chunk}: prob[{i}] expected {e}, got {a}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn exchange_counters_track_communication() {
+    relax_min_local_qubits();
+    // A single rank keeps every qubit local, so no gate exchanges.
+    let ctx = DistributedContext::from_comm(Arc::new(LoopbackComm {
+        shared: LoopbackShared::new(1),
+        rank: 0,
+    }));
+    let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
+    dist.init(4, 0).unwrap();
+    dist.apply(&inst_h(3)).unwrap();
+    assert_eq!(dist.exchange_messages(), 0, "single rank never exchanges");
+
+    // At 2 ranks qubit 3 is global: the diagonal Z and Rz are free, each H costs
+    // one exchange.
+    let counts = loopback_exchange_counts(
+        &{
+            let mut b = CircuitBuilder::new(4);
+            b.z(3).rz(0.3, 3).h(3).h(3);
+            b.build()
+        },
+        2,
+    );
+    assert_eq!(counts, 2, "two global H gates cost two exchanges");
+}
+
+#[test]
+fn tiled_exchange_splits_messages_not_volume() {
+    relax_min_local_qubits();
+    let circuit = {
+        let mut b = CircuitBuilder::new(5);
+        b.h(4);
+        b.build()
+    };
+    let full = loopback_exchange_stats(&circuit, 2, 1 << 20);
+    let tiled = loopback_exchange_stats(&circuit, 2, 4);
+    assert_eq!(full.0, 1, "full slice is one message");
+    assert_eq!(tiled.0, 4, "16 amplitudes in chunks of 4 is four messages");
+    assert_eq!(full.1, tiled.1, "total amplitudes exchanged is unchanged");
+}
+
+fn inst_h(q: usize) -> crate::circuit::Instruction {
+    crate::circuit::Instruction::Gate {
+        gate: crate::gates::Gate::H,
+        targets: crate::circuit::smallvec![q],
+    }
+}
+
+/// Run `circuit` across `size` ranks and return rank 0's exchange message count.
+fn loopback_exchange_counts(circuit: &Circuit, size: usize) -> u64 {
+    loopback_exchange_stats(circuit, size, usize::MAX).0
+}
+
+/// Run `circuit` across `size` ranks with the given exchange chunk; return rank
+/// 0's `(message_count, amplitude_count)`.
+fn loopback_exchange_stats(circuit: &Circuit, size: usize, chunk: usize) -> (u64, u64) {
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_exchange_chunk(chunk);
+                    backend
+                        .init(circuit.num_qubits, circuit.num_classical_bits)
+                        .unwrap();
+                    backend.apply_instructions(&circuit.instructions).unwrap();
+                    (backend.exchange_messages(), backend.exchange_amplitudes())
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let mut results: Vec<(u64, u64)> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let first = results.swap_remove(0);
+    results.clear();
+    first
+}
+
+#[test]
 fn reports_global_qubit_count_for_single_rank() {
     let ctx = DistributedContext::serial();
     let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
     dist.init(5, 0).unwrap();
     assert_eq!(dist.num_qubits(), 5);
-    // Single rank: every qubit is local.
     assert!(dist.supports_fused_gates());
 }

--- a/src/distributed/mod.rs
+++ b/src/distributed/mod.rs
@@ -4,7 +4,7 @@
 //! define their own state partitioning and use this module for rank access.
 //!
 //! Available contexts:
-//! - [`DistributedContext::serial`]: a single rank for tests and non-MPI runs.
+//! - [`DistributedContext::serial`]: one rank for tests and runs without MPI.
 //! - [`DistributedContext::world`]: the MPI world communicator (requires the
 //!   `distributed-mpi` feature and an MPI launcher).
 //!
@@ -29,6 +29,20 @@ pub fn min_local_qubits() -> usize {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
     *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_MIN_LOCAL_QUBITS", MIN_LOCAL_QUBITS_DEFAULT, 1))
+}
+
+/// Maximum number of amplitudes exchanged per message for a global one qubit
+/// gate. Chunking bounds the receive buffer to this value.
+///
+/// Tunable via `PRISM_DIST_EXCHANGE_CHUNK`. The default (`usize::MAX`) keeps the
+/// original one message behavior, so there is no change unless set.
+pub const EXCHANGE_CHUNK_DEFAULT: usize = usize::MAX;
+
+/// Chunk size in amplitudes for tiled global one qubit exchange.
+pub fn exchange_chunk() -> usize {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_EXCHANGE_CHUNK", EXCHANGE_CHUNK_DEFAULT, 1))
 }
 
 #[inline]
@@ -60,7 +74,7 @@ impl DistributedContext {
         Arc::new(Self { comm })
     }
 
-    /// Single rank. Used by tests and by non-MPI runs.
+    /// Single rank. Used by tests and runs without MPI.
     pub fn serial() -> Arc<Self> {
         Self::from_comm(Arc::new(SerialComm))
     }

--- a/src/distributed/mod.rs
+++ b/src/distributed/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! Available contexts:
 //! - [`DistributedContext::serial`]: one rank for tests and runs without MPI.
-//! - [`DistributedContext::world`]: the MPI world communicator (requires the
+//! - `DistributedContext::world`: the MPI world communicator (requires the
 //!   `distributed-mpi` feature and an MPI launcher).
 //!
 //! Tuning thresholds are cached after the first environment variable read.
@@ -43,6 +43,22 @@ pub fn exchange_chunk() -> usize {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
     *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_EXCHANGE_CHUNK", EXCHANGE_CHUNK_DEFAULT, 1))
+}
+
+/// Whether the distributed backend relabels qubits to keep busy qubits local.
+///
+/// On by default. Relabeling turns SWAP gates into zero-communication map
+/// updates and moves global qubits into local positions with a half-slice
+/// exchange before non-diagonal gates touch them. Set `PRISM_DIST_RELABEL=0`
+/// to disable and force direct per-gate exchange.
+pub fn relabel_enabled() -> bool {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("PRISM_DIST_RELABEL")
+            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+            .unwrap_or(true)
+    })
 }
 
 #[inline]


### PR DESCRIPTION
## Summary

Adds distributed statevector support for measurement, reset, classical conditionals, exchange counters, and tiled global one qubit exchange. Also extends loopback and MPI checks to verify deterministic measurement across rank counts, and aligns distributed reset with statevector projection semantics.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| Distributed global one qubit exchange | Not run | Not run | Unknown | Unknown |
| Distributed fused or batched gates spanning rank bits | Not run | Not run | Unknown | Unknown |
| Distributed measurement and reset | Not run | Not run | Unknown | Unknown |


## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Validated in this pass:

- `cargo fmt --check`
- `cargo clippy --features distributed --lib -- -D warnings`
- `cargo test --features distributed backend::distributed_statevector -- --nocapture`, 30 passed
- `. .\scripts\mpi-env.ps1; cargo check --example dist_mpi_check --features distributed-mpi`

## Hotspot notes

Touched distributed statevector gate dispatch and communication paths:

- `DistributedStatevectorBackend::apply_global_1q`
- `DistributedStatevectorBackend::apply_local_controlled_1q`
- `DistributedStatevectorBackend::apply_controlled_phase_dist`
- `DistributedStatevectorBackend::apply_rzz_phases_dist`
- `DistributedStatevectorBackend::apply_2q_two_global`

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

Architecture docs still need review because this changes distributed backend behavior and exposes communication counters.

## Breaking changes

None expected. Distributed measurement, reset, and conditionals move from unsupported to supported. Reset now follows existing statevector projection semantics.

## Risks and rollback

Main risk is performance regression in distributed hot paths due to added routing, counters, tiling, or delegation through inner backend kernels. Rollback is straightforward by reverting this change; `PRISM_DIST_EXCHANGE_CHUNK` also leaves default global one qubit exchange as one message unless configured.

## Pre-merge checklist

- [ ] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green