### PR TITLE
feat(distributed): add statevector shot sampling

### DIFF
--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -20,7 +20,7 @@ scalar path is used.
 
 | Backend | x86-64 | AVX2/FMA/BMI2 | ARM64 | NEON | CUDA (NVIDIA) | ROCm (AMD) | Distributed |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Statevector | Yes | SIMD | Yes | SIMD | Yes | Planned | Planned |
+| Statevector | Yes | SIMD | Yes | SIMD | Yes | Planned | Yes |
 | Stabilizer | Yes | SIMD | Yes | SIMD | Yes | Planned | Planned |
 | Factored Stabilizer | Yes | SIMD | Yes | SIMD | No | Planned | Planned |
 | Sparse | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
@@ -42,15 +42,19 @@ Notes:
 - **CUDA** covers the optional `gpu` feature. Only the statevector and stabilizer
   paths have device kernels; every other backend runs on CPU. See the
   [GPU Backend](./gpu.md) guide.
+- **Distributed** covers the optional `distributed` and `distributed-mpi` features.
+  The statevector backend splits the state across MPI ranks with exact results,
+  including gates, measurement, reset, and multi-shot sampling without gathering
+  the dense state. Use `simulate(&circuit).distributed(context)`.
 
 ## Not yet supported
 
 | Target | Status | Notes |
 | --- | --- | --- |
 | ROCm (AMD GPU) | Planned | No AMD device kernels; the GPU path is CUDA-only |
-| Distributed CPU | Planned | No multi-node execution |
 | Distributed GPU | Planned | No multi-node GPU execution |
 | Multi-GPU | Planned | A GPU context binds a single device |
+| Distributed noisy shots | Planned | Noise models are rejected on the distributed backend; trajectory execution is not lockstep across ranks |
 
 These targets are listed so the matrix reflects the roadmap rather than hiding
-the gaps. Distributed execution is not a code path PRISM-Q exposes today.
+the gaps.

--- a/examples/dist_mpi_check.rs
+++ b/examples/dist_mpi_check.rs
@@ -120,7 +120,11 @@ fn run() {
     // Measurement determinism: with a fixed seed every rank count must produce
     // the same classical outcomes. The script compares the printed signature
     // across `-n 1/2/4`. Reuse the existing context (MPI initializes only once).
-    measurement_check(ctx, num_qubits);
+    measurement_check(ctx.clone(), num_qubits);
+
+    // Shot sampling: terminal measurements sample basis indices without
+    // gathering the dense state on any rank.
+    shots_check(ctx, num_qubits);
 }
 
 #[cfg(feature = "distributed-mpi")]
@@ -183,5 +187,51 @@ fn measurement_check(
             direct.exchange_messages(),
             direct.exchange_amplitudes()
         );
