### PR TITLE
feat(sim): add Pauli expectation value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use sim::unified_pauli::{
 };
 pub use sim::{
     BackendKind, CountsResult, FactoredBlock, MarginalsResult, Probabilities, RunOutcome, Seeded,
-    ShotsResult, Simulate, Unseeded, bitstring, run_on, run_qasm, simulate,
+    ShotsResult, Simulate, Unseeded, bitstring, run_expectation_values, run_on, run_qasm, simulate,
 };
 
 #[cfg(feature = "gpu")]

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -33,12 +33,15 @@ pub use shots::{ShotsResult, bitstring};
 
 use std::collections::HashMap;
 
+use num_complex::Complex64;
+
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::{Backend, max_statevector_qubits};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 use shots::{packed_shots_to_classical_bits, sample_shots};
 use terminal_sampling::{sample_counts_from_state, sample_shots_from_state};
+use unified_pauli::{PauliAxis, PauliTerm};
 
 type TerminalStatevector = (StatevectorBackend, Vec<(usize, usize)>);
 
@@ -214,6 +217,24 @@ impl<'c> Simulate<'c, Seeded> {
             });
         }
         run_marginals_result_with(self.kind, self.circuit, seed)
+    }
+
+    /// Compute `⟨ψ|P|ψ⟩` for each joint Pauli observable on the circuit's
+    /// output state, honoring the selected backend.
+    ///
+    /// Each observable is a product of single-qubit Paulis (identity factors
+    /// omitted). The circuit must be unitary. Clifford circuits propagate each
+    /// observable exactly; non-Clifford circuits use the state vector.
+    #[inline]
+    pub fn expectation_values(self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let seed = self.seed_value();
+        if self.noise_model.is_some() {
+            return Err(PrismError::BackendUnsupported {
+                backend: format!("{:?}", self.kind),
+                operation: "expectation values with an inline noise model".into(),
+            });
+        }
+        run_expectation_values_with(self.kind, self.circuit, observables, seed)
     }
 }
 
@@ -711,6 +732,188 @@ fn run_marginals_result_with(
             ),
         })
     }
