### PR TITLE
chore(circuit): add reset to CircuitBuilder

### DIFF
--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -128,6 +128,15 @@ impl CircuitBuilder {
         self
     }
 
+    /// Reset `qubit` to |0⟩.
+    ///
+    /// # Panics
+    /// Panics if `qubit` is out of bounds.
+    pub fn reset(&mut self, qubit: usize) -> &mut Self {
+        self.circuit.add_reset(qubit);
+        self
+    }
+
     /// Measure all qubits into classical bits with matching indices.
     ///
     /// Expands `num_classical_bits` if needed to accommodate all qubits.
@@ -237,6 +246,26 @@ mod tests {
             .filter(|i| matches!(i, Instruction::Measure { .. }))
             .collect();
         assert_eq!(measures.len(), 3);
+    }
+
+    #[test]
+    fn builder_reset_emits_instruction_and_chains() {
+        let c = CircuitBuilder::new(2).x(0).reset(0).h(1).build();
+        assert_eq!(c.instructions.len(), 3);
+        assert!(matches!(
+            c.instructions.as_slice(),
+            [
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: x_targets,
+                },
+                Instruction::Reset { qubit: 0 },
+                Instruction::Gate {
+                    gate: Gate::H,
+                    targets: h_targets,
+                },
+            ] if x_targets.as_slice() == [0] && h_targets.as_slice() == [1]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add the missing fluent `CircuitBuilder::reset` API so programmatic circuits can append reset operations without dropping down to `Circuit::add_reset`. The method preserves the existing bounds checks and chaining style, and regression coverage verifies the exact emitted instruction order.

Closes #46.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. This is a builder convenience method that delegates to the existing circuit IR operation.

Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally (CUDA is unavailable on this host; the repository's CI feature set was used instead)
- [x] `cargo test --features "parallel,serialization"` passes locally
- [x] `cargo test --no-default-features` passes locally
- [x] `cargo clippy --all-targets --features "parallel,serialization" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel,serialization"` passes with `RUSTDOCFLAGS="-D warnings"`
- [x] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend (not applicable)
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu` (not applicable)

The no-default-features clippy invocation on macOS Rust 1.97.1 reports the pre-existing unused `radix4_butterfly_slices_neon` helper in `src/backend/statevector/kernels.rs`; scoped no-default clippy passes when allowing that existing `dead_code` lint. The exact upstream base SHA is green in GitHub CI, including its no-default, macOS ARM64, aarch64, GPU compile, coverage, and license jobs.

## Hotspot notes

N/A. No simulation or gate-application hot paths are changed.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural (not applicable)
- [ ] Design or research notes added where required for new subsystems (not applicable)

## Breaking changes

None. This is an additive public API.

## Risks and rollback

The blast radius is limited to one new builder method and its documentation. It delegates directly to the existing `Circuit::add_reset`, so bounds behavior and IR construction stay centralized. Reverting the commit fully removes the API.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green

## AI usage

Codex was used to inspect the issue and repository policies, implement the builder method and regression test, run the validation commands, and help prepare this pull request description. I reviewed the resulting code, tests, diff, and validation output before submission.