+    }
+}
+
+#[cfg(feature = "distributed-mpi")]
+fn shots_check(ctx: std::sync::Arc<prism_q::distributed::DistributedContext>, num_qubits: usize) {
+    use prism_q::circuit::builder::CircuitBuilder;
+
+    const SEED: u64 = 42;
+    const NUM_SHOTS: usize = 200;
+
+    let n = num_qubits;
+    let mut b = CircuitBuilder::new_with_classical(n, n);
+    b.h(0);
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    for q in 0..n {
+        b.measure(q, q);
+    }
+    let circuit = b.build();
+
+    let rank = ctx.rank();
+    let size = ctx.size();
+    let result = prism_q::simulate(&circuit)
+        .distributed(ctx)
+        .seed(SEED)
+        .shots(NUM_SHOTS)
+        .expect("distributed shots");
+
+    let mut ones = 0usize;
+    let mut sig: u64 = 0xcbf2_9ce4_8422_2325;
+    for shot in &result.shots {
+        assert!(
+            shot.iter().all(|&bit| bit == shot[0]),
+            "GHZ shot must be all zeros or all ones"
+        );
+        ones += shot[0] as usize;
+        sig = (sig ^ shot[0] as u64).wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    assert!(
+        ones > 0 && ones < NUM_SHOTS,
+        "200 GHZ shots should produce both outcomes"
+    );
+
+    if rank == 0 {
+        println!("SHOTS: {size} ranks, ones={ones}/{NUM_SHOTS}, shots_sig=0x{sig:016x}");
     }
 }

--- a/scripts/test-mpi.ps1
+++ b/scripts/test-mpi.ps1
@@ -34,6 +34,7 @@ if (-not (Test-Path $mpiexec)) { $mpiexec = "mpiexec" }
 # The check circuit is small, so relax the local qubit floor to let it
 # distribute across ranks on a single host.
 $measSigs = @{}
+$shotSigs = @{}
 foreach ($n in $RankCounts) {
     Write-Host "`n== mpiexec -n $n dist_mpi_check =="
     $out = & $mpiexec -n $n -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe
@@ -45,6 +46,11 @@ foreach ($n in $RankCounts) {
         throw "measurement signature missing at -n $n"
     }
     $measSigs[$n] = $match.Matches[0].Groups[1].Value
+    $match = $out | Select-String -Pattern 'shots_sig=(\S+)' | Select-Object -First 1
+    if (-not $match) {
+        throw "shots signature missing at -n $n"
+    }
+    $shotSigs[$n] = $match.Matches[0].Groups[1].Value
 }
 
 $unique = $measSigs.Values | Select-Object -Unique
@@ -52,5 +58,11 @@ if ($unique.Count -gt 1) {
     throw "measurement outcomes differ across rank counts: $($measSigs | Out-String)"
 }
 Write-Host "`nMeasurement determinism: signature $($unique) identical across ranks."
+
+$uniqueShots = $shotSigs.Values | Select-Object -Unique
+if ($uniqueShots.Count -gt 1) {
+    throw "shot outcomes differ across rank counts: $($shotSigs | Out-String)"
+}
+Write-Host "Shot sampling determinism: signature $($uniqueShots) identical across ranks."
 
 Write-Host "`nAll distributed MPI checks passed."

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -78,8 +78,17 @@
 //! communication volume. Use these counters to evaluate qubit reordering and
 //! routing, since one host cannot measure real network latency.
 //!
-//! Not implemented yet: distributed shot sampling, and lookahead epoch planning
-//! that batches several relabels into one exchange.
+//! # Shot sampling
+//!
+//! Circuits whose measurements are terminal sample shots without gathering the
+//! dense state or probability vector on any rank; communication scales with
+//! the rank count and shot count, never with the state size. See
+//! [`DistributedStatevectorBackend::sample_state_indices`] for the algorithm.
+//! Circuits with mid-circuit measurements fall back to one lockstep run per
+//! shot.
+//!
+//! Not implemented yet: lookahead epoch planning that batches several relabels
+//! into one exchange.
 
 #[cfg(test)]
 mod tests;
@@ -430,6 +439,73 @@ impl DistributedStatevectorBackend {
         self.qubit_map[global_q] = local_pos;
         self.phys_map.swap(local_pos, global_pos);
         self.refresh_map_identity();
+    }
+
+    /// Physically swap the qubits at positions `a < b` and update the map.
+    /// When both positions are local, this runs the inner SWAP kernel. When one
+    /// position is local and one is global, this reuses the half-slice relabel
+    /// exchange. When both positions are global, this exchanges full slices
+    /// between rank pairs whose two bits differ.
+    fn swap_physical_positions(&mut self, a: usize, b: usize) {
+        debug_assert!(
+            a < b,
+            "positions must be ordered: branch selection assumes a < b"
+        );
+        let local = self.local_qubits();
+        if b < local {
+            self.inner
+                .apply(&Instruction::Gate {
+                    gate: Gate::Swap,
+                    targets: smallvec![a, b],
+                })
+                .expect("local SWAP cannot fail");
+        } else if a < local {
+            self.relabel_swap(a, b);
+            return;
+        } else {
+            let ga = self.global_bit(a);
+            let gb = self.global_bit(b);
+            let rank = self.context.rank();
+            if ((rank >> ga) ^ (rank >> gb)) & 1 == 1 {
+                let partner = rank ^ ((1usize << ga) | (1usize << gb));
+                let len = self.inner.state.len();
+                let chunk = self.exchange_chunk.min(len).max(1);
+                if self.recv.len() != chunk {
+                    self.recv.resize(chunk, Complex64::new(0.0, 0.0));
+                }
+                let mut off = 0;
+                while off < len {
+                    let end = (off + chunk).min(len);
+                    self.count_exchange(end - off);
+                    let recv = &mut self.recv[..end - off];
+                    self.context
+                        .comm()
+                        .sendrecv_c64(partner, &self.inner.state[off..end], recv);
+                    self.inner.state[off..end].copy_from_slice(recv);
+                    off = end;
+                }
+            }
+        }
+        let qa = self.phys_map[a];
+        let qb = self.phys_map[b];
+        self.qubit_map[qa] = b;
+        self.qubit_map[qb] = a;
+        self.phys_map.swap(a, b);
+        self.refresh_map_identity();
+    }
+
+    /// Physically reorder the state until every circuit qubit occupies its own
+    /// position. Runs in lockstep on every rank because the maps are identical.
+    /// Each misplaced qubit costs at most one exchange. The identity map
+    /// returns without work.
+    fn restore_identity_map(&mut self) {
+        while !self.map_identity {
+            let Some(pos) = (0..self.num_qubits).find(|&p| self.phys_map[p] != p) else {
+                break;
+            };
+            let src = self.qubit_map[pos];
+            self.swap_physical_positions(pos, src);
+        }
     }
 
     /// Translate an instruction into physical positions: map the targets and
@@ -1097,6 +1173,82 @@ impl DistributedStatevectorBackend {
         } else {
             self.qubit_map[qubit]
         }
+    }
+
+    /// Sample `num_shots` computational basis indices in circuit qubit order
+    /// without gathering the dense state or probability vector on any rank.
+    ///
+    /// Relabeled qubits are first restored to their circuit positions with
+    /// bounded exchanges, so each rank owns a contiguous slice in circuit
+    /// order. Each rank then builds a cumulative distribution for its local
+    /// slice. One gather shares a single mass value from each rank. Every rank
+    /// assigns each shot to an owning rank from the same seeded draw stream,
+    /// the owner samples its local distribution, and a tiled sum reduction
+    /// distributes the sampled indices. Buffers scale with the rank count and
+    /// shot count, not the global state size.
+    ///
+    /// Collective: every rank must call this with identical `num_shots` and
+    /// `seed`. The result is identical on every rank and reproduces the dense
+    /// sampling path draw for draw, independent of the rank count, except
+    /// when accumulated rounding differences move a draw across an interval
+    /// edge in the cumulative distribution.
+    pub fn sample_state_indices(&mut self, num_shots: usize, seed: u64) -> Result<Vec<u64>> {
+        if self.num_qubits > 53 {
+            return Err(self.unsupported(
+                "shot sampling above 53 qubits: index transport is exact only below 2^53",
+            ));
+        }
+        if num_shots == 0 {
+            return Ok(Vec::new());
+        }
+        self.restore_identity_map();
+        debug_assert!(self.map_identity);
+
+        let mut local_cdf = self.inner.probabilities()?;
+        let mut acc = 0.0f64;
+        for p in local_cdf.iter_mut() {
+            acc += *p;
+            *p = acc;
+        }
+
+        let masses = self.context.comm().allgather_f64(&[acc]);
+        let mut rank_cdf = Vec::with_capacity(masses.len());
+        let mut total = 0.0f64;
+        for &m in &masses {
+            total += m;
+            rank_cdf.push(total);
+        }
+        if let Some(last) = rank_cdf.last_mut() {
+            *last = 1.0;
+        }
+
+        let rank = self.context.rank();
+        let local_qubits = self.local_qubits();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut indices = vec![0.0f64; num_shots];
+        for slot in indices.iter_mut() {
+            let r: f64 = rng.random();
+            // First rank whose cumulative mass reaches r. The strict
+            // comparison matches the dense binary search at exact boundary
+            // hits and never selects an empty interval.
+            let owner = rank_cdf.partition_point(|&c| c < r);
+            if owner != rank {
+                continue;
+            }
+            let residual = if owner == 0 {
+                r
+            } else {
+                r - rank_cdf[owner - 1]
+            };
+            let local_idx = crate::sim::shots::sample_from_cdf(&local_cdf, residual);
+            *slot = (((rank as u64) << local_qubits) | local_idx as u64) as f64;
+        }
+
+        const REDUCE_CHUNK: usize = 1 << 20;
+        for chunk in indices.chunks_mut(REDUCE_CHUNK) {
+            self.context.comm().allreduce_sum_f64_slice(chunk);
+        }
+        Ok(indices.into_iter().map(|v| v as u64).collect())
     }
 
     /// Zero the amplitudes inconsistent with `qubit == outcome`.

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -27,6 +27,10 @@ struct LoopbackState {
     arrived: usize,
     cslots: Vec<Vec<Complex64>>,
     fslots: Vec<f64>,
+    reduce: Vec<f64>,
+    // Largest block sent by a rank to allgather. Shot sampling tests
+    // assert this stays at one element, proving no dense gather happened.
+    max_gather_block: usize,
     // Mailboxes indexed by `sender * size + receiver`. FIFO order matches MPI
     // sendrecv order and stays separate from collective barriers.
     mailbox: Vec<VecDeque<Vec<Complex64>>>,
@@ -41,6 +45,8 @@ impl LoopbackShared {
                 arrived: 0,
                 cslots: vec![Vec::new(); size],
                 fslots: vec![0.0; size],
+                reduce: Vec::new(),
+                max_gather_block: 0,
                 mailbox: (0..size * size).map(|_| VecDeque::new()).collect(),
             }),
             cv: Condvar::new(),
