### PR TITLE
feat(sim): unify backend dispatch behind a per-family resolver

### DIFF
--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -50,6 +50,20 @@ pub(crate) fn max_tensor_probability_qubits() -> usize {
     })
 }
 
+/// Measured-bit cap for the dense terminal-sampling path, which materializes
+/// one outcome distribution plus one CDF (two f64 per outcome). Above the cap
+/// the samplers stream with sorted thresholds instead.
+pub(crate) fn max_dense_outcome_bits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_DENSE_OUTCOME_BITS",
+            2 * size_of::<f64>(),
+            "dense outcome sampling cap",
+        )
+    })
+}
+
 fn configured_or_detected_dense_qubits(
     env_var: &str,
     bytes_per_basis_state: usize,

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -214,7 +214,41 @@ fn detect_physical_memory_bytes() -> Option<u64> {
     Some(status.ull_total_phys)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "macos")]
+fn detect_physical_memory_bytes() -> Option<u64> {
+    // SAFETY: signature matches the documented libSystem sysctlbyname ABI:
+    // a C-string name, an output buffer with its length passed by pointer,
+    // and an unused input buffer, returning 0 on success.
+    unsafe extern "C" {
+        fn sysctlbyname(
+            name: *const std::ffi::c_char,
+            oldp: *mut std::ffi::c_void,
+            oldlenp: *mut usize,
+            newp: *mut std::ffi::c_void,
+            newlen: usize,
+        ) -> i32;
+    }
+
+    let mut memsize: u64 = 0;
+    let mut len = size_of::<u64>();
+    // SAFETY: oldp points to an 8-byte buffer and oldlenp holds its size;
+    // hw.memsize is a u64 sysctl.
+    let ret = unsafe {
+        sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            (&mut memsize as *mut u64).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 || len != size_of::<u64>() || memsize == 0 {
+        return None;
+    }
+    Some(memsize)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn detect_physical_memory_bytes() -> Option<u64> {
     let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
     for line in meminfo.lines() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -70,8 +70,8 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) use memory::{
-    dense_probability_len, dense_statevector_len, max_statevector_qubits, reserve_dense_output,
-    tensor_probability_len,
+    dense_probability_len, dense_statevector_len, max_dense_outcome_bits, max_statevector_qubits,
+    reserve_dense_output, tensor_probability_len,
 };
 
 #[inline(always)]

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -93,6 +93,8 @@ pub struct StabilizerBackend {
     pub(super) pending_gpu_ops: Vec<u32>,
     #[cfg(feature = "gpu")]
     pub(super) gpu_batch_scratch: CliffordBatchScratch,
+    #[cfg(feature = "gpu")]
+    pub(super) gpu_soft: bool,
 }
 
 impl Clone for StabilizerBackend {
@@ -132,6 +134,8 @@ impl Clone for StabilizerBackend {
             pending_gpu_ops: Vec::new(),
             #[cfg(feature = "gpu")]
             gpu_batch_scratch: CliffordBatchScratch::default(),
+            #[cfg(feature = "gpu")]
+            gpu_soft: self.gpu_soft,
         }
     }
 }
@@ -162,7 +166,48 @@ impl StabilizerBackend {
             pending_gpu_ops: Vec::new(),
             #[cfg(feature = "gpu")]
             gpu_batch_scratch: CliffordBatchScratch::default(),
+            #[cfg(feature = "gpu")]
+            gpu_soft: false,
         }
+    }
+
+    /// Initialise the host-resident identity tableau. Shared by the CPU init
+    /// path and the soft GPU fallback in [`Backend::init`].
+    fn init_host(&mut self, n: usize, nw: usize, num_classical_bits: usize) -> Result<()> {
+        self.n = n;
+        self.num_words = nw;
+
+        let total_rows = 2 * n + 1;
+        let stride = 2 * nw;
+
+        self.xz = vec![0u64; total_rows * stride];
+        self.phase = vec![false; total_rows];
+
+        for i in 0..n {
+            let word = i / 64;
+            let bit = i % 64;
+            self.xz[i * stride + word] |= 1u64 << bit;
+            self.xz[(i + n) * stride + nw + word] |= 1u64 << bit;
+        }
+
+        self.qubit_active = (0..n).map(|q| vec![q as u32, (n + q) as u32]).collect();
+        self.total_weight = 2 * n;
+        self.sgi_max_active = 2;
+
+        let want_lazy = self.lazy_destab;
+        self.lazy_destab = false;
+        self.gate_row_start = 0;
+        #[cfg(feature = "gpu")]
+        {
+            self.pending_gpu_ops.clear();
+            self.gpu_batch_scratch.clear();
+        }
+
+        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
+        if want_lazy {
+            self.enable_lazy_destab();
+        }
+        Ok(())
     }
 
     /// Opt into GPU acceleration using the given shared execution context.
@@ -172,6 +217,18 @@ impl StabilizerBackend {
     #[cfg(feature = "gpu")]
     pub fn with_gpu(mut self, context: Arc<GpuContext>) -> Self {
         self.gpu_context = Some(context);
+        self
+    }
+
+    /// Opt into GPU acceleration but fall back to the host tableau if the device
+    /// allocation fails at [`Backend::init`], instead of erroring. Mirrors
+    /// [`StatevectorBackend::with_gpu_auto`](crate::backend::statevector::StatevectorBackend::with_gpu_auto);
+    /// used by the `Auto` GPU dispatch path, where an unfit or racing device must
+    /// degrade to CPU rather than surface a failure.
+    #[cfg(feature = "gpu")]
+    pub fn with_gpu_auto(mut self, context: Arc<GpuContext>) -> Self {
+        self.gpu_context = Some(context);
+        self.gpu_soft = true;
         self
     }
 
@@ -1332,9 +1389,17 @@ impl Backend for StabilizerBackend {
         #[cfg(feature = "gpu")]
         if let Some(ctx) = self.gpu_context.clone() {
             // Allocate the device tableau first so an allocation failure returns
-            // cleanly without touching any existing state. Only once the tableau
-            // Commit the transition to GPU mode only after the device state is available.
-            let tableau = GpuTableau::new(ctx, n)?;
+            // cleanly without touching any existing state. The transition to GPU
+            // mode commits only once the tableau is live.
+            let tableau = match GpuTableau::new(ctx, n) {
+                Ok(tableau) => tableau,
+                Err(_) if self.gpu_soft => {
+                    self.gpu_context = None;
+                    self.gpu_tableau = None;
+                    return self.init_host(n, nw, num_classical_bits);
+                }
+                Err(e) => return Err(e),
+            };
             self.n = n;
             self.num_words = nw;
             self.xz.clear();
@@ -1351,40 +1416,7 @@ impl Backend for StabilizerBackend {
             return Ok(());
         }
 
-        self.n = n;
-        self.num_words = nw;
-
-        let total_rows = 2 * n + 1;
-        let stride = 2 * nw;
-
-        self.xz = vec![0u64; total_rows * stride];
-        self.phase = vec![false; total_rows];
-
-        for i in 0..n {
-            let word = i / 64;
-            let bit = i % 64;
-            self.xz[i * stride + word] |= 1u64 << bit;
-            self.xz[(i + n) * stride + nw + word] |= 1u64 << bit;
-        }
-
-        self.qubit_active = (0..n).map(|q| vec![q as u32, (n + q) as u32]).collect();
-        self.total_weight = 2 * n;
-        self.sgi_max_active = 2;
-
-        let want_lazy = self.lazy_destab;
-        self.lazy_destab = false;
-        self.gate_row_start = 0;
-        #[cfg(feature = "gpu")]
-        {
-            self.pending_gpu_ops.clear();
-            self.gpu_batch_scratch.clear();
-        }
-
-        crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
-        if want_lazy {
-            self.enable_lazy_destab();
-        }
-        Ok(())
+        self.init_host(n, nw, num_classical_bits)
     }
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {

--- a/src/backend/stabilizer/tests.rs
+++ b/src/backend/stabilizer/tests.rs
@@ -967,6 +967,40 @@ mod gpu_scaffold {
         assert!(matches!(err, PrismError::BackendUnsupported { .. }));
     }
 
+    /// `with_gpu_auto` is the soft (fail-closed) mode. On the stub context,
+    /// `GpuTableau::new` fails at `init`, but instead of surfacing the error the
+    /// backend must degrade to the host tableau and run correctly. A GHZ chain
+    /// then measures deterministically-correlated bits, proving the fallback
+    /// produced a working CPU stabilizer rather than a corrupt half-state.
+    #[test]
+    fn with_gpu_auto_falls_back_to_host_on_stub() {
+        use crate::gates::Gate;
+
+        let ctx = GpuContext::stub_for_tests();
+        let mut backend = StabilizerBackend::new(42).with_gpu_auto(ctx);
+        backend
+            .init(4, 4)
+            .expect("soft mode must fall back to host, not error");
+        assert_eq!(backend.num_qubits(), 4);
+
+        let mut circuit = Circuit::new(4, 4);
+        circuit.add_gate(Gate::H, &[0]);
+        for i in 0..3 {
+            circuit.add_gate(Gate::Cx, &[i, i + 1]);
+        }
+        for i in 0..4 {
+            circuit.add_measure(i, i);
+        }
+        for inst in &circuit.instructions {
+            backend.apply(inst).unwrap();
+        }
+        let bits = backend.classical_results();
+        assert!(
+            bits.iter().all(|&b| b == bits[0]),
+            "GHZ measurement bits must all agree: {bits:?}"
+        );
+    }
+
     /// Constructing with `with_gpu(ctx)` but then not initialising must leave
     /// the backend in a usable (context-only) state.
     #[test]

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -427,6 +427,20 @@ impl StatevectorBackend {
         self.pending_norm * self.pending_norm
     }
 
+    /// Whether the amplitudes live in device memory. When true, the host
+    /// `state_vector()` slice is empty; read the state through
+    /// [`probabilities`](crate::backend::Backend::probabilities) or
+    /// [`export_statevector`](crate::backend::Backend::export_statevector).
+    #[cfg(feature = "gpu")]
+    pub(crate) fn is_gpu_resident(&self) -> bool {
+        self.gpu_state.is_some()
+    }
+
+    #[cfg(not(feature = "gpu"))]
+    pub(crate) fn is_gpu_resident(&self) -> bool {
+        false
+    }
+
     /// Initialize the backend from a pre-computed state vector.
     ///
     /// Accepts ownership of the amplitude vector, bypassing the default |0...0⟩
@@ -449,9 +463,26 @@ impl StatevectorBackend {
             });
         }
         self.num_qubits = dim.trailing_zeros() as usize;
-        self.state = state;
         self.pending_norm = 1.0;
         crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
+
+        #[cfg(feature = "gpu")]
+        if let Some(ctx) = self.gpu_context.clone() {
+            match GpuState::from_host_amplitudes(ctx, &state) {
+                Ok(gpu) => {
+                    self.state.clear();
+                    self.gpu_state = Some(gpu);
+                    return Ok(());
+                }
+                Err(e) if !self.gpu_soft => return Err(e),
+                Err(_) => {
+                    self.gpu_context = None;
+                    self.gpu_state = None;
+                }
+            }
+        }
+
+        self.state = state;
         Ok(())
     }
 
@@ -571,7 +602,10 @@ impl Backend for StatevectorBackend {
                     return Ok(());
                 }
                 Err(e) if !self.gpu_soft => return Err(e),
-                Err(_) => self.gpu_context = None,
+                Err(_) => {
+                    self.gpu_context = None;
+                    self.gpu_state = None;
+                }
             }
         }
 

--- a/src/gpu/memory.rs
+++ b/src/gpu/memory.rs
@@ -27,6 +27,16 @@ impl<T: DeviceRepr + ValidAsZeroBits> GpuBuffer<T> {
 }
 
 impl<T: DeviceRepr> GpuBuffer<T> {
+    /// Allocate a device buffer initialized from `host` in one transfer,
+    /// skipping the zero fill of [`alloc_zeros`](Self::alloc_zeros).
+    pub fn from_host(device: &GpuDevice, host: &[T]) -> Result<Self> {
+        let stream = device.stream()?;
+        let slice = stream
+            .clone_htod(host)
+            .map_err(|e| driver_err("from_host", e))?;
+        Ok(Self { slice })
+    }
+
     /// Copy `host.len()` elements from host to device (in-place).
     pub fn copy_from_host(&mut self, device: &GpuDevice, host: &[T]) -> Result<()> {
         let stream = device.stream()?;

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -218,6 +218,47 @@ impl GpuContext {
         Ok(amplitude_bytes <= available)
     }
 
+    /// Whether the currently-available VRAM holds a dense statevector for
+    /// `num_qubits` plus the reduction scratch `GpuState` keeps live.
+    ///
+    /// Budgets the `2 * 2^n` f64 amplitude buffer (16 bytes/amplitude), one
+    /// `2^n` f64 probabilities scratch buffer (8 bytes/amplitude), and one
+    /// byte per amplitude of margin for the measurement partials
+    /// (`ceil(2^n / 512)` f64) and launcher metadata, so `2^n * 25` bytes
+    /// total. This is the fail-fast gate for the `Auto` GPU statevector
+    /// leaf; the backend's soft mode ([`StatevectorBackend::with_gpu_auto`](crate::backend::statevector::StatevectorBackend::with_gpu_auto))
+    /// is the backstop for any residual transient allocation that slips past it.
+    pub fn fits_statevector_with_scratch(&self, num_qubits: usize) -> Result<bool> {
+        if num_qubits >= usize::BITS as usize - 5 {
+            return Ok(false);
+        }
+        let bytes = (1usize << num_qubits).checked_mul(25).ok_or_else(|| {
+            crate::error::PrismError::InvalidParameter {
+                message: format!("num_qubits={num_qubits} overflows usize"),
+            }
+        })?;
+        Ok(bytes <= self.vram_available()?)
+    }
+
+    /// Whether the currently-available VRAM holds a stabilizer tableau for
+    /// `num_qubits`, matching the device layout in [`GpuTableau`].
+    ///
+    /// The tableau stores `(2n+1)` rows of `2 * ceil(n/64)` u64 words plus one
+    /// phase byte per row; the fixed measurement scratch is negligible. Used as
+    /// the fail-closed gate for the `Auto` GPU stabilizer leaf.
+    pub fn fits_tableau(&self, num_qubits: usize) -> Result<bool> {
+        let total_rows = num_qubits.checked_mul(2).and_then(|r| r.checked_add(1));
+        let num_words = num_qubits.div_ceil(64).max(1);
+        let xz_words = total_rows.and_then(|rows| rows.checked_mul(2 * num_words));
+        let bytes = xz_words
+            .and_then(|w| w.checked_mul(8))
+            .and_then(|b| b.checked_add(total_rows.unwrap_or(usize::MAX)));
+        match bytes {
+            Some(bytes) => Ok(bytes <= self.vram_available()?),
+            None => Ok(false),
+        }
+    }
+
     pub(crate) fn device(&self) -> &GpuDevice {
         &self.device
     }
@@ -272,6 +313,27 @@ impl GpuState {
         };
         kernels::dense::launch_set_initial_state(&context, &mut state)?;
         Ok(state)
+    }
+
+    /// Allocate a device state initialized from host amplitudes. The slice
+    /// length must be a power of two of at least 2; callers validate before
+    /// converting.
+    pub fn from_host_amplitudes(context: Arc<GpuContext>, amps: &[Complex64]) -> Result<Self> {
+        debug_assert!(amps.len().is_power_of_two() && amps.len() >= 2);
+        let num_qubits = amps.len().trailing_zeros() as usize;
+        let mut host = Vec::with_capacity(amps.len() * 2);
+        for a in amps {
+            host.push(a.re);
+            host.push(a.im);
+        }
+        let buffer = GpuBuffer::<f64>::from_host(context.device(), &host)?;
+        Ok(Self {
+            context,
+            buffer,
+            num_qubits,
+            pending_norm: 1.0,
+            probs_scratch: std::cell::RefCell::new(None),
+        })
     }
 
     /// Number of qubits the buffer is sized for.
@@ -520,5 +582,39 @@ mod tests {
         // which no GPU has. The function clamps these to `Ok(false)` before
         // touching the device, so even the stub context returns cleanly.
         assert!(!ctx.fits_statevector(128).unwrap());
+    }
+
+    #[test]
+    fn fits_statevector_with_scratch_rejects_cleanly_on_stub() {
+        let ctx = GpuContext::stub_for_tests();
+        assert!(matches!(
+            ctx.fits_statevector_with_scratch(4).unwrap_err(),
+            PrismError::BackendUnsupported { .. }
+        ));
+    }
+
+    #[test]
+    fn fits_statevector_with_scratch_clamps_overflow_before_device() {
+        let ctx = GpuContext::stub_for_tests();
+        // Past the overflow boundary the scratch budget clamps to `Ok(false)`
+        // without touching the (stub) device.
+        assert!(!ctx.fits_statevector_with_scratch(128).unwrap());
+    }
+
+    #[test]
+    fn fits_tableau_rejects_cleanly_on_stub() {
+        let ctx = GpuContext::stub_for_tests();
+        assert!(matches!(
+            ctx.fits_tableau(64).unwrap_err(),
+            PrismError::BackendUnsupported { .. }
+        ));
+    }
+
+    #[test]
+    fn fits_tableau_clamps_overflow_before_device() {
+        let ctx = GpuContext::stub_for_tests();
+        // A qubit count whose tableau byte budget overflows usize must clamp to
+        // `Ok(false)` rather than reaching the device or panicking.
+        assert!(!ctx.fits_tableau(usize::MAX / 2).unwrap());
     }
 }