+}
+
+/// Compute `⟨ψ|P|ψ⟩` for each joint Pauli observable on a unitary circuit's
+/// output state, using automatic backend selection. See
+/// [`Simulate::expectation_values`] for explicit backend control.
+pub fn run_expectation_values(
+    circuit: &Circuit,
+    observables: &[Vec<PauliTerm>],
+    seed: u64,
+) -> Result<Vec<f64>> {
+    run_expectation_values_with(BackendKind::Auto, circuit, observables, seed)
+}
+
+fn run_expectation_values_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    observables: &[Vec<PauliTerm>],
+    seed: u64,
+) -> Result<Vec<f64>> {
+    if has_nonunitary_or_classical_ops(circuit) {
+        return Err(PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "expectation values require a unitary circuit without measurements, resets, or conditionals".into(),
+        });
+    }
+
+    match &kind {
+        BackendKind::StochasticPauli { num_samples } => observables
+            .iter()
+            .enumerate()
+            .map(|(i, obs)| {
+                unified_pauli::run_spp_observable(
+                    circuit,
+                    obs,
+                    *num_samples,
+                    seed.wrapping_add(i as u64),
+                )
+                .map(|r| r.mean)
+            })
+            .collect(),
+        BackendKind::DeterministicPauli { epsilon, max_terms } => observables
+            .iter()
+            .map(|obs| {
+                unified_pauli::run_spd_observable(circuit, obs, *epsilon, *max_terms)
+                    .map(|r| r.mean)
+            })
+            .collect(),
+        BackendKind::Auto | BackendKind::Stabilizer | BackendKind::FactoredStabilizer => {
+            if circuit.is_clifford_only() {
+                observables
+                    .iter()
+                    .map(|obs| {
+                        unified_pauli::run_spd_observable(circuit, obs, 0.0, 0).map(|r| r.mean)
+                    })
+                    .collect()
+            } else if matches!(kind, BackendKind::Auto) {
+                if circuit.num_qubits > max_statevector_qubits() {
+                    return Err(PrismError::IncompatibleBackend {
+                        backend: format!("{kind:?}"),
+                        reason: format!(
+                            "expectation values for a {}-qubit non-Clifford circuit exceed the statevector cap ({} qubits); no exact accelerated path exists for arbitrary Pauli observables here",
+                            circuit.num_qubits,
+                            max_statevector_qubits()
+                        ),
+                    });
+                }
+                expectation_values_statevector(circuit, observables, seed)
+            } else {
+                Err(PrismError::IncompatibleBackend {
+                    backend: format!("{kind:?}"),
+                    reason: "stabilizer backends require a Clifford-only circuit".into(),
+                })
+            }
+        }
+        BackendKind::Statevector => expectation_values_statevector(circuit, observables, seed),
+        other => Err(PrismError::IncompatibleBackend {
+            backend: format!("{other:?}"),
+            reason: "expectation values support Auto, Statevector, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli".into(),
+        }),
+    }
+}
+
+fn expectation_values_statevector(
+    circuit: &Circuit,
+    observables: &[Vec<PauliTerm>],
+    seed: u64,
+) -> Result<Vec<f64>> {
+    // Validate before the 2^n simulation so bad observables fail cheaply.
+    let masks = observables
+        .iter()
+        .map(|obs| pauli_masks(obs, circuit.num_qubits))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut backend = StatevectorBackend::new(seed);
+    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
+        std::borrow::Cow::Borrowed(circuit)
+    } else {
+        crate::circuit::expand_qft_blocks(circuit)
+    };
+    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    backend.init(fused.num_qubits, fused.num_classical_bits)?;
+    backend.apply_instructions(&fused.instructions)?;
+
+    let state = backend.state_vector();
+    let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+    Ok(masks
+        .iter()
+        .map(|&(xmask, zmask, num_y)| {
+            pauli_expectation_from_masks(state, xmask, zmask, num_y, norm)
+        })
+        .collect())
+}
+
+/// Validate a joint Pauli observable and reduce it to `(Xmask, Zmask, #Y)`,
+/// where `Xmask` covers X and Y factors and `Zmask` covers Z and Y factors.
+fn pauli_masks(observable: &[PauliTerm], num_qubits: usize) -> Result<(usize, usize, u32)> {
+    let mut xmask = 0usize;
+    let mut zmask = 0usize;
+    let mut num_y = 0u32;
+    let mut seen = vec![false; num_qubits];
+    for term in observable {
+        if term.qubit >= num_qubits {
+            return Err(PrismError::InvalidQubit {
+                index: term.qubit,
+                register_size: num_qubits,
+            });
+        }
+        if seen[term.qubit] {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "joint Pauli observable has duplicate factor on qubit {}",
+                    term.qubit
+                ),
+            });
+        }
+        seen[term.qubit] = true;
+        let bit = 1usize << term.qubit;
+        match term.axis {
+            PauliAxis::X => xmask |= bit,
+            PauliAxis::Z => zmask |= bit,
+            PauliAxis::Y => {
+                xmask |= bit;
+                zmask |= bit;
+                num_y += 1;
+            }
+        }
+    }
+    Ok((xmask, zmask, num_y))
+}
+
+/// Exact `⟨ψ|P|ψ⟩` from the reduced observable masks, where `P` acts as
+/// `P|j⟩ = i^{#Y}·(-1)^{popcount(j & Zmask)}·|j ⊕ Xmask⟩`. Normalization
+/// independent, so raw backend amplitudes are fine.
+fn pauli_expectation_from_masks(
+    state: &[Complex64],
+    xmask: usize,
+    zmask: usize,
+    num_y: u32,
+    norm: f64,
+) -> f64 {
+    if norm == 0.0 {
+        return 0.0;
+    }
+
+    let mut acc = Complex64::new(0.0, 0.0);
+    for (j, &amp) in state.iter().enumerate() {
+        let partner = state[j ^ xmask];
+        let sign = if (j & zmask).count_ones() & 1 == 1 {
+            -1.0
+        } else {
+            1.0
+        };
+        acc += partner.conj() * amp * sign;
+    }
+
+    let i_pow = match num_y % 4 {
+        0 => Complex64::new(1.0, 0.0),
+        1 => Complex64::new(0.0, 1.0),
+        2 => Complex64::new(-1.0, 0.0),
+        _ => Complex64::new(0.0, -1.0),
+    };
+    (acc * i_pow).re / norm
 }
 
 /// Multi-shot execution for the distributed statevector backend.

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -1,0 +1,183 @@
+//! Public API coverage for `run_expectation_values` and
+//! `Simulate::expectation_values`.
+
+use prism_q::gates::Gate;
+use prism_q::{BackendKind, Circuit, PauliAxis, PauliTerm, run_expectation_values, simulate};
+
+const TOL: f64 = 1e-10;
+
+fn bell() -> Circuit {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c
+}
+
+fn assert_close(got: &[f64], want: &[f64], tol: f64) {
+    assert_eq!(got.len(), want.len());
+    for (g, w) in got.iter().zip(want) {
+        assert!((g - w).abs() < tol, "got {g}, want {w}");
+    }
+}
+
+#[test]
+fn clifford_expectations_are_exact() {
+    // Bell state: <ZZ>=<XX>=1, <YY>=-1, <Z0>=0, and the empty (identity) = 1.
+    let vals = run_expectation_values(
+        &bell(),
+        &[
+            vec![PauliTerm::z(0), PauliTerm::z(1)],
+            vec![PauliTerm::x(0), PauliTerm::x(1)],
+            vec![PauliTerm::y(0), PauliTerm::y(1)],
+            vec![PauliTerm::z(0)],
+            vec![],
+        ],
+        42,
+    )
+    .unwrap();
+    assert_close(&vals, &[1.0, 1.0, -1.0, 0.0, 1.0], TOL);
+}
+
+#[test]
+fn plus_state_single_qubit() {
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::H, &[0]);
+    let vals = run_expectation_values(
+        &c,
+        &[
+            vec![PauliTerm::x(0)],
+            vec![PauliTerm::y(0)],
+            vec![PauliTerm::z(0)],
+        ],
+        42,
+    )
+    .unwrap();
+    assert_close(&vals, &[1.0, 0.0, 0.0], TOL);
+}
+
+#[test]
+fn non_clifford_statevector_route_matches_analytic() {
+    let theta = 0.7_f64;
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::Rx(theta), &[0]);
+    // Rx(theta)|0>: <X>=0, <Y>=-sin(theta), <Z>=cos(theta).
+    let vals = run_expectation_values(
+        &c,
+        &[
+            vec![PauliTerm::x(0)],
+            vec![PauliTerm::y(0)],
+            vec![PauliTerm::z(0)],
+        ],
+        42,
+    )
+    .unwrap();
+    assert_close(&vals, &[0.0, -theta.sin(), theta.cos()], TOL);
+}
+
+#[test]
+fn clifford_route_matches_statevector_route() {
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::S, &[0]);
+    let observables = [
+        vec![PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)],
+        vec![PauliTerm::z(0), PauliTerm::z(2)],
+        vec![PauliTerm::new(1, PauliAxis::X)],
+    ];
+    let auto = run_expectation_values(&c, &observables, 42).unwrap();
+    let sv = simulate(&c)
+        .backend(BackendKind::Statevector)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    assert_close(&auto, &sv, TOL);
+}
+
+#[test]
+fn clifford_t_deterministic_pauli_matches_statevector() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::H, &[1]);
+    let observables = [
+        vec![PauliTerm::x(0), PauliTerm::x(1)],
+        vec![PauliTerm::z(0)],
+    ];
+    let sv = simulate(&c)
+        .backend(BackendKind::Statevector)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    let spd = simulate(&c)
+        .backend(BackendKind::DeterministicPauli {
+            epsilon: 0.0,
+            max_terms: 0,
+        })
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    assert_close(&spd, &sv, 1e-9);
+}
+
+#[test]
+fn stochastic_pauli_seeds_each_observable_independently() {
+    // H,T,H gives a stochastic estimate; two identical observables must draw
+    // from distinct sample streams rather than sharing one seed.
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::H, &[0]);
+    let z0 = vec![PauliTerm::z(0)];
+    let vals = simulate(&c)
+        .backend(BackendKind::StochasticPauli { num_samples: 64 })
+        .seed(42)
+        .expectation_values(&[z0.clone(), z0])
+        .unwrap();
+    assert!(vals[0] != vals[1], "identical observables shared a seed");
+}
+
+#[test]
+fn invalid_observable_is_rejected() {
+    use prism_q::PrismError::{InvalidParameter, InvalidQubit};
+    let c = bell();
+    assert!(matches!(
+        run_expectation_values(&c, &[vec![PauliTerm::z(5)]], 42).unwrap_err(),
+        InvalidQubit { .. }
+    ));
+    assert!(matches!(
+        run_expectation_values(&c, &[vec![PauliTerm::z(0), PauliTerm::x(0)]], 42).unwrap_err(),
+        InvalidParameter { .. }
+    ));
+}
+
+#[test]
+fn non_unitary_circuit_is_rejected() {
+    // Rejected for every backend kind, with empty and non-empty observables.
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\nh q[0];\nc[0] = measure q[0];";
+    let c = prism_q::circuit::openqasm::parse(qasm).unwrap();
+    let observables: [&[Vec<PauliTerm>]; 2] = [&[], &[vec![PauliTerm::z(0)]]];
+    for backend in [
+        BackendKind::Auto,
+        BackendKind::Statevector,
+        BackendKind::DeterministicPauli {
+            epsilon: 0.0,
+            max_terms: 0,
+        },
+        BackendKind::StochasticPauli { num_samples: 16 },
+    ] {
+        for obs in observables {
+            let err = simulate(&c)
+                .backend(backend.clone())
+                .seed(42)
+                .expectation_values(obs)
+                .unwrap_err();
+            assert!(
+                matches!(err, prism_q::PrismError::IncompatibleBackend { .. }),
+                "{backend:?} accepted a non-unitary circuit"
+            );
+        }
+    }
+}

