### PR TITLE
test(bench): add opt-in 28q/30q statevector Criterion rows

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -66,6 +66,19 @@ fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement:
     }
 }
 
+/// Statevector rows above 26q, opted in via `PRISM_BENCH_HIGH_QUBITS=<max>`.
+///
+/// Off by default: a dense `.run()` holds the statevector and its readback
+/// probability vector at once, so 28q peaks near 6 GiB and 30q near 24 GiB.
+/// `<max>` bounds the largest row a host admits.
+fn high_qubit_sizes() -> Vec<usize> {
+    let cap: usize = std::env::var("PRISM_BENCH_HIGH_QUBITS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0);
+    [28, 30].into_iter().filter(|&n| n <= cap).collect()
+}
+
 // ---- Bench-specific circuit builders (not shared) ----
 
 fn qft_like_circuit(n_qubits: usize) -> Circuit {
@@ -259,7 +272,9 @@ fn bench_statevector_random(c: &mut Criterion) {
     let mut group = c.benchmark_group("statevector/random_d10");
     configure_group(&mut group);
 
-    for &n in &[4, 8, 12, 16, 20] {
+    let mut sizes = vec![4, 8, 12, 16, 20];
+    sizes.extend(high_qubit_sizes());
+    for &n in &sizes {
         let circuit = circuits::random_circuit(n, 10, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
@@ -323,7 +338,9 @@ fn bench_statevector_qft_textbook(c: &mut Criterion) {
     let mut group = c.benchmark_group("statevector/qft_textbook");
     configure_group(&mut group);
 
-    for &n in &[4, 8, 12, 16, 20, 22, 24, 26] {
+    let mut sizes = vec![4, 8, 12, 16, 20, 22, 24, 26];
+    sizes.extend(high_qubit_sizes());
+    for &n in &sizes {
         let circuit = circuits::qft_circuit(n);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {


### PR DESCRIPTION
## Summary

Extend the statevector Criterion sweeps to 28q and 30q so high-qubit
optimization work has named baseline rows to measure against. The rows are
opt-in via `PRISM_BENCH_HIGH_QUBITS=<max>` and off by default, since a dense
run at these sizes needs several to tens of GiB. No simulation code is touched.

## Scope

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. This PR adds benchmark rows only; no simulation,
fusion, or kernel code is touched. With `PRISM_BENCH_HIGH_QUBITS` unset the
existing rows are byte-identical.

New-row sanity reading (not a regression baseline; bench-fast, i7-6700K,
`--features parallel`):

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| statevector/qft_textbook/28 | (new row) | ~20.1 s/iter | n/a | n/a |
| statevector/qft_textbook/30 | (new row) | not run locally (~24 GiB) | n/a | n/a |

Regression verdict: PASS (no hot-path code changed)

## Correctness

- [ ] `cargo test --all-features` passes locally (not run; no source under test changed, bench harness only)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (defer to CI)
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes (defer to CI; no public API added)
- [ ] New public API has docstrings (N/A, helper is private)
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend (N/A)
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu` (N/A)

Build verified: `cargo bench --bench circuits --features parallel --no-run` compiles clean.

## Hotspot notes

N/A. No hot path touched. The change only registers additional Criterion rows;
the simulation, fusion, and kernel paths are unchanged.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural (N/A)
- [ ] Design or research notes added where required for new subsystems (N/A)

## Breaking changes

None. The new rows are inert unless `PRISM_BENCH_HIGH_QUBITS` is set, so the
default benchmark suite and all runtime behavior are unchanged.

## Risks and rollback

Blast radius is limited to the benchmark binary. The rows are gated behind
`PRISM_BENCH_HIGH_QUBITS` and off by default, so nothing new runs under a bare
`cargo bench` or in CI. A 30q run peaks near 24 GiB, so the cap lets a host
opt into 28q without 30q. Rollback is reverting a single bench file with no
runtime or API impact.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