@@ -90,6 +96,7 @@ impl RankComm for LoopbackComm {
     fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
         {
             let mut st = self.shared.state.lock().unwrap();
+            st.max_gather_block = st.max_gather_block.max(local.len());
             st.cslots[self.rank] = local.to_vec();
         }
         self.shared.barrier();
@@ -118,6 +125,29 @@ impl RankComm for LoopbackComm {
         };
         self.shared.barrier();
         sum
+    }
+
+    fn allreduce_sum_f64_slice(&self, values: &mut [f64]) {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            if st.reduce.len() != values.len() {
+                st.reduce = vec![0.0; values.len()];
+            }
+            for (acc, &v) in st.reduce.iter_mut().zip(values.iter()) {
+                *acc += v;
+            }
+        }
+        self.shared.barrier();
+        {
+            let st = self.shared.state.lock().unwrap();
+            values.copy_from_slice(&st.reduce);
+        }
+        self.shared.barrier();
+        if self.rank == 0 {
+            let mut st = self.shared.state.lock().unwrap();
+            st.reduce.clear();
+        }
+        self.shared.barrier();
     }
 
     fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
@@ -1040,4 +1070,212 @@ fn reports_global_qubit_count_for_single_rank() {
     dist.init(5, 0).unwrap();
     assert_eq!(dist.num_qubits(), 5);
     assert!(dist.supports_fused_gates());
+}
+
+/// Run distributed multi-shot sampling across simulated ranks. Returns the
+/// shots for every rank and the largest allgather block sent by any rank.
+fn loopback_shots(
+    circuit: &Circuit,
+    size: usize,
+    num_shots: usize,
+) -> (Vec<Vec<Vec<bool>>>, usize) {
+    let shared = LoopbackShared::new(size);
+    let handles: Vec<_> = (0..size)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::Builder::new()
+                .stack_size(64 * 1024 * 1024)
+                .spawn(move || {
+                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                    let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
+                    crate::sim::run_shots_with(kind, &circuit, num_shots, SEED)
+                        .expect("distributed shots")
+                        .shots
+                })
+                .expect("spawn rank thread")
+        })
+        .collect();
+    let results: Vec<Vec<Vec<bool>>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let max_gather = shared.state.lock().unwrap().max_gather_block;
+    (results, max_gather)
+}
+
+/// Sample shots through the production dense sampler, so the comparison
+/// tests prove distributed sampling reproduces the real dense path.
+fn dense_reference_shots(circuit: &Circuit, num_shots: usize) -> Vec<Vec<bool>> {
+    let stripped = circuit.without_measurements();
+    crate::sim::shots::sample_shots(
+        &crate::sim::Probabilities::Dense(reference_probs(&stripped)),
+        &circuit.measurement_map(),
+        circuit.num_classical_bits,
+        num_shots,
+        SEED,
+    )
+}
+
+#[test]
+fn shots_terminal_uniform_match_dense_across_rank_counts() {
+    relax_min_local_qubits();
+    let mut circuit = Circuit::new(4, 4);
+    for q in 0..4 {
+        circuit.add_gate(crate::gates::Gate::H, &[q]);
+    }
+    for q in 0..4 {
+        circuit.add_measure(q, q);
+    }
+    let expected = dense_reference_shots(&circuit, 64);
+    for size in [1usize, 2, 4] {
+        let (per_rank, _) = loopback_shots(&circuit, size, 64);
+        for shots in &per_rank {
+            assert_eq!(shots, &expected, "size {size}");
+        }
+    }
+}
+
+#[test]
+fn shots_terminal_ghz_match_dense_across_rank_counts() {
+    relax_min_local_qubits();
+    let mut circuit = Circuit::new(4, 4);
+    circuit.add_gate(crate::gates::Gate::H, &[0]);
+    for q in 0..3 {
+        circuit.add_gate(crate::gates::Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..4 {
+        circuit.add_measure(q, q);
+    }
+    let expected = dense_reference_shots(&circuit, 100);
+    let mut saw = [false, false];
+    for shot in &expected {
+        assert!(
+            shot.iter().all(|&b| b == shot[0]),
+            "GHZ shot must be uniform"
+        );
+        saw[shot[0] as usize] = true;
+    }
+    assert!(saw[0] && saw[1], "100 GHZ shots should hit both outcomes");
+    for size in [1usize, 2, 4] {
+        let (per_rank, _) = loopback_shots(&circuit, size, 100);
+        for shots in &per_rank {
+            assert_eq!(shots, &expected, "size {size}");
+        }
+    }
+}
+
+#[test]
+fn shots_restore_relabeled_qubits_before_sampling() {
+    relax_min_local_qubits();
+    // The swap leaves q3 = 1. At 2 and 4 ranks, q3 is a rank bit, so relabeling
+    // turns the swap into a map update and sampling must first restore the
+    // relabeled qubits to their circuit positions.
+    let mut circuit = Circuit::new(4, 4);
+    circuit.add_gate(crate::gates::Gate::X, &[0]);
+    circuit.add_gate(crate::gates::Gate::Swap, &[0, 3]);
+    for q in 0..4 {
+        circuit.add_measure(q, q);
+    }
+    for size in [1usize, 2, 4] {
+        let (per_rank, _) = loopback_shots(&circuit, size, 8);
+        for shots in &per_rank {
+            for shot in shots {
+                assert_eq!(shot, &vec![false, false, false, true], "size {size}");
+            }
+        }
+    }
+}
+
+#[test]
+fn shots_sample_without_dense_gather() {
+    relax_min_local_qubits();
+    let mut circuit = Circuit::new(6, 6);
+    for q in 0..6 {
+        circuit.add_gate(crate::gates::Gate::H, &[q]);
+    }
+    for q in 0..6 {
+        circuit.add_measure(q, q);
+    }
+    let (per_rank, max_gather) = loopback_shots(&circuit, 4, 32);
+    for shots in &per_rank {
+        assert_eq!(shots, &per_rank[0], "shots must be identical on every rank");
+    }
+    assert_eq!(
+        max_gather, 1,
+        "terminal sampling must only gather one mass value per rank"
+    );
+}
+
+#[test]
+fn shots_mid_circuit_match_across_rank_counts() {
+    relax_min_local_qubits();
+    let mut circuit = Circuit::new(4, 2);
+    circuit.add_gate(crate::gates::Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.add_gate(crate::gates::Gate::Cx, &[0, 1]);
+    circuit.add_measure(1, 1);
+    let (reference, _) = loopback_shots(&circuit, 1, 20);
+    let expected = &reference[0];
+    let mut saw = [false, false];
+    for shot in expected {
+        assert_eq!(shot[0], shot[1], "copied bit must match the measured bit");
+        saw[shot[0] as usize] = true;
+    }
+    assert!(
+        saw[0] && saw[1],
+        "20 fair coin shots should hit both outcomes"
+    );
+    for size in [2usize, 4] {
+        let (per_rank, _) = loopback_shots(&circuit, size, 20);
+        for shots in &per_rank {
+            assert_eq!(shots, expected, "size {size}");
+        }
+    }
+}
+
+#[test]
+fn noisy_shots_rejected_on_distributed_kind() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(crate::gates::Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    let noise = crate::sim::noise::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+    let kind = crate::sim::BackendKind::StatevectorDistributed {
+        context: DistributedContext::serial(),
+    };
+    let err = crate::sim::run_shots_with_noise(kind, &circuit, &noise, 10, SEED).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::PrismError::IncompatibleBackend { .. }
+    ));
+}
+
+#[test]
+fn shots_without_measurements_still_validate_configuration() {
+    relax_min_local_qubits();
+    // Three ranks is not a power of two; the error must surface even though a
+    // circuit without measurements needs no execution to produce all false shots.
+    // The init failure happens before any collective, so ranks do not block.
+    let circuit = Circuit::new(4, 0);
+    let shared = LoopbackShared::new(3);
+    let handles: Vec<_> = (0..3)
+        .map(|rank| {
+            let comm = LoopbackComm {
+                shared: shared.clone(),
+                rank,
+            };
+            let circuit = circuit.clone();
+            std::thread::spawn(move || {
+                let ctx = DistributedContext::from_comm(Arc::new(comm));
+                let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
+                crate::sim::run_shots_with(kind, &circuit, 8, SEED).is_err()
+            })
+        })
+        .collect();
+    for handle in handles {
+        assert!(
+            handle.join().unwrap(),
+            "non power of two rank count must error"
+        );
+    }
 }

--- a/src/distributed/comm.rs
+++ b/src/distributed/comm.rs
@@ -31,6 +31,24 @@ pub trait RankComm: std::fmt::Debug + Send + Sync {
     /// Sum a scalar across all ranks; every rank receives the total.
     fn allreduce_sum_f64(&self, value: f64) -> f64;
 
+    /// Elementwise sum of `values` across all ranks, in place. Every rank
+    /// receives the same per-element totals.
+    ///
+    /// The default gathers every rank's block and sums elementwise, which
+    /// costs `size * len` transfer. Override with a native reduction when the
+    /// transport has one.
+    fn allreduce_sum_f64_slice(&self, values: &mut [f64]) {
+        let n = values.len();
+        if n == 0 {
+            return;
+        }
+        let gathered = self.allgather_f64(values);
+        values.fill(0.0);
+        for (i, &v) in gathered.iter().enumerate() {
+            values[i % n] += v;
+        }
+    }
+
     /// Exchange equal length amplitude blocks with `partner`.
     ///
     /// On return, `recv` holds `partner`'s `send` block. `send` and `recv` must
@@ -70,6 +88,9 @@ impl RankComm for SerialComm {
     fn allreduce_sum_f64(&self, value: f64) -> f64 {
         value
     }
+
+    #[inline]
+    fn allreduce_sum_f64_slice(&self, _values: &mut [f64]) {}
 
     #[inline]
     fn sendrecv_c64(&self, _partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
@@ -173,6 +194,13 @@ impl RankComm for MpiComm {
         self.world
             .all_reduce_into(&value, &mut out, mpi::collective::SystemOperation::sum());
         out
+    }
+
+    fn allreduce_sum_f64_slice(&self, values: &mut [f64]) {
+        use mpi::traits::CommunicatorCollectives;
+        let send = values.to_vec();
+        self.world
+            .all_reduce_into(&send[..], values, mpi::collective::SystemOperation::sum());
     }
 
     fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -226,8 +226,6 @@ pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> 
         | BackendKind::DeterministicPauli { .. } => false,
         #[cfg(feature = "gpu")]
         BackendKind::StabilizerGpu { .. } => false,
-        #[cfg(feature = "distributed")]
-        BackendKind::StatevectorDistributed { context } => context.size() == 1,
         BackendKind::Auto => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
         _ => true,
     }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -9,7 +9,7 @@ mod dispatch;
 pub mod homological;
 pub mod noise;
 mod probability;
-mod shots;
+pub(crate) mod shots;
 pub mod stabilizer_rank;
 mod terminal_sampling;
 mod trajectory;
@@ -713,6 +713,76 @@ fn run_marginals_result_with(
     }
 }
 
+/// Multi-shot execution for the distributed statevector backend.
+///
+/// Every rank runs this function in lockstep. Circuits with only terminal
+/// measurements run once and sample basis indices without gathering the dense
+/// state on any rank. Circuits with mid-circuit measurements run once per shot,
+/// prefused, with per-shot seeds matching the generic slow path.
+#[cfg(feature = "distributed")]
+fn run_shots_distributed(
+    context: std::sync::Arc<crate::distributed::DistributedContext>,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> Result<ShotsResult> {
+    use crate::backend::distributed_statevector::DistributedStatevectorBackend;
+
+    let meas_map = circuit.measurement_map();
+    if meas_map.is_empty() {
+        // No measurements means every shot is all false, but init must still
+        // run so invalid rank counts and local qubit floor violations surface as
+        // errors instead of fabricated output.
+        let mut backend = DistributedStatevectorBackend::new(context, seed);
+        backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
+        return Ok(ShotsResult {
+            shots: vec![vec![false; circuit.num_classical_bits]; num_shots],
+            num_classical_bits: circuit.num_classical_bits,
+        });
+    }
+
+    if circuit.has_terminal_measurements_only() {
+        let stripped = circuit.without_measurements();
+        let mut backend = DistributedStatevectorBackend::new(context, seed);
+        execute(&mut backend, &stripped, &SimOptions::classical_only())?;
+        let indices = backend.sample_state_indices(num_shots, seed)?;
+        let shots = indices
+            .iter()
+            .map(|&idx| {
+                let mut shot = vec![false; circuit.num_classical_bits];
+                for &(qubit, cbit) in &meas_map {
+                    shot[cbit] = (idx >> qubit) & 1 == 1;
+                }
+                shot
+            })
+            .collect();
+        return Ok(ShotsResult {
+            shots,
+            num_classical_bits: circuit.num_classical_bits,
+        });
+    }
+
+    let probe = DistributedStatevectorBackend::new(context.clone(), seed);
+    let expanded: std::borrow::Cow<'_, Circuit> = if probe.supports_qft_block() {
+        std::borrow::Cow::Borrowed(circuit)
+    } else {
+        crate::circuit::expand_qft_blocks(circuit)
+    };
+    let fused = crate::circuit::fusion::fuse_circuit(&expanded, probe.supports_fused_gates());
+    let opts = SimOptions::classical_only();
+    let mut shots = Vec::with_capacity(num_shots);
+    for i in 0..num_shots {
+        let shot_seed = seed.wrapping_add(i as u64);
+        let mut backend = DistributedStatevectorBackend::new(context.clone(), shot_seed);
+        let result = execute_circuit(&mut backend, &fused, &opts)?;
+        shots.push(result.classical_bits);
+    }
+    Ok(ShotsResult {
+        shots,
+        num_classical_bits: circuit.num_classical_bits,
+    })
+}
+
 /// Execute a circuit multiple times with explicit backend selection.
 pub(crate) fn run_shots_with(
     kind: BackendKind,
@@ -720,6 +790,14 @@ pub(crate) fn run_shots_with(
     num_shots: usize,
     seed: u64,
 ) -> Result<ShotsResult> {
+    // The distributed backend runs every rank in lockstep, so shot execution
+    // must not route through shortcuts that reshape the collective call
+    // sequence. Dispatch directly.
+    #[cfg(feature = "distributed")]
+    if let BackendKind::StatevectorDistributed { context } = &kind {
+        return run_shots_distributed(context.clone(), circuit, num_shots, seed);
+    }
+
     // Compiled sampler: O(n²·m) compile + O(r·m/64) per shot with LUT.
     // Always polynomial, avoids the O(2^k) probability computation path.
     // Explicit `StabilizerGpu` attaches its CUDA context here so repeated shot
@@ -922,6 +1000,20 @@ pub(crate) fn run_shots_with_noise(
     num_shots: usize,
     seed: u64,
 ) -> Result<ShotsResult> {
+    // Trajectory execution runs shots on Rayon worker threads, whose
+    // scheduling order differs per rank. Per-shot distributed backends would
+    // issue collectives out of lockstep and deadlock or corrupt exchanges.
+    // Reject until a lockstep noisy path exists.
+    #[cfg(feature = "distributed")]
+    if matches!(kind, BackendKind::StatevectorDistributed { .. }) {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "noisy shot sampling is not supported on the distributed backend; \
+                     trajectory execution cannot keep rank collectives in lockstep"
+                .into(),
+        });
+    }
+
     if !kind.supports_noisy_per_shot() {
         return Err(crate::error::PrismError::IncompatibleBackend {
             backend: format!("{kind:?}"),

--- a/src/sim/shots.rs
+++ b/src/sim/shots.rs
@@ -88,14 +88,14 @@ pub(super) fn build_cdf(probs: &[f64]) -> Vec<f64> {
     cdf
 }
 
-pub(super) fn sample_from_cdf(cdf: &[f64], r: f64) -> usize {
+pub(crate) fn sample_from_cdf(cdf: &[f64], r: f64) -> usize {
     match cdf.binary_search_by(|p| p.partial_cmp(&r).unwrap_or(std::cmp::Ordering::Equal)) {
         Ok(i) => i,
         Err(i) => i.min(cdf.len() - 1),
     }
 }
 
-pub(super) fn sample_shots(
+pub(crate) fn sample_shots(
     probs: &Probabilities,
     meas_map: &[(usize, usize)],
     num_classical_bits: usize,


### PR DESCRIPTION
## Summary

Adds distributed statevector shot execution for terminal and mid-circuit measurement workloads. Terminal measurement circuits sample basis indices without gathering the dense state, while mid-circuit measurement circuits run lockstep shots with seeds matching the generic slow path. Noisy distributed shots are rejected until trajectory execution can preserve rank collective ordering.

## Scope

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Benchmark data has not been collected. Required before merge because this changes distributed statevector shot execution.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| Distributed terminal shot sampling | Not run | Not run | N/A | No |

Regression verdict: FAIL until benchmark data is attached.

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend: N/A, no new gate, backend, or fusion pass
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`: N/A, no GPU change

Additional validation: `cargo test --features distributed shots_` passes.

## Hotspot notes

Touches `DistributedStatevectorBackend::sample_state_indices`, `restore_identity_map`, `swap_physical_positions`, `run_shots_distributed`, and `RankComm::allreduce_sum_f64_slice`.

Terminal shot sampling avoids dense state gathers by sharing one mass value per rank and distributing sampled indices through tiled reductions. Profiler output has not been collected.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

Capability docs and module docs were updated. Add a performance decision log entry before merge if this is treated as a major performance decision.

## Breaking changes

No public API breakage.

Distributed noisy shots now return `IncompatibleBackend` instead of entering trajectory execution.

## Risks and rollback

Primary risk is collective ordering drift across ranks or sampling differences near cumulative distribution boundaries. Roll back by removing the direct distributed shot dispatch and returning the distributed backend to the previous unsupported shot path. The feature remains gated behind `distributed` and `distributed-mpi`.

## Pre-merge checklist

- [ ] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green