--- a/src/sim/decomposed.rs
+++ b/src/sim/decomposed.rs
@@ -2,8 +2,8 @@ use crate::circuit::Circuit;
 use crate::error::Result;
 
 use super::{
-    BackendKind, FactoredBlock, Probabilities, RunOutcome, SimOptions, execute_circuit,
-    select_backend, validate_explicit_backend,
+    BackendKind, FactoredBlock, Probabilities, RunOutcome, SimOptions, dispatch::BackendPlan,
+    execute_circuit,
 };
 
 pub(super) const MIN_DECOMPOSITION_QUBITS: usize = 8;
@@ -29,6 +29,11 @@ fn run_blocks_maybe_par(
         let all_small = _components
             .iter()
             .all(|c| c.len() < MAX_BLOCK_QUBITS_FOR_PAR);
+        #[cfg(feature = "gpu")]
+        let all_small = all_small
+            && _components
+                .iter()
+                .all(|c| !super::dispatch::may_resolve_to_gpu(kind, c.len()));
         if all_small && k >= 2 {
             use rayon::prelude::*;
             crate::backend::init_thread_pool();
@@ -132,7 +137,7 @@ fn merge_decomposed_results(
 }
 
 pub(super) fn run_decomposed_prefused(
-    kind: &BackendKind,
+    block_plans: &[BackendPlan],
     components: &[Vec<usize>],
     partitions: &[(Circuit, Vec<usize>, Vec<usize>)],
     fused_blocks: &[std::borrow::Cow<'_, Circuit>],
@@ -149,12 +154,7 @@ pub(super) fn run_decomposed_prefused(
     let results: Vec<Result<RunOutcome>> = (0..k)
         .map(|i| {
             let block_seed = seed.wrapping_add(i as u64);
-            let sub = &partitions[i].0;
-            let block_kind = kind.clone();
-            if !block_kind.is_auto() {
-                validate_explicit_backend(&block_kind, sub)?;
-            }
-            let mut backend = select_backend(&block_kind, sub, block_seed, false);
+            let mut backend = block_plans[i].build(block_seed);
             execute_circuit(&mut *backend, &fused_blocks[i], &block_opts)
         })
         .collect();

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -21,13 +21,6 @@ use crate::distributed::DistributedContext;
 
 use super::{RunOutcome, try_backend_probabilities};
 
-pub(super) enum DispatchAction {
-    Backend(Box<dyn Backend>),
-    StabilizerRank,
-    StochasticPauli { num_samples: usize },
-    DeterministicPauli { epsilon: f64, max_terms: usize },
-}
-
 pub(super) const AUTO_MPS_BOND_DIM: usize = 256;
 
 pub(super) const MAX_AUTO_T_COUNT_EXACT: usize = 18;
@@ -97,17 +90,18 @@ pub enum BackendKind {
     /// Automatic backend selection with GPU acceleration opted in.
     ///
     /// Makes the same shape-based routing decisions as [`BackendKind::Auto`],
-    /// but when the selected backend (per sub-block, after subsystem
-    /// decomposition) is the dense statevector or the stabilizer tableau and the
-    /// block clears the qubit-count crossover with VRAM to spare, that block runs
-    /// on the supplied context. Every other choice, and every block that fails
-    /// the crossover or VRAM check, runs on the identical CPU path Auto would
-    /// take. The statevector path also degrades to the host when the device
-    /// allocation itself fails, so a missing, unfit, or racing device stays on
-    /// CPU rather than erroring. Acceleration reaches whichever entry points
-    /// route a selected statevector block through dispatch; some sampling and
-    /// expectation fast paths still build a host statevector directly and stay
-    /// on CPU pending the routing unification noted in `auto_gpu_choice_to_backend`.
+    /// but when the selected family (per sub-block, after subsystem
+    /// decomposition) has a device capability row and the block clears the
+    /// qubit-count crossover with VRAM to spare, that block runs on the
+    /// supplied context. Every other choice, and every block that fails the
+    /// crossover or VRAM check, runs on the identical CPU path Auto would
+    /// take. Device paths resolve soft: an allocation that fails after the
+    /// VRAM check degrades to the host, so a missing, unfit, or racing device
+    /// stays on CPU rather than erroring.
+    ///
+    /// Acceleration reaches every entry point through one resolution
+    /// mechanism: single runs, terminal shot and counts sampling, expectation
+    /// values, temporal-Clifford tails, and non-Pauli noisy trajectories.
     ///
     /// The context is user-supplied and is never acquired implicitly.
     #[cfg(feature = "gpu")]
@@ -252,48 +246,35 @@ pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -
     Ok(())
 }
 
-pub(super) fn supports_fused_for_kind(kind: &BackendKind, circuit: &Circuit) -> bool {
-    match kind {
-        BackendKind::Stabilizer
-        | BackendKind::FactoredStabilizer
-        | BackendKind::StabilizerRank
-        | BackendKind::StochasticPauli { .. }
-        | BackendKind::DeterministicPauli { .. } => false,
-        #[cfg(feature = "gpu")]
-        BackendKind::StabilizerGpu { .. } => false,
-        _ if kind.is_auto() => !(circuit.is_clifford_only() && circuit.has_entangling_gates()),
-        _ => true,
-    }
-}
-
+/// Simulator family, independent of how it was selected (auto routing or an
+/// explicit kind) and of where it executes (host or device).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AutoBackendChoice {
+pub(super) enum Family {
     ProductState,
     Stabilizer,
     Sparse,
     Mps,
     Factored,
+    FactoredStabilizer,
+    TensorNetwork,
     Statevector,
 }
 
-fn select_auto_backend_choice(
-    circuit: &Circuit,
-    has_partial_independence: bool,
-) -> AutoBackendChoice {
+fn select_auto_backend_choice(circuit: &Circuit, has_partial_independence: bool) -> Family {
     if !circuit.has_entangling_gates() {
-        AutoBackendChoice::ProductState
+        Family::ProductState
     } else if circuit.is_clifford_only() {
-        AutoBackendChoice::Stabilizer
+        Family::Stabilizer
     } else if circuit.num_qubits > max_statevector_qubits() {
         if circuit.is_sparse_friendly() {
-            AutoBackendChoice::Sparse
+            Family::Sparse
         } else {
-            AutoBackendChoice::Mps
+            Family::Mps
         }
     } else if has_partial_independence {
-        AutoBackendChoice::Factored
+        Family::Factored
     } else {
-        AutoBackendChoice::Statevector
+        Family::Statevector
     }
 }
 
@@ -303,174 +284,335 @@ pub(super) fn auto_selects_cpu_statevector(
 ) -> bool {
     matches!(
         select_auto_backend_choice(circuit, has_partial_independence),
-        AutoBackendChoice::Statevector
+        Family::Statevector
     )
 }
 
-/// Build a `StatevectorBackend` configured for GPU execution if the circuit
-/// is large enough to clear the crossover, otherwise a plain host
-/// backend. Called from `select_dispatch` (which runs per sub-block after
-/// decomposition) so small blocks transparently stay on CPU.
+/// Execution target for a resolved family: host, or a device context with a
+/// resolved failure mode. `soft` builds fall back to the host if device
+/// allocation fails at `init`; hard builds surface the error.
+#[derive(Clone)]
+pub(super) enum Accel {
+    Cpu,
+    #[cfg(feature = "gpu")]
+    Gpu {
+        context: Arc<GpuContext>,
+        soft: bool,
+    },
+}
+
+/// Device eligibility for one family: the qubit crossover and the VRAM-fit
+/// predicate, owned together. Families without device kernels are `None` rows
+/// in [`gpu_capability`]; adding a device path for a family means adding its
+/// row there, not touching dispatch.
 #[cfg(feature = "gpu")]
-fn statevector_gpu_with_crossover(
-    context: &Arc<GpuContext>,
-    circuit: &Circuit,
-    seed: u64,
-) -> StatevectorBackend {
-    if circuit.num_qubits >= crate::gpu::min_qubits() {
-        StatevectorBackend::new(seed).with_gpu(context.clone())
-    } else {
-        StatevectorBackend::new(seed)
+struct GpuCapability {
+    min_qubits: fn() -> usize,
+    fits: fn(&Arc<GpuContext>, usize) -> bool,
+}
+
+/// Families with a `gpu_capability` row. Keep in sync with the match below;
+/// a new device family needs an entry in both.
+#[cfg(feature = "gpu")]
+const GPU_CAPABLE_FAMILIES: [Family; 2] = [Family::Statevector, Family::Stabilizer];
+
+#[cfg(feature = "gpu")]
+fn gpu_capability(family: Family) -> Option<GpuCapability> {
+    match family {
+        Family::Statevector => Some(GpuCapability {
+            min_qubits: crate::gpu::min_qubits,
+            fits: |ctx, n| ctx.fits_statevector_with_scratch(n).unwrap_or(false),
+        }),
+        Family::Stabilizer => Some(GpuCapability {
+            min_qubits: crate::gpu::stabilizer_min_qubits,
+            fits: |ctx, n| ctx.fits_tableau(n).unwrap_or(false),
+        }),
+        Family::ProductState
+        | Family::Sparse
+        | Family::Mps
+        | Family::Factored
+        | Family::FactoredStabilizer
+        | Family::TensorNetwork => None,
     }
 }
 
-/// Build a `StabilizerBackend` configured for GPU execution if the circuit
-/// is large enough to clear the stabilizer crossover, otherwise a plain
-/// host backend.
-#[cfg(feature = "gpu")]
-fn stabilizer_gpu_with_crossover(
-    context: &Arc<GpuContext>,
-    circuit: &Circuit,
-    seed: u64,
-) -> StabilizerBackend {
-    if circuit.num_qubits >= crate::gpu::stabilizer_min_qubits() {
-        StabilizerBackend::new(seed).with_gpu(context.clone())
-    } else {
-        StabilizerBackend::new(seed)
-    }
-}
-
-/// Build a `StatevectorBackend` for the `AutoGpu` path. Routes the block to the
-/// device only when it clears the qubit crossover and the current VRAM holds the
-/// amplitude buffer plus scratch headroom. Every failing case, including a stub
-/// or absent device that makes the VRAM query error, falls back to the host
-/// backend rather than surfacing an error.
+/// The one decision point for CPU vs GPU execution of a family.
 ///
-/// Headroom: `fits_statevector(n + 1)` requires `2^(n+1) * 16` free bytes, which
-/// covers the `2^n * 16` byte amplitude buffer plus the probabilities and
-/// measurement scratch (up to `2^n * 8` bytes each) with margin.
+/// `AutoGpu` requires the family's capability row, the qubit crossover, and the
+/// VRAM-fit gate, and resolves soft so an allocation race still degrades to the
+/// host. An explicit GPU kind applies only the crossover for its own family and
+/// resolves hard: the user asked for the device, so an unfit device errors
+/// loudly. Every other kind, and every family without a capability row,
+/// resolves to the host.
+///
+/// The verdict (including the VRAM query) is intended to be taken once per
+/// user-level call and reused across shots; soft-mode init fallback covers
+/// VRAM shrinking after the fact.
 #[cfg(feature = "gpu")]
-fn auto_statevector_backend(
-    context: &Arc<GpuContext>,
-    circuit: &Circuit,
-    seed: u64,
-) -> StatevectorBackend {
-    let fits = circuit.num_qubits >= crate::gpu::min_qubits()
-        && context
-            .fits_statevector(circuit.num_qubits + 1)
-            .unwrap_or(false);
-    if fits {
-        StatevectorBackend::new(seed).with_gpu_auto(context.clone())
-    } else {
-        StatevectorBackend::new(seed)
+pub(super) fn accel_for(kind: &BackendKind, family: Family, num_qubits: usize) -> Accel {
+    let Some((context, soft)) = gpu_request(kind, family) else {
+        return Accel::Cpu;
+    };
+    let Some(cap) = gpu_capability(family) else {
+        return Accel::Cpu;
+    };
+    if num_qubits < (cap.min_qubits)() {
+        return Accel::Cpu;
+    }
+    if soft && !(cap.fits)(context, num_qubits) {
+        return Accel::Cpu;
+    }
+    Accel::Gpu {
+        context: context.clone(),
+        soft,
     }
 }
 
-fn auto_choice_to_backend(choice: AutoBackendChoice, seed: u64) -> Box<dyn Backend> {
-    match choice {
-        AutoBackendChoice::ProductState => Box::new(ProductStateBackend::new(seed)),
-        AutoBackendChoice::Stabilizer => Box::new(StabilizerBackend::new(seed)),
-        AutoBackendChoice::Sparse => Box::new(SparseBackend::new(seed)),
-        AutoBackendChoice::Mps => Box::new(MpsBackend::new(seed, AUTO_MPS_BOND_DIM)),
-        AutoBackendChoice::Factored => {
-            Box::new(crate::backend::factored::FactoredBackend::new(seed))
-        }
-        AutoBackendChoice::Statevector => Box::new(StatevectorBackend::new(seed)),
-    }
-}
-
-/// Map an auto choice to a backend, routing the GPU-eligible leaves
-/// (statevector and stabilizer) onto `context` through their respective
-/// crossovers. Non-eligible choices resolve to the same CPU backend as the
-/// plain `Auto` path.
-// TODO: replace these per-leaf arms with one per-choice mechanism where each backend owns its threshold, VRAM fit, and CPU fallback, so new GPU backends and every sampling/expectation/noise path route uniformly.
+/// Which (kind, family) pairs request device execution, and whether the
+/// request resolves soft. Shared by [`accel_for`] and [`may_resolve_to_gpu`]
+/// so the kind-to-family matching lives in one place.
 #[cfg(feature = "gpu")]
-fn auto_gpu_choice_to_backend(
-    choice: AutoBackendChoice,
-    context: &Arc<GpuContext>,
-    circuit: &Circuit,
-    seed: u64,
-) -> Box<dyn Backend> {
-    match choice {
-        AutoBackendChoice::Statevector => {
-            Box::new(auto_statevector_backend(context, circuit, seed))
-        }
-        AutoBackendChoice::Stabilizer => {
-            Box::new(stabilizer_gpu_with_crossover(context, circuit, seed))
-        }
-        other => auto_choice_to_backend(other, seed),
+fn gpu_request(kind: &BackendKind, family: Family) -> Option<(&Arc<GpuContext>, bool)> {
+    match (kind, family) {
+        (BackendKind::AutoGpu { context }, _) => Some((context, true)),
+        (BackendKind::StatevectorGpu { context }, Family::Statevector) => Some((context, false)),
+        (BackendKind::StabilizerGpu { context }, Family::Stabilizer) => Some((context, false)),
+        _ => None,
     }
 }
 
-pub(super) fn select_dispatch(
-    kind: &BackendKind,
-    circuit: &Circuit,
-    seed: u64,
-    has_partial_independence: bool,
-) -> DispatchAction {
-    match kind {
-        BackendKind::Auto => {
-            let choice = select_auto_backend_choice(circuit, has_partial_independence);
-            DispatchAction::Backend(auto_choice_to_backend(choice, seed))
-        }
+/// Whether this kind could resolve any family to the device at the given
+/// width. Over-approximates [`accel_for`]: it applies only the qubit
+/// crossover and skips the VRAM-fit gate, so the verdict cannot flip between
+/// a scheduling decision and the later per-block resolution. Multi-block
+/// drivers consult it before spreading work across threads; GPU backends
+/// share one CUDA stream per context and must not execute concurrently.
+#[cfg(feature = "gpu")]
+pub(super) fn may_resolve_to_gpu(kind: &BackendKind, num_qubits: usize) -> bool {
+    GPU_CAPABLE_FAMILIES.into_iter().any(|family| {
+        gpu_request(kind, family).is_some()
+            && gpu_capability(family).is_some_and(|cap| num_qubits >= (cap.min_qubits)())
+    })
+}
+
+#[cfg(not(feature = "gpu"))]
+pub(super) fn accel_for(_kind: &BackendKind, _family: Family, _num_qubits: usize) -> Accel {
+    Accel::Cpu
+}
+
+pub(super) fn build_statevector(accel: &Accel, seed: u64) -> StatevectorBackend {
+    match accel {
+        Accel::Cpu => StatevectorBackend::new(seed),
         #[cfg(feature = "gpu")]
-        BackendKind::AutoGpu { context } => {
-            let choice = select_auto_backend_choice(circuit, has_partial_independence);
-            DispatchAction::Backend(auto_gpu_choice_to_backend(choice, context, circuit, seed))
-        }
-        BackendKind::Statevector => {
-            DispatchAction::Backend(Box::new(StatevectorBackend::new(seed)))
-        }
-        BackendKind::Stabilizer => DispatchAction::Backend(Box::new(StabilizerBackend::new(seed))),
-        BackendKind::Sparse => DispatchAction::Backend(Box::new(SparseBackend::new(seed))),
-        BackendKind::Mps { max_bond_dim } => {
-            DispatchAction::Backend(Box::new(MpsBackend::new(seed, *max_bond_dim)))
-        }
-        BackendKind::ProductState => {
-            DispatchAction::Backend(Box::new(ProductStateBackend::new(seed)))
-        }
-        BackendKind::TensorNetwork => {
-            DispatchAction::Backend(Box::new(TensorNetworkBackend::new(seed)))
-        }
-        BackendKind::Factored => DispatchAction::Backend(Box::new(
-            crate::backend::factored::FactoredBackend::new(seed),
-        )),
-        BackendKind::FactoredStabilizer => DispatchAction::Backend(Box::new(
-            crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed),
-        )),
-        BackendKind::StabilizerRank => DispatchAction::StabilizerRank,
-        BackendKind::StochasticPauli { num_samples } => DispatchAction::StochasticPauli {
-            num_samples: *num_samples,
-        },
-        BackendKind::DeterministicPauli { epsilon, max_terms } => {
-            DispatchAction::DeterministicPauli {
-                epsilon: *epsilon,
-                max_terms: *max_terms,
+        Accel::Gpu {
+            context,
+            soft: true,
+        } => StatevectorBackend::new(seed).with_gpu_auto(context.clone()),
+        #[cfg(feature = "gpu")]
+        Accel::Gpu {
+            context,
+            soft: false,
+        } => StatevectorBackend::new(seed).with_gpu(context.clone()),
+    }
+}
+
+fn build_stabilizer(accel: &Accel, seed: u64) -> StabilizerBackend {
+    match accel {
+        Accel::Cpu => StabilizerBackend::new(seed),
+        #[cfg(feature = "gpu")]
+        Accel::Gpu {
+            context,
+            soft: true,
+        } => StabilizerBackend::new(seed).with_gpu_auto(context.clone()),
+        #[cfg(feature = "gpu")]
+        Accel::Gpu {
+            context,
+            soft: false,
+        } => StabilizerBackend::new(seed).with_gpu(context.clone()),
+    }
+}
+
+/// Resolved family plus acceleration for one user-level call. `build` is
+/// cheap enough to call once per shot or per trajectory: a constructor, a
+/// `Box::new`, and at most one `Arc` clone. All circuit analysis and every
+/// driver VRAM query happen earlier, in [`resolve`].
+#[derive(Clone)]
+pub(super) enum BackendPlan {
+    ProductState,
+    Sparse,
+    TensorNetwork,
+    Factored,
+    FactoredStabilizer,
+    Mps {
+        max_bond_dim: usize,
+    },
+    Stabilizer {
+        accel: Accel,
+    },
+    Statevector {
+        accel: Accel,
+    },
+    #[cfg(feature = "distributed")]
+    Distributed(Arc<DistributedContext>),
+}
+
+impl BackendPlan {
+    pub(super) fn build(&self, seed: u64) -> Box<dyn Backend> {
+        match self {
+            BackendPlan::ProductState => Box::new(ProductStateBackend::new(seed)),
+            BackendPlan::Sparse => Box::new(SparseBackend::new(seed)),
+            BackendPlan::TensorNetwork => Box::new(TensorNetworkBackend::new(seed)),
+            BackendPlan::Factored => Box::new(crate::backend::factored::FactoredBackend::new(seed)),
+            BackendPlan::FactoredStabilizer => {
+                Box::new(crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed))
+            }
+            BackendPlan::Mps { max_bond_dim } => Box::new(MpsBackend::new(seed, *max_bond_dim)),
+            BackendPlan::Stabilizer { accel } => Box::new(build_stabilizer(accel, seed)),
+            BackendPlan::Statevector { accel } => Box::new(build_statevector(accel, seed)),
+            #[cfg(feature = "distributed")]
+            BackendPlan::Distributed(context) => {
+                Box::new(DistributedStatevectorBackend::new(context.clone(), seed))
             }
         }
-        #[cfg(feature = "gpu")]
-        BackendKind::StatevectorGpu { context } => DispatchAction::Backend(Box::new(
-            statevector_gpu_with_crossover(context, circuit, seed),
-        )),
-        #[cfg(feature = "gpu")]
-        BackendKind::StabilizerGpu { context } => DispatchAction::Backend(Box::new(
-            stabilizer_gpu_with_crossover(context, circuit, seed),
-        )),
-        #[cfg(feature = "distributed")]
-        BackendKind::StatevectorDistributed { context } => DispatchAction::Backend(Box::new(
-            DistributedStatevectorBackend::new(context.clone(), seed),
-        )),
+    }
+
+    pub(super) fn is_gpu(&self) -> bool {
+        match self {
+            BackendPlan::Stabilizer { accel } | BackendPlan::Statevector { accel } => {
+                !matches!(accel, Accel::Cpu)
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether the fusion pipeline should synthesize fused-matrix gates for
+    /// this plan. Tableau-based families reject non-Clifford fused matrices;
+    /// every dense or factored representation accepts them.
+    pub(super) fn supports_fused(&self) -> bool {
+        !matches!(
+            self,
+            BackendPlan::Stabilizer { .. } | BackendPlan::FactoredStabilizer
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn family(&self) -> Family {
+        match self {
+            BackendPlan::ProductState => Family::ProductState,
+            BackendPlan::Sparse => Family::Sparse,
+            BackendPlan::TensorNetwork => Family::TensorNetwork,
+            BackendPlan::Factored => Family::Factored,
+            BackendPlan::FactoredStabilizer => Family::FactoredStabilizer,
+            BackendPlan::Mps { .. } => Family::Mps,
+            BackendPlan::Stabilizer { .. } => Family::Stabilizer,
+            BackendPlan::Statevector { .. } => Family::Statevector,
+            #[cfg(feature = "distributed")]
+            BackendPlan::Distributed(_) => Family::Statevector,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn accel(&self) -> &Accel {
+        match self {
+            BackendPlan::Stabilizer { accel } | BackendPlan::Statevector { accel } => accel,
+            _ => &Accel::Cpu,
+        }
     }
 }
 
-pub(super) fn select_backend(
+/// Whole-call routing decision produced by [`resolve`]. Backend execution is
+/// described by a buildable [`BackendPlan`]; the remaining variants are the
+/// non-backend engines (stabilizer rank, Pauli propagation) that callers
+/// handle outside the `Backend` world.
+pub(super) enum ExecutionPlan {
+    Backend(BackendPlan),
+    StabilizerRank,
+    StochasticPauli { num_samples: usize },
+    DeterministicPauli { epsilon: f64, max_terms: usize },
+}
+
+pub(super) fn plan_for_family(
+    kind: &BackendKind,
+    family: Family,
+    num_qubits: usize,
+) -> BackendPlan {
+    match family {
+        Family::ProductState => BackendPlan::ProductState,
+        Family::Sparse => BackendPlan::Sparse,
+        Family::TensorNetwork => BackendPlan::TensorNetwork,
+        Family::Factored => BackendPlan::Factored,
+        Family::FactoredStabilizer => BackendPlan::FactoredStabilizer,
+        Family::Mps => BackendPlan::Mps {
+            max_bond_dim: AUTO_MPS_BOND_DIM,
+        },
+        Family::Stabilizer => BackendPlan::Stabilizer {
+            accel: accel_for(kind, Family::Stabilizer, num_qubits),
+        },
+        Family::Statevector => BackendPlan::Statevector {
+            accel: accel_for(kind, Family::Statevector, num_qubits),
+        },
+    }
+}
+
+/// Resolve `kind` against `circuit` into an [`ExecutionPlan`], exactly once
+/// per user-level call. Auto kinds run the shape-based decision tree; explicit
+/// kinds map 1:1 onto their family. The CPU-vs-GPU verdict, including the
+/// VRAM-fit query, is taken here through [`accel_for`] and reused across
+/// shots; soft-mode init fallback covers VRAM shrinking after resolution.
+pub(super) fn resolve(
     kind: &BackendKind,
     circuit: &Circuit,
-    seed: u64,
     has_partial_independence: bool,
-) -> Box<dyn Backend> {
-    match select_dispatch(kind, circuit, seed, has_partial_independence) {
-        DispatchAction::Backend(b) => b,
+) -> ExecutionPlan {
+    let family = match kind {
+        BackendKind::Auto => select_auto_backend_choice(circuit, has_partial_independence),
+        #[cfg(feature = "gpu")]
+        BackendKind::AutoGpu { .. } => {
+            select_auto_backend_choice(circuit, has_partial_independence)
+        }
+        BackendKind::Statevector => Family::Statevector,
+        BackendKind::Stabilizer => Family::Stabilizer,
+        BackendKind::Sparse => Family::Sparse,
+        BackendKind::Mps { max_bond_dim } => {
+            return ExecutionPlan::Backend(BackendPlan::Mps {
+                max_bond_dim: *max_bond_dim,
+            });
+        }
+        BackendKind::ProductState => Family::ProductState,
+        BackendKind::TensorNetwork => Family::TensorNetwork,
+        BackendKind::Factored => Family::Factored,
+        BackendKind::FactoredStabilizer => Family::FactoredStabilizer,
+        BackendKind::StabilizerRank => return ExecutionPlan::StabilizerRank,
+        BackendKind::StochasticPauli { num_samples } => {
+            return ExecutionPlan::StochasticPauli {
+                num_samples: *num_samples,
+            };
+        }
+        BackendKind::DeterministicPauli { epsilon, max_terms } => {
+            return ExecutionPlan::DeterministicPauli {
+                epsilon: *epsilon,
+                max_terms: *max_terms,
+            };
+        }
+        #[cfg(feature = "gpu")]
+        BackendKind::StatevectorGpu { .. } => Family::Statevector,
+        #[cfg(feature = "gpu")]
+        BackendKind::StabilizerGpu { .. } => Family::Stabilizer,
+        #[cfg(feature = "distributed")]
+        BackendKind::StatevectorDistributed { context } => {
+            return ExecutionPlan::Backend(BackendPlan::Distributed(context.clone()));
+        }
+    };
+    ExecutionPlan::Backend(plan_for_family(kind, family, circuit.num_qubits))
+}
+
+pub(super) fn resolve_backend(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    has_partial_independence: bool,
+) -> BackendPlan {
+    match resolve(kind, circuit, has_partial_independence) {
+        ExecutionPlan::Backend(plan) => plan,
         _ => unreachable!("non-backend dispatch should be handled by caller"),
     }
 }
@@ -506,11 +648,23 @@ pub(super) fn has_temporal_clifford_opportunity(kind: &BackendKind, circuit: &Ci
     prefix_gates >= min_gates && prefix_gates < circuit.instructions.len()
 }
 
-pub(super) fn try_temporal_clifford(
+/// Temporal-Clifford execution split into a seed-independent plan and a
+/// per-seed run, so shot loops split and fuse the circuit once instead of
+/// once per shot. The stabilizer prefix runs on the host tableau; the
+/// crossover data in [`gpu_capability`] makes a device prefix unreachable
+/// here (temporal-Clifford requires fitting the dense statevector, far below
+/// the stabilizer crossover).
+pub(super) struct TemporalCliffordPlan {
+    prefix: Circuit,
+    fused_tail: Circuit,
+    tail_num_classical_bits: usize,
+    tail_accel: Accel,
+}
+
+pub(super) fn plan_temporal_clifford(
     kind: &BackendKind,
     circuit: &Circuit,
-    seed: u64,
-) -> Option<Result<RunOutcome>> {
+) -> Option<TemporalCliffordPlan> {
     if !kind.is_auto() {
         return None;
     }
@@ -521,44 +675,54 @@ pub(super) fn try_temporal_clifford(
     if prefix.gate_count() < min_clifford_prefix_gates(circuit.num_qubits) {
         return None;
     }
+    let tail_accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
+    let tail_num_classical_bits = tail.num_classical_bits;
+    let fused_tail = match &tail_accel {
+        Accel::Cpu => crate::circuit::fusion::fuse_circuit(&tail, true).into_owned(),
+        #[cfg(feature = "gpu")]
+        Accel::Gpu { .. } => {
+            let expanded = crate::circuit::expand_qft_blocks(&tail);
+            crate::circuit::fusion::fuse_circuit(&expanded, true).into_owned()
+        }
+    };
+    Some(TemporalCliffordPlan {
+        prefix,
+        fused_tail,
+        tail_num_classical_bits,
+        tail_accel,
+    })
+}
 
+pub(super) fn run_temporal_clifford(
+    plan: &TemporalCliffordPlan,
+    seed: u64,
+    want_probabilities: bool,
+) -> Result<RunOutcome> {
     let mut stab = StabilizerBackend::new(seed);
-    if let Err(e) = stab.init(prefix.num_qubits, prefix.num_classical_bits) {
-        return Some(Err(e));
-    }
+    stab.init(plan.prefix.num_qubits, plan.prefix.num_classical_bits)?;
     stab.enable_lazy_destab();
-    for inst in &prefix.instructions {
-        if let Err(e) = stab.apply(inst) {
-            return Some(Err(e));
-        }
+    for inst in &plan.prefix.instructions {
+        stab.apply(inst)?;
     }
 
-    let state = match stab.export_statevector() {
-        Ok(s) => s,
-        Err(e) => return Some(Err(e)),
+    let state = stab.export_statevector()?;
+
+    let mut sv = build_statevector(&plan.tail_accel, seed);
+    sv.init_from_state(state, plan.tail_num_classical_bits)?;
+    for inst in &plan.fused_tail.instructions {
+        sv.apply(inst)?;
+    }
+
+    let probabilities = if want_probabilities {
+        try_backend_probabilities(&sv)?
+    } else {
+        None
     };
 
-    let mut sv = StatevectorBackend::new(seed);
-    if let Err(e) = sv.init_from_state(state, tail.num_classical_bits) {
-        return Some(Err(e));
-    }
-
-    let fused_tail = crate::circuit::fusion::fuse_circuit(&tail, sv.supports_fused_gates());
-    for inst in &fused_tail.instructions {
-        if let Err(e) = sv.apply(inst) {
-            return Some(Err(e));
-        }
-    }
-
-    let probabilities = match try_backend_probabilities(&sv) {
-        Ok(probs) => probs,
-        Err(e) => return Some(Err(e)),
-    };
-
-    Some(Ok(RunOutcome {
+    Ok(RunOutcome {
         classical_bits: sv.classical_results().to_vec(),
         probabilities,
-    }))
+    })
 }
 
 #[cfg(all(test, feature = "gpu"))]
@@ -769,5 +933,325 @@ mod gpu_crossover_tests {
             run_query(explicit, &circuit, 42).unwrap_err(),
             PrismError::BackendUnsupported { .. }
         ));
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod accel_tests {
+    use super::*;
+
+    fn stub() -> Arc<GpuContext> {
+        GpuContext::stub_for_tests()
+    }
+
+    fn is_cpu(accel: &Accel) -> bool {
+        matches!(accel, Accel::Cpu)
+    }
+
+    #[test]
+    fn auto_gpu_statevector_below_crossover_is_cpu() {
+        let kind = BackendKind::AutoGpu { context: stub() };
+        let n = crate::gpu::min_qubits() - 1;
+        assert!(is_cpu(&accel_for(&kind, Family::Statevector, n)));
+    }
+
+    /// Above the crossover the stub cannot report VRAM, so the fit gate fails
+    /// closed and the soft path resolves to the host.
+    #[test]
+    fn auto_gpu_statevector_fits_fails_closed_on_stub() {
+        let kind = BackendKind::AutoGpu { context: stub() };
+        let n = crate::gpu::min_qubits() + 2;
+        assert!(is_cpu(&accel_for(&kind, Family::Statevector, n)));
+    }
+
+    #[test]
+    fn auto_gpu_cpu_only_families_stay_cpu() {
+        let kind = BackendKind::AutoGpu { context: stub() };
+        for family in [
+            Family::ProductState,
+            Family::Sparse,
+            Family::Mps,
+            Family::Factored,
+            Family::FactoredStabilizer,
+            Family::TensorNetwork,
+        ] {
+            assert!(is_cpu(&accel_for(&kind, family, 1 << 10)), "{family:?}");
+        }
+    }
+
+    #[test]
+    fn explicit_statevector_gpu_is_hard_at_crossover_and_cpu_below() {
+        let kind = BackendKind::StatevectorGpu { context: stub() };
+        let n = crate::gpu::min_qubits();
+        assert!(matches!(
+            accel_for(&kind, Family::Statevector, n),
+            Accel::Gpu { soft: false, .. }
+        ));
+        assert!(is_cpu(&accel_for(&kind, Family::Statevector, n - 1)));
+    }
+
+    #[test]
+    fn explicit_stabilizer_gpu_is_hard_at_crossover_and_cpu_below() {
+        let kind = BackendKind::StabilizerGpu { context: stub() };
+        let n = crate::gpu::stabilizer_min_qubits();
+        assert!(matches!(
+            accel_for(&kind, Family::Stabilizer, n),
+            Accel::Gpu { soft: false, .. }
+        ));
+        assert!(is_cpu(&accel_for(&kind, Family::Stabilizer, n - 1)));
+    }
+
+    /// An explicit GPU kind accelerates only its own family; any other family
+    /// resolves to the host regardless of size.
+    #[test]
+    fn explicit_kind_other_family_is_cpu() {
+        let sv = BackendKind::StatevectorGpu { context: stub() };
+        assert!(is_cpu(&accel_for(&sv, Family::Stabilizer, 1 << 20)));
+        let stab = BackendKind::StabilizerGpu { context: stub() };
+        assert!(is_cpu(&accel_for(&stab, Family::Statevector, 1 << 20)));
+    }
+
+    #[test]
+    fn cpu_kinds_are_cpu_everywhere() {
+        for family in [Family::Statevector, Family::Stabilizer] {
+            assert!(is_cpu(&accel_for(&BackendKind::Auto, family, 1 << 20)));
+            assert!(is_cpu(&accel_for(
+                &BackendKind::Statevector,
+                family,
+                1 << 20
+            )));
+        }
+    }
+
+    /// `init_from_state` on a soft GPU backend degrades to the host when the
+    /// device upload fails, preserving the supplied amplitudes.
+    #[test]
+    fn init_from_state_soft_falls_back_to_host_on_stub() {
+        use num_complex::Complex64;
+        let mut sv = StatevectorBackend::new(42).with_gpu_auto(stub());
+        let amp = Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);
+        let state = vec![amp, Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0), amp];
+        sv.init_from_state(state.clone(), 0).unwrap();
+        let exported = sv.export_statevector().unwrap();
+        for (e, s) in exported.iter().zip(&state) {
+            assert!((e - s).norm() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn init_from_state_hard_errors_on_stub() {
+        use num_complex::Complex64;
+        let mut sv = StatevectorBackend::new(42).with_gpu(stub());
+        let err = sv
+            .init_from_state(vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)], 0)
+            .unwrap_err();
+        assert!(matches!(err, PrismError::BackendUnsupported { .. }));
+    }
+}
+
+/// Table-driven coverage of [`resolve`]: every backend kind against every
+/// circuit shape class, asserting the resolved family and execution target.
+/// This is the contract that all simulator families dispatch uniformly on
+/// both targets; extend it when a family gains a capability row.
+#[cfg(test)]
+mod dispatch_matrix_tests {
+    use super::*;
+    use crate::gates::Gate;
+
+    fn product(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, 0);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        c
+    }
+
+    fn clifford(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, 0);
+        c.add_gate(Gate::H, &[0]);
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        c
+    }
+
+    fn dense(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, 0);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        c
+    }
+
+    fn oversize_sparse() -> Circuit {
+        let n = max_statevector_qubits() + 1;
+        let mut c = Circuit::new(n, 0);
+        for q in 0..n {
+            c.add_gate(Gate::T, &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        c
+    }
+
+    fn oversize_dense() -> Circuit {
+        let n = max_statevector_qubits() + 1;
+        let mut c = Circuit::new(n, 0);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        c
+    }
+
+    fn resolved(kind: &BackendKind, circuit: &Circuit, hpi: bool) -> BackendPlan {
+        match resolve(kind, circuit, hpi) {
+            ExecutionPlan::Backend(plan) => plan,
+            _ => panic!("expected a backend plan"),
+        }
+    }
+
+    fn assert_cpu_family(kind: &BackendKind, circuit: &Circuit, hpi: bool, family: Family) {
+        let plan = resolved(kind, circuit, hpi);
+        assert_eq!(plan.family(), family, "kind {kind:?}");
+        assert!(
+            matches!(plan.accel(), Accel::Cpu),
+            "kind {kind:?} family {family:?} must resolve to the host"
+        );
+    }
+
+    fn auto_kinds() -> Vec<BackendKind> {
+        #[cfg(feature = "gpu")]
+        {
+            vec![
+                BackendKind::Auto,
+                BackendKind::AutoGpu {
+                    context: GpuContext::stub_for_tests(),
+                },
+            ]
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            vec![BackendKind::Auto]
+        }
+    }
+
+    /// Auto and AutoGpu make identical family choices across every circuit
+    /// shape class; on the stub context every choice resolves to the host
+    /// (small circuits by crossover, large ones by the fail-closed VRAM gate).
+    #[test]
+    fn auto_family_matrix() {
+        for kind in auto_kinds() {
+            assert_cpu_family(&kind, &product(6), false, Family::ProductState);
+            assert_cpu_family(&kind, &clifford(6), false, Family::Stabilizer);
+            assert_cpu_family(&kind, &clifford(16), false, Family::Stabilizer);
+            assert_cpu_family(&kind, &dense(8), false, Family::Statevector);
+            assert_cpu_family(&kind, &dense(16), false, Family::Statevector);
+            assert_cpu_family(&kind, &dense(8), true, Family::Factored);
+            assert_cpu_family(&kind, &oversize_sparse(), false, Family::Sparse);
+            assert_cpu_family(&kind, &oversize_dense(), false, Family::Mps);
+        }
+    }
+
+    #[test]
+    fn auto_oversize_mps_uses_auto_bond_dim() {
+        for kind in auto_kinds() {
+            let plan = resolved(&kind, &oversize_dense(), false);
+            assert!(matches!(
+                plan,
+                BackendPlan::Mps {
+                    max_bond_dim: AUTO_MPS_BOND_DIM
+                }
+            ));
+        }
+    }
+
+    /// Explicit CPU kinds map 1:1 onto their family regardless of circuit
+    /// shape, always on the host.
+    #[test]
+    fn explicit_cpu_kind_matrix() {
+        let circuit = dense(6);
+        let cases = [
+            (BackendKind::Statevector, Family::Statevector),
+            (BackendKind::Stabilizer, Family::Stabilizer),
+            (BackendKind::Sparse, Family::Sparse),
+            (BackendKind::ProductState, Family::ProductState),
+            (BackendKind::TensorNetwork, Family::TensorNetwork),
+            (BackendKind::Factored, Family::Factored),
+            (BackendKind::FactoredStabilizer, Family::FactoredStabilizer),
+        ];
+        for (kind, family) in cases {
+            assert_cpu_family(&kind, &circuit, false, family);
+        }
+
+        let plan = resolved(&BackendKind::Mps { max_bond_dim: 77 }, &circuit, false);
+        assert!(matches!(plan, BackendPlan::Mps { max_bond_dim: 77 }));
+    }
+
+    #[test]
+    fn non_backend_kinds_resolve_to_their_engines() {
+        let circuit = dense(6);
+        assert!(matches!(
+            resolve(&BackendKind::StabilizerRank, &circuit, false),
+            ExecutionPlan::StabilizerRank
+        ));
+        assert!(matches!(
+            resolve(
+                &BackendKind::StochasticPauli { num_samples: 9 },
+                &circuit,
+                false
+            ),
+            ExecutionPlan::StochasticPauli { num_samples: 9 }
+        ));
+        assert!(matches!(
+            resolve(
+                &BackendKind::DeterministicPauli {
+                    epsilon: 0.5,
+                    max_terms: 3
+                },
+                &circuit,
+                false
+            ),
+            ExecutionPlan::DeterministicPauli {
+                epsilon: e,
+                max_terms: 3
+            } if e == 0.5
+        ));
+    }
+
+    /// Explicit GPU kinds resolve hard device execution at their crossover
+    /// (no VRAM gate) and host execution below it; the family choice never
+    /// changes with the target.
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn explicit_gpu_kind_matrix() {
+        let sv_kind = BackendKind::StatevectorGpu {
+            context: GpuContext::stub_for_tests(),
+        };
+        let large = dense(crate::gpu::min_qubits());
+        let plan = resolved(&sv_kind, &large, false);
+        assert_eq!(plan.family(), Family::Statevector);
+        assert!(matches!(plan.accel(), Accel::Gpu { soft: false, .. }));
+        assert_cpu_family(
+            &sv_kind,
+            &dense(crate::gpu::min_qubits() - 1),
+            false,
+            Family::Statevector,
+        );
+
+        let stab_kind = BackendKind::StabilizerGpu {
+            context: GpuContext::stub_for_tests(),
+        };
+        let huge = Circuit::new(crate::gpu::stabilizer_min_qubits(), 0);
+        let plan = resolved(&stab_kind, &huge, false);
+        assert_eq!(plan.family(), Family::Stabilizer);
+        assert!(matches!(plan.accel(), Accel::Gpu { soft: false, .. }));
+        assert_cpu_family(&stab_kind, &clifford(8), false, Family::Stabilizer);
     }
 }

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -1086,8 +1086,20 @@ mod dispatch_matrix_tests {
         c
     }
 
-    fn oversize_sparse() -> Circuit {
-        let n = max_statevector_qubits() + 1;
+    /// One qubit past the statevector memory cap, or `None` when memory
+    /// detection failed and the cap is disabled (no width is oversize then).
+    fn oversize_qubits() -> Option<usize> {
+        let cap = max_statevector_qubits();
+        if cap >= usize::BITS as usize {
+            eprintln!(
+                "SKIP: statevector qubit cap disabled on this host; skipping oversize checks"
+            );
+            return None;
+        }
+        Some(cap + 1)
+    }
+
+    fn oversize_sparse(n: usize) -> Circuit {
         let mut c = Circuit::new(n, 0);
         for q in 0..n {
             c.add_gate(Gate::T, &[q]);
@@ -1098,8 +1110,7 @@ mod dispatch_matrix_tests {
         c
     }
 
-    fn oversize_dense() -> Circuit {
-        let n = max_statevector_qubits() + 1;
+    fn oversize_dense(n: usize) -> Circuit {
         let mut c = Circuit::new(n, 0);
         for q in 0..n {
             c.add_gate(Gate::Rx(0.3), &[q]);
@@ -1147,6 +1158,7 @@ mod dispatch_matrix_tests {
     /// (small circuits by crossover, large ones by the fail-closed VRAM gate).
     #[test]
     fn auto_family_matrix() {
+        let oversize = oversize_qubits();
         for kind in auto_kinds() {
             assert_cpu_family(&kind, &product(6), false, Family::ProductState);
             assert_cpu_family(&kind, &clifford(6), false, Family::Stabilizer);
@@ -1154,15 +1166,18 @@ mod dispatch_matrix_tests {
             assert_cpu_family(&kind, &dense(8), false, Family::Statevector);
             assert_cpu_family(&kind, &dense(16), false, Family::Statevector);
             assert_cpu_family(&kind, &dense(8), true, Family::Factored);
-            assert_cpu_family(&kind, &oversize_sparse(), false, Family::Sparse);
-            assert_cpu_family(&kind, &oversize_dense(), false, Family::Mps);
+            if let Some(n) = oversize {
+                assert_cpu_family(&kind, &oversize_sparse(n), false, Family::Sparse);
+                assert_cpu_family(&kind, &oversize_dense(n), false, Family::Mps);
+            }
         }
     }
 
     #[test]
     fn auto_oversize_mps_uses_auto_bond_dim() {
+        let Some(n) = oversize_qubits() else { return };
         for kind in auto_kinds() {
-            let plan = resolved(&kind, &oversize_dense(), false);
+            let plan = resolved(&kind, &oversize_dense(n), false);
             assert!(matches!(
                 plan,
                 BackendPlan::Mps {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -21,12 +21,12 @@ use decomposed::{
 };
 pub use dispatch::BackendKind;
 use dispatch::{
-    AUTO_APPROX_MAX_TERMS, AUTO_MPS_BOND_DIM, AUTO_SPD_MAX_TERMS, DispatchAction,
+    AUTO_APPROX_MAX_TERMS, AUTO_SPD_MAX_TERMS, BackendPlan, ExecutionPlan, Family,
     MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
     MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
-    MIN_QUBITS_FOR_SPD_AUTO, auto_selects_cpu_statevector, has_temporal_clifford_opportunity,
-    select_backend, select_dispatch, stabilizer_rank_budget, supports_fused_for_kind,
-    try_temporal_clifford, validate_explicit_backend,
+    MIN_QUBITS_FOR_SPD_AUTO, accel_for, auto_selects_cpu_statevector, build_statevector,
+    has_temporal_clifford_opportunity, plan_for_family, plan_temporal_clifford, resolve,
+    resolve_backend, run_temporal_clifford, stabilizer_rank_budget, validate_explicit_backend,
 };
 pub use probability::{FactoredBlock, Probabilities, ProbabilitiesIter};
 pub use shots::{ShotsResult, bitstring};
@@ -40,7 +40,10 @@ use crate::backend::{Backend, max_statevector_qubits};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 use shots::{packed_shots_to_classical_bits, sample_shots};
-use terminal_sampling::{sample_counts_from_state, sample_shots_from_state};
+use terminal_sampling::{
+    sample_counts_from_probs, sample_counts_from_state, sample_shots_from_probs,
+    sample_shots_from_state,
+};
 use unified_pauli::{PauliAxis, PauliTerm};
 
 type TerminalStatevector = (StatevectorBackend, Vec<(usize, usize)>);
@@ -339,66 +342,62 @@ fn run_with_internal(
     // calls every rank must issue in the same order. Dispatch directly.
     #[cfg(feature = "distributed")]
     if matches!(kind, BackendKind::StatevectorDistributed { .. }) {
-        return match select_dispatch(&kind, circuit, seed, false) {
-            DispatchAction::Backend(mut backend) => execute(&mut *backend, circuit, &opts),
-            _ => unreachable!("StatevectorDistributed always dispatches to a backend"),
-        };
+        let mut backend = resolve_backend(&kind, circuit, false).build(seed);
+        return execute(&mut *backend, circuit, &opts);
     }
-    let mut has_partial_independence = false;
-    if circuit.num_qubits >= MIN_DECOMPOSITION_QUBITS {
-        let components = circuit.independent_subsystems();
-        if components.len() > 1 {
-            if should_decompose(&components, circuit.num_qubits) {
-                let max_block = components.iter().map(|c| c.len()).max().unwrap_or(0);
-                if kind.is_auto()
-                    && circuit.is_clifford_only()
-                    && circuit.num_qubits >= MIN_FACTORED_STABILIZER_QUBITS
-                    && max_block >= MIN_BLOCK_FOR_FACTORED_STAB
-                {
-                    let mut backend =
-                        crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed);
-                    let fs_opts = if circuit.num_qubits > 64 {
-                        SimOptions {
-                            probabilities: false,
-                        }
-                    } else {
-                        opts
-                    };
-                    return execute(&mut backend, circuit, &fs_opts);
+    let (decompose, has_partial_independence) = analyze_independence(circuit);
+    if let Some(components) = decompose {
+        let max_block = components.iter().map(|c| c.len()).max().unwrap_or(0);
+        if kind.is_auto()
+            && circuit.is_clifford_only()
+            && circuit.num_qubits >= MIN_FACTORED_STABILIZER_QUBITS
+            && max_block >= MIN_BLOCK_FOR_FACTORED_STAB
+        {
+            let mut backend =
+                crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed);
+            let fs_opts = if circuit.num_qubits > 64 {
+                SimOptions {
+                    probabilities: false,
                 }
-                return run_decomposed(&kind, &components, circuit, seed, &opts);
+            } else {
+                opts
+            };
+            return execute(&mut backend, circuit, &fs_opts);
+        }
+        return run_decomposed(&kind, &components, circuit, seed, &opts);
+    }
+    if kind.is_auto() && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS {
+        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
+            if t <= MAX_AUTO_T_COUNT_APPROX
+                && t <= sr_budget
+                && !has_nonunitary_or_classical_ops(circuit)
+            {
+                let sr = if t <= MAX_AUTO_T_COUNT_EXACT {
+                    stabilizer_rank::run_stabilizer_rank(circuit, seed)?
+                } else {
+                    stabilizer_rank::run_stabilizer_rank_approx(
+                        circuit,
+                        AUTO_APPROX_MAX_TERMS,
+                        seed,
+                    )?
+                };
+                return Ok(probs_only_result(sr.probabilities));
             }
-            has_partial_independence = true;
         }
     }
-    if kind.is_auto()
-        && circuit.is_clifford_plus_t()
-        && circuit.has_t_gates()
-        && !has_nonunitary_or_classical_ops(circuit)
-        && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
-    {
-        let t = circuit.t_count();
-        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
-        if t <= MAX_AUTO_T_COUNT_EXACT && t <= sr_budget {
-            let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
-            return Ok(probs_only_result(sr.probabilities));
-        }
-        if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
-            let sr =
-                stabilizer_rank::run_stabilizer_rank_approx(circuit, AUTO_APPROX_MAX_TERMS, seed)?;
-            return Ok(probs_only_result(sr.probabilities));
-        }
+    if let Some(tc) = plan_temporal_clifford(&kind, circuit) {
+        return run_temporal_clifford(&tc, seed, opts.probabilities);
     }
-    if let Some(result) = try_temporal_clifford(&kind, circuit, seed) {
-        return result;
-    }
-    match select_dispatch(&kind, circuit, seed, has_partial_independence) {
-        DispatchAction::Backend(mut backend) => execute(&mut *backend, circuit, &opts),
-        DispatchAction::StabilizerRank => {
+    match resolve(&kind, circuit, has_partial_independence) {
+        ExecutionPlan::Backend(plan) => {
+            let mut backend = plan.build(seed);
+            execute(&mut *backend, circuit, &opts)
+        }
+        ExecutionPlan::StabilizerRank => {
             let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
             Ok(probs_only_result(sr.probabilities))
         }
-        DispatchAction::StochasticPauli { num_samples } => {
+        ExecutionPlan::StochasticPauli { num_samples } => {
             Err(crate::error::PrismError::IncompatibleBackend {
                 backend: format!(
                     "{:?}",
@@ -407,7 +406,7 @@ fn run_with_internal(
                 reason: "StochasticPauli produces marginal estimates only; use `simulate(...).marginals()`".into(),
             })
         }
-        DispatchAction::DeterministicPauli { epsilon, max_terms } => {
+        ExecutionPlan::DeterministicPauli { epsilon, max_terms } => {
             Err(crate::error::PrismError::IncompatibleBackend {
                 backend: format!(
                     "{:?}",
@@ -512,30 +511,53 @@ fn compile_measurements_for_kind(
     Ok(sampler)
 }
 
-fn auto_terminal_statevector_candidate(circuit: &Circuit) -> bool {
-    let mut has_partial_independence = false;
+/// Independence analysis shared by the routing prelude in
+/// `run_with_internal`, the shots slow path, and the terminal fast-path
+/// candidacy. Returns the components to decompose with when full
+/// decomposition should fire, plus the partial-independence flag otherwise.
+fn analyze_independence(circuit: &Circuit) -> (Option<Vec<Vec<usize>>>, bool) {
     if circuit.num_qubits >= MIN_DECOMPOSITION_QUBITS {
         let components = circuit.independent_subsystems();
         if components.len() > 1 {
             if should_decompose(&components, circuit.num_qubits) {
-                return false;
+                return (Some(components), false);
             }
-            has_partial_independence = true;
+            return (None, true);
         }
+    }
+    (None, false)
+}
+
+/// `(t_count, stabilizer_rank_budget)` when the auto Clifford+T family gate
+/// passes. Callers apply their own per-entry-point T-count ceilings.
+fn auto_clifford_t_budget(circuit: &Circuit) -> Option<(usize, usize)> {
+    (circuit.is_clifford_plus_t() && circuit.has_t_gates()).then(|| {
+        (
+            circuit.t_count(),
+            stabilizer_rank_budget(circuit.num_qubits),
+        )
+    })
+}
+
+/// Mirrors the routing precedence of `run_with_internal` (decomposition, then
+/// Clifford+T stabilizer rank, then temporal Clifford, then family choice)
+/// through the shared predicates. Keep the check order aligned when either
+/// side changes.
+fn auto_terminal_statevector_candidate(circuit: &Circuit) -> bool {
+    let (decompose, has_partial_independence) = analyze_independence(circuit);
+    if decompose.is_some() {
+        return false;
     }
 
     if !auto_selects_cpu_statevector(circuit, has_partial_independence) {
         return false;
     }
 
-    if circuit.is_clifford_plus_t()
-        && circuit.has_t_gates()
-        && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
-    {
-        let t = circuit.t_count();
-        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
-        if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
-            return false;
+    if circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS {
+        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
+            if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
+                return false;
+            }
         }
     }
 
@@ -546,7 +568,12 @@ fn terminal_statevector_candidate(kind: &BackendKind, circuit: &Circuit) -> bool
     if kind.is_auto() {
         return auto_terminal_statevector_candidate(circuit);
     }
-    matches!(kind, BackendKind::Statevector)
+    match kind {
+        BackendKind::Statevector => true,
+        #[cfg(feature = "gpu")]
+        BackendKind::StatevectorGpu { .. } => true,
+        _ => false,
+    }
 }
 
 fn try_terminal_statevector_backend(
@@ -568,7 +595,8 @@ fn try_terminal_statevector_backend(
         return Ok(None);
     }
 
-    let mut backend = StatevectorBackend::new(seed);
+    let accel = accel_for(kind, Family::Statevector, stripped.num_qubits);
+    let mut backend = build_statevector(&accel, seed);
     let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
         std::borrow::Cow::Borrowed(&stripped)
     } else {
@@ -614,6 +642,16 @@ pub(crate) fn run_counts_with(
     }
 
     if let Some((backend, meas_map)) = try_terminal_statevector_backend(&kind, circuit, seed)? {
+        if backend.is_gpu_resident() {
+            let probs = backend.probabilities()?;
+            return Ok(sample_counts_from_probs(
+                &probs,
+                &meas_map,
+                circuit.num_classical_bits,
+                num_shots,
+                seed,
+            ));
+        }
         return Ok(sample_counts_from_state(
             backend.state_vector(),
             backend.probability_scale(),
@@ -816,7 +854,7 @@ fn run_expectation_values_with(
                         ),
                     });
                 }
-                expectation_values_statevector(circuit, observables, seed)
+                expectation_values_statevector(&kind, circuit, observables, seed)
             } else {
                 Err(PrismError::IncompatibleBackend {
                     backend: format!("{kind:?}"),
@@ -824,15 +862,28 @@ fn run_expectation_values_with(
                 })
             }
         }
-        BackendKind::Statevector => expectation_values_statevector(circuit, observables, seed),
-        other => Err(PrismError::IncompatibleBackend {
-            backend: format!("{other:?}"),
-            reason: "expectation values support Auto, Statevector, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli".into(),
-        }),
+        BackendKind::Statevector => {
+            expectation_values_statevector(&kind, circuit, observables, seed)
+        }
+        #[cfg(feature = "gpu")]
+        BackendKind::StatevectorGpu { .. } => {
+            expectation_values_statevector(&kind, circuit, observables, seed)
+        }
+        other => {
+            #[cfg(feature = "gpu")]
+            let supported = "expectation values support Auto, AutoGpu, Statevector, StatevectorGpu, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli";
+            #[cfg(not(feature = "gpu"))]
+            let supported = "expectation values support Auto, Statevector, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli";
+            Err(PrismError::IncompatibleBackend {
+                backend: format!("{other:?}"),
+                reason: supported.into(),
+            })
+        }
     }
 }
 
 fn expectation_values_statevector(
+    kind: &BackendKind,
     circuit: &Circuit,
     observables: &[Vec<PauliTerm>],
     seed: u64,
@@ -843,7 +894,8 @@ fn expectation_values_statevector(
         .map(|obs| pauli_masks(obs, circuit.num_qubits))
         .collect::<Result<Vec<_>>>()?;
 
-    let mut backend = StatevectorBackend::new(seed);
+    let accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
+    let mut backend = build_statevector(&accel, seed);
     let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
         std::borrow::Cow::Borrowed(circuit)
     } else {
@@ -853,7 +905,13 @@ fn expectation_values_statevector(
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
 
-    let state = backend.state_vector();
+    let exported;
+    let state: &[Complex64] = if backend.is_gpu_resident() {
+        exported = backend.export_statevector()?;
+        &exported
+    } else {
+        backend.state_vector()
+    };
     let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
     Ok(masks
         .iter()
@@ -1052,14 +1110,25 @@ pub(crate) fn run_shots_with(
     }
 
     if let Some((backend, meas_map)) = try_terminal_statevector_backend(&kind, circuit, seed)? {
-        let shots = sample_shots_from_state(
-            backend.state_vector(),
-            backend.probability_scale(),
-            &meas_map,
-            circuit.num_classical_bits,
-            num_shots,
-            seed,
-        );
+        let shots = if backend.is_gpu_resident() {
+            let probs = backend.probabilities()?;
+            sample_shots_from_probs(
+                &probs,
+                &meas_map,
+                circuit.num_classical_bits,
+                num_shots,
+                seed,
+            )
+        } else {
+            sample_shots_from_state(
+                backend.state_vector(),
+                backend.probability_scale(),
+                &meas_map,
+                circuit.num_classical_bits,
+                num_shots,
+                seed,
+            )
+        };
         return Ok(ShotsResult {
             shots,
             num_classical_bits: circuit.num_classical_bits,
@@ -1071,14 +1140,12 @@ pub(crate) fn run_shots_with(
     }
     if kind.is_auto()
         && circuit.has_terminal_measurements_only()
-        && circuit.is_clifford_plus_t()
-        && circuit.has_t_gates()
         && circuit.num_qubits > MAX_STABILIZER_RANK_QUBITS
     {
-        let t = circuit.t_count();
-        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
-        if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
-            return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
+            if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
+                return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+            }
         }
     }
 
@@ -1107,22 +1174,7 @@ pub(crate) fn run_shots_with(
         validate_explicit_backend(&kind, circuit)?;
     }
 
-    let mut has_partial_independence = false;
-    let decompose = if circuit.num_qubits >= MIN_DECOMPOSITION_QUBITS {
-        let comps = circuit.independent_subsystems();
-        if comps.len() > 1 {
-            if should_decompose(&comps, circuit.num_qubits) {
-                Some(comps)
-            } else {
-                has_partial_independence = true;
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let (decompose, has_partial_independence) = analyze_independence(circuit);
 
     if matches!(kind, BackendKind::StabilizerRank) {
         return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
@@ -1136,35 +1188,55 @@ pub(crate) fn run_shots_with(
             reason: "Pauli propagation backends do not support mid-circuit measurements".into(),
         });
     }
-    if kind.is_auto() && circuit.is_clifford_plus_t() && circuit.has_t_gates() {
-        let t = circuit.t_count();
-        let sr_budget = stabilizer_rank_budget(circuit.num_qubits);
-        if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
-            return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+    if kind.is_auto() {
+        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
+            if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
+                return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
+            }
         }
     }
 
     if has_temporal_clifford_opportunity(&kind, circuit) {
-        return run_shots_fallback(&kind, circuit, num_shots, seed);
+        if decompose.is_none() {
+            if let Some(tc) = plan_temporal_clifford(&kind, circuit) {
+                return collect_shots(circuit, num_shots, seed, |shot_seed| {
+                    Ok(run_temporal_clifford(&tc, shot_seed, false)?.classical_bits)
+                });
+            }
+        }
+        // Decomposable circuits with a temporal prefix keep the per-shot
+        // full-pipeline route; the prefix spans blocks that decomposition
+        // would otherwise split.
+        let opts = SimOptions::classical_only();
+        return collect_shots(circuit, num_shots, seed, |shot_seed| {
+            Ok(run_with_internal(kind.clone(), circuit, shot_seed, opts)?.classical_bits)
+        });
     }
 
-    let supports_fused = supports_fused_for_kind(&kind, circuit);
-    let mut shots = Vec::with_capacity(num_shots);
     let opts = SimOptions::classical_only();
 
     if let Some(ref comps) = decompose {
         let partitions = circuit.partition_subcircuits(comps);
-        let fused_blocks: Vec<_> = partitions
+        let block_plans: Vec<BackendPlan> = partitions
             .iter()
             .map(|(sub, _, _)| {
-                crate::circuit::fusion::fuse_circuit(sub, supports_fused_for_kind(&kind, sub))
+                if !kind.is_auto() {
+                    validate_explicit_backend(&kind, sub)?;
+                }
+                Ok(resolve_backend(&kind, sub, false))
+            })
+            .collect::<Result<_>>()?;
+        let fused_blocks: Vec<_> = partitions
+            .iter()
+            .zip(&block_plans)
+            .map(|((sub, _, _), plan)| {
+                crate::circuit::fusion::fuse_circuit(sub, plan.supports_fused())
             })
             .collect();
 
-        for i in 0..num_shots {
-            let shot_seed = seed.wrapping_add(i as u64);
+        collect_shots(circuit, num_shots, seed, |shot_seed| {
             let result = run_decomposed_prefused(
-                &kind,
+                &block_plans,
                 comps,
                 &partitions,
                 &fused_blocks,
@@ -1172,23 +1244,52 @@ pub(crate) fn run_shots_with(
                 &opts,
                 circuit,
             )?;
-            shots.push(result.classical_bits);
-        }
+            Ok(result.classical_bits)
+        })
     } else {
-        let fused = crate::circuit::fusion::fuse_circuit(circuit, supports_fused);
+        let plan = resolve_backend(&kind, circuit, has_partial_independence);
+        let fused = crate::circuit::fusion::fuse_circuit(circuit, plan.supports_fused());
 
-        for i in 0..num_shots {
-            let shot_seed = seed.wrapping_add(i as u64);
-            let mut backend = select_backend(&kind, circuit, shot_seed, has_partial_independence);
-            let result = execute_circuit(&mut *backend, &fused, &opts)?;
-            shots.push(result.classical_bits);
-        }
+        collect_shots(circuit, num_shots, seed, |shot_seed| {
+            let mut backend = plan.build(shot_seed);
+            Ok(execute_circuit(&mut *backend, &fused, &opts)?.classical_bits)
+        })
     }
+}
 
+fn collect_shots(
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+    mut shot: impl FnMut(u64) -> Result<Vec<bool>>,
+) -> Result<ShotsResult> {
+    let mut shots = Vec::with_capacity(num_shots);
+    for i in 0..num_shots {
+        shots.push(shot(seed.wrapping_add(i as u64))?);
+    }
     Ok(ShotsResult {
         shots,
         num_classical_bits: circuit.num_classical_bits,
     })
+}
+
+/// Family choice for auto-routed non-Pauli noise trajectories. Restricted to
+/// families whose trajectory operations (1q Kraus, qubit probability, reduced
+/// density matrix, reset) are supported; the statevector leaf carries the
+/// kind's acceleration.
+fn general_noise_plan(kind: &BackendKind, circuit: &Circuit) -> BackendPlan {
+    let family = if !circuit.has_entangling_gates() {
+        Family::ProductState
+    } else if circuit.num_qubits > max_statevector_qubits() {
+        if circuit.is_sparse_friendly() {
+            Family::Sparse
+        } else {
+            Family::Mps
+        }
+    } else {
+        Family::Statevector
+    };
+    plan_for_family(kind, family, circuit.num_qubits)
 }
 
 /// Execute a noisy circuit for multiple shots with explicit backend selection.
@@ -1198,22 +1299,6 @@ pub(crate) fn run_shots_with(
 /// For all other cases, falls back to per-shot simulation with noise injection.
 /// The compiled noisy path is limited to terminal measurements with no resets
 /// or classical conditionals.
-fn auto_general_noise_backend(circuit: &Circuit) -> BackendKind {
-    if !circuit.has_entangling_gates() {
-        BackendKind::ProductState
-    } else if circuit.num_qubits > max_statevector_qubits() {
-        if circuit.is_sparse_friendly() {
-            BackendKind::Sparse
-        } else {
-            BackendKind::Mps {
-                max_bond_dim: AUTO_MPS_BOND_DIM,
-            }
-        }
-    } else {
-        BackendKind::Statevector
-    }
-}
-
 pub(crate) fn run_shots_with_noise(
     kind: BackendKind,
     circuit: &Circuit,
@@ -1309,38 +1394,19 @@ pub(crate) fn run_shots_with_noise(
         }
     }
 
-    let trajectory_kind = if kind.is_auto() && !noise_model.is_pauli_only() {
-        auto_general_noise_backend(circuit)
+    let plan = if kind.is_auto() && !noise_model.is_pauli_only() {
+        general_noise_plan(&kind, circuit)
     } else {
-        kind
+        resolve_backend(&kind, circuit, false)
     };
-
     trajectory::run_trajectories(
-        |s| select_backend(&trajectory_kind, circuit, s, false),
+        |s| plan.build(s),
         circuit,
         noise_model,
         num_shots,
         seed,
+        plan.is_gpu(),
     )
-}
-
-fn run_shots_fallback(
-    kind: &BackendKind,
-    circuit: &Circuit,
-    num_shots: usize,
-    seed: u64,
-) -> Result<ShotsResult> {
-    let mut shots = Vec::with_capacity(num_shots);
-    let opts = SimOptions::classical_only();
-    for i in 0..num_shots {
-        let shot_seed = seed.wrapping_add(i as u64);
-        let result = run_with_internal(kind.clone(), circuit, shot_seed, opts)?;
-        shots.push(result.classical_bits);
-    }
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
 }
 
 #[cfg(test)]
@@ -1476,21 +1542,21 @@ mod tests {
     #[test]
     fn test_auto_selects_product() {
         let circuit = make_product_circuit();
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, false);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, false).build(42);
         assert_eq!(backend.name(), "productstate");
     }
 
     #[test]
     fn test_auto_selects_stabilizer() {
         let circuit = make_clifford_circuit();
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, false);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, false).build(42);
         assert_eq!(backend.name(), "stabilizer");
     }
 
     #[test]
     fn test_auto_selects_statevector() {
         let circuit = make_general_circuit();
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, false);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, false).build(42);
         assert_eq!(backend.name(), "statevector");
     }
 
@@ -1583,7 +1649,7 @@ mod tests {
         circuit.add_gate(Gate::H, &[0]);
         circuit.add_gate(Gate::T, &[0]);
         circuit.add_gate(Gate::Cx, &[0, 1]);
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, false);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, false).build(42);
         assert_eq!(backend.name(), "statevector");
     }
 
@@ -1593,14 +1659,14 @@ mod tests {
         circuit.add_gate(Gate::H, &[0]);
         circuit.add_gate(Gate::T, &[0]);
         circuit.add_gate(Gate::Cx, &[0, 1]);
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, true);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, true).build(42);
         assert_eq!(backend.name(), "factored");
     }
 
     #[test]
     fn test_auto_ignores_partial_independence_when_no_entangling() {
         let circuit = make_product_circuit();
-        let backend = select_backend(&BackendKind::Auto, &circuit, 42, true);
+        let backend = resolve_backend(&BackendKind::Auto, &circuit, true).build(42);
         assert_eq!(backend.name(), "productstate");
     }
 
@@ -1787,12 +1853,12 @@ mod tests {
 
         let (sub_a, _, _) = c.extract_subcircuit(&components[0]);
         assert!(sub_a.is_clifford_only());
-        let backend_a = select_backend(&BackendKind::Auto, &sub_a, 42, false);
+        let backend_a = resolve_backend(&BackendKind::Auto, &sub_a, false).build(42);
         assert_eq!(backend_a.name(), "stabilizer");
 
         let (sub_b, _, _) = c.extract_subcircuit(&components[1]);
         assert!(!sub_b.is_clifford_only());
-        let backend_b = select_backend(&BackendKind::Auto, &sub_b, 43, false);
+        let backend_b = resolve_backend(&BackendKind::Auto, &sub_b, false).build(43);
         assert_eq!(backend_b.name(), "statevector");
 
         // End-to-end: auto (decomposed) must match monolithic statevector
@@ -2101,7 +2167,7 @@ mod tests {
             BackendKind::Mps { max_bond_dim: 64 },
         ] {
             let label = format!("{backend_kind:?}/post-measure");
-            let mut backend = select_backend(&backend_kind, &circuit, 42, false);
+            let mut backend = resolve_backend(&backend_kind, &circuit, false).build(42);
             run_on(backend.as_mut(), &circuit).unwrap();
             let state = backend.export_statevector().unwrap();
             assert_unit_norm(&state, &label);
@@ -2117,7 +2183,7 @@ mod tests {
             (BackendKind::Mps { max_bond_dim: 128 }, "mps/qft8"),
             (BackendKind::TensorNetwork, "tn/qft8"),
         ] {
-            let mut backend = select_backend(&kind, &circuit, 42, false);
+            let mut backend = resolve_backend(&kind, &circuit, false).build(42);
             run_on(backend.as_mut(), &circuit).unwrap();
             let state = backend.export_statevector().unwrap();
             assert_unit_norm(&state, label);
@@ -3157,5 +3223,321 @@ mod tests {
             .unwrap()
             .to_vec();
         assert_probs_match(BackendKind::StabilizerRank, &circuit, &sv_probs, 1e-6);
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod terminal_gpu_stub_tests {
+    use super::*;
+    use crate::gates::Gate;
+    use crate::gpu::GpuContext;
+
+    fn terminal_circuit(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, n);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        for q in 0..n {
+            c.add_measure(q, q);
+        }
+        c
+    }
+
+    fn auto_gpu_stub() -> BackendKind {
+        BackendKind::AutoGpu {
+            context: GpuContext::stub_for_tests(),
+        }
+    }
+
+    /// The terminal fast path resolves the accel through the capability table.
+    /// On the stub the VRAM gate fails closed, so `AutoGpu` must take the
+    /// identical host path as `Auto`: same sampler, same RNG stream, byte-equal
+    /// counts.
+    #[test]
+    fn auto_gpu_terminal_counts_match_auto_on_stub() {
+        let circuit = terminal_circuit(16);
+        let auto_counts = run_counts_with(BackendKind::Auto, &circuit, 500, 42).unwrap();
+        let gpu_counts = run_counts_with(auto_gpu_stub(), &circuit, 500, 42).unwrap();
+        assert_eq!(auto_counts, gpu_counts);
+    }
+
+    #[test]
+    fn auto_gpu_terminal_shots_match_auto_on_stub() {
+        let circuit = terminal_circuit(16);
+        let auto_shots = run_shots_with(BackendKind::Auto, &circuit, 64, 42).unwrap();
+        let gpu_shots = run_shots_with(auto_gpu_stub(), &circuit, 64, 42).unwrap();
+        assert_eq!(auto_shots.shots, gpu_shots.shots);
+    }
+
+    /// Explicit `StatevectorGpu` is a terminal-fast-path candidate. Above the
+    /// crossover it resolves hard, so the stub's failed allocation surfaces
+    /// instead of falling back, proving the device path was reached.
+    #[test]
+    fn statevector_gpu_terminal_counts_hard_above_crossover_on_stub() {
+        let circuit = terminal_circuit(16);
+        let kind = BackendKind::StatevectorGpu {
+            context: GpuContext::stub_for_tests(),
+        };
+        let err = run_counts_with(kind, &circuit, 100, 42).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::PrismError::BackendUnsupported { .. }
+        ));
+    }
+
+    /// Below the crossover the explicit GPU kind resolves to the host and must
+    /// match explicit `Statevector` byte-exact through the terminal path.
+    #[test]
+    fn statevector_gpu_terminal_counts_below_crossover_match_statevector() {
+        let circuit = terminal_circuit(6);
+        let kind = BackendKind::StatevectorGpu {
+            context: GpuContext::stub_for_tests(),
+        };
+        let sv = run_counts_with(BackendKind::Statevector, &circuit, 200, 42).unwrap();
+        let gpu = run_counts_with(kind, &circuit, 200, 42).unwrap();
+        assert_eq!(sv, gpu);
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod expectation_gpu_stub_tests {
+    use super::unified_pauli::{PauliAxis, PauliTerm};
+    use super::*;
+    use crate::gates::Gate;
+    use crate::gpu::GpuContext;
+
+    fn dense_circuit(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, 0);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        c
+    }
+
+    fn observables() -> Vec<Vec<PauliTerm>> {
+        vec![
+            vec![PauliTerm::new(0, PauliAxis::Z)],
+            vec![
+                PauliTerm::new(1, PauliAxis::X),
+                PauliTerm::new(2, PauliAxis::Y),
+            ],
+        ]
+    }
+
+    #[test]
+    fn auto_gpu_expectation_matches_auto_on_stub() {
+        let circuit = dense_circuit(16);
+        let auto_vals =
+            run_expectation_values_with(BackendKind::Auto, &circuit, &observables(), 42).unwrap();
+        let gpu_vals = run_expectation_values_with(
+            BackendKind::AutoGpu {
+                context: GpuContext::stub_for_tests(),
+            },
+            &circuit,
+            &observables(),
+            42,
+        )
+        .unwrap();
+        assert_eq!(auto_vals, gpu_vals);
+    }
+
+    /// Explicit `StatevectorGpu` expectation values resolve hard above the
+    /// crossover, so the stub's failed allocation surfaces.
+    #[test]
+    fn statevector_gpu_expectation_hard_above_crossover_on_stub() {
+        let circuit = dense_circuit(16);
+        let err = run_expectation_values_with(
+            BackendKind::StatevectorGpu {
+                context: GpuContext::stub_for_tests(),
+            },
+            &circuit,
+            &observables(),
+            42,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::PrismError::BackendUnsupported { .. }
+        ));
+    }
+
+    #[test]
+    fn statevector_gpu_expectation_below_crossover_matches_statevector() {
+        let circuit = dense_circuit(6);
+        let sv =
+            run_expectation_values_with(BackendKind::Statevector, &circuit, &observables(), 42)
+                .unwrap();
+        let gpu = run_expectation_values_with(
+            BackendKind::StatevectorGpu {
+                context: GpuContext::stub_for_tests(),
+            },
+            &circuit,
+            &observables(),
+            42,
+        )
+        .unwrap();
+        assert_eq!(sv, gpu);
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod noise_gpu_stub_tests {
+    use super::*;
+    use crate::gates::Gate;
+    use crate::gpu::GpuContext;
+
+    fn noisy_circuit(n: usize) -> Circuit {
+        let mut c = Circuit::new(n, n);
+        for q in 0..n {
+            c.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        for q in 0..n {
+            c.add_measure(q, q);
+        }
+        c
+    }
+
+    /// AutoGpu + non-Pauli noise resolves the trajectory plan through the
+    /// capability table. On the stub the VRAM gate fails closed, so the run
+    /// must be byte-identical to `Auto`.
+    #[test]
+    fn auto_gpu_general_noise_matches_auto_on_stub() {
+        let circuit = noisy_circuit(14);
+        let noise = noise::NoiseModel::with_amplitude_damping(&circuit, 0.05);
+        let auto_shots = run_shots_with_noise(BackendKind::Auto, &circuit, &noise, 16, 42).unwrap();
+        let gpu_shots = run_shots_with_noise(
+            BackendKind::AutoGpu {
+                context: GpuContext::stub_for_tests(),
+            },
+            &circuit,
+            &noise,
+            16,
+            42,
+        )
+        .unwrap();
+        assert_eq!(auto_shots.shots, gpu_shots.shots);
+    }
+
+    /// A non-entangling circuit resolves to the product-state family for
+    /// general noise under AutoGpu, per the capability table (no GPU row).
+    #[test]
+    fn auto_gpu_general_noise_product_circuit_matches_auto() {
+        let mut circuit = Circuit::new(6, 6);
+        for q in 0..6 {
+            circuit.add_gate(Gate::Rx(0.4), &[q]);
+        }
+        for q in 0..6 {
+            circuit.add_measure(q, q);
+        }
+        let noise = noise::NoiseModel::with_amplitude_damping(&circuit, 0.05);
+        let auto_shots = run_shots_with_noise(BackendKind::Auto, &circuit, &noise, 64, 42).unwrap();
+        let gpu_shots = run_shots_with_noise(
+            BackendKind::AutoGpu {
+                context: GpuContext::stub_for_tests(),
+            },
+            &circuit,
+            &noise,
+            64,
+            42,
+        )
+        .unwrap();
+        assert_eq!(auto_shots.shots, gpu_shots.shots);
+    }
+}
+
+#[cfg(test)]
+mod terminal_candidate_matrix_tests {
+    use super::*;
+    use crate::gates::Gate;
+
+    fn rx_cx_chain(circuit: &mut Circuit, qubits: std::ops::Range<usize>) {
+        for q in qubits.clone() {
+            circuit.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        for q in qubits.start..qubits.end - 1 {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+
+    #[test]
+    fn dense_entangled_circuit_is_candidate() {
+        let mut circuit = Circuit::new(8, 0);
+        rx_cx_chain(&mut circuit, 0..8);
+        assert!(auto_terminal_statevector_candidate(&circuit));
+    }
+
+    #[test]
+    fn decomposable_circuit_is_not_candidate() {
+        let mut circuit = Circuit::new(12, 0);
+        rx_cx_chain(&mut circuit, 0..6);
+        rx_cx_chain(&mut circuit, 6..12);
+        assert!(!auto_terminal_statevector_candidate(&circuit));
+    }
+
+    #[test]
+    fn partial_independent_circuit_is_not_candidate() {
+        let mut circuit = Circuit::new(10, 0);
+        rx_cx_chain(&mut circuit, 0..8);
+        rx_cx_chain(&mut circuit, 8..10);
+        assert!(!auto_terminal_statevector_candidate(&circuit));
+    }
+
+    /// A Clifford+T circuit inside the stabilizer-rank budget routes to the
+    /// rank engine; one T past the budget falls back to the statevector and
+    /// becomes a candidate. Pins the shared budget helper at its boundary.
+    #[test]
+    fn clifford_t_budget_boundary_flips_candidacy() {
+        let n = 10;
+        let budget = stabilizer_rank_budget(n);
+        assert_eq!(budget, 2);
+
+        let mut within = Circuit::new(n, 0);
+        within.add_gate(Gate::H, &[0]);
+        for q in 0..n - 1 {
+            within.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        for q in 0..budget {
+            within.add_gate(Gate::T, &[q]);
+        }
+        assert!(!auto_terminal_statevector_candidate(&within));
+
+        let mut beyond = Circuit::new(n, 0);
+        beyond.add_gate(Gate::H, &[0]);
+        for q in 0..n - 1 {
+            beyond.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        for q in 0..budget + 1 {
+            beyond.add_gate(Gate::T, &[q]);
+        }
+        assert!(auto_terminal_statevector_candidate(&beyond));
+    }
+
+    #[test]
+    fn temporal_prefix_circuit_is_not_candidate() {
+        let n = 8;
+        let mut circuit = Circuit::new(n, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        for _ in 0..3 {
+            for q in 0..n - 1 {
+                circuit.add_gate(Gate::Cx, &[q, q + 1]);
+            }
+        }
+        for q in 0..n {
+            circuit.add_gate(Gate::Rx(0.3), &[q]);
+        }
+        assert!(has_temporal_clifford_opportunity(
+            &BackendKind::Auto,
+            &circuit
+        ));
+        assert!(!auto_terminal_statevector_candidate(&circuit));
     }
 }

--- a/src/sim/terminal_sampling.rs
+++ b/src/sim/terminal_sampling.rs
@@ -13,7 +13,6 @@ use rayon::prelude::*;
 
 use super::shots::{build_cdf, sample_from_cdf};
 
-const MAX_DENSE_OUTCOME_BITS: usize = 22;
 const MAX_DENSE_COUNT_BINS: usize = 1 << 20;
 
 #[derive(Clone)]
@@ -94,12 +93,14 @@ impl CompactMeasurementMap {
         self.prefix_bits == Some(self.num_bits()) && (1usize << self.num_bits()) == state_len
     }
 
+    #[inline(always)]
     fn fill_shot_from_state_index(&self, state_idx: usize, shot: &mut [bool]) {
         for (&qubit, &cbit) in self.qubits.iter().zip(self.cbits.iter()) {
             shot[cbit] = (state_idx >> qubit) & 1 == 1;
         }
     }
 
+    #[inline(always)]
     fn packed_key_from_compact(&self, key: usize, m_words: usize) -> Vec<u64> {
         let mut packed = vec![0u64; m_words];
         for (bit, &cbit) in self.cbits.iter().enumerate() {
@@ -110,6 +111,7 @@ impl CompactMeasurementMap {
         packed
     }
 
+    #[inline(always)]
     fn packed_key_from_state_index(&self, state_idx: usize, m_words: usize) -> Vec<u64> {
         let mut packed = vec![0u64; m_words];
         for (&qubit, &cbit) in self.qubits.iter().zip(self.cbits.iter()) {
@@ -155,8 +157,9 @@ fn build_state_outcome_distribution(
     state: &[Complex64],
     norm_sq: f64,
     map: &CompactMeasurementMap,
+    max_dense_bits: usize,
 ) -> Option<Vec<f64>> {
-    if map.num_bits() > MAX_DENSE_OUTCOME_BITS {
+    if map.num_bits() > max_dense_bits {
         return None;
     }
 
@@ -350,6 +353,196 @@ fn sample_counts_streaming_from_state(
     counts
 }
 
+fn build_probs_outcome_distribution(
+    probs: &[f64],
+    map: &CompactMeasurementMap,
+    max_dense_bits: usize,
+) -> Option<Vec<f64>> {
+    if map.num_bits() > max_dense_bits {
+        return None;
+    }
+
+    let outcomes = 1usize << map.num_bits();
+
+    #[cfg(feature = "parallel")]
+    if probs.len() >= crate::backend::MIN_PAR_ELEMS && outcomes <= (1usize << 16) {
+        let out = probs
+            .par_chunks(crate::backend::MIN_PAR_ELEMS)
+            .enumerate()
+            .map(|(chunk_idx, chunk)| {
+                let mut local = vec![0.0f64; outcomes];
+                let base = chunk_idx * crate::backend::MIN_PAR_ELEMS;
+                for (offset, &p) in chunk.iter().enumerate() {
+                    let key = map.compact_key(base + offset);
+                    local[key] += p;
+                }
+                local
+            })
+            .reduce(
+                || vec![0.0f64; outcomes],
+                |mut a, b| {
+                    for (dst, src) in a.iter_mut().zip(b) {
+                        *dst += src;
+                    }
+                    a
+                },
+            );
+        return Some(out);
+    }
+
+    let mut out = vec![0.0f64; outcomes];
+    for (idx, &p) in probs.iter().enumerate() {
+        out[map.compact_key(idx)] += p;
+    }
+    Some(out)
+}
+
+fn sample_shots_streaming_from_probs(
+    probs: &[f64],
+    map: &CompactMeasurementMap,
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> Vec<Vec<bool>> {
+    let thresholds = sorted_thresholds(num_shots, seed);
+    let mut shots = vec![vec![false; num_classical_bits]; num_shots];
+    let mut cumulative = 0.0f64;
+    let mut next = 0usize;
+
+    for (state_idx, &p) in probs.iter().enumerate() {
+        cumulative += p;
+        while next < thresholds.len() && thresholds[next].0 <= cumulative {
+            let shot_idx = thresholds[next].1;
+            map.fill_shot_from_state_index(state_idx, &mut shots[shot_idx]);
+            next += 1;
+        }
+    }
+
+    let fallback_idx = probs.len().saturating_sub(1);
+    while next < thresholds.len() {
+        let shot_idx = thresholds[next].1;
+        map.fill_shot_from_state_index(fallback_idx, &mut shots[shot_idx]);
+        next += 1;
+    }
+
+    shots
+}
+
+fn sample_counts_streaming_from_probs(
+    probs: &[f64],
+    map: &CompactMeasurementMap,
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> HashMap<Vec<u64>, u64> {
+    let thresholds = sorted_thresholds(num_shots, seed);
+    let m_words = num_classical_bits.div_ceil(64).max(1);
+    let mut counts = HashMap::with_capacity(num_shots.min(probs.len()));
+    let mut cumulative = 0.0f64;
+    let mut next = 0usize;
+
+    for (state_idx, &p) in probs.iter().enumerate() {
+        cumulative += p;
+        let start = next;
+        while next < thresholds.len() && thresholds[next].0 <= cumulative {
+            next += 1;
+        }
+        let hits = next - start;
+        if hits != 0 {
+            let packed = map.packed_key_from_state_index(state_idx, m_words);
+            *counts.entry(packed).or_insert(0) += hits as u64;
+        }
+    }
+
+    let fallback_idx = probs.len().saturating_sub(1);
+    let fallback_hits = thresholds.len() - next;
+    if fallback_hits != 0 {
+        let packed = map.packed_key_from_state_index(fallback_idx, m_words);
+        *counts.entry(packed).or_insert(0) += fallback_hits as u64;
+    }
+
+    counts
+}
+
+pub(super) fn sample_shots_from_probs(
+    probs: &[f64],
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> Vec<Vec<bool>> {
+    if meas_map.is_empty() {
+        return vec![vec![false; num_classical_bits]; num_shots];
+    }
+
+    let map = CompactMeasurementMap::new(meas_map, num_classical_bits);
+    if map.num_bits() == 0 {
+        return vec![vec![false; num_classical_bits]; num_shots];
+    }
+
+    sample_shots_streaming_from_probs(probs, &map, num_classical_bits, num_shots, seed)
+}
+
+pub(super) fn sample_counts_from_probs(
+    probs: &[f64],
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+) -> HashMap<Vec<u64>, u64> {
+    sample_counts_from_probs_capped(
+        probs,
+        meas_map,
+        num_classical_bits,
+        num_shots,
+        seed,
+        crate::backend::max_dense_outcome_bits(),
+    )
+}
+
+fn sample_counts_from_probs_capped(
+    probs: &[f64],
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+    num_shots: usize,
+    seed: u64,
+    max_dense_bits: usize,
+) -> HashMap<Vec<u64>, u64> {
+    if num_shots == 0 {
+        return HashMap::new();
+    }
+
+    let m_words = num_classical_bits.div_ceil(64).max(1);
+    if meas_map.is_empty() {
+        let mut counts = HashMap::with_capacity(1);
+        counts.insert(vec![0u64; m_words], num_shots as u64);
+        return counts;
+    }
+
+    let map = CompactMeasurementMap::new(meas_map, num_classical_bits);
+    if map.num_bits() == 0 {
+        let mut counts = HashMap::with_capacity(1);
+        counts.insert(vec![0u64; m_words], num_shots as u64);
+        return counts;
+    }
+
+    if map.num_bits() <= max_dense_bits && map.direct_state_key(probs.len()) {
+        return sample_counts_from_outcome_distribution(
+            probs,
+            &map,
+            num_classical_bits,
+            num_shots,
+            seed,
+        );
+    }
+
+    if let Some(outcome) = build_probs_outcome_distribution(probs, &map, max_dense_bits) {
+        sample_counts_from_outcome_distribution(&outcome, &map, num_classical_bits, num_shots, seed)
+    } else {
+        sample_counts_streaming_from_probs(probs, &map, num_classical_bits, num_shots, seed)
+    }
+}
+
 pub(super) fn sample_shots_from_state(
     state: &[Complex64],
     norm_sq: f64,
@@ -396,7 +589,12 @@ pub(super) fn sample_counts_from_state(
         return counts;
     }
 
-    if let Some(probs) = build_state_outcome_distribution(state, norm_sq, &map) {
+    if let Some(probs) = build_state_outcome_distribution(
+        state,
+        norm_sq,
+        &map,
+        crate::backend::max_dense_outcome_bits(),
+    ) {
         sample_counts_from_outcome_distribution(&probs, &map, num_classical_bits, num_shots, seed)
     } else {
         sample_counts_streaming_from_state(
@@ -407,5 +605,37 @@ pub(super) fn sample_counts_from_state(
             num_shots,
             seed,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Above the dense-outcome cap the direct-key shortcut must not build a
+    /// dense CDF; counts route through the same streaming sampler as the host
+    /// path, so the entry point and the streaming sampler agree byte-for-byte.
+    /// Below the cap the shortcut takes the CDF sampler, which draws from a
+    /// different RNG stream.
+    #[test]
+    fn counts_from_probs_stream_above_dense_outcome_cap() {
+        let bits = 11;
+        let len = 1usize << bits;
+        let mut probs = vec![0.0f64; len];
+        let spikes = [0usize, 123, len / 3, len / 2 + 7, len - 1];
+        for &s in &spikes {
+            probs[s] = 0.2;
+        }
+        let meas_map: Vec<(usize, usize)> = (0..bits).map(|q| (q, q)).collect();
+        let map = CompactMeasurementMap::new(&meas_map, bits);
+        assert!(map.direct_state_key(len));
+
+        let above_cap = sample_counts_from_probs_capped(&probs, &meas_map, bits, 300, 42, bits - 1);
+        let via_streaming = sample_counts_streaming_from_probs(&probs, &map, bits, 300, 42);
+        assert_eq!(above_cap, via_streaming);
+
+        let below_cap = sample_counts_from_probs_capped(&probs, &meas_map, bits, 300, 42, bits);
+        let total: u64 = below_cap.values().sum();
+        assert_eq!(total, 300);
     }
 }

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -352,16 +352,31 @@ pub(crate) fn run_trajectory_shot(
     Ok(results)
 }
 
+/// Shot-level parallelism stops where kernel-level parallelism starts. At and
+/// above the backend parallel threshold the statevector kernels already
+/// saturate the pool, and nesting shot tasks inside kernel joins piles stolen
+/// shot frames onto one worker stack until it overflows. Same guard as
+/// `MAX_BLOCK_QUBITS_FOR_PAR` in the decomposed path.
+#[cfg(feature = "parallel")]
+const MAX_QUBITS_FOR_PAR_SHOTS: usize = 14;
+
+/// `force_serial` keeps every trajectory on one thread. Device-resident
+/// backends set it: parallel trajectories would allocate one device state per
+/// Rayon thread against a single-state VRAM verdict, and concurrent launches
+/// on one device serialize anyway.
 pub(crate) fn run_trajectories(
     backend_factory: impl Fn(u64) -> Box<dyn Backend> + Sync,
     circuit: &Circuit,
     noise: &NoiseModel,
     num_shots: usize,
     seed: u64,
+    force_serial: bool,
 ) -> Result<ShotsResult> {
+    #[cfg(not(feature = "parallel"))]
+    let _ = force_serial;
     #[cfg(feature = "parallel")]
     {
-        if circuit.num_qubits <= 20 && num_shots >= 4 {
+        if !force_serial && circuit.num_qubits < MAX_QUBITS_FOR_PAR_SHOTS && num_shots >= 4 {
             return run_trajectories_par(&backend_factory, circuit, noise, num_shots, seed);
         }
     }
@@ -425,7 +440,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 500, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 500, 42, false).unwrap();
         assert_eq!(result.shots.len(), 500);
 
         let all_zero: Vec<bool> = vec![false; n];
@@ -451,7 +466,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, false).unwrap();
         let num_zero = result.shots.iter().filter(|s| !s[0]).count();
         // With gamma=0.9 on |1⟩, P(decay) ≈ 0.9
         assert!(
@@ -483,7 +498,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &pd_noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &pd_noise, 1000, 42, false).unwrap();
         let num_one = result.shots.iter().filter(|s| s[0]).count();
         // Phase damping on |1⟩ should keep it as |1⟩ (only dephases superpositions)
         assert_eq!(num_one, 1000, "PD should not change |1⟩ population");
@@ -501,7 +516,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, false).unwrap();
         let num_one = result.shots.iter().filter(|s| s[0]).count();
         // Should see ~30% readout flips
         assert!(
@@ -529,7 +544,7 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let result = run_trajectories(factory, &circuit, &noise, 1000, 42).unwrap();
+        let result = run_trajectories(factory, &circuit, &noise, 1000, 42, false).unwrap();
         // With 50% 2q depolarizing, varied outcomes should appear.
         let num_00 = result.shots.iter().filter(|s| !s[0] && !s[1]).count();
         assert!(
@@ -553,8 +568,8 @@ mod tests {
             Box::new(crate::backend::statevector::StatevectorBackend::new(s))
         };
 
-        let r1 = run_trajectories(factory, &circuit, &noise, 100, 42).unwrap();
-        let r2 = run_trajectories(factory, &circuit, &noise, 100, 42).unwrap();
+        let r1 = run_trajectories(factory, &circuit, &noise, 100, 42, false).unwrap();
+        let r2 = run_trajectories(factory, &circuit, &noise, 100, 42, false).unwrap();
         assert_eq!(r1.shots, r2.shots, "same seed must produce same results");
     }
 }

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -778,6 +778,41 @@ fn statevector_gpu_builder_matches_cpu_random() {
     }
 }
 
+/// A mid-circuit measurement forces the per-shot slow path. With
+/// `BackendKind::StatevectorGpu` at 14q each per-shot backend routes to the
+/// device, and outcomes must match the host statevector shot-for-shot: both
+/// backends draw the same RNG stream for the same shot seed.
+#[test]
+fn statevector_gpu_mid_measure_shots_match_cpu() {
+    use prism_q::{BackendKind, Circuit};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let mut circuit = Circuit::new(14, 2);
+    circuit.add_gate(Gate::H, &[0]);
+    for q in 0..13 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    circuit.add_measure(0, 0);
+    circuit.add_gate(Gate::H, &[1]);
+    circuit.add_measure(1, 1);
+
+    let cpu = prism_q::simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(42)
+        .shots(16)
+        .expect("cpu shots failed");
+    let gpu = prism_q::simulate(&circuit)
+        .backend(BackendKind::StatevectorGpu {
+            context: f.ctx.clone(),
+        })
+        .seed(42)
+        .shots(16)
+        .expect("gpu shots failed");
+
+    assert_eq!(cpu.shots, gpu.shots);
+}
+
 // ============================================================================
 // Stabilizer GPU scaffold
 // ============================================================================
@@ -1886,4 +1921,427 @@ fn sample_bulk_packed_device_counts_match_host_counts() {
     let host_counts = device.to_host().unwrap().counts();
 
     assert_eq!(device_counts, host_counts);
+}
+
+// ============================================================================
+// AutoGpu terminal sampling
+// ============================================================================
+
+fn terminal_rx_cx_circuit(n: usize) -> prism_q::Circuit {
+    let mut circuit = prism_q::Circuit::new(n, n);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::Rz(0.5), &[q]);
+    }
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn one_frequencies_from_counts(
+    counts: &std::collections::HashMap<Vec<u64>, u64>,
+    num_qubits: usize,
+    num_shots: u64,
+) -> Vec<f64> {
+    let mut ones = vec![0u64; num_qubits];
+    for (key, count) in counts {
+        for (q, one_count) in ones.iter_mut().enumerate() {
+            if (key[q / 64] >> (q % 64)) & 1 == 1 {
+                *one_count += count;
+            }
+        }
+    }
+    ones.into_iter()
+        .map(|c| c as f64 / num_shots as f64)
+        .collect()
+}
+
+/// Terminal counts under `gpu_auto` simulate on device and sample from the
+/// device-reduced probabilities. Same seed twice must reproduce identical
+/// counts, and per-qubit frequencies must agree with the CPU `Auto` sampler
+/// within statistical tolerance (different samplers, same distribution).
+#[test]
+fn auto_gpu_terminal_counts_match_cpu_auto() {
+    use prism_q::{BackendKind, simulate};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 16;
+    let num_shots = 50_000;
+    let circuit = terminal_rx_cx_circuit(n);
+
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Auto)
+        .seed(42)
+        .sample_counts(num_shots)
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .sample_counts(num_shots)
+        .unwrap();
+    let gpu_again = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .sample_counts(num_shots)
+        .unwrap();
+
+    assert_eq!(
+        gpu.counts, gpu_again.counts,
+        "same seed must reproduce identical GPU counts"
+    );
+
+    let total: u64 = gpu.counts.values().sum();
+    assert_eq!(total, num_shots as u64);
+
+    let cpu_freq = one_frequencies_from_counts(&cpu.counts, n, num_shots as u64);
+    let gpu_freq = one_frequencies_from_counts(&gpu.counts, n, num_shots as u64);
+    for q in 0..n {
+        let diff = (cpu_freq[q] - gpu_freq[q]).abs();
+        assert!(
+            diff < 0.02,
+            "qubit {q}: cpu freq={}, gpu freq={}, diff={diff}",
+            cpu_freq[q],
+            gpu_freq[q]
+        );
+    }
+}
+
+/// Terminal shots under `gpu_auto`: deterministic per seed, per-qubit
+/// frequencies statistically matching the CPU `Auto` path.
+#[test]
+fn auto_gpu_terminal_shots_match_cpu_auto() {
+    use prism_q::{BackendKind, simulate};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 16;
+    let num_shots = 4000;
+    let circuit = terminal_rx_cx_circuit(n);
+
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Auto)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+    let gpu_again = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+
+    assert_eq!(
+        gpu.shots, gpu_again.shots,
+        "same seed must reproduce identical GPU shots"
+    );
+    assert_eq!(gpu.shots.len(), num_shots);
+
+    let freq = |shots: &[Vec<bool>]| -> Vec<f64> {
+        let mut ones = vec![0usize; n];
+        for shot in shots {
+            for (q, one_count) in ones.iter_mut().enumerate() {
+                if shot[q] {
+                    *one_count += 1;
+                }
+            }
+        }
+        ones.into_iter()
+            .map(|c| c as f64 / shots.len() as f64)
+            .collect()
+    };
+
+    let cpu_freq = freq(&cpu.shots);
+    let gpu_freq = freq(&gpu.shots);
+    for q in 0..n {
+        let diff = (cpu_freq[q] - gpu_freq[q]).abs();
+        assert!(
+            diff < 0.05,
+            "qubit {q}: cpu freq={}, gpu freq={}, diff={diff}",
+            cpu_freq[q],
+            gpu_freq[q]
+        );
+    }
+}
+
+/// Explicit `StatevectorGpu` terminal counts route through the same terminal
+/// fast path as `AutoGpu`: device simulation, device-reduced probabilities,
+/// and the same host sampler, so identical seeds produce identical counts.
+#[test]
+fn statevector_gpu_terminal_counts_match_auto_gpu() {
+    use prism_q::simulate;
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let circuit = terminal_rx_cx_circuit(16);
+    let num_shots = 20_000;
+    let auto_gpu = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .sample_counts(num_shots)
+        .unwrap();
+    let explicit = simulate(&circuit)
+        .gpu(f.ctx.clone())
+        .seed(42)
+        .sample_counts(num_shots)
+        .unwrap();
+    assert_eq!(auto_gpu.counts, explicit.counts);
+}
+
+/// Expectation values under `gpu_auto` and explicit `.gpu(...)` simulate on
+/// device and export amplitudes for the Pauli mask reduction. GPU kernel
+/// float ordering differs from the host, so agreement is 1e-8, not 1e-12.
+#[test]
+fn gpu_expectation_values_match_cpu() {
+    use prism_q::{BackendKind, PauliAxis, PauliTerm, simulate};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 16;
+    let mut circuit = prism_q::Circuit::new(n, 0);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::Rz(0.5), &[q]);
+    }
+
+    let obs = vec![
+        vec![PauliTerm::new(0, PauliAxis::Z)],
+        vec![PauliTerm::new(3, PauliAxis::X)],
+        vec![
+            PauliTerm::new(5, PauliAxis::Y),
+            PauliTerm::new(7, PauliAxis::Z),
+        ],
+        vec![
+            PauliTerm::new(1, PauliAxis::X),
+            PauliTerm::new(2, PauliAxis::Y),
+            PauliTerm::new(4, PauliAxis::Z),
+        ],
+    ];
+
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Auto)
+        .seed(42)
+        .expectation_values(&obs)
+        .unwrap();
+    let auto_gpu = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .seed(42)
+        .expectation_values(&obs)
+        .unwrap();
+    let explicit = simulate(&circuit)
+        .gpu(f.ctx.clone())
+        .seed(42)
+        .expectation_values(&obs)
+        .unwrap();
+
+    for (i, ((c, a), e)) in cpu.iter().zip(&auto_gpu).zip(&explicit).enumerate() {
+        assert!(
+            (c - a).abs() < 1e-8,
+            "obs {i}: cpu={c}, auto_gpu={a}, diff={}",
+            (c - a).abs()
+        );
+        assert!(
+            (c - e).abs() < 1e-8,
+            "obs {i}: cpu={c}, explicit gpu={e}, diff={}",
+            (c - e).abs()
+        );
+    }
+}
+
+// ============================================================================
+// Temporal-Clifford GPU tail
+// ============================================================================
+
+fn temporal_prefix(n: usize) -> prism_q::Circuit {
+    let mut circuit = prism_q::Circuit::new(n, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    for _ in 0..3 {
+        for q in 0..n - 1 {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    circuit
+}
+
+fn assert_run_probs_match(circuit: &prism_q::Circuit, ctx: &std::sync::Arc<GpuContext>) {
+    use prism_q::{BackendKind, simulate};
+
+    let cpu = simulate(circuit)
+        .backend(BackendKind::Auto)
+        .seed(42)
+        .run()
+        .unwrap();
+    let gpu = simulate(circuit)
+        .gpu_auto(ctx.clone())
+        .seed(42)
+        .run()
+        .unwrap();
+
+    let cp = cpu.probabilities.expect("cpu probs").to_vec();
+    let gp = gpu.probabilities.expect("gpu probs").to_vec();
+    assert_eq!(cp.len(), gp.len());
+    for (i, (c, g)) in cp.iter().zip(gp.iter()).enumerate() {
+        let diff = (c - g).abs();
+        assert!(
+            diff < 1e-10,
+            "prob mismatch at {i}: cpu={c}, gpu={g}, diff={diff}"
+        );
+    }
+}
+
+/// Long Clifford prefix + non-Clifford tail under `gpu_auto`: the prefix runs
+/// on the host tableau, the exported state uploads to the device, and the tail
+/// runs there. Probabilities must match the CPU `Auto` temporal path.
+#[test]
+fn auto_gpu_temporal_clifford_matches_cpu_auto() {
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 15;
+    let mut circuit = temporal_prefix(n);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    assert_run_probs_match(&circuit, &f.ctx);
+}
+
+/// Same shape with a `QftBlock` tail: the device tail cannot run the native
+/// host FFT path, so the block is expanded at plan time. Catches any route
+/// that hands an unexpanded block to the device kernels.
+#[test]
+fn auto_gpu_temporal_clifford_qft_tail_matches_cpu_auto() {
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 15;
+    let mut circuit = temporal_prefix(n);
+    let targets: Vec<usize> = (0..n).collect();
+    circuit.add_gate(
+        Gate::QftBlock {
+            start: 0,
+            num: n as u8,
+        },
+        &targets,
+    );
+    for q in 0..n {
+        circuit.add_gate(Gate::Rz(0.5), &[q]);
+    }
+    assert_run_probs_match(&circuit, &f.ctx);
+}
+
+/// Device round-trip for `init_from_state`: uploaded amplitudes must export
+/// back unchanged.
+#[test]
+fn init_from_state_gpu_round_trip() {
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 4;
+    let dim = 1usize << n;
+    let mut state: Vec<Complex64> = (0..dim)
+        .map(|i| Complex64::new(0.3 + i as f64, 0.1 * i as f64))
+        .collect();
+    let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt();
+    for a in &mut state {
+        *a /= norm;
+    }
+
+    let mut sv = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    sv.init_from_state(state.clone(), 0).unwrap();
+    let exported = sv.export_statevector().unwrap();
+    assert_eq!(exported.len(), state.len());
+    for (i, (e, s)) in exported.iter().zip(&state).enumerate() {
+        let diff = (e - s).norm();
+        assert!(diff < 1e-12, "amp {i}: uploaded={s:?}, exported={e:?}");
+    }
+}
+
+// ============================================================================
+// AutoGpu noisy trajectories
+// ============================================================================
+
+/// Non-Pauli (amplitude damping) noise under `gpu_auto`: trajectories build
+/// soft device statevectors per shot and run serially. Per-qubit frequencies
+/// must agree statistically with the CPU `Auto` trajectory engine, and the
+/// run must be reproducible per seed.
+#[test]
+fn auto_gpu_noisy_trajectories_match_cpu_auto() {
+    use prism_q::NoiseModel;
+    use prism_q::simulate;
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 14;
+    let num_shots = 400;
+    let mut circuit = prism_q::Circuit::new(n, n);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    let noise = NoiseModel::with_amplitude_damping(&circuit, 0.05);
+    let cpu = simulate(&circuit)
+        .noise(&noise)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .noise(&noise)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+    let gpu_again = simulate(&circuit)
+        .gpu_auto(f.ctx.clone())
+        .noise(&noise)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+
+    assert_eq!(
+        gpu.shots, gpu_again.shots,
+        "same seed must reproduce identical noisy GPU shots"
+    );
+
+    let freq = |shots: &[Vec<bool>]| -> Vec<f64> {
+        let mut ones = vec![0usize; n];
+        for shot in shots {
+            for (q, one_count) in ones.iter_mut().enumerate() {
+                if shot[q] {
+                    *one_count += 1;
+                }
+            }
+        }
+        ones.into_iter()
+            .map(|c| c as f64 / shots.len() as f64)
+            .collect()
+    };
+
+    let cpu_freq = freq(&cpu.shots);
+    let gpu_freq = freq(&gpu.shots);
+    for q in 0..n {
+        let diff = (cpu_freq[q] - gpu_freq[q]).abs();
+        assert!(
+            diff < 0.15,
+            "qubit {q}: cpu freq={}, gpu freq={}, diff={diff}",
+            cpu_freq[q],
+            gpu_freq[q]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Backend selection, construction, and GPU acceleration were entangled across eight
routes (dispatch, three hardcoded statevector fast paths, a CPU-only noise router,
per-shot selection loops), so `AutoGpu`/`StatevectorGpu` contexts were silently dropped
on the counts, shots, expectation, and noisy paths. This PR restructures dispatch into
three layers: a resolver that picks a family once per call, a cheap per-shot backend
builder, and a per-family GPU capability table that owns every crossover and VRAM
verdict. Every entry point now routes through the one mechanism on both CPU and GPU.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Quiet machine, `--features parallel`, Criterion pairs against `main`. Full
`bench_shots_perf` and `circuits` suites ran; representative touched-path rows below.
Flags outside these rows failed to reproduce under focused A/B/A reruns with a measured
noise floor (mirror-image swings on untouched paths in both directions).

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| api_queries/shots_terminal_12q_100000 | 14.124 ms | 14.240 ms | +0.1% | Yes |
| api_queries/sample_counts_terminal_12q_100000 | 3.045 ms | 3.026 ms | -0.5% | Yes |
| api_queries/run_auto_12q | 116.5 us | 117.0 us | +0.5% | Yes |
| run_counts_terminal/nonclifford_full_18q/100000 | 17.18 ms | 16.24 ms | -3.2% | Yes |
| run_counts_terminal/nonclifford_subset_20q_8m/10000 | 25.61 ms | 24.85 ms | -3.0% | Yes |
| run_shots/nonclifford_full_18q/1000 | 3.821 ms | 3.842 ms | +0.5% | Yes |
| run_shots/bell_16q/100000 | 9.463 ms | 9.430 ms | -0.4% | Yes |
| compiled_counts/PackedShots_counts_20q/100000 | 6.682 ms | 6.744 ms | +0.9% | Yes |
| decomposition/20q_block4_decomposed/4 | 37.16 us | 36.90 us | -0.7% | Yes |
| decomposition/20q_block4_monolithic/4 | 22.44 ms | 21.71 ms | -3.3% | Yes |
| factored/random_d10/statevector/20 | 1.987 ms | 1.948 ms | -2.0% | Yes |
| factored/random_d10/factored/20 | 1.631 ms | 1.616 ms | -1.0% | Yes |

Regression verdict: PASS

One real regression surfaced and was fixed during the gate: the new `_from_probs`
sampler twins gave the per-shot `CompactMeasurementMap` helpers a second caller, which
outlined them from the ~150 ns/shot streaming loops (+7-10% on 12q high-shot terminal
sampling). `#[inline(always)]` on the helpers restored parity; the table reflects the
fixed state.

## Correctness

- [x] `cargo test --all-features` passes locally (run as `cargo nextest run --features
  "parallel gpu"`, 1794 tests; the `distributed-mpi` feature does not build on this
  machine, exercised in CI instead)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (with `--features "parallel gpu"`, same caveat)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
  (61 tests on GTX 1080 Ti, including new goldens for AutoGpu terminal counts/shots,
  explicit-GPU terminal counts, expectation values, temporal tails with QftBlock
  expansion, device state round-trip, and noisy trajectories)

A dispatch-matrix test suite asserts the resolved family and execution target for every
`BackendKind` against every circuit shape class (product, Clifford, Clifford+T,
oversize sparse-friendly, partially independent, dense), including fail-closed VRAM
gating on stub contexts and hard-error behavior for explicit GPU kinds.

## Hotspot notes

Touched hot paths: the per-shot loops in `run_shots_with` and
`run_decomposed_prefused` (selection hoisted out, `BackendPlan::build` is
constructor + `Box::new` + at most one `Arc` clone per shot), the terminal sampling
loops in `terminal_sampling.rs` (`#[inline(always)]` on per-shot helpers), and
`run_temporal_clifford` (per-shot probability computation now skipped when only
classical bits are needed). No flamegraph attached; the Criterion pairs above cover
each affected group directly.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

The dispatch restructure is structural; an architecture doc update describing the
resolver, `BackendPlan`, and the per-family capability table is queued as an immediate
follow-up before the next feature lands on top.

## Breaking changes

- `simulate(...).expectation_values(...)` now accepts `BackendKind::StatevectorGpu`
  (previously rejected with `IncompatibleBackend`).
- Finite seeded outputs change for explicit `StatevectorGpu` terminal counts/shots and
  for GPU-executed sampling generally: device runs sample from device-reduced
  probabilities rather than host amplitudes. Distributions are unchanged; `Auto` and
  all CPU kinds are byte-identical to before (regression-tested).
- CPU noisy trajectories at 14-20 qubits now run shots serially (gate kernels
  parallelize internally at 14+). This fixes a latent stack overflow from nested
  shot-level and kernel-level rayon parallelism; per-shot seeding is unchanged, so
  results are identical.

## Risks and rollback

GPU routing changes are confined to the opt-in `AutoGpu`/`StatevectorGpu`/
`StabilizerGpu` kinds and the `gpu` feature; default CPU behavior is byte-identical
and pinned by seeded tests. The crossover and VRAM gates remain tunable at runtime
(`PRISM_GPU_MIN_QUBITS`, `PRISM_STABILIZER_GPU_MIN_QUBITS`), so a misbehaving device
path can be forced back to CPU without a revert by raising the crossover. Soft mode
falls back to the host on any device allocation failure at init. The riskiest new
plumbing (device upload in `init_from_state`) is covered by a device round-trip golden
and a stub fallback test.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green