--- a/tests/expectation_values_oversize.rs
+++ b/tests/expectation_values_oversize.rs
@@ -1,0 +1,27 @@
+//! Oversize guard for the Auto non-Clifford expectation-value route.
+//!
+//! Isolated in its own test binary: it overrides `PRISM_MAX_SV_QUBITS`, which
+//! `max_statevector_qubits()` caches per process, so it must not share a process
+//! with tests that expect the real memory-derived cap.
+
+use prism_q::gates::Gate;
+use prism_q::{Circuit, PauliTerm, run_expectation_values};
+
+#[test]
+fn auto_non_clifford_oversize_returns_clean_error() {
+    // SAFETY: single test in this binary; the variable is set before any cap
+    // query and no other thread is running.
+    unsafe { std::env::set_var("PRISM_MAX_SV_QUBITS", "4") };
+
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, 1]);
+
+    let err = run_expectation_values(&c, &[vec![PauliTerm::z(0)]], 42).unwrap_err();
+    assert!(
+        matches!(err, prism_q::PrismError::IncompatibleBackend { .. }),
+        "expected a clean statevector-cap error, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Add `run_expectation_values` and `Simulate::expectation_values`, which return
the expectation value of joint Pauli string observables on the output state of
a unitary circuit. This gives VQE and QAOA users a direct observable API
instead of reconstructing values from probabilities.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot path changes. The feature adds a new API and does not alter gate
kernels, fusion, or dispatch of existing backends.

Regression verdict: PASS

## Correctness

- [x] Tests pass locally (`cargo nextest run`, 1663 passing, plus doctests)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New behavior has tests against the statevector backend
- [ ] GPU affecting change runs golden_gpu

Note: the all features variants (`gpu`, `distributed`) were deferred to CI
because the local host lacks the CUDA toolkit and libclang for the MPI
bindings. The feature touches neither path.

## Hotspot notes

N/A.

## Architecture or design changes

- [ ] docs/architecture updated
- [ ] Design or research notes added

No structural change. Routing reuses the existing Pauli propagation and
statevector paths.

## Breaking changes

None. The change is additive.

## Risks and rollback

Low blast radius. The new functions are self contained and unused by existing
run, shots, and marginals paths, so a revert removes the API without affecting
other behavior

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
