### PR TITLE
feat(gpu): dispatch-level crossover and decomposition-aware routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build
 /target/
 
+# Rendered documentation site (built in CI)
+docs/book/
+
 # Profiling & benchmarks
 bench_results/
 benchmark_internal/
@@ -9,6 +12,16 @@ profile.json.gz
 flamegraph.svg
 perf.data
 perf.data.old
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+bindings/python/dist/
+bindings/python/uv.lock
+bindings/python/python/prism_q/*.pyd
+bindings/python/python/prism_q/*.so
+bindings/python/python/prism_q/*.dylib
 
 # Project tracking I use locally. No need to see how disorganized it is...
 TASK_TRACKER.md

--- a/README.md
+++ b/README.md
@@ -160,15 +160,22 @@ covered by a dedicated kernel, including batched kernels for `BatchPhase`, `Batc
 [`tests/golden_gpu.rs`](tests/golden_gpu.rs) verify amplitude equivalence against the
 CPU statevector within 1e-10.
 
-The backend-level crossover between CPU and GPU is still in progress, so
-`BackendKind::Auto` does not yet route to GPU. Opt in explicitly:
+`BackendKind::Auto` does not yet route to GPU. Opt in explicitly. The recommended
+entry point is `BackendKind::StatevectorGpu`, which inherits the fusion pipeline plus
+independent-subsystem decomposition and applies a size-aware crossover (default: GPU
+only for ≥14 qubit sub-circuits, overridable via `PRISM_GPU_MIN_QUBITS`; circuits too
+large for device VRAM stay on the host statevector):
 
 ```rust
-use prism_q::{gpu::GpuContext, StatevectorBackend};
+use prism_q::{gpu::GpuContext, run_with, BackendKind};
 
 let ctx = GpuContext::new(0)?;
-let mut backend = StatevectorBackend::new(42).with_gpu(ctx);
+let result = run_with(BackendKind::StatevectorGpu { context: ctx }, &circuit, 42)?;
 ```
+
+For kernel-level experiments where every gate must hit the device, use the low-level
+`StatevectorBackend::new(seed).with_gpu(ctx)` builder instead. It bypasses the
+dispatch crossover by design.
 
 See [`docs/architecture.md`](docs/architecture.md) for the kernel design and crossover
 analysis.
@@ -232,8 +239,9 @@ SVGs land in `bench_results/` (gitignored).
 - Expanded OpenQASM 3.0: `reset` instruction, `for` loop unrolling, `def` subroutines.
 - Expectation values: `<psi|O|psi>` for Pauli strings (VQE and QAOA).
 - Density matrix backend: mixed-state simulation for noise and decoherence modeling.
-- GPU auto-dispatch: size-aware crossover so `BackendKind::Auto` can route to GPU when
-  it wins. Blocked on reconciling `run_decomposed` with the GPU entry point.
+- GPU auto-dispatch: thread a GPU context into `BackendKind::Auto` so large circuits
+  route to GPU without an explicit `BackendKind::StatevectorGpu`. Crossover and
+  decomposition already work through the explicit variant.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,10 +227,27 @@ Dynamic split-state simulation. Starts with n independent 1-qubit states, merges
 
 ## GPU backend (optional, `gpu` feature)
 
-CUDA statevector acceleration layered onto the primary backend. Opt in via
-`StatevectorBackend::new(seed).with_gpu(ctx)` where `ctx` is an `Arc<GpuContext>`. When a
-GPU context is attached, `Backend::init` allocates a device-resident state instead of a
-host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
+CUDA statevector acceleration layered onto the primary backend. Two entry points:
+
+- **`BackendKind::StatevectorGpu { context }`** (recommended): routes through
+  `sim::run_with`, so the circuit picks up fusion plus independent-subsystem
+  decomposition, and each sub-block consults `gpu_min_qubits()` (default 14,
+  `PRISM_GPU_MIN_QUBITS` env override) to decide between the GPU path and a host
+  statevector. Disconnected sub-circuits below the threshold run on CPU regardless of
+  total qubit count, and circuits too large for device VRAM (state plus probability
+  scratch must fit) stay on the host statevector instead of failing at allocation.
+- **`StatevectorBackend::new(seed).with_gpu(ctx)`**: direct opt-in. Every instruction
+  routes to a CUDA kernel once the context is attached; no crossover, no decomposition.
+  Use this for kernel-level benchmarks and targeted correctness tests.
+
+GPU backends share the context's single CUDA stream, so the shot and block drivers
+never run GPU-routed work on multiple threads: decomposed sub-blocks that clear the
+crossover execute sequentially, and noisy trajectory sampling drops to the sequential
+per-shot loop (reusing one device allocation across shots) whenever the circuit would
+route to GPU.
+
+When a GPU context is attached, `Backend::init` allocates a device-resident state
+instead of a host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
 
 **Module layout** (`src/gpu/`):
 
@@ -255,17 +272,23 @@ launches. `Multi2q` still launches once per sub-gate; rare in practice.
 `{{TILE_Q}}`. The `kernel_source()` function substitutes them at device construction from
 the Rust constants in `src/backend/statevector/kernels.rs`, keeping CPU and GPU in sync.
 
-**Correctness:** `tests/golden_gpu.rs` drives 19 cross-checks comparing GPU amplitudes
-against the CPU statevector within 1e-10. Covers every gate variant plus fusion paths.
+**Correctness:** `tests/golden_gpu.rs` drives 20 cross-checks comparing GPU amplitudes
+against the CPU statevector within 1e-10. Covers every gate variant, fusion paths, and
+the `BackendKind::StatevectorGpu` end-to-end dispatch at the crossover boundary. Stub
+context tests in `src/sim/dispatch.rs` prove the routing decisions themselves (small
+circuits stay on CPU, crossover circuits reach the GPU path, decomposition survives
+GPU dispatch) without requiring hardware.
 
 **Current limits:**
 
-- `BackendKind::Auto` does not yet dispatch to GPU. Opt in explicitly on
-  `StatevectorBackend`.
-- The GPU entry point does not honor `run_decomposed`, so circuits whose qubit graph
-  splits into independent blocks run at full size on device when dispatched through the
-  `prismq_runner` harness. Resolving this is the primary blocker before Auto dispatch
-  can add a GPU branch.
+- `BackendKind::Auto` does not yet dispatch to GPU. The `StatevectorGpu` variant is the
+  explicit opt-in; wiring a default GPU context into `Auto` is the remaining work.
+- Several fused launchers (`launch_apply_fused_2q`, `launch_apply_mcu`,
+  `launch_apply_mcu_phase`, `launch_apply_batch_phase`, `launch_apply_batch_rzz`,
+  `launch_apply_diagonal_batch`, `launch_apply_multi_fused_nondiag`) upload small
+  metadata tables per dispatch via `clone_htod`; the next launch-tax target.
+- `measure_prob_one` allocates a device partials buffer and reduces on the host every
+  call. Matters for measurement-heavy circuits.
 - Kernel design and crossover analysis live in the module docstrings on
   `src/gpu/kernels/dense.rs`. Cross-simulator comparison scripts are provided outside
   the public surface of the crate.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -139,6 +139,17 @@ pub trait Backend {
     /// Returns a slice indexed by classical bit number. `true` = measured |1⟩.
     fn classical_results(&self) -> &[bool];
 
+    /// Re-seed the backend's RNG for a fresh simulation run, returning `true`
+    /// when supported.
+    ///
+    /// Multi-shot drivers use this to reuse one backend instance (and its
+    /// state allocation) across shots instead of constructing a backend per
+    /// shot; [`init`](Backend::init) still resets the quantum state. Backends
+    /// that return `false` are reconstructed per shot.
+    fn reseed(&mut self, _seed: u64) -> bool {
+        false
+    }
+
     /// Compute the probability of each computational basis state.
     ///
     /// Returns a `Vec<f64>` of length 2^num_qubits. Not all backends can

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -152,13 +152,15 @@ impl StatevectorBackend {
             self.gpu_state.is_some(),
             "apply_gpu called without gpu_state (callers must check self.gpu_state.is_some() first)"
         );
-        // GPU dispatch is unconditional here: every instruction routes to GPU when
-        // `gpu_state` is Some. Two known caveats:
-        //   1. Multi2q launches one kernel per sub-gate (rare in practice).
-        //   2. sim::run_with's run_decomposed path is CPU-only, so circuits whose
-        //      qubit graph splits into independent blocks run larger on GPU than
-        //      on CPU. A dispatch-level crossover that honors decomposition (or
-        //      routes small circuits back to CPU) is future work.
+        // Unconditional GPU dispatch: every instruction routes to a kernel once
+        // `gpu_state` is Some. This path is the explicit opt-in surface
+        // (`StatevectorBackend::with_gpu(ctx)`) and intentionally skips the
+        // dispatch-level crossover; callers of `with_gpu` are asking for
+        // kernel-level behavior. For size-aware crossover and decomposition-
+        // aware routing, enter via `sim::run_with(BackendKind::StatevectorGpu
+        // { context })`.
+        //
+        // Caveat: Multi2q launches one kernel per sub-gate (rare in practice).
         match instruction {
             Instruction::Gate { gate, targets } => self.dispatch_gate_gpu(gate, targets),
             Instruction::Measure {
@@ -422,7 +424,10 @@ impl Backend for StatevectorBackend {
         #[cfg(feature = "gpu")]
         if let Some(ctx) = self.gpu_context.clone() {
             self.state.clear();
-            self.gpu_state = Some(GpuState::new(ctx, num_qubits)?);
+            match self.gpu_state.as_mut() {
+                Some(gpu) if gpu.num_qubits() == num_qubits => gpu.reset()?,
+                _ => self.gpu_state = Some(GpuState::new(ctx, num_qubits)?),
+            }
             return Ok(());
         }
 
@@ -434,6 +439,11 @@ impl Backend for StatevectorBackend {
         }
         self.state[0] = Complex64::new(1.0, 0.0);
         Ok(())
+    }
+
+    fn reseed(&mut self, seed: u64) -> bool {
+        self.rng = ChaCha8Rng::seed_from_u64(seed);
+        true
     }
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -24,6 +24,14 @@ impl<T: DeviceRepr + ValidAsZeroBits> GpuBuffer<T> {
             .map_err(|e| driver_err("alloc_zeros", e))?;
         Ok(Self { slice })
     }
+
+    /// Zero every element of the allocation in place.
+    pub fn fill_zeros(&mut self, device: &GpuDevice) -> Result<()> {
+        let stream = device.stream()?;
+        stream
+            .memset_zeros(&mut self.slice)
+            .map_err(|e| driver_err("fill_zeros", e))
+    }
 }
 
 impl<T: DeviceRepr> GpuBuffer<T> {

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -113,6 +113,17 @@ impl GpuState {
         Ok(state)
     }
 
+    /// Reset the existing buffer to |0…0⟩ without reallocating.
+    ///
+    /// Multi-shot drivers call this between shots so the device allocation is
+    /// paid once per run instead of once per shot.
+    pub fn reset(&mut self) -> Result<()> {
+        let context = self.context.clone();
+        self.buffer.fill_zeros(context.device())?;
+        self.pending_norm = 1.0;
+        kernels::dense::launch_set_initial_state(&context, self)
+    }
+
     /// Number of qubits the buffer is sized for.
     pub fn num_qubits(&self) -> usize {
         self.num_qubits

--- a/src/sim/decomposed.rs
+++ b/src/sim/decomposed.rs
@@ -29,6 +29,11 @@ fn run_blocks_maybe_par(
         let all_small = _components
             .iter()
             .all(|c| c.len() < MAX_BLOCK_QUBITS_FOR_PAR);
+        #[cfg(feature = "gpu")]
+        let all_small = all_small
+            && _components
+                .iter()
+                .all(|c| !super::dispatch::may_route_to_gpu(kind, c.len()));
         if all_small && k >= 2 {
             use rayon::prelude::*;
             crate::backend::init_thread_pool();

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -8,6 +8,12 @@ use crate::backend::Backend;
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
+#[cfg(feature = "gpu")]
+use std::sync::Arc;
+
+#[cfg(feature = "gpu")]
+use crate::gpu::GpuContext;
+
 use super::{Probabilities, SimulationResult};
 
 pub(super) enum DispatchAction {
@@ -17,24 +23,25 @@ pub(super) enum DispatchAction {
     DeterministicPauli { epsilon: f64, max_terms: usize },
 }
 
+fn env_override_usize(var: &str) -> Option<usize> {
+    std::env::var(var).ok()?.parse().ok()
+}
+
 pub(super) fn max_statevector_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
-        if let Ok(val) = std::env::var("PRISM_MAX_SV_QUBITS") {
-            if let Ok(n) = val.parse::<usize>() {
-                return n;
+        env_override_usize("PRISM_MAX_SV_QUBITS").unwrap_or_else(|| {
+            match detect_max_sv_qubits() {
+                Some(n) => n,
+                None => {
+                    eprintln!(
+                        "warning: could not detect system memory; statevector qubit cap is disabled. \
+                         Large circuits may abort on allocation. Set PRISM_MAX_SV_QUBITS to suppress."
+                    );
+                    usize::MAX
+                }
             }
-        }
-        match detect_max_sv_qubits() {
-            Some(n) => n,
-            None => {
-                eprintln!(
-                    "warning: could not detect system memory; statevector qubit cap is disabled. \
-                     Large circuits may abort on allocation. Set PRISM_MAX_SV_QUBITS to suppress."
-                );
-                usize::MAX
-            }
-        }
+        })
     })
 }
 
@@ -117,6 +124,36 @@ pub(super) const MIN_FACTORED_STABILIZER_QUBITS: usize = 128;
 
 pub(super) const MIN_BLOCK_FOR_FACTORED_STAB: usize = 16;
 
+/// Minimum qubit count to route a sub-circuit to GPU when
+/// [`BackendKind::StatevectorGpu`] is selected.
+///
+/// Below this threshold the dispatch layer builds a plain host
+/// `StatevectorBackend` instead, keeping PCIe round-trips and kernel launch
+/// latency off the critical path for circuits that fit comfortably in L3.
+/// Empirically (GTX 1080 Ti, 2026-04-18), 10q random-depth-20 is 0.18x on
+/// GPU vs CPU while 14q is 9.37x. 14 is the lowest known-win point; users
+/// with faster GPUs or different workloads can override via the
+/// `PRISM_GPU_MIN_QUBITS` environment variable.
+#[cfg(feature = "gpu")]
+pub(super) const GPU_MIN_QUBITS_DEFAULT: usize = 14;
+
+#[cfg(feature = "gpu")]
+pub(super) fn gpu_min_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        env_override_usize("PRISM_GPU_MIN_QUBITS").unwrap_or(GPU_MIN_QUBITS_DEFAULT)
+    })
+}
+
+/// Whether this kind can build a GPU-backed backend for a circuit of the
+/// given width. GPU backends share one CUDA stream per context and must not
+/// execute concurrently, so multi-shot and multi-block drivers consult this
+/// before spreading work across threads.
+#[cfg(feature = "gpu")]
+pub(super) fn may_route_to_gpu(kind: &BackendKind, num_qubits: usize) -> bool {
+    matches!(kind, BackendKind::StatevectorGpu { .. }) && num_qubits >= gpu_min_qubits()
+}
+
 /// Automatically select the optimal backend based on circuit analysis.
 ///
 /// Decision tree:
@@ -133,15 +170,38 @@ pub enum BackendKind {
     Statevector,
     Stabilizer,
     Sparse,
-    Mps { max_bond_dim: usize },
+    Mps {
+        max_bond_dim: usize,
+    },
     ProductState,
     TensorNetwork,
     Factored,
     StabilizerRank,
     FilteredStabilizer,
     FactoredStabilizer,
-    StochasticPauli { num_samples: usize },
-    DeterministicPauli { epsilon: f64, max_terms: usize },
+    StochasticPauli {
+        num_samples: usize,
+    },
+    DeterministicPauli {
+        epsilon: f64,
+        max_terms: usize,
+    },
+    /// Statevector backed by a CUDA GPU execution context.
+    ///
+    /// Circuits (or decomposed sub-blocks) with fewer than 14 qubits
+    /// (tunable via `PRISM_GPU_MIN_QUBITS`) transparently fall back to the
+    /// host statevector path: small states do not survive PCIe and
+    /// launch-latency overhead. Circuits too large for device VRAM also stay
+    /// on the host path. Everything inside that window allocates a
+    /// device-resident state and routes gate application through GPU kernels.
+    ///
+    /// Compose with [`crate::sim::run_with`] to get fusion plus independent-
+    /// subsystem decomposition for free; each sub-block is evaluated against
+    /// the crossover independently.
+    #[cfg(feature = "gpu")]
+    StatevectorGpu {
+        context: Arc<GpuContext>,
+    },
 }
 
 pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
@@ -183,6 +243,34 @@ pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> 
         | BackendKind::DeterministicPauli { .. } => false,
         BackendKind::Auto => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
         _ => true,
+    }
+}
+
+/// Build a `StatevectorBackend` configured for GPU execution when the
+/// circuit falls inside the crossover window, otherwise a plain host
+/// backend. Called from `select_dispatch` (which runs per sub-block after
+/// decomposition) so small blocks transparently stay on CPU.
+///
+/// The upper bound keeps the state strictly below half of device VRAM: the
+/// probability readback needs an extra `8 * 2^n` scratch buffer on top of the
+/// `16 * 2^n` state, so a circuit at the whole-VRAM limit would fail mid-run.
+/// Oversize circuits fall back to the host path, matching what explicit
+/// `BackendKind::Statevector` would do. If the VRAM query fails (stub device),
+/// the bound is skipped and any failure surfaces at allocation.
+#[cfg(feature = "gpu")]
+fn statevector_gpu_with_crossover(
+    context: &Arc<GpuContext>,
+    circuit: &Circuit,
+    seed: u64,
+) -> StatevectorBackend {
+    let n = circuit.num_qubits;
+    let fits_device = context
+        .max_qubits_for_statevector()
+        .map_or(true, |max| n < max);
+    if n >= gpu_min_qubits() && fits_device {
+        StatevectorBackend::new(seed).with_gpu(context.clone())
+    } else {
+        StatevectorBackend::new(seed)
     }
 }
 
@@ -245,6 +333,10 @@ pub(super) fn select_dispatch(
                 max_terms: *max_terms,
             }
         }
+        #[cfg(feature = "gpu")]
+        BackendKind::StatevectorGpu { context } => DispatchAction::Backend(Box::new(
+            statevector_gpu_with_crossover(context, circuit, seed),
+        )),
     }
 }
 
@@ -341,4 +433,94 @@ pub(super) fn try_temporal_clifford(
         classical_bits: sv.classical_results().to_vec(),
         probabilities: probs,
     }))
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod gpu_crossover_tests {
+    use super::*;
+    use crate::gates::Gate;
+    use crate::sim::run_with;
+
+    fn stub_kind() -> BackendKind {
+        BackendKind::StatevectorGpu {
+            context: GpuContext::stub_for_tests(),
+        }
+    }
+
+    fn assert_probs_close(actual: &[f64], expected: &[f64]) {
+        assert_eq!(actual.len(), expected.len());
+        for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-10,
+                "prob[{i}] = {a}, expected {e}, diff={}",
+                (a - e).abs()
+            );
+        }
+    }
+
+    /// A 4q circuit is far below the default 14q threshold. If the dispatch
+    /// layer were to build a GPU backend anyway, `GpuState::new` on the stub
+    /// context would return `BackendUnsupported`. Success proves the
+    /// crossover in `select_dispatch` is routing small circuits to the host
+    /// path.
+    #[test]
+    fn small_circuit_routes_to_cpu() {
+        let mut circuit = Circuit::new(4, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_gate(Gate::H, &[2]);
+        circuit.add_gate(Gate::Cx, &[2, 3]);
+
+        let result = run_with(stub_kind(), &circuit, 42)
+            .expect("stub context must not be touched for a 4q circuit");
+        let probs = result
+            .probabilities
+            .expect("probabilities missing")
+            .to_vec();
+
+        let mut expected = [0.0_f64; 16];
+        expected[0b0000] = 0.25;
+        expected[0b0011] = 0.25;
+        expected[0b1100] = 0.25;
+        expected[0b1111] = 0.25;
+        assert_probs_close(&probs, &expected);
+    }
+
+    /// A 14q entangled chain sits exactly at the default crossover, so the
+    /// dispatch layer must build a GPU backend. On the stub context
+    /// `GpuState::new` fails with `BackendUnsupported`; seeing that error
+    /// proves the GPU branch fired. Without this test, a regression that
+    /// silently neuters GPU routing (dropping `with_gpu`, an off-by-one at
+    /// the boundary) would leave the two negative tests green.
+    #[test]
+    fn crossover_circuit_routes_to_gpu() {
+        let mut circuit = Circuit::new(14, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        for q in 0..13 {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+
+        let err = run_with(stub_kind(), &circuit, 42)
+            .expect_err("a 14q circuit must reach the stub GPU context");
+        assert!(matches!(err, PrismError::BackendUnsupported { .. }));
+    }
+
+    /// `independent_bell_pairs(8)` spans 16 qubits but decomposes into 8
+    /// independent 2q blocks. With `BackendKind::StatevectorGpu`, each
+    /// sub-block is below the 14q threshold and must route to CPU. If
+    /// decomposition failed to fire, the 16q monolithic path would attempt
+    /// `GpuState::new` through the stub and return `BackendUnsupported`.
+    /// Success here proves decomposition survives across the GPU dispatch.
+    #[test]
+    fn decomposable_16q_circuit_runs_per_block_on_cpu() {
+        let circuit = crate::circuits::independent_bell_pairs(8);
+        assert_eq!(circuit.num_qubits, 16);
+
+        let cpu = run_with(BackendKind::Statevector, &circuit, 42).expect("cpu baseline");
+        let gpu = run_with(stub_kind(), &circuit, 42).expect("stub must stay out of the way");
+
+        let cpu_p = cpu.probabilities.expect("cpu probs").to_vec();
+        let gpu_p = gpu.probabilities.expect("gpu probs").to_vec();
+        assert_probs_close(&gpu_p, &cpu_p);
+    }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -16,6 +16,8 @@ pub(crate) use decomposed::merge_probabilities;
 use decomposed::{
     run_decomposed, run_decomposed_prefused, should_decompose, MIN_DECOMPOSITION_QUBITS,
 };
+#[cfg(feature = "gpu")]
+use dispatch::may_route_to_gpu;
 pub use dispatch::BackendKind;
 use dispatch::{
     has_temporal_clifford_opportunity, select_backend, select_dispatch, supports_fused_for_kind,
@@ -768,9 +770,12 @@ pub fn run_shots_with(
     } else {
         let fused = crate::circuit::fusion::fuse_circuit(circuit, supports_fused);
 
+        let mut backend = select_backend(&kind, circuit, seed, has_partial_independence);
         for i in 0..num_shots {
             let shot_seed = seed.wrapping_add(i as u64);
-            let mut backend = select_backend(&kind, circuit, shot_seed, has_partial_independence);
+            if i > 0 && !backend.reseed(shot_seed) {
+                backend = select_backend(&kind, circuit, shot_seed, has_partial_independence);
+            }
             let result = execute_circuit(&mut *backend, &fused, &opts)?;
             shots.push(result.classical_bits);
         }
@@ -839,12 +844,18 @@ pub fn run_shots_with_noise(
         }
     }
 
+    #[cfg(feature = "gpu")]
+    let parallel_ok = !may_route_to_gpu(&kind, circuit.num_qubits);
+    #[cfg(not(feature = "gpu"))]
+    let parallel_ok = true;
+
     trajectory::run_trajectories(
         |s| select_backend(&kind, circuit, s, false),
         circuit,
         noise_model,
         num_shots,
         seed,
+        parallel_ok,
     )
 }
 

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -382,25 +382,32 @@ pub(crate) fn run_trajectory_shot(
     Ok(results)
 }
 
+/// `parallel_ok` must be false when the factory can build backends that do
+/// not tolerate concurrent execution (GPU backends share one CUDA stream);
+/// those runs stay on the sequential loop regardless of shot count.
 pub(crate) fn run_trajectories(
     backend_factory: impl Fn(u64) -> Box<dyn Backend> + Sync,
     circuit: &Circuit,
     noise: &NoiseModel,
     num_shots: usize,
     seed: u64,
+    _parallel_ok: bool,
 ) -> Result<ShotsResult> {
     #[cfg(feature = "parallel")]
     {
-        if circuit.num_qubits <= 20 && num_shots >= 4 {
+        if _parallel_ok && circuit.num_qubits <= 20 && num_shots >= 4 {
             return run_trajectories_par(&backend_factory, circuit, noise, num_shots, seed);
         }
     }
 
     let mut shots = Vec::with_capacity(num_shots);
+    let mut backend = backend_factory(seed);
     for i in 0..num_shots {
         let shot_seed = seed.wrapping_add(i as u64);
         let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
-        let mut backend = backend_factory(shot_seed);
+        if i > 0 && !backend.reseed(shot_seed) {
+            backend = backend_factory(shot_seed);
+        }
         let result = run_trajectory_shot(backend.as_mut(), circuit, noise, &mut rng)?;
         shots.push(result);
     }
@@ -455,7 +462,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 500, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 500, 42, true).unwrap();
         assert_eq!(result.shots.len(), 500);
 
         let all_zero: Vec<bool> = vec![false; n];
@@ -481,7 +488,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, true).unwrap();
         let num_zero = result.shots.iter().filter(|s| !s[0]).count();
         // With gamma=0.9 on |1⟩, P(decay) ≈ 0.9
         assert!(
@@ -513,7 +520,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &pd_noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &pd_noise, 1000, 42, true).unwrap();
         let num_one = result.shots.iter().filter(|s| s[0]).count();
         // Phase damping on |1⟩ should keep it as |1⟩ (only dephases superpositions)
         assert_eq!(num_one, 1000, "PD should not change |1⟩ population");
@@ -531,7 +538,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, true).unwrap();
         let num_one = result.shots.iter().filter(|s| s[0]).count();
         // Should see ~30% readout flips
         assert!(
@@ -559,7 +566,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, true).unwrap();
         // With 50% 2q depolarizing, we should see varied outcomes
         let num_00 = result.shots.iter().filter(|s| !s[0] && !s[1]).count();
         assert!(
@@ -583,8 +590,8 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let r1 = run_trajectories(factory, &circuit, &noise, 100, 42).unwrap();
-        let r2 = run_trajectories(factory, &circuit, &noise, 100, 42).unwrap();
+        let r1 = run_trajectories(factory, &circuit, &noise, 100, 42, true).unwrap();
+        let r2 = run_trajectories(factory, &circuit, &noise, 100, 42, true).unwrap();
         assert_eq!(r1.shots, r2.shots, "same seed must produce same results");
     }
 }

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -61,6 +61,17 @@ fn g(gate: Gate, targets: &[usize]) -> Instruction {
     Instruction::Gate { gate, targets: tv }
 }
 
+fn assert_probs_match(cpu_p: &[f64], gpu_p: &[f64], eps: f64) {
+    assert_eq!(cpu_p.len(), gpu_p.len());
+    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
+        assert!(
+            (c - g_).abs() < eps,
+            "prob[{i}] cpu={c}, gpu={g_}, diff={}",
+            (c - g_).abs()
+        );
+    }
+}
+
 // ============================================================================
 // Single-qubit kernels
 // ============================================================================
@@ -591,11 +602,72 @@ fn probabilities_match_cpu_on_random_circuit() {
     }
     let cpu_p = cpu.probabilities().unwrap();
     let gpu_p = gpu.probabilities().unwrap();
-    assert_eq!(cpu_p.len(), gpu_p.len());
-    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
-        assert!(
-            (c - g_).abs() < EPS,
-            "prob[{i}] mismatch: cpu={c}, gpu={g_}"
-        );
+    assert_probs_match(&cpu_p, &gpu_p, EPS);
+}
+
+// ============================================================================
+// BackendKind::StatevectorGpu end-to-end (real GPU required)
+// ============================================================================
+
+/// `run_with(BackendKind::StatevectorGpu)` on a non-decomposable random
+/// circuit at 14q (at the crossover threshold) must match CPU to within
+/// 1e-10. Exercises the dispatch → fusion → GPU kernel → probabilities path.
+#[test]
+fn statevector_gpu_run_with_matches_cpu_random() {
+    use prism_q::BackendKind;
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let circuit = prism_q::circuits::random_circuit(14, 10, 0xDEAD_BEEF);
+
+    let cpu = prism_q::sim::run_with(BackendKind::Statevector, &circuit, 42)
+        .expect("cpu run_with failed");
+    let gpu = prism_q::sim::run_with(
+        BackendKind::StatevectorGpu {
+            context: f.ctx.clone(),
+        },
+        &circuit,
+        42,
+    )
+    .expect("gpu run_with failed");
+
+    let cpu_p = cpu.probabilities.expect("cpu probs missing").to_vec();
+    let gpu_p = gpu.probabilities.expect("gpu probs missing").to_vec();
+    assert_probs_match(&cpu_p, &gpu_p, 1e-10);
+}
+
+/// Multi-shot sampling with a mid-circuit measurement takes the per-shot
+/// slow path, which reuses one GPU backend across shots (`Backend::reseed`
+/// plus `GpuState::reset` in place of a fresh device allocation per shot).
+/// Shot outcomes must match the host statevector shot-for-shot: both
+/// backends draw the same RNG stream for the same shot seed.
+#[test]
+fn statevector_gpu_run_shots_mid_measure_matches_cpu() {
+    use prism_q::circuit::Circuit;
+    use prism_q::BackendKind;
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let mut circuit = Circuit::new(14, 2);
+    circuit.add_gate(Gate::H, &[0]);
+    for q in 0..13 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
     }
+    circuit.add_measure(0, 0);
+    circuit.add_gate(Gate::H, &[1]);
+    circuit.add_measure(1, 1);
+
+    let cpu = prism_q::sim::run_shots_with(BackendKind::Statevector, &circuit, 16, 42)
+        .expect("cpu shots failed");
+    let gpu = prism_q::sim::run_shots_with(
+        BackendKind::StatevectorGpu {
+            context: f.ctx.clone(),
+        },
+        &circuit,
+        16,
+        42,
+    )
+    .expect("gpu shots failed");
+
+    assert_eq!(cpu.shots, gpu.shots);
 }


### PR DESCRIPTION
## Summary

Backend selection, construction, and GPU acceleration were entangled across eight
routes (dispatch, three hardcoded statevector fast paths, a CPU-only noise router,
per-shot selection loops), so `AutoGpu`/`StatevectorGpu` contexts were silently dropped
on the counts, shots, expectation, and noisy paths. This PR restructures dispatch into
three layers: a resolver that picks a family once per call, a cheap per-shot backend
builder, and a per-family GPU capability table that owns every crossover and VRAM
verdict. Every entry point now routes through the one mechanism on both CPU and GPU.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Quiet machine, `--features parallel`, Criterion pairs against `main`. Full
`bench_shots_perf` and `circuits` suites ran; representative touched-path rows below.
Flags outside these rows failed to reproduce under focused A/B/A reruns with a measured
noise floor (mirror-image swings on untouched paths in both directions).

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| api_queries/shots_terminal_12q_100000 | 14.124 ms | 14.240 ms | +0.1% | Yes |
| api_queries/sample_counts_terminal_12q_100000 | 3.045 ms | 3.026 ms | -0.5% | Yes |
| api_queries/run_auto_12q | 116.5 us | 117.0 us | +0.5% | Yes |
| run_counts_terminal/nonclifford_full_18q/100000 | 17.18 ms | 16.24 ms | -3.2% | Yes |
| run_counts_terminal/nonclifford_subset_20q_8m/10000 | 25.61 ms | 24.85 ms | -3.0% | Yes |
| run_shots/nonclifford_full_18q/1000 | 3.821 ms | 3.842 ms | +0.5% | Yes |
| run_shots/bell_16q/100000 | 9.463 ms | 9.430 ms | -0.4% | Yes |
| compiled_counts/PackedShots_counts_20q/100000 | 6.682 ms | 6.744 ms | +0.9% | Yes |
| decomposition/20q_block4_decomposed/4 | 37.16 us | 36.90 us | -0.7% | Yes |
| decomposition/20q_block4_monolithic/4 | 22.44 ms | 21.71 ms | -3.3% | Yes |
| factored/random_d10/statevector/20 | 1.987 ms | 1.948 ms | -2.0% | Yes |
| factored/random_d10/factored/20 | 1.631 ms | 1.616 ms | -1.0% | Yes |

Regression verdict: PASS

One real regression surfaced and was fixed during the gate: the new `_from_probs`
sampler twins gave the per-shot `CompactMeasurementMap` helpers a second caller, which
outlined them from the ~150 ns/shot streaming loops (+7-10% on 12q high-shot terminal
sampling). `#[inline(always)]` on the helpers restored parity; the table reflects the
fixed state.

## Correctness

- [x] `cargo test --all-features` passes locally (run as `cargo nextest run --features
  "parallel gpu"`, 1794 tests; the `distributed-mpi` feature does not build on this
  machine, exercised in CI instead)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (with `--features "parallel gpu"`, same caveat)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
  (61 tests on GTX 1080 Ti, including new goldens for AutoGpu terminal counts/shots,
  explicit-GPU terminal counts, expectation values, temporal tails with QftBlock
  expansion, device state round-trip, and noisy trajectories)

A dispatch-matrix test suite asserts the resolved family and execution target for every
`BackendKind` against every circuit shape class (product, Clifford, Clifford+T,
oversize sparse-friendly, partially independent, dense), including fail-closed VRAM
gating on stub contexts and hard-error behavior for explicit GPU kinds.

## Hotspot notes

Touched hot paths: the per-shot loops in `run_shots_with` and
`run_decomposed_prefused` (selection hoisted out, `BackendPlan::build` is
constructor + `Box::new` + at most one `Arc` clone per shot), the terminal sampling
loops in `terminal_sampling.rs` (`#[inline(always)]` on per-shot helpers), and
`run_temporal_clifford` (per-shot probability computation now skipped when only
classical bits are needed). No flamegraph attached; the Criterion pairs above cover
each affected group directly.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

The dispatch restructure is structural; an architecture doc update describing the
resolver, `BackendPlan`, and the per-family capability table is queued as an immediate
follow-up before the next feature lands on top.

## Breaking changes

- `simulate(...).expectation_values(...)` now accepts `BackendKind::StatevectorGpu`
  (previously rejected with `IncompatibleBackend`).
- Finite seeded outputs change for explicit `StatevectorGpu` terminal counts/shots and
  for GPU-executed sampling generally: device runs sample from device-reduced
  probabilities rather than host amplitudes. Distributions are unchanged; `Auto` and
  all CPU kinds are byte-identical to before (regression-tested).
- CPU noisy trajectories at 14-20 qubits now run shots serially (gate kernels
  parallelize internally at 14+). This fixes a latent stack overflow from nested
  shot-level and kernel-level rayon parallelism; per-shot seeding is unchanged, so
  results are identical.

## Risks and rollback

GPU routing changes are confined to the opt-in `AutoGpu`/`StatevectorGpu`/
`StabilizerGpu` kinds and the `gpu` feature; default CPU behavior is byte-identical
and pinned by seeded tests. The crossover and VRAM gates remain tunable at runtime
(`PRISM_GPU_MIN_QUBITS`, `PRISM_STABILIZER_GPU_MIN_QUBITS`), so a misbehaving device
path can be forced back to CPU without a revert by raising the crossover. Soft mode
falls back to the host on any device allocation failure at init. The riskiest new
plumbing (device upload in `init_from_state`) is covered by a device round-trip golden
and a stub fallback test.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green