### PR TITLE
feat(examples): add qv profile circuit

### DIFF
--- a/examples/profile_circuit.rs
+++ b/examples/profile_circuit.rs
@@ -29,9 +29,10 @@ fn build_circuit(name: &str, n: usize) -> Circuit {
         "ghz" => circuits::ghz_circuit(n),
         "deep" => circuits::random_circuit(n, 50, SEED),
         "qaoa" => circuits::qaoa_circuit(n, 3, SEED),
+        "qv" => circuits::quantum_volume_circuit(n, n, SEED),
         other => {
             eprintln!("Unknown circuit: {other}");
-            eprintln!("Available: qft, random, hea, qpe, clifford, ghz, deep, qaoa");
+            eprintln!("Available: qft, random, hea, qpe, clifford, ghz, deep, qaoa, qv");
             std::process::exit(1);
         }
     }
@@ -110,7 +111,7 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 {
         eprintln!("Usage: profile_circuit <circuit> <n_qubits> [iterations]");
-        eprintln!("  circuit: qft | random | hea | qpe | clifford | ghz | deep | qaoa");
+        eprintln!("  circuit: qft | random | hea | qpe | clifford | ghz | deep | qaoa | qv");
         eprintln!("  iterations: default 5");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

Adds quantum volume (`qv`) support to the `profile_circuit` example so the profiler can inspect the same QV workload already covered by the benchmark suite. Fixes #53.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| N/A | N/A | N/A | N/A | N/A |

Regression verdict: WAIVER

This only adds an example CLI dispatch branch and help text; simulator hot paths are unchanged.

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [ ] `cargo doc --no-deps --all-features` passes
- [ ] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Local commands run:

- `cargo run --features parallel --example profile_circuit -- qv 4 1`
- `cargo run --release --features parallel --example profile_circuit -- qv 12 3`
- `cargo fmt --all -- --check`
- `cargo test --features parallel`
- `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks`
- `cargo doc --no-deps --features parallel`
- `cargo test --doc --features parallel`

Local `--all-features` commands were blocked by missing system MPI libraries for the optional `distributed-mpi` feature: `mpi-sys` could not find MPICH/OpenMPI.

## Hotspot notes

N/A, no hot paths were touched.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No structural changes.

## Breaking changes

None.

## Risks and rollback

Low risk: this only adds a new accepted example circuit name. Rollback is reverting the example dispatch/help text change.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
