### PR TITLE
test(bench): add high-shot chunked sampling bench and memory profiler

### DIFF
--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -27,6 +27,21 @@ use std::time::Duration;
 const SEED: u64 = 0xDEAD_BEEF;
 const API_QUERY_SHOTS: usize = 100_000;
 
+// Base high-shot counts always run; 100M/1B are added only when
+// PRISM_BENCH_HIGH_SHOTS=<max> is set, capped by <max>, so a bare `cargo bench`
+// stays fast. A 1B row exercises the streaming chunked path, which sibling bulk
+// rows cannot reach without materializing every shot.
+fn high_shot_counts() -> Vec<usize> {
+    let cap: usize = std::env::var("PRISM_BENCH_HIGH_SHOTS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0);
+    [100_000_000, 1_000_000_000]
+        .into_iter()
+        .filter(|&n| n <= cap)
+        .collect()
+}
+
 fn run_shots_with(
     kind: BackendKind,
     circuit: &Circuit,
@@ -792,6 +807,65 @@ fn bench_analytical_marginals(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_chunked_high_shots(c: &mut Criterion) {
+    use prism_q::{HistogramAccumulator, MarginalsAccumulator, PauliExpectationAccumulator};
+
+    let mut group = c.benchmark_group("chunked_high_shots");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(3));
+
+    let mut shot_counts = vec![1_000_000, 10_000_000];
+    shot_counts.extend(high_shot_counts());
+
+    let clifford = clifford_circuit_with_measurements(100, 10);
+    let ghz = ghz_circuit_with_measurements(100);
+
+    for &shots in &shot_counts {
+        group.bench_with_input(
+            BenchmarkId::new("marginals/clifford_d10_100q", shots),
+            &shots,
+            |b, &shots| {
+                let mut sampler = prism_q::compile_measurements(&clifford, SEED).unwrap();
+                b.iter(|| {
+                    let mut acc = MarginalsAccumulator::new(100);
+                    sampler.sample_chunked(shots, &mut acc);
+                    acc.marginals()
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("expectation/clifford_d10_100q", shots),
+            &shots,
+            |b, &shots| {
+                let mut sampler = prism_q::compile_measurements(&clifford, SEED).unwrap();
+                let observables = vec![vec![0, 1], vec![10, 20], vec![50, 99]];
+                b.iter(|| {
+                    let mut acc = PauliExpectationAccumulator::new(observables.clone());
+                    sampler.sample_chunked(shots, &mut acc);
+                    acc.expectations()
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("histogram/ghz_100q", shots),
+            &shots,
+            |b, &shots| {
+                let mut sampler = prism_q::compile_measurements(&ghz, SEED).unwrap();
+                b.iter(|| {
+                    let mut acc = HistogramAccumulator::new();
+                    sampler.sample_chunked(shots, &mut acc);
+                    acc.into_counts()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_api_queries,
@@ -808,5 +882,6 @@ criterion_group!(
     bench_homological_compile,
     bench_homological_sample,
     bench_analytical_marginals,
+    bench_chunked_high_shots,
 );
 criterion_main!(benches);

--- a/examples/profile_chunked_memory.rs
+++ b/examples/profile_chunked_memory.rs
@@ -1,0 +1,203 @@
+//! Peak-memory profiler for the chunked (streaming) compiled-sampling path.
+//!
+//! `sample_chunked` folds one `PackedShots` chunk at a time into a bounded
+//! accumulator, so peak heap allocation should track the per-chunk budget
+//! (`default_chunk_size`) rather than the total shot count. A tracking global
+//! allocator records the allocated-bytes high-water mark of each run; the run
+//! passes when peak stays flat as total shots grow.
+//!
+//! Histogram is profiled on GHZ (two distinct outcomes) because its state grows
+//! with the number of distinct outcomes and is only chunk-bounded on a
+//! low-entropy circuit. Marginals and expectation are bounded on any circuit and
+//! use a high-rank Clifford circuit.
+//!
+//! ```text
+//! cargo run --release --features parallel --example profile_chunked_memory
+//! cargo run --release --features parallel --example profile_chunked_memory -- 1000000000
+//! ```
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+use prism_q::circuit::Circuit;
+use prism_q::circuits;
+use prism_q::sim::compiled::default_chunk_size;
+use prism_q::{
+    CompiledSampler, HistogramAccumulator, MarginalsAccumulator, PauliExpectationAccumulator,
+    compile_measurements,
+};
+
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct TrackingAlloc;
+
+// SAFETY: every method forwards to the System allocator with the caller's
+// original layout and only adds atomic byte counting around it, so all
+// GlobalAlloc safety obligations are discharged by System.
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwarding the caller's layout unchanged to System.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let now = CURRENT.fetch_add(layout.size(), Relaxed) + layout.size();
+            PEAK.fetch_max(now, Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        CURRENT.fetch_sub(layout.size(), Relaxed);
+        // SAFETY: `ptr`/`layout` are the pair returned by our `alloc`.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwarding the caller's pointer, layout, and new size to System.
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            if new_size >= layout.size() {
+                let now =
+                    CURRENT.fetch_add(new_size - layout.size(), Relaxed) + new_size - layout.size();
+                PEAK.fetch_max(now, Relaxed);
+            } else {
+                CURRENT.fetch_sub(layout.size() - new_size, Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static ALLOC: TrackingAlloc = TrackingAlloc;
+
+/// Pin the peak to the current live bytes and return that baseline, so a run's
+/// peak growth is measured above the memory already resident before it starts.
+fn reset_peak() -> usize {
+    let base = CURRENT.load(Relaxed);
+    PEAK.store(base, Relaxed);
+    base
+}
+
+fn peak() -> usize {
+    PEAK.load(Relaxed)
+}
+
+const SEED: u64 = 0xDEAD_BEEF;
+const QUBITS: usize = 100;
+const DEFAULT_SHOTS: [usize; 2] = [20_000_000, 100_000_000];
+/// Peak may vary run-to-run from allocator jitter and sub-chunk rounding on the
+/// smallest shot count; flag growth only when it clears this factor.
+const TOLERANCE: f64 = 1.5;
+
+fn measured(mut c: Circuit) -> Circuit {
+    let n = c.num_qubits;
+    c.num_classical_bits = n;
+    for i in 0..n {
+        c.add_measure(i, i);
+    }
+    c
+}
+
+fn mib(bytes: usize) -> String {
+    format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
+}
+
+fn profile_family(
+    name: &str,
+    num_meas: usize,
+    mut sampler: CompiledSampler,
+    shot_counts: &[usize],
+    mut run: impl FnMut(&mut CompiledSampler, usize) -> f64,
+) -> bool {
+    let m_words = num_meas.div_ceil(64);
+    let chunk = default_chunk_size(num_meas);
+    println!(
+        "\n{name}  (chunk_size={chunk} shots, chunk_buf~{})",
+        mib(chunk * m_words * 8)
+    );
+
+    let mut deltas = Vec::new();
+    for &shots in shot_counts {
+        let base = reset_peak();
+        let checksum = run(&mut sampler, shots);
+        let delta = peak().saturating_sub(base);
+        deltas.push(delta);
+        println!(
+            "  shots={shots:>13}  peak_alloc={:>11}  checksum={checksum:.4}",
+            mib(delta)
+        );
+    }
+
+    let first = *deltas.first().unwrap_or(&0);
+    let last = *deltas.last().unwrap_or(&0);
+    let bounded = last as f64 <= first as f64 * TOLERANCE;
+    println!(
+        "  -> {}",
+        if bounded {
+            "bounded"
+        } else {
+            "GROWS WITH SHOTS"
+        }
+    );
+    bounded
+}
+
+fn main() {
+    let shot_counts: Vec<usize> = match std::env::args()
+        .nth(1)
+        .and_then(|a| a.parse::<usize>().ok())
+    {
+        Some(extra) => DEFAULT_SHOTS.iter().copied().chain([extra]).collect(),
+        None => DEFAULT_SHOTS.to_vec(),
+    };
+
+    let clifford = measured(circuits::clifford_heavy_circuit(QUBITS, 10, SEED));
+    let ghz = measured(circuits::ghz_circuit(QUBITS));
+
+    let mut ok = true;
+
+    ok &= profile_family(
+        "histogram / ghz_100q",
+        QUBITS,
+        compile_measurements(&ghz, SEED).unwrap(),
+        &shot_counts,
+        |s, shots| {
+            let mut acc = HistogramAccumulator::new();
+            s.sample_chunked(shots, &mut acc);
+            acc.into_counts().len() as f64
+        },
+    );
+
+    ok &= profile_family(
+        "marginals / clifford_d10_100q",
+        QUBITS,
+        compile_measurements(&clifford, SEED).unwrap(),
+        &shot_counts,
+        |s, shots| {
+            let mut acc = MarginalsAccumulator::new(QUBITS);
+            s.sample_chunked(shots, &mut acc);
+            acc.marginals().iter().sum()
+        },
+    );
+
+    ok &= profile_family(
+        "expectation / clifford_d10_100q",
+        QUBITS,
+        compile_measurements(&clifford, SEED).unwrap(),
+        &shot_counts,
+        |s, shots| {
+            let mut acc =
+                PauliExpectationAccumulator::new(vec![vec![0, 1], vec![10, 20], vec![50, 99]]);
+            s.sample_chunked(shots, &mut acc);
+            acc.expectations().iter().sum()
+        },
+    );
+
+    if ok {
+        println!("\nPASS: peak allocation stays bounded by chunk_size across shot counts");
+    } else {
+        eprintln!("\nFAIL: peak allocation grew with total shots");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
## Summary

Add focused measurement coverage for the streaming (chunked) compiled-sampling
path: a 1B-capable Criterion group and a selfverifying memory profiler.
Together they give high shot sampling named baseline rows and empirically confirm
that peak memory stays bounded by chunk size rather than total shots. No
simulation code is touched.

## Scope

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. This PR adds a benchmark group and a profiling example
only; no sampling, accumulator, fusion, or kernel code is modified. With
PRISM_BENCH_HIGH_SHOTS unset the new group tops out at 10M and adds only fast
rows.

Informational readings (not a regression baseline; i7-6700K, --features parallel):

| Row | Shots | Time |
| --- | --- | --- |
| chunked_high_shots/marginals/clifford_d10_100q | 1M | 9.1 ms |
| chunked_high_shots/marginals/clifford_d10_100q | 10M | 58.8 ms |
| chunked_high_shots/marginals/clifford_d10_100q | 100M (gated) | 521 ms |

Profiler peak-allocation (bounded across a 5x shot range, ~256 MiB chunk budget):

| Accumulator | 20M | 100M |
| --- | --- | --- |
| histogram / ghz_100q | 237.6 MiB | 237.5 MiB |
| marginals / clifford_d10_100q | 206.3 MiB | 206.3 MiB |
| expectation / clifford_d10_100q | 206.3 MiB | 208.3 MiB |

Regression verdict: PASS (no hot-path code changed)

## Correctness

- [ ] `cargo test --all-features` passes locally (not run; no source under test changed)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings` passes
- [ ] `cargo fmt --check` passes -> passes (checked)
- [ ] `cargo doc --no-deps --all-features` passes (defer to CI; no public API added)
- [ ] New public API has docstrings (N/A)
- [ ] New gate, backend, or fusion pass has golden tests (N/A)
- [ ] GPU-affecting change runs golden_gpu (N/A)

Functional verification: `cargo run --release --features parallel --example
profile_chunked_memory` prints PASS with peak flat across shot counts. The
chunked bench group runs the default and gated rows without materializing every
shot.

Note: `clippy --all-features` cannot run on this host (pre-existing mpi-sys /
libclang toolchain gap under the distributed-mpi feature); neither changed file
touches MPI or GPU code, so clippy was scoped to `--features parallel`.

## Hotspot notes

N/A. No hot path touched. The change registers a new Criterion group and adds a
standalone profiling example.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural (N/A)
- [ ] Design or research notes added where required for new subsystems (N/A)

## Breaking changes

None. The example installs a tracking global allocator only within its own
binary; the library and all runtime behavior are unchanged. The new bench rows
are inert above 10M unless PRISM_BENCH_HIGH_SHOTS is set.

## Risks and rollback

Blast radius is limited to the benchmark binary and one example. High-shot rows
are gated behind PRISM_BENCH_HIGH_SHOTS and off by default; a 1B row is ~5 s per
iteration, hence opt-in. Rollback is reverting one bench file and deleting one
example, with no runtime or API impact.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
