### PR TITLE
fix: only use latest macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
 
   test-macos-arm:
     name: Test macOS ARM64
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,8 +26,7 @@ jobs:
       matrix:
         platform:
           - { os: linux, runner: ubuntu-latest, target: x86_64 }
-          - { os: macos, runner: macos-13, target: x86_64 }
-          - { os: macos, runner: macos-14, target: aarch64 }
+          - { os: macos, runner: macos-latest, target: aarch64 }
           - { os: windows, runner: windows-latest, target: x64 }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Just updating to latest for GH mac os workflows. Seems these runners are picked up faster + we should just use this.