### PR TITLE
refactor: consolidate shared scaffolding across sim, fusion, GPU, and backends

### DIFF
--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -7,32 +7,11 @@ use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_ma
 use prism_q::backend::Backend;
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
-use prism_q::sim;
 use prism_q::{BackendKind, StatevectorBackend};
 use std::hint::black_box;
-use std::time::Duration;
 
-fn run_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    seed: u64,
-) -> prism_q::Result<prism_q::RunOutcome> {
-    sim::simulate(circuit).backend(kind).seed(seed).run()
-}
-
-fn is_fast() -> bool {
-    cfg!(feature = "bench-fast")
-}
-
-fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    if is_fast() {
-        group.sample_size(10);
-        group.warm_up_time(Duration::from_millis(200));
-        group.measurement_time(Duration::from_secs(1));
-    } else {
-        group.sample_size(10);
-    }
-}
+mod common;
+use common::{configure_group, run_with};
 
 const QUBIT_COUNTS: [usize; 5] = [4, 8, 12, 16, 20];
 

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -28,43 +28,10 @@ use prism_q::circuit::Circuit;
 use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::gpu::GpuContext;
-use prism_q::{BackendKind, StabilizerBackend, StatevectorBackend, sim};
+use prism_q::{BackendKind, StabilizerBackend, StatevectorBackend};
 
-const SEED: u64 = 0xDEAD_BEEF;
-
-fn run_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    seed: u64,
-) -> prism_q::Result<prism_q::RunOutcome> {
-    sim::simulate(circuit).backend(kind).seed(seed).run()
-}
-
-fn run_shots_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    num_shots: usize,
-    seed: u64,
-) -> prism_q::Result<prism_q::ShotsResult> {
-    sim::simulate(circuit)
-        .backend(kind)
-        .seed(seed)
-        .shots(num_shots)
-}
-
-fn is_fast() -> bool {
-    cfg!(feature = "bench-fast")
-}
-
-fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    if is_fast() {
-        group.sample_size(10);
-        group.warm_up_time(Duration::from_millis(200));
-        group.measurement_time(Duration::from_secs(1));
-    } else {
-        group.sample_size(10);
-    }
-}
+mod common;
+use common::{SEED, configure_group, is_fast, run_shots_with, run_with};
 
 fn shared_ctx() -> Option<Arc<GpuContext>> {
     static CTX: OnceLock<Option<Arc<GpuContext>>> = OnceLock::new();

--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -24,7 +24,9 @@ use std::collections::HashMap;
 use std::hint::black_box;
 use std::time::Duration;
 
-const SEED: u64 = 0xDEAD_BEEF;
+mod common;
+use common::{SEED, run_shots_with};
+
 const API_QUERY_SHOTS: usize = 100_000;
 
 // Base high-shot counts always run; 100M/1B are added only when
@@ -40,18 +42,6 @@ fn high_shot_counts() -> Vec<usize> {
         .into_iter()
         .filter(|&n| n <= cap)
         .collect()
-}
-
-fn run_shots_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    num_shots: usize,
-    seed: u64,
-) -> prism_q::Result<prism_q::ShotsResult> {
-    sim::simulate(circuit)
-        .backend(kind)
-        .seed(seed)
-        .shots(num_shots)
 }
 
 fn run_counts_with(

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -16,27 +16,8 @@ use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 use std::time::Duration;
 
-const SEED: u64 = 0xDEAD_BEEF;
-
-fn run_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    seed: u64,
-) -> prism_q::Result<prism_q::RunOutcome> {
-    sim::simulate(circuit).backend(kind).seed(seed).run()
-}
-
-fn run_shots_with(
-    kind: BackendKind,
-    circuit: &Circuit,
-    num_shots: usize,
-    seed: u64,
-) -> prism_q::Result<prism_q::ShotsResult> {
-    sim::simulate(circuit)
-        .backend(kind)
-        .seed(seed)
-        .shots(num_shots)
-}
+mod common;
+use common::{SEED, configure_group, run_shots_with, run_with};
 
 fn run_shots_with_noise(
     kind: BackendKind,
@@ -50,20 +31,6 @@ fn run_shots_with_noise(
         .noise(noise)
         .seed(seed)
         .shots(num_shots)
-}
-
-fn is_fast() -> bool {
-    cfg!(feature = "bench-fast")
-}
-
-fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    if is_fast() {
-        group.sample_size(10);
-        group.warm_up_time(Duration::from_millis(200));
-        group.measurement_time(Duration::from_secs(1));
-    } else {
-        group.sample_size(10);
-    }
 }
 
 /// Statevector rows above 26q, opted in via `PRISM_BENCH_HIGH_QUBITS=<max>`.

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,48 @@
+//! Shared helpers for the bench targets.
+//!
+//! Each bench file declares `mod common;` and imports the helpers it
+//! needs. Group timing lives here so `--features bench-fast` shortens
+//! every target the same way.
+
+#![allow(dead_code)]
+
+use prism_q::BackendKind;
+use prism_q::circuit::Circuit;
+use prism_q::sim;
+use std::time::Duration;
+
+pub const SEED: u64 = 0xDEAD_BEEF;
+
+pub fn run_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> prism_q::Result<prism_q::RunOutcome> {
+    sim::simulate(circuit).backend(kind).seed(seed).run()
+}
+
+pub fn run_shots_with(
+    kind: BackendKind,
+    circuit: &Circuit,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .seed(seed)
+        .shots(num_shots)
+}
+
+pub fn is_fast() -> bool {
+    cfg!(feature = "bench-fast")
+}
+
+pub fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
+    if is_fast() {
+        group.sample_size(10);
+        group.warm_up_time(Duration::from_millis(200));
+        group.measurement_time(Duration::from_secs(1));
+    } else {
+        group.sample_size(10);
+    }
+}

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -106,15 +106,9 @@ use crate::backend::{Backend, dense_probability_len, dense_statevector_len, meas
 use crate::circuit::{Instruction, SmallVec, smallvec};
 use crate::distributed::DistributedContext;
 use crate::error::{PrismError, Result};
-use crate::gates::{DiagEntry, Gate};
+use crate::gates::{DiagEntry, Gate, is_diagonal_2x2};
 
 const BACKEND_NAME: &str = "distributed_statevector";
-
-/// Whether a 2x2 matrix is diagonal.
-#[inline]
-fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
-    mat[0][1].norm() < 1e-12 && mat[1][0].norm() < 1e-12
-}
 
 /// Visit every circuit qubit an instruction touches: the instruction targets
 /// plus qubit indices stored inside batched gate data. Indices may repeat.

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -24,17 +24,13 @@ use crate::gates::{DiagEntry, Gate};
 #[cfg(feature = "parallel")]
 use crate::backend::statevector::SendPtr;
 #[cfg(feature = "parallel")]
-use crate::backend::{MIN_PAR_ELEMS, MIN_PAR_ITERS, PARALLEL_THRESHOLD_QUBITS};
+use crate::backend::{
+    MIN_PAR_ELEMS, MIN_PAR_ITERS, PARALLEL_THRESHOLD_QUBITS, chunk_min_len as par_chunk_min_len,
+};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 type GateList = SmallVec<[(usize, [[Complex64; 2]; 2]); 4]>;
-
-#[cfg(feature = "parallel")]
-#[inline(always)]
-fn par_chunk_min_len(chunk_size: usize) -> usize {
-    (MIN_PAR_ELEMS / chunk_size).max(1)
-}
 
 struct SubState {
     state: Vec<Complex64>,
@@ -150,7 +146,8 @@ impl FactoredBackend {
     }
 
     /// Central gate dispatch. Translates global qubit indices to local and
-    /// calls sequential SIMD kernels on the sub-state slice.
+    /// applies the sequential or Rayon kernel on the sub-state slice; the
+    /// parallel path engages at `PARALLEL_THRESHOLD_QUBITS`.
     #[inline(always)]
     fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         if let Gate::MultiFused(data) = gate {
@@ -186,11 +183,22 @@ impl FactoredBackend {
         };
 
         #[cfg(feature = "parallel")]
-        {
+        let par = {
             let sub = self.substates[ss_idx].as_ref().unwrap();
-            if sub.qubits.len() >= PARALLEL_THRESHOLD_QUBITS {
-                return self.dispatch_gate_par(ss_idx, gate, targets);
-            }
+            sub.qubits.len() >= PARALLEL_THRESHOLD_QUBITS
+        };
+
+        macro_rules! seq_or_par {
+            ($seq:expr, $par:expr) => {{
+                #[cfg(feature = "parallel")]
+                if par {
+                    $par
+                } else {
+                    $seq
+                }
+                #[cfg(not(feature = "parallel"))]
+                $seq
+            }};
         }
 
         match gate {
@@ -198,68 +206,95 @@ impl FactoredBackend {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let q0 = Self::local_qubit(sub, targets[0]);
                 let q1 = Self::local_qubit(sub, targets[1]);
-                apply_rzz_seq(&mut sub.state, q0, q1, *theta);
+                seq_or_par!(
+                    apply_rzz_seq(&mut sub.state, q0, q1, *theta),
+                    par_apply_rzz(&mut sub.state, q0, q1, *theta)
+                );
             }
             Gate::Cx => {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let ctrl = Self::local_qubit(sub, targets[0]);
                 let tgt = Self::local_qubit(sub, targets[1]);
-                apply_cx_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt);
+                seq_or_par!(
+                    apply_cx_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt),
+                    par_apply_cx(&mut sub.state, ctrl, tgt)
+                );
             }
             Gate::Cz => {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let q0 = Self::local_qubit(sub, targets[0]);
                 let q1 = Self::local_qubit(sub, targets[1]);
-                apply_cz_seq(&mut sub.state, sub.qubits.len(), q0, q1);
+                seq_or_par!(
+                    apply_cz_seq(&mut sub.state, sub.qubits.len(), q0, q1),
+                    par_apply_cz(&mut sub.state, q0, q1)
+                );
             }
             Gate::Swap => {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let q0 = Self::local_qubit(sub, targets[0]);
                 let q1 = Self::local_qubit(sub, targets[1]);
-                apply_swap_seq(&mut sub.state, sub.qubits.len(), q0, q1);
+                seq_or_par!(
+                    apply_swap_seq(&mut sub.state, sub.qubits.len(), q0, q1),
+                    par_apply_swap(&mut sub.state, q0, q1)
+                );
             }
             Gate::Cu(mat) => {
+                let sub = self.substates[ss_idx].as_mut().unwrap();
+                let ctrl = Self::local_qubit(sub, targets[0]);
+                let tgt = Self::local_qubit(sub, targets[1]);
                 if let Some(phase) = gate.controlled_phase() {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let ctrl = Self::local_qubit(sub, targets[0]);
-                    let tgt = Self::local_qubit(sub, targets[1]);
-                    apply_cu_phase_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt, phase);
+                    seq_or_par!(
+                        apply_cu_phase_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt, phase),
+                        par_apply_cu_phase(&mut sub.state, sub.qubits.len(), ctrl, tgt, phase)
+                    );
                 } else {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let ctrl = Self::local_qubit(sub, targets[0]);
-                    let tgt = Self::local_qubit(sub, targets[1]);
-                    apply_cu_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt, **mat);
+                    seq_or_par!(
+                        apply_cu_seq(&mut sub.state, sub.qubits.len(), ctrl, tgt, **mat),
+                        par_apply_cu(&mut sub.state, sub.qubits.len(), ctrl, tgt, **mat)
+                    );
                 }
             }
             Gate::Mcu(data) => {
                 let nc = data.num_controls as usize;
+                let sub = self.substates[ss_idx].as_mut().unwrap();
+                let local_ctrls: SmallVec<[usize; 4]> = targets[..nc]
+                    .iter()
+                    .map(|&q| Self::local_qubit(sub, q))
+                    .collect();
+                let local_tgt = Self::local_qubit(sub, targets[nc]);
                 if let Some(phase) = gate.controlled_phase() {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let local_ctrls: SmallVec<[usize; 4]> = targets[..nc]
-                        .iter()
-                        .map(|&q| Self::local_qubit(sub, q))
-                        .collect();
-                    let local_tgt = Self::local_qubit(sub, targets[nc]);
-                    apply_mcu_phase_seq(
-                        &mut sub.state,
-                        sub.qubits.len(),
-                        &local_ctrls,
-                        local_tgt,
-                        phase,
+                    seq_or_par!(
+                        apply_mcu_phase_seq(
+                            &mut sub.state,
+                            sub.qubits.len(),
+                            &local_ctrls,
+                            local_tgt,
+                            phase,
+                        ),
+                        par_apply_mcu_phase(
+                            &mut sub.state,
+                            sub.qubits.len(),
+                            &local_ctrls,
+                            local_tgt,
+                            phase,
+                        )
                     );
                 } else {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let local_ctrls: SmallVec<[usize; 4]> = targets[..nc]
-                        .iter()
-                        .map(|&q| Self::local_qubit(sub, q))
-                        .collect();
-                    let local_tgt = Self::local_qubit(sub, targets[nc]);
-                    apply_mcu_seq(
-                        &mut sub.state,
-                        sub.qubits.len(),
-                        &local_ctrls,
-                        local_tgt,
-                        data.mat,
+                    seq_or_par!(
+                        apply_mcu_seq(
+                            &mut sub.state,
+                            sub.qubits.len(),
+                            &local_ctrls,
+                            local_tgt,
+                            data.mat,
+                        ),
+                        par_apply_mcu(
+                            &mut sub.state,
+                            sub.qubits.len(),
+                            &local_ctrls,
+                            local_tgt,
+                            data.mat,
+                        )
                     );
                 }
             }
@@ -271,14 +306,25 @@ impl FactoredBackend {
                     .iter()
                     .map(|&(gq, ph)| (Self::local_qubit(sub, gq), ph))
                     .collect();
-                apply_batch_phase_seq(&mut sub.state, sub.qubits.len(), local_ctrl, &local_phases);
+                seq_or_par!(
+                    apply_batch_phase_seq(
+                        &mut sub.state,
+                        sub.qubits.len(),
+                        local_ctrl,
+                        &local_phases,
+                    ),
+                    par_apply_batch_phase(&mut sub.state, local_ctrl, &local_phases)
+                );
             }
             Gate::BatchRzz(data) => {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 for &(q0, q1, theta) in &data.edges {
                     let lq0 = Self::local_qubit(sub, q0);
                     let lq1 = Self::local_qubit(sub, q1);
-                    apply_rzz_seq(&mut sub.state, lq0, lq1, theta);
+                    seq_or_par!(
+                        apply_rzz_seq(&mut sub.state, lq0, lq1, theta),
+                        par_apply_rzz(&mut sub.state, lq0, lq1, theta)
+                    );
                 }
             }
             Gate::DiagonalBatch(data) => {
@@ -288,21 +334,44 @@ impl FactoredBackend {
                         DiagEntry::Phase1q { qubit, d0, d1 } => {
                             let lq = Self::local_qubit(sub, *qubit);
                             let skip_lo = (d0.re - 1.0).abs() < 1e-15 && d0.im.abs() < 1e-15;
-                            simd::apply_diagonal_sequential(&mut sub.state, lq, *d0, *d1, skip_lo);
+                            seq_or_par!(
+                                simd::apply_diagonal_sequential(
+                                    &mut sub.state,
+                                    lq,
+                                    *d0,
+                                    *d1,
+                                    skip_lo,
+                                ),
+                                par_apply_diagonal(&mut sub.state, lq, *d0, *d1, skip_lo)
+                            );
                         }
                         DiagEntry::Phase2q { q0, q1, phase } => {
                             let lq0 = Self::local_qubit(sub, *q0);
                             let lq1 = Self::local_qubit(sub, *q1);
-                            apply_cu_phase_seq(&mut sub.state, sub.qubits.len(), lq0, lq1, *phase);
+                            seq_or_par!(
+                                apply_cu_phase_seq(
+                                    &mut sub.state,
+                                    sub.qubits.len(),
+                                    lq0,
+                                    lq1,
+                                    *phase,
+                                ),
+                                par_apply_cu_phase(
+                                    &mut sub.state,
+                                    sub.qubits.len(),
+                                    lq0,
+                                    lq1,
+                                    *phase,
+                                )
+                            );
                         }
                         DiagEntry::Parity2q { q0, q1, same, diff } => {
                             let lq0 = Self::local_qubit(sub, *q0);
                             let lq1 = Self::local_qubit(sub, *q1);
-                            let n = sub.state.len();
-                            for i in 0..n {
-                                let parity = ((i >> lq0) ^ (i >> lq1)) & 1;
-                                sub.state[i] *= if parity == 0 { *same } else { *diff };
-                            }
+                            seq_or_par!(
+                                apply_parity2q_seq(&mut sub.state, lq0, lq1, *same, *diff),
+                                par_apply_parity2q(&mut sub.state, lq0, lq1, *same, *diff)
+                            );
                         }
                     }
                 }
@@ -311,8 +380,15 @@ impl FactoredBackend {
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let q0 = Self::local_qubit(sub, targets[0]);
                 let q1 = Self::local_qubit(sub, targets[1]);
-                let prepared = simd::PreparedGate2q::new(mat);
-                prepared.apply_full(&mut sub.state, sub.qubits.len(), q0, q1);
+                seq_or_par!(
+                    simd::PreparedGate2q::new(mat).apply_full(
+                        &mut sub.state,
+                        sub.qubits.len(),
+                        q0,
+                        q1,
+                    ),
+                    par_apply_fused2q(&mut sub.state, sub.qubits.len(), q0, q1, mat)
+                );
             }
             Gate::MultiFused(_) | Gate::Multi2q(_) => unreachable!(),
             _ => {
@@ -321,16 +397,22 @@ impl FactoredBackend {
                 let local = Self::local_qubit(sub, targets[0]);
                 if gate.is_diagonal_1q() {
                     let skip_lo = is_phase_one(mat[0][0]);
-                    simd::apply_diagonal_sequential(
-                        &mut sub.state,
-                        local,
-                        mat[0][0],
-                        mat[1][1],
-                        skip_lo,
+                    seq_or_par!(
+                        simd::apply_diagonal_sequential(
+                            &mut sub.state,
+                            local,
+                            mat[0][0],
+                            mat[1][1],
+                            skip_lo,
+                        ),
+                        par_apply_diagonal(&mut sub.state, local, mat[0][0], mat[1][1], skip_lo)
                     );
                 } else {
-                    let prepared = simd::PreparedGate1q::new(&mat);
-                    prepared.apply_full_sequential(&mut sub.state, local);
+                    seq_or_par!(
+                        simd::PreparedGate1q::new(&mat)
+                            .apply_full_sequential(&mut sub.state, local),
+                        par_apply_1q(&mut sub.state, local, &mat)
+                    );
                 }
             }
         }
@@ -367,151 +449,6 @@ impl FactoredBackend {
                 prepared.apply_full_sequential(&mut sub.state, local_tgt);
             }
         }
-    }
-
-    #[cfg(feature = "parallel")]
-    fn dispatch_gate_par(&mut self, ss_idx: usize, gate: &Gate, targets: &[usize]) -> Result<()> {
-        match gate {
-            Gate::Rzz(theta) => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let q0 = Self::local_qubit(sub, targets[0]);
-                let q1 = Self::local_qubit(sub, targets[1]);
-                par_apply_rzz(&mut sub.state, q0, q1, *theta);
-            }
-            Gate::Cx => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let ctrl = Self::local_qubit(sub, targets[0]);
-                let tgt = Self::local_qubit(sub, targets[1]);
-                par_apply_cx(&mut sub.state, ctrl, tgt);
-            }
-            Gate::Cz => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let q0 = Self::local_qubit(sub, targets[0]);
-                let q1 = Self::local_qubit(sub, targets[1]);
-                par_apply_cz(&mut sub.state, q0, q1);
-            }
-            Gate::Swap => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let q0 = Self::local_qubit(sub, targets[0]);
-                let q1 = Self::local_qubit(sub, targets[1]);
-                par_apply_swap(&mut sub.state, q0, q1);
-            }
-            Gate::Cu(mat) => {
-                if let Some(phase) = gate.controlled_phase() {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let ctrl = Self::local_qubit(sub, targets[0]);
-                    let tgt = Self::local_qubit(sub, targets[1]);
-                    par_apply_cu_phase(&mut sub.state, sub.qubits.len(), ctrl, tgt, phase);
-                } else {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let ctrl = Self::local_qubit(sub, targets[0]);
-                    let tgt = Self::local_qubit(sub, targets[1]);
-                    par_apply_cu(&mut sub.state, sub.qubits.len(), ctrl, tgt, **mat);
-                }
-            }
-            Gate::Mcu(data) => {
-                let nc = data.num_controls as usize;
-                if let Some(phase) = gate.controlled_phase() {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let local_ctrls: SmallVec<[usize; 4]> = targets[..nc]
-                        .iter()
-                        .map(|&q| Self::local_qubit(sub, q))
-                        .collect();
-                    let local_tgt = Self::local_qubit(sub, targets[nc]);
-                    par_apply_mcu_phase(
-                        &mut sub.state,
-                        sub.qubits.len(),
-                        &local_ctrls,
-                        local_tgt,
-                        phase,
-                    );
-                } else {
-                    let sub = self.substates[ss_idx].as_mut().unwrap();
-                    let local_ctrls: SmallVec<[usize; 4]> = targets[..nc]
-                        .iter()
-                        .map(|&q| Self::local_qubit(sub, q))
-                        .collect();
-                    let local_tgt = Self::local_qubit(sub, targets[nc]);
-                    par_apply_mcu(
-                        &mut sub.state,
-                        sub.qubits.len(),
-                        &local_ctrls,
-                        local_tgt,
-                        data.mat,
-                    );
-                }
-            }
-            Gate::BatchPhase(data) => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let local_ctrl = Self::local_qubit(sub, targets[0]);
-                let local_phases: SmallVec<[(usize, Complex64); 8]> = data
-                    .phases
-                    .iter()
-                    .map(|&(gq, ph)| (Self::local_qubit(sub, gq), ph))
-                    .collect();
-                par_apply_batch_phase(&mut sub.state, local_ctrl, &local_phases);
-            }
-            Gate::BatchRzz(data) => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                for &(q0, q1, theta) in &data.edges {
-                    let lq0 = Self::local_qubit(sub, q0);
-                    let lq1 = Self::local_qubit(sub, q1);
-                    par_apply_rzz(&mut sub.state, lq0, lq1, theta);
-                }
-            }
-            Gate::DiagonalBatch(data) => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                for entry in &data.entries {
-                    match entry {
-                        DiagEntry::Phase1q { qubit, d0, d1 } => {
-                            let lq = Self::local_qubit(sub, *qubit);
-                            let skip_lo = (d0.re - 1.0).abs() < 1e-15 && d0.im.abs() < 1e-15;
-                            par_apply_diagonal(&mut sub.state, lq, *d0, *d1, skip_lo);
-                        }
-                        DiagEntry::Phase2q { q0, q1, phase } => {
-                            let lq0 = Self::local_qubit(sub, *q0);
-                            let lq1 = Self::local_qubit(sub, *q1);
-                            par_apply_cu_phase(&mut sub.state, sub.qubits.len(), lq0, lq1, *phase);
-                        }
-                        DiagEntry::Parity2q { q0, q1, same, diff } => {
-                            let lq0 = Self::local_qubit(sub, *q0);
-                            let lq1 = Self::local_qubit(sub, *q1);
-                            let phases = [*same, *diff];
-                            sub.state
-                                .par_chunks_mut(MIN_PAR_ELEMS)
-                                .enumerate()
-                                .for_each(|(chunk_idx, chunk)| {
-                                    let base = chunk_idx * MIN_PAR_ELEMS;
-                                    for (j, amp) in chunk.iter_mut().enumerate() {
-                                        let i = base + j;
-                                        let parity = ((i >> lq0) ^ (i >> lq1)) & 1;
-                                        *amp *= phases[parity];
-                                    }
-                                });
-                        }
-                    }
-                }
-            }
-            Gate::Fused2q(mat) => {
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let q0 = Self::local_qubit(sub, targets[0]);
-                let q1 = Self::local_qubit(sub, targets[1]);
-                par_apply_fused2q(&mut sub.state, sub.qubits.len(), q0, q1, mat);
-            }
-            Gate::MultiFused(_) | Gate::Multi2q(_) => unreachable!(),
-            _ => {
-                let mat = gate.matrix_2x2();
-                let sub = self.substates[ss_idx].as_mut().unwrap();
-                let local = Self::local_qubit(sub, targets[0]);
-                if gate.is_diagonal_1q() {
-                    let skip_lo = is_phase_one(mat[0][0]);
-                    par_apply_diagonal(&mut sub.state, local, mat[0][0], mat[1][1], skip_lo);
-                } else {
-                    par_apply_1q(&mut sub.state, local, &mat);
-                }
-            }
-        }
-        Ok(())
     }
 
     fn apply_reset(&mut self, qubit: usize) {
@@ -792,6 +729,43 @@ fn apply_rzz_seq(state: &mut [Complex64], q0: usize, q1: usize, theta: f64) {
         let parity = ((i >> q0) ^ (i >> q1)) & 1;
         *amp *= phases[parity];
     }
+}
+
+#[inline(always)]
+fn apply_parity2q_seq(
+    state: &mut [Complex64],
+    q0: usize,
+    q1: usize,
+    same: Complex64,
+    diff: Complex64,
+) {
+    let phases = [same, diff];
+    for (i, amp) in state.iter_mut().enumerate() {
+        let parity = ((i >> q0) ^ (i >> q1)) & 1;
+        *amp *= phases[parity];
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn par_apply_parity2q(
+    state: &mut [Complex64],
+    q0: usize,
+    q1: usize,
+    same: Complex64,
+    diff: Complex64,
+) {
+    let phases = [same, diff];
+    state
+        .par_chunks_mut(MIN_PAR_ELEMS)
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let base = chunk_idx * MIN_PAR_ELEMS;
+            for (j, amp) in chunk.iter_mut().enumerate() {
+                let i = base + j;
+                let parity = ((i >> q0) ^ (i >> q1)) & 1;
+                *amp *= phases[parity];
+            }
+        });
 }
 
 fn apply_cz_seq(state: &mut [Complex64], num_qubits: usize, q0: usize, q1: usize) {

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -11,7 +11,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
-use crate::backend::stabilizer::kernels::rowmul_words;
+use crate::backend::stabilizer::kernels::{rowmul_words, rowops};
 use crate::backend::{Backend, dense_probability_len, dense_statevector_len, reserve_dense_output};
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
@@ -59,329 +59,78 @@ impl SubTableau {
         self.qubits.iter().position(|&q| q == global).unwrap()
     }
 
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn par_rows(&self) -> bool {
+        self.n >= MIN_QUBITS_FOR_PAR_GATES
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    #[inline(always)]
+    fn par_rows(&self) -> bool {
+        false
+    }
+
     fn apply_h(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xw = row[word];
-            let zw = row[nw + word];
-            let x = xw & bit_mask;
-            let z = zw & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[word] = (xw & !bit_mask) | z;
-            row[nw + word] = (zw & !bit_mask) | x;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::h_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_s(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[nw + word] ^= x;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::s_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_sdg(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            row[nw + word] ^= x;
-            let z_new = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z_new != 0);
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_x(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            *phase ^= (row[nw + word] & bit_mask) != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::x_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_y(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            *phase ^= ((row[word] ^ row[nw + word]) & bit_mask) != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::y_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_z(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            *phase ^= (row[word] & bit_mask) != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::z_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_sx(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (z != 0) && (x == 0);
-            row[word] ^= z;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sx_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_sxdg(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[word] ^= z;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sxdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     fn apply_cx(&mut self, ctrl: usize, tgt: usize) {
-        let cw = ctrl / 64;
-        let cb = 1u64 << (ctrl % 64);
-        let tw = tgt / 64;
-        let tb = 1u64 << (tgt % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xc = (row[cw] & cb) != 0;
-            let zc = (row[nw + cw] & cb) != 0;
-            let xt = (row[tw] & tb) != 0;
-            let zt = (row[nw + tw] & tb) != 0;
-            *phase ^= xc && zt && (xt == zc);
-            if xc {
-                row[tw] ^= tb;
-            }
-            if zt {
-                row[nw + cw] ^= cb;
-            }
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::cx_all(
+            &mut self.xz,
+            &mut self.phase,
+            self.num_words,
+            par,
+            ctrl,
+            tgt,
+        );
     }
 
     fn apply_cz(&mut self, a: usize, b: usize) {
-        let aw = a / 64;
-        let ab = 1u64 << (a % 64);
-        let bw = b / 64;
-        let bb = 1u64 << (b % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xa = (row[aw] & ab) != 0;
-            let za = (row[nw + aw] & ab) != 0;
-            let xb = (row[bw] & bb) != 0;
-            let zb = (row[nw + bw] & bb) != 0;
-            *phase ^= xa && xb && (za != zb);
-            if xa {
-                row[nw + bw] ^= bb;
-            }
-            if xb {
-                row[nw + aw] ^= ab;
-            }
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::cz_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
     }
 
     fn apply_swap(&mut self, a: usize, b: usize) {
-        let aw = a / 64;
-        let ab = 1u64 << (a % 64);
-        let bw = b / 64;
-        let bb = 1u64 << (b % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], _phase: &mut bool| {
-            let xa = (row[aw] & ab) != 0;
-            let za = (row[nw + aw] & ab) != 0;
-            let xb = (row[bw] & bb) != 0;
-            let zb = (row[nw + bw] & bb) != 0;
-            row[aw] = (row[aw] & !ab) | if xb { ab } else { 0 };
-            row[bw] = (row[bw] & !bb) | if xa { bb } else { 0 };
-            row[nw + aw] = (row[nw + aw] & !ab) | if zb { ab } else { 0 };
-            row[nw + bw] = (row[nw + bw] & !bb) | if za { bb } else { 0 };
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::swap_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
     }
 
     fn dispatch_gate(&mut self, gate: &Gate, local_targets: &[usize]) -> Result<()> {
@@ -409,40 +158,15 @@ impl SubTableau {
     }
 
     fn rowmul(&mut self, h: usize, i: usize) {
-        debug_assert_ne!(h, i);
-        let stride = self.stride();
-        let nw = self.num_words;
-        let base_h = h * stride;
-        let base_i = i * stride;
-        let initial = if self.phase[i] { 2u64 } else { 0 } + if self.phase[h] { 2u64 } else { 0 };
-        // SAFETY: h != i so row regions are non-overlapping.
-        let (dst_x, dst_z, src_x, src_z) = unsafe {
-            let ptr = self.xz.as_mut_ptr();
-            (
-                std::slice::from_raw_parts_mut(ptr.add(base_h), nw),
-                std::slice::from_raw_parts_mut(ptr.add(base_h + nw), nw),
-                std::slice::from_raw_parts(ptr.add(base_i) as *const u64, nw),
-                std::slice::from_raw_parts(ptr.add(base_i + nw) as *const u64, nw),
-            )
-        };
-        let sum = rowmul_words(dst_x, dst_z, src_x, src_z, initial);
-        self.phase[h] = (sum & 3) >= 2;
+        rowops::rowmul(&mut self.xz, &mut self.phase, self.num_words, h, i);
     }
 
     fn copy_row(&mut self, dst: usize, src: usize) {
-        let stride = self.stride();
-        let src_start = src * stride;
-        let dst_start = dst * stride;
-        self.xz
-            .copy_within(src_start..src_start + stride, dst_start);
-        self.phase[dst] = self.phase[src];
+        rowops::copy_row(&mut self.xz, &mut self.phase, self.num_words, dst, src);
     }
 
     fn zero_row(&mut self, r: usize) {
-        let stride = self.stride();
-        let start = r * stride;
-        self.xz[start..start + stride].fill(0);
-        self.phase[r] = false;
+        rowops::zero_row(&mut self.xz, &mut self.phase, self.num_words, r);
     }
 
     fn measure(&mut self, local_q: usize, rng: &mut ChaCha8Rng) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -48,6 +48,12 @@ pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
 pub(crate) const MIN_PAR_ELEMS: usize = 4096;
 
 #[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) fn chunk_min_len(chunk_size: usize) -> usize {
+    (MIN_PAR_ELEMS / chunk_size).max(1)
+}
+
+#[cfg(feature = "parallel")]
 pub(crate) const MIN_PAR_ITERS: usize = 2048;
 
 #[cfg(feature = "parallel")]

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -257,31 +257,26 @@ impl SparseBackend {
         self.prune();
     }
 
+    fn masked_prob(&self, mask: usize, bit_set: bool) -> f64 {
+        #[cfg(feature = "parallel")]
+        if self.state.len() >= MIN_STATES_FOR_PAR {
+            return self
+                .state
+                .par_iter()
+                .filter(|&(&idx, _)| (idx & mask != 0) == bit_set)
+                .map(|(_, amp)| amp.norm_sqr())
+                .sum();
+        }
+        self.state
+            .iter()
+            .filter(|&(&idx, _)| (idx & mask != 0) == bit_set)
+            .map(|(_, amp)| amp.norm_sqr())
+            .sum()
+    }
+
     fn apply_reset(&mut self, qubit: usize) {
         let mask = 1usize << qubit;
-
-        #[cfg(feature = "parallel")]
-        let prob_zero: f64 = if self.state.len() >= MIN_STATES_FOR_PAR {
-            self.state
-                .par_iter()
-                .filter(|&(&idx, _)| idx & mask == 0)
-                .map(|(_, amp)| amp.norm_sqr())
-                .sum()
-        } else {
-            self.state
-                .iter()
-                .filter(|&(&idx, _)| idx & mask == 0)
-                .map(|(_, amp)| amp.norm_sqr())
-                .sum()
-        };
-
-        #[cfg(not(feature = "parallel"))]
-        let prob_zero: f64 = self
-            .state
-            .iter()
-            .filter(|&(&idx, _)| idx & mask == 0)
-            .map(|(_, amp)| amp.norm_sqr())
-            .sum();
+        let prob_zero = self.masked_prob(mask, false);
 
         if prob_zero > 0.0 {
             let inv_norm = 1.0 / prob_zero.sqrt();
@@ -301,29 +296,7 @@ impl SparseBackend {
 
     fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
         let mask = 1usize << qubit;
-
-        #[cfg(feature = "parallel")]
-        let prob_one: f64 = if self.state.len() >= MIN_STATES_FOR_PAR {
-            self.state
-                .par_iter()
-                .filter(|&(&idx, _)| idx & mask != 0)
-                .map(|(_, amp)| amp.norm_sqr())
-                .sum()
-        } else {
-            self.state
-                .iter()
-                .filter(|&(&idx, _)| idx & mask != 0)
-                .map(|(_, amp)| amp.norm_sqr())
-                .sum()
-        };
-
-        #[cfg(not(feature = "parallel"))]
-        let prob_one: f64 = self
-            .state
-            .iter()
-            .filter(|&(&idx, _)| idx & mask != 0)
-            .map(|(_, amp)| amp.norm_sqr())
-            .sum();
+        let prob_one = self.masked_prob(mask, true);
 
         let outcome = self.rng.random::<f64>() < prob_one;
         self.classical_bits[classical_bit] = outcome;

--- a/src/backend/stabilizer/kernels/mod.rs
+++ b/src/backend/stabilizer/kernels/mod.rs
@@ -1,4 +1,5 @@
 mod batch;
+pub(crate) mod rowops;
 mod simd;
 
 pub(crate) use batch::MIN_WORDS_FOR_BATCH;
@@ -58,301 +59,77 @@ impl StabilizerBackend {
         2 * self.num_words
     }
 
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn par_rows(&self) -> bool {
+        self.n >= MIN_QUBITS_FOR_PAR_GATES
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    #[inline(always)]
+    fn par_rows(&self) -> bool {
+        false
+    }
+
     #[inline(always)]
     fn apply_h(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xw = row[word];
-            let zw = row[nw + word];
-            let x = xw & bit_mask;
-            let z = zw & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[word] = (xw & !bit_mask) | z;
-            row[nw + word] = (zw & !bit_mask) | x;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::h_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_s(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[nw + word] ^= x;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::s_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_sdg(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            row[nw + word] ^= x;
-            let z_new = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z_new != 0);
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_x(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &[u64], phase: &mut bool| {
-            let z = row[nw + word] & bit_mask;
-            *phase ^= z != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::x_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_y(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &[u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (x ^ z) != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::y_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_z(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-
-        let row_op = |row: &[u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            *phase ^= x != 0;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::z_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_cx(&mut self, control: usize, target: usize) {
-        let c_word = control / 64;
-        let c_bit = control % 64;
-        let c_mask = 1u64 << c_bit;
-        let t_word = target / 64;
-        let t_bit = target % 64;
-        let t_mask = 1u64 << t_bit;
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xa = (row[c_word] >> c_bit) & 1;
-            let za = (row[nw + c_word] >> c_bit) & 1;
-            let xb = (row[t_word] >> t_bit) & 1;
-            let zb = (row[nw + t_word] >> t_bit) & 1;
-
-            *phase ^= (xa & zb & (xb ^ za ^ 1)) == 1;
-
-            if xa == 1 {
-                row[t_word] ^= t_mask;
-            }
-            if zb == 1 {
-                row[nw + c_word] ^= c_mask;
-            }
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::cx_all(
+            &mut self.xz,
+            &mut self.phase,
+            self.num_words,
+            par,
+            control,
+            target,
+        );
     }
 
     #[inline(always)]
     fn apply_cz(&mut self, a: usize, b: usize) {
-        let a_word = a / 64;
-        let a_bit = a % 64;
-        let a_mask = 1u64 << a_bit;
-        let b_word = b / 64;
-        let b_bit = b % 64;
-        let b_mask = 1u64 << b_bit;
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let xa = (row[a_word] >> a_bit) & 1;
-            let xb = (row[b_word] >> b_bit) & 1;
-            let za = (row[nw + a_word] >> a_bit) & 1;
-            let zb = (row[nw + b_word] >> b_bit) & 1;
-
-            *phase ^= (xa & xb & (za ^ zb)) == 1;
-
-            if xb == 1 {
-                row[nw + a_word] ^= a_mask;
-            }
-            if xa == 1 {
-                row[nw + b_word] ^= b_mask;
-            }
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::cz_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
     }
 
     #[inline(always)]
     fn apply_swap(&mut self, a: usize, b: usize) {
-        let a_word = a / 64;
-        let a_bit = a % 64;
-        let a_mask = 1u64 << a_bit;
-        let b_word = b / 64;
-        let b_bit = b % 64;
-        let b_mask = 1u64 << b_bit;
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], _phase: &mut bool| {
-            let xa = (row[a_word] >> a_bit) & 1;
-            let xb = (row[b_word] >> b_bit) & 1;
-            if xa != xb {
-                row[a_word] ^= a_mask;
-                row[b_word] ^= b_mask;
-            }
-
-            let za = (row[nw + a_word] >> a_bit) & 1;
-            let zb = (row[nw + b_word] >> b_bit) & 1;
-            if za != zb {
-                row[nw + a_word] ^= a_mask;
-                row[nw + b_word] ^= b_mask;
-            }
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::swap_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
     }
 
     pub(super) fn sgi_enabled(&self) -> bool {
@@ -366,8 +143,7 @@ impl StabilizerBackend {
     }
 
     fn sgi_apply_1q(&mut self, gate: &Gate, q: usize) {
-        let word = q / 64;
-        let bit_mask = 1u64 << (q % 64);
+        let qb = rowops::QubitBit::of(q);
         let stride = self.stride();
         let nw = self.num_words;
 
@@ -376,52 +152,14 @@ impl StabilizerBackend {
             let phase = &mut self.phase[g as usize];
 
             match gate {
-                Gate::H => {
-                    let xw = row[word];
-                    let zw = row[nw + word];
-                    let x = xw & bit_mask;
-                    let z = zw & bit_mask;
-                    *phase ^= (x != 0) && (z != 0);
-                    row[word] = (xw & !bit_mask) | z;
-                    row[nw + word] = (zw & !bit_mask) | x;
-                }
-                Gate::S => {
-                    let x = row[word] & bit_mask;
-                    let z = row[nw + word] & bit_mask;
-                    *phase ^= (x != 0) && (z != 0);
-                    row[nw + word] ^= x;
-                }
-                Gate::Sdg => {
-                    let x = row[word] & bit_mask;
-                    row[nw + word] ^= x;
-                    let z_new = row[nw + word] & bit_mask;
-                    *phase ^= (x != 0) && (z_new != 0);
-                }
-                Gate::X => {
-                    let z = row[nw + word] & bit_mask;
-                    *phase ^= z != 0;
-                }
-                Gate::Y => {
-                    let x = row[word] & bit_mask;
-                    let z = row[nw + word] & bit_mask;
-                    *phase ^= (x ^ z) != 0;
-                }
-                Gate::Z => {
-                    let x = row[word] & bit_mask;
-                    *phase ^= x != 0;
-                }
-                Gate::SX => {
-                    let x = row[word] & bit_mask;
-                    let z = row[nw + word] & bit_mask;
-                    *phase ^= (z != 0) && (x == 0);
-                    row[word] ^= z;
-                }
-                Gate::SXdg => {
-                    let x = row[word] & bit_mask;
-                    let z = row[nw + word] & bit_mask;
-                    *phase ^= (x != 0) && (z != 0);
-                    row[word] ^= z;
-                }
+                Gate::H => rowops::h_row(row, phase, nw, qb),
+                Gate::S => rowops::s_row(row, phase, nw, qb),
+                Gate::Sdg => rowops::sdg_row(row, phase, nw, qb),
+                Gate::X => rowops::x_row(row, phase, nw, qb),
+                Gate::Y => rowops::y_row(row, phase, nw, qb),
+                Gate::Z => rowops::z_row(row, phase, nw, qb),
+                Gate::SX => rowops::sx_row(row, phase, nw, qb),
+                Gate::SXdg => rowops::sxdg_row(row, phase, nw, qb),
                 _ => {}
             }
         }
@@ -454,12 +192,10 @@ impl StabilizerBackend {
     }
 
     fn sgi_apply_cx(&mut self, ctrl: usize, tgt: usize) {
-        let c_word = ctrl / 64;
-        let c_bit = ctrl % 64;
-        let c_mask = 1u64 << c_bit;
-        let t_word = tgt / 64;
-        let t_bit = tgt % 64;
-        let t_mask = 1u64 << t_bit;
+        let c = rowops::QubitBit::of(ctrl);
+        let t = rowops::QubitBit::of(tgt);
+        let (c_word, c_bit) = (c.word, c.bit);
+        let (t_word, t_bit) = (t.word, t.bit);
         let stride = self.stride();
         let nw = self.num_words;
 
@@ -477,14 +213,7 @@ impl StabilizerBackend {
             let xb = (row[t_word] >> t_bit) & 1;
             let zb = (row[nw + t_word] >> t_bit) & 1;
 
-            *phase ^= (xa & zb & (xb ^ za ^ 1)) == 1;
-
-            if xa == 1 {
-                row[t_word] ^= t_mask;
-            }
-            if zb == 1 {
-                row[nw + c_word] ^= c_mask;
-            }
+            rowops::cx_row(row, phase, nw, c, t);
 
             let new_xa = (row[c_word] >> c_bit) & 1;
             let new_za = (row[nw + c_word] >> c_bit) & 1;
@@ -528,12 +257,10 @@ impl StabilizerBackend {
     }
 
     fn sgi_apply_cz(&mut self, a: usize, b: usize) {
-        let a_word = a / 64;
-        let a_bit = a % 64;
-        let a_mask = 1u64 << a_bit;
-        let b_word = b / 64;
-        let b_bit = b % 64;
-        let b_mask = 1u64 << b_bit;
+        let qa = rowops::QubitBit::of(a);
+        let qb = rowops::QubitBit::of(b);
+        let (a_word, a_bit) = (qa.word, qa.bit);
+        let (b_word, b_bit) = (qb.word, qb.bit);
         let stride = self.stride();
         let nw = self.num_words;
 
@@ -551,14 +278,7 @@ impl StabilizerBackend {
             let za = (row[nw + a_word] >> a_bit) & 1;
             let zb = (row[nw + b_word] >> b_bit) & 1;
 
-            *phase ^= (xa & xb & (za ^ zb)) == 1;
-
-            if xb == 1 {
-                row[nw + a_word] ^= a_mask;
-            }
-            if xa == 1 {
-                row[nw + b_word] ^= b_mask;
-            }
+            rowops::cz_row(row, phase, nw, qa, qb);
 
             let new_xa = (row[a_word] >> a_bit) & 1;
             let new_za = (row[nw + a_word] >> a_bit) & 1;
@@ -602,12 +322,10 @@ impl StabilizerBackend {
     }
 
     fn sgi_apply_swap(&mut self, a: usize, b: usize) {
-        let a_word = a / 64;
-        let a_bit = a % 64;
-        let a_mask = 1u64 << a_bit;
-        let b_word = b / 64;
-        let b_bit = b % 64;
-        let b_mask = 1u64 << b_bit;
+        let qa = rowops::QubitBit::of(a);
+        let qb = rowops::QubitBit::of(b);
+        let (a_word, a_bit) = (qa.word, qa.bit);
+        let (b_word, b_bit) = (qb.word, qb.bit);
         let stride = self.stride();
         let nw = self.num_words;
 
@@ -619,19 +337,7 @@ impl StabilizerBackend {
             let g = self.sgi_merge_buf[i];
             let row = &mut self.xz[g as usize * stride..(g as usize + 1) * stride];
 
-            let xa = (row[a_word] >> a_bit) & 1;
-            let xb = (row[b_word] >> b_bit) & 1;
-            if xa != xb {
-                row[a_word] ^= a_mask;
-                row[b_word] ^= b_mask;
-            }
-
-            let za = (row[nw + a_word] >> a_bit) & 1;
-            let zb = (row[nw + b_word] >> b_bit) & 1;
-            if za != zb {
-                row[nw + a_word] ^= a_mask;
-                row[nw + b_word] ^= b_mask;
-            }
+            rowops::swap_row(row, nw, qa, qb);
 
             let new_xa = (row[a_word] >> a_bit) & 1;
             let new_za = (row[nw + a_word] >> a_bit) & 1;
@@ -915,60 +621,14 @@ impl StabilizerBackend {
 
     #[inline(always)]
     fn apply_sx(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (z != 0) && (x == 0);
-            row[word] ^= z;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sx_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     #[inline(always)]
     fn apply_sxdg(&mut self, a: usize) {
-        let word = a / 64;
-        let bit_mask = 1u64 << (a % 64);
-        let stride = self.stride();
-        let nw = self.num_words;
-
-        let row_op = |row: &mut [u64], phase: &mut bool| {
-            let x = row[word] & bit_mask;
-            let z = row[nw + word] & bit_mask;
-            *phase ^= (x != 0) && (z != 0);
-            row[word] ^= z;
-        };
-
-        #[cfg(feature = "parallel")]
-        if self.n >= MIN_QUBITS_FOR_PAR_GATES {
-            use rayon::prelude::*;
-            self.xz
-                .par_chunks_mut(stride)
-                .zip(self.phase.par_iter_mut())
-                .for_each(|(row, phase)| row_op(row, phase));
-            return;
-        }
-
-        for (row, phase) in self.xz.chunks_mut(stride).zip(self.phase.iter_mut()) {
-            row_op(row, phase);
-        }
+        let par = self.par_rows();
+        rowops::sxdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     pub(super) fn apply_instructions_sgi(&mut self, instructions: &[Instruction]) -> Result<()> {

--- a/src/backend/stabilizer/kernels/rowops.rs
+++ b/src/backend/stabilizer/kernels/rowops.rs
@@ -1,0 +1,294 @@
+//! Row-level Clifford tableau operations shared by the dense stabilizer
+//! backend, its SGI path, and the factored sub-tableaux.
+//!
+//! Rows live in a flat `xz` buffer of `2 * nw` words per row (X words then
+//! Z words) with a parallel `phase` bit per row. Callers resolve a qubit to
+//! a `QubitBit` once per gate; the per-row functions take the precomputed
+//! coordinates so no derivation sits inside the row loop.
+
+use super::simd::rowmul_words;
+
+#[derive(Clone, Copy)]
+pub(crate) struct QubitBit {
+    pub word: usize,
+    pub bit: usize,
+    pub mask: u64,
+}
+
+impl QubitBit {
+    #[inline(always)]
+    pub(crate) fn of(q: usize) -> Self {
+        QubitBit {
+            word: q / 64,
+            bit: q % 64,
+            mask: 1u64 << (q % 64),
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn h_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let xw = row[a.word];
+    let zw = row[nw + a.word];
+    let x = xw & a.mask;
+    let z = zw & a.mask;
+    *phase ^= (x != 0) && (z != 0);
+    row[a.word] = (xw & !a.mask) | z;
+    row[nw + a.word] = (zw & !a.mask) | x;
+}
+
+#[inline(always)]
+pub(crate) fn s_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    let z = row[nw + a.word] & a.mask;
+    *phase ^= (x != 0) && (z != 0);
+    row[nw + a.word] ^= x;
+}
+
+#[inline(always)]
+pub(crate) fn sdg_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    row[nw + a.word] ^= x;
+    let z_new = row[nw + a.word] & a.mask;
+    *phase ^= (x != 0) && (z_new != 0);
+}
+
+#[inline(always)]
+pub(crate) fn x_row(row: &[u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let z = row[nw + a.word] & a.mask;
+    *phase ^= z != 0;
+}
+
+#[inline(always)]
+pub(crate) fn y_row(row: &[u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    let z = row[nw + a.word] & a.mask;
+    *phase ^= (x ^ z) != 0;
+}
+
+#[inline(always)]
+pub(crate) fn z_row(row: &[u64], phase: &mut bool, _nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    *phase ^= x != 0;
+}
+
+#[inline(always)]
+pub(crate) fn sx_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    let z = row[nw + a.word] & a.mask;
+    *phase ^= (z != 0) && (x == 0);
+    row[a.word] ^= z;
+}
+
+#[inline(always)]
+pub(crate) fn sxdg_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit) {
+    let x = row[a.word] & a.mask;
+    let z = row[nw + a.word] & a.mask;
+    *phase ^= (x != 0) && (z != 0);
+    row[a.word] ^= z;
+}
+
+#[inline(always)]
+pub(crate) fn cx_row(row: &mut [u64], phase: &mut bool, nw: usize, c: QubitBit, t: QubitBit) {
+    let xa = (row[c.word] >> c.bit) & 1;
+    let za = (row[nw + c.word] >> c.bit) & 1;
+    let xb = (row[t.word] >> t.bit) & 1;
+    let zb = (row[nw + t.word] >> t.bit) & 1;
+
+    *phase ^= (xa & zb & (xb ^ za ^ 1)) == 1;
+
+    if xa == 1 {
+        row[t.word] ^= t.mask;
+    }
+    if zb == 1 {
+        row[nw + c.word] ^= c.mask;
+    }
+}
+
+#[inline(always)]
+pub(crate) fn cz_row(row: &mut [u64], phase: &mut bool, nw: usize, a: QubitBit, b: QubitBit) {
+    let xa = (row[a.word] >> a.bit) & 1;
+    let xb = (row[b.word] >> b.bit) & 1;
+    let za = (row[nw + a.word] >> a.bit) & 1;
+    let zb = (row[nw + b.word] >> b.bit) & 1;
+
+    *phase ^= (xa & xb & (za ^ zb)) == 1;
+
+    if xb == 1 {
+        row[nw + a.word] ^= a.mask;
+    }
+    if xa == 1 {
+        row[nw + b.word] ^= b.mask;
+    }
+}
+
+#[inline(always)]
+pub(crate) fn swap_row(row: &mut [u64], nw: usize, a: QubitBit, b: QubitBit) {
+    let xa = (row[a.word] >> a.bit) & 1;
+    let xb = (row[b.word] >> b.bit) & 1;
+    if xa != xb {
+        row[a.word] ^= a.mask;
+        row[b.word] ^= b.mask;
+    }
+
+    let za = (row[nw + a.word] >> a.bit) & 1;
+    let zb = (row[nw + b.word] >> b.bit) & 1;
+    if za != zb {
+        row[nw + a.word] ^= a.mask;
+        row[nw + b.word] ^= b.mask;
+    }
+}
+
+#[inline(always)]
+pub(crate) fn sweep(
+    xz: &mut [u64],
+    phase: &mut [bool],
+    nw: usize,
+    par: bool,
+    row_op: impl Fn(&mut [u64], &mut bool) + Send + Sync,
+) {
+    let stride = 2 * nw;
+    #[cfg(feature = "parallel")]
+    if par {
+        use rayon::prelude::*;
+        xz.par_chunks_mut(stride)
+            .zip(phase.par_iter_mut())
+            .for_each(|(row, phase)| row_op(row, phase));
+        return;
+    }
+    #[cfg(not(feature = "parallel"))]
+    let _ = par;
+    for (row, phase) in xz.chunks_mut(stride).zip(phase.iter_mut()) {
+        row_op(row, phase);
+    }
+}
+
+#[inline(always)]
+pub(crate) fn h_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| h_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn s_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| s_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn sdg_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| sdg_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn x_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| x_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn y_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| y_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn z_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| z_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn sx_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| sx_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn sxdg_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize) {
+    let a = QubitBit::of(a);
+    sweep(xz, phase, nw, par, |row, phase| sxdg_row(row, phase, nw, a));
+}
+
+#[inline(always)]
+pub(crate) fn cx_all(
+    xz: &mut [u64],
+    phase: &mut [bool],
+    nw: usize,
+    par: bool,
+    control: usize,
+    target: usize,
+) {
+    let c = QubitBit::of(control);
+    let t = QubitBit::of(target);
+    sweep(xz, phase, nw, par, |row, phase| {
+        cx_row(row, phase, nw, c, t)
+    });
+}
+
+#[inline(always)]
+pub(crate) fn cz_all(xz: &mut [u64], phase: &mut [bool], nw: usize, par: bool, a: usize, b: usize) {
+    let a = QubitBit::of(a);
+    let b = QubitBit::of(b);
+    sweep(xz, phase, nw, par, |row, phase| {
+        cz_row(row, phase, nw, a, b)
+    });
+}
+
+#[inline(always)]
+pub(crate) fn swap_all(
+    xz: &mut [u64],
+    phase: &mut [bool],
+    nw: usize,
+    par: bool,
+    a: usize,
+    b: usize,
+) {
+    let a = QubitBit::of(a);
+    let b = QubitBit::of(b);
+    sweep(xz, phase, nw, par, |row, _phase| swap_row(row, nw, a, b));
+}
+
+/// Multiply row `h` by row `i` (replace `h` with the Pauli product).
+///
+/// Fused phase+XOR: AG g-function with wordwise popcount, row XOR in the
+/// same loop to avoid a separate memory pass.
+pub(crate) fn rowmul(xz: &mut [u64], phase: &mut [bool], nw: usize, h: usize, i: usize) {
+    debug_assert_ne!(h, i);
+    let stride = 2 * nw;
+    let base_h = h * stride;
+    let base_i = i * stride;
+
+    let initial_sum = if phase[i] { 2u64 } else { 0 } + if phase[h] { 2u64 } else { 0 };
+
+    // SAFETY: h != i, so row regions [base_h..base_h+stride] and
+    // [base_i..base_i+stride] are non-overlapping.
+    let (dst_x, dst_z, src_x, src_z) = unsafe {
+        let ptr = xz.as_mut_ptr();
+        (
+            std::slice::from_raw_parts_mut(ptr.add(base_h), nw),
+            std::slice::from_raw_parts_mut(ptr.add(base_h + nw), nw),
+            std::slice::from_raw_parts(ptr.add(base_i) as *const u64, nw),
+            std::slice::from_raw_parts(ptr.add(base_i + nw) as *const u64, nw),
+        )
+    };
+
+    let sum = rowmul_words(dst_x, dst_z, src_x, src_z, initial_sum);
+    phase[h] = (sum & 3) >= 2;
+}
+
+pub(crate) fn copy_row(xz: &mut [u64], phase: &mut [bool], nw: usize, dst: usize, src: usize) {
+    let stride = 2 * nw;
+    let src_start = src * stride;
+    let dst_start = dst * stride;
+    xz.copy_within(src_start..src_start + stride, dst_start);
+    phase[dst] = phase[src];
+}
+
+pub(crate) fn zero_row(xz: &mut [u64], phase: &mut [bool], nw: usize, r: usize) {
+    let stride = 2 * nw;
+    let start = r * stride;
+    xz[start..start + stride].fill(0);
+    phase[r] = false;
+}

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -733,49 +733,16 @@ impl StabilizerBackend {
         self.apply_gates_only_word_batch(instructions)
     }
 
-    /// Multiply row `h` by row `i` (replace `h` with the Pauli product).
-    ///
-    /// Fused phase+XOR: AG g-function with wordwise popcount, row XOR in the
-    /// same loop to avoid a separate memory pass.
     pub(super) fn rowmul(&mut self, h: usize, i: usize) {
-        let stride = self.stride();
-        let nw = self.num_words;
-        let base_h = h * stride;
-        let base_i = i * stride;
-
-        let initial_sum =
-            if self.phase[i] { 2u64 } else { 0 } + if self.phase[h] { 2u64 } else { 0 };
-
-        // SAFETY: h != i in all callers, so row regions [base_h..base_h+stride]
-        // and [base_i..base_i+stride] are non-overlapping.
-        let (dst_x, dst_z, src_x, src_z) = unsafe {
-            let ptr = self.xz.as_mut_ptr();
-            (
-                std::slice::from_raw_parts_mut(ptr.add(base_h), nw),
-                std::slice::from_raw_parts_mut(ptr.add(base_h + nw), nw),
-                std::slice::from_raw_parts(ptr.add(base_i) as *const u64, nw),
-                std::slice::from_raw_parts(ptr.add(base_i + nw) as *const u64, nw),
-            )
-        };
-
-        let sum = rowmul_words(dst_x, dst_z, src_x, src_z, initial_sum);
-        self.phase[h] = (sum & 3) >= 2;
+        kernels::rowops::rowmul(&mut self.xz, &mut self.phase, self.num_words, h, i);
     }
 
     pub(super) fn copy_row(&mut self, dst: usize, src: usize) {
-        let stride = self.stride();
-        let src_start = src * stride;
-        let dst_start = dst * stride;
-        self.xz
-            .copy_within(src_start..src_start + stride, dst_start);
-        self.phase[dst] = self.phase[src];
+        kernels::rowops::copy_row(&mut self.xz, &mut self.phase, self.num_words, dst, src);
     }
 
     pub(super) fn zero_row(&mut self, r: usize) {
-        let stride = self.stride();
-        let start = r * stride;
-        self.xz[start..start + stride].fill(0);
-        self.phase[r] = false;
+        kernels::rowops::zero_row(&mut self.xz, &mut self.phase, self.num_words, r);
     }
 
     pub(super) fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -21,13 +21,7 @@ use crate::gates::{DiagEntry, Gate};
 use rayon::prelude::*;
 
 #[cfg(feature = "parallel")]
-use crate::backend::MIN_PAR_ITERS;
-
-#[cfg(feature = "parallel")]
-#[inline(always)]
-fn chunk_min_len(chunk_size: usize) -> usize {
-    (MIN_PAR_ELEMS / chunk_size).max(1)
-}
+use crate::backend::{MIN_PAR_ITERS, chunk_min_len};
 
 /// Largest qubit target whose full period (2^(t+1) elements) fits within `tile_size`.
 #[inline(always)]
@@ -2677,14 +2671,10 @@ impl StatevectorBackend {
         let mut p1 = 0.0f64;
         let mut r = Complex64::new(0.0, 0.0);
         for block in self.state.chunks(block_size) {
-            let (lo, hi) = block.split_at(half);
-            for i in 0..half {
-                let a0 = lo[i];
-                let a1 = hi[i];
-                p0 += a0.norm_sqr();
-                p1 += a1.norm_sqr();
-                r += a1 * a0.conj();
-            }
+            let (b0, b1, br) = super::rdm_block_sums(block, half);
+            p0 += b0;
+            p1 += b1;
+            r += br;
         }
 
         let scale = Complex64::new(norm_sq, 0.0);
@@ -2705,20 +2695,7 @@ impl StatevectorBackend {
             .state
             .par_chunks(block_size)
             .with_min_len(chunk_min_len(block_size))
-            .map(|block| {
-                let (lo, hi) = block.split_at(half);
-                let mut p0 = 0.0f64;
-                let mut p1 = 0.0f64;
-                let mut r = Complex64::new(0.0, 0.0);
-                for i in 0..half {
-                    let a0 = lo[i];
-                    let a1 = hi[i];
-                    p0 += a0.norm_sqr();
-                    p1 += a1.norm_sqr();
-                    r += a1 * a0.conj();
-                }
-                (p0, p1, r)
-            })
+            .map(|block| super::rdm_block_sums(block, half))
             .reduce(
                 || (0.0, 0.0, Complex64::new(0.0, 0.0)),
                 |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -67,6 +67,24 @@ use rayon::prelude::*;
 #[cfg(feature = "parallel")]
 pub(crate) use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS};
 
+/// Per-block partial sums for a 1q reduced density matrix: `(p0, p1, r)` over
+/// one `2 * 2^qubit` block whose low half holds the qubit-0 amplitudes.
+#[inline(always)]
+pub(super) fn rdm_block_sums(block: &[Complex64], half: usize) -> (f64, f64, Complex64) {
+    let (lo, hi) = block.split_at(half);
+    let mut p0 = 0.0f64;
+    let mut p1 = 0.0f64;
+    let mut r = Complex64::new(0.0, 0.0);
+    for i in 0..half {
+        let a0 = lo[i];
+        let a1 = hi[i];
+        p0 += a0.norm_sqr();
+        p1 += a1.norm_sqr();
+        r += a1 * a0.conj();
+    }
+    (p0, p1, r)
+}
+
 #[cfg(feature = "gpu")]
 fn reduced_density_matrix_from_state(state: &[Complex64], qubit: usize) -> [[Complex64; 2]; 2] {
     let half = 1usize << qubit;
@@ -76,14 +94,10 @@ fn reduced_density_matrix_from_state(state: &[Complex64], qubit: usize) -> [[Com
     let mut r = Complex64::new(0.0, 0.0);
 
     for block in state.chunks(block_size) {
-        let (lo, hi) = block.split_at(half);
-        for i in 0..half {
-            let a0 = lo[i];
-            let a1 = hi[i];
-            p0 += a0.norm_sqr();
-            p1 += a1.norm_sqr();
-            r += a1 * a0.conj();
-        }
+        let (b0, b1, br) = rdm_block_sums(block, half);
+        p0 += b0;
+        p1 += b1;
+        r += br;
     }
 
     [

--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -45,6 +45,15 @@ macro_rules! gate_1q_param {
     };
 }
 
+macro_rules! gate_2q {
+    ($name:ident, $variant:ident, $a:ident, $b:ident) => {
+        pub fn $name(&mut self, $a: usize, $b: usize) -> &mut Self {
+            self.circuit.add_gate(Gate::$variant, &[$a, $b]);
+            self
+        }
+    };
+}
+
 impl CircuitBuilder {
     /// Create a builder for a circuit with `num_qubits` qubits and no classical bits.
     pub fn new(num_qubits: usize) -> Self {
@@ -82,20 +91,9 @@ impl CircuitBuilder {
         self
     }
 
-    pub fn cx(&mut self, control: usize, target: usize) -> &mut Self {
-        self.circuit.add_gate(Gate::Cx, &[control, target]);
-        self
-    }
-
-    pub fn cz(&mut self, q0: usize, q1: usize) -> &mut Self {
-        self.circuit.add_gate(Gate::Cz, &[q0, q1]);
-        self
-    }
-
-    pub fn swap(&mut self, q0: usize, q1: usize) -> &mut Self {
-        self.circuit.add_gate(Gate::Swap, &[q0, q1]);
-        self
-    }
+    gate_2q!(cx, Cx, control, target);
+    gate_2q!(cz, Cz, q0, q1);
+    gate_2q!(swap, Swap, q0, q1);
 
     pub fn cu(&mut self, mat: [[Complex64; 2]; 2], control: usize, target: usize) -> &mut Self {
         self.circuit.add_gate(Gate::cu(mat), &[control, target]);

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -84,85 +84,55 @@ fn classify_op(gate: &Gate, targets: &[usize]) -> (String, OpKind) {
     (label, kind)
 }
 
+fn place_op(moments: &mut Vec<Vec<PlacedOp>>, moment: usize, op: PlacedOp) {
+    if moment >= moments.len() {
+        moments.resize_with(moment + 1, Vec::new);
+    }
+    moments[moment].push(op);
+}
+
 pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
-    let n = circuit.num_qubits;
-    let mut qubit_depth = vec![0usize; n];
     let mut moments: Vec<Vec<PlacedOp>> = Vec::new();
 
-    for inst in &circuit.instructions {
-        match inst {
+    super::for_each_placement(&circuit.instructions, circuit.num_qubits, |inst, d| {
+        let op = match inst {
             Instruction::Gate { gate, targets } => {
-                let max_d = targets.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
                 let (label, kind) = classify_op(gate, targets);
-                let op = PlacedOp {
+                PlacedOp {
                     label,
                     qubits: SmallVec::from_slice(targets),
                     kind,
                     gate: Some(gate.clone()),
-                };
-                if max_d >= moments.len() {
-                    moments.resize_with(max_d + 1, Vec::new);
-                }
-                moments[max_d].push(op);
-                for &q in targets.iter() {
-                    qubit_depth[q] = max_d + 1;
                 }
             }
             Instruction::Measure {
                 qubit,
                 classical_bit,
-            } => {
-                let d = qubit_depth[*qubit];
-                let op = PlacedOp {
-                    label: "M".into(),
-                    qubits: smallvec::smallvec![*qubit],
-                    kind: OpKind::Measure {
-                        cbit: *classical_bit,
-                    },
-                    gate: None,
-                };
-                if d >= moments.len() {
-                    moments.resize_with(d + 1, Vec::new);
-                }
-                moments[d].push(op);
-                qubit_depth[*qubit] = d + 1;
-            }
-            Instruction::Reset { qubit } => {
-                let d = qubit_depth[*qubit];
-                let op = PlacedOp {
-                    label: "|0⟩".into(),
-                    qubits: smallvec::smallvec![*qubit],
-                    kind: OpKind::Reset,
-                    gate: None,
-                };
-                if d >= moments.len() {
-                    moments.resize_with(d + 1, Vec::new);
-                }
-                moments[d].push(op);
-                qubit_depth[*qubit] = d + 1;
-            }
-            Instruction::Barrier { qubits } => {
-                let max_d = qubits.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
-                let op = PlacedOp {
-                    label: String::new(),
-                    qubits: SmallVec::from_slice(qubits),
-                    kind: OpKind::Barrier,
-                    gate: None,
-                };
-                if max_d >= moments.len() {
-                    moments.resize_with(max_d + 1, Vec::new);
-                }
-                moments[max_d].push(op);
-                for &q in qubits.iter() {
-                    qubit_depth[q] = max_d;
-                }
-            }
+            } => PlacedOp {
+                label: "M".into(),
+                qubits: smallvec::smallvec![*qubit],
+                kind: OpKind::Measure {
+                    cbit: *classical_bit,
+                },
+                gate: None,
+            },
+            Instruction::Reset { qubit } => PlacedOp {
+                label: "|0⟩".into(),
+                qubits: smallvec::smallvec![*qubit],
+                kind: OpKind::Reset,
+                gate: None,
+            },
+            Instruction::Barrier { qubits } => PlacedOp {
+                label: String::new(),
+                qubits: SmallVec::from_slice(qubits),
+                kind: OpKind::Barrier,
+                gate: None,
+            },
             Instruction::Conditional {
                 condition,
                 gate,
                 targets,
             } => {
-                let max_d = targets.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
                 let cbit_label = match condition {
                     ClassicalCondition::BitIsOne(b) => format!("c[{}]", b),
                     ClassicalCondition::BitIsZero(b) => format!("!c[{}]", b),
@@ -181,22 +151,16 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                         format!("c[{}..{}]!={}", offset, offset + size, value)
                     }
                 };
-                let op = PlacedOp {
+                PlacedOp {
                     label: gate.to_string(),
                     qubits: SmallVec::from_slice(targets),
                     kind: OpKind::Conditional { cbit_label },
                     gate: Some(gate.clone()),
-                };
-                if max_d >= moments.len() {
-                    moments.resize_with(max_d + 1, Vec::new);
-                }
-                moments[max_d].push(op);
-                for &q in targets.iter() {
-                    qubit_depth[q] = max_d + 1;
                 }
             }
-        }
-    }
+        };
+        place_op(&mut moments, d, op);
+    });
     moments
 }
 

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -25,8 +25,8 @@ use num_complex::Complex64;
 
 use super::{Circuit, Instruction, SmallVec, smallvec};
 use crate::gates::{
-    DiagEntry, DiagonalBatchData, Gate, Multi2qData, MultiFusedData, kron_2x2, mat_mul_2x2,
-    mat_mul_4x4,
+    DiagEntry, DiagonalBatchData, Gate, Multi2qData, MultiFusedData, is_diagonal_2x2,
+    is_diagonal_4x4, kron_2x2, mat_mul_2x2, mat_mul_4x4,
 };
 
 use super::fusion_phase::{batch_post_phase_1q, fuse_controlled_phases};
@@ -81,6 +81,14 @@ const MIN_QUBITS_FOR_MULTI_2Q_FUSION: usize = MIN_QUBITS_FOR_2Q_FUSION;
 
 /// Minimum batch size for multi-2q fusion (single gate not worth wrapping).
 const MIN_MULTI_2Q_BATCH: usize = 2;
+
+/// Append `q` to a fused-instruction target list unless already present.
+#[inline]
+pub(super) fn push_unique(qubits: &mut SmallVec<[usize; 4]>, q: usize) {
+    if !qubits.contains(&q) {
+        qubits.push(q);
+    }
+}
 
 /// Returns the qubits touched by an instruction.
 fn inst_qubits(inst: &Instruction) -> &[usize] {
@@ -209,11 +217,7 @@ pub(crate) fn cancel_self_inverse_pairs(circuit: &Circuit) -> Cow<'_, Circuit> {
         .map(|(_, inst)| inst.clone())
         .collect();
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
+    Cow::Owned(circuit.with_instructions(output))
 }
 
 fn is_identity(mat: &[[Complex64; 2]; 2]) -> bool {
@@ -276,53 +280,17 @@ fn flush(pending: &mut Option<PendingFusion>, output: &mut Vec<Instruction>) {
     }
 }
 
-/// Returns true if the circuit has at least one pair of consecutive single-qubit
-/// gates on the same qubit (with no intervening flush trigger on that qubit).
-fn has_fusable_gates(circuit: &Circuit) -> bool {
-    if circuit.instructions.len() <= 1 {
-        return false;
-    }
-    let mut has_pending = vec![false; circuit.num_qubits];
-    for inst in &circuit.instructions {
-        match inst {
-            Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
-                let q = targets[0];
-                if has_pending[q] {
-                    return true;
-                }
-                has_pending[q] = true;
-            }
-            Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
-                for &q in targets {
-                    has_pending[q] = false;
-                }
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                has_pending[*qubit] = false;
-            }
-            Instruction::Barrier { qubits } => {
-                for &q in qubits {
-                    has_pending[q] = false;
-                }
-            }
-        }
-    }
-    false
-}
-
 /// Fuse consecutive single-qubit gates on the same target into one `Gate::Fused`.
 ///
-/// Returns a `Cow::Borrowed` reference to the original circuit when no fusion
-/// opportunities exist (zero overhead), or a `Cow::Owned` new circuit with
-/// fused instructions. The fused circuit produces identical simulation results.
+/// Returns a `Cow::Borrowed` reference to the original circuit when no two
+/// consecutive 1q gates share a qubit (zero overhead), or a `Cow::Owned` new
+/// circuit with fused instructions. The fused circuit produces identical
+/// simulation results.
 pub(crate) fn fuse_single_qubit_gates(circuit: &Circuit) -> Cow<'_, Circuit> {
-    if !has_fusable_gates(circuit) {
-        return Cow::Borrowed(circuit);
-    }
-
     let n = circuit.num_qubits;
     let mut pending: Vec<Option<PendingFusion>> = (0..n).map(|_| None).collect();
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
+    let mut changed = false;
 
     for inst in &circuit.instructions {
         match inst {
@@ -332,6 +300,7 @@ pub(crate) fn fuse_single_qubit_gates(circuit: &Circuit) -> Cow<'_, Circuit> {
                 match &mut pending[q] {
                     Some(p) => {
                         p.matrix = mat_mul_2x2(&mat, &p.matrix);
+                        changed = true;
                     }
                     slot => {
                         *slot = Some(PendingFusion {
@@ -341,18 +310,8 @@ pub(crate) fn fuse_single_qubit_gates(circuit: &Circuit) -> Cow<'_, Circuit> {
                     }
                 }
             }
-            Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
-                for &q in targets.iter() {
-                    flush(&mut pending[q], &mut output);
-                }
-                output.push(inst.clone());
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                flush(&mut pending[*qubit], &mut output);
-                output.push(inst.clone());
-            }
-            Instruction::Barrier { qubits } => {
-                for &q in qubits.iter() {
+            _ => {
+                for &q in inst_qubits(inst) {
                     flush(&mut pending[q], &mut output);
                 }
                 output.push(inst.clone());
@@ -364,97 +323,11 @@ pub(crate) fn fuse_single_qubit_gates(circuit: &Circuit) -> Cow<'_, Circuit> {
         flush(slot, &mut output);
     }
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
-}
-
-/// Returns true if any 1q gate could be moved earlier without violating dependencies.
-///
-/// Accounts for commutation: diagonal 1q gates on CX control or CZ qubits
-/// are not blocked by those gates.
-fn has_reorder_opportunity(circuit: &Circuit) -> bool {
-    if circuit.instructions.len() <= 1 {
-        return false;
+    if changed {
+        Cow::Owned(circuit.with_instructions(output))
+    } else {
+        Cow::Borrowed(circuit)
     }
-    // block_all[q] = position of last instruction that blocks ALL 1q gates on q
-    // block_diag[q] = position of last instruction that blocks diagonal 1q gates on q
-    // None means "never blocked", the 1q gate can move to position 0.
-    let mut block_all: Vec<Option<usize>> = vec![None; circuit.num_qubits];
-    let mut block_diag: Vec<Option<usize>> = vec![None; circuit.num_qubits];
-    let mut last_non1q_pos: Option<usize> = None;
-
-    for (i, inst) in circuit.instructions.iter().enumerate() {
-        match inst {
-            Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
-                let q = targets[0];
-                if let Some(pos) = last_non1q_pos {
-                    let blocked_at = if gate.is_diagonal_1q() {
-                        block_diag[q]
-                    } else {
-                        block_all[q]
-                    };
-                    match blocked_at {
-                        None => return true,
-                        Some(b) if pos > b => return true,
-                        _ => {}
-                    }
-                }
-                block_all[q] = Some(i);
-                block_diag[q] = Some(i);
-            }
-            Instruction::Gate { gate, targets } => {
-                last_non1q_pos = Some(i);
-                match gate {
-                    Gate::Cx => {
-                        block_all[targets[0]] = Some(i);
-                        // block_diag[targets[0]] unchanged, diagonal commutes on control
-                        block_all[targets[1]] = Some(i);
-                        block_diag[targets[1]] = Some(i);
-                    }
-                    Gate::Cz | Gate::Rzz(_) => {
-                        block_all[targets[0]] = Some(i);
-                        block_all[targets[1]] = Some(i);
-                        // block_diag unchanged, diagonal commutes on both
-                    }
-                    Gate::BatchRzz(_) | Gate::DiagonalBatch(_) => {
-                        for &q in targets.iter() {
-                            block_all[q] = Some(i);
-                        }
-                        // block_diag unchanged, all-diagonal gate
-                    }
-                    _ => {
-                        for &q in targets.iter() {
-                            block_all[q] = Some(i);
-                            block_diag[q] = Some(i);
-                        }
-                    }
-                }
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                last_non1q_pos = Some(i);
-                block_all[*qubit] = Some(i);
-                block_diag[*qubit] = Some(i);
-            }
-            Instruction::Barrier { qubits } => {
-                last_non1q_pos = Some(i);
-                for &q in qubits.iter() {
-                    block_all[q] = Some(i);
-                    block_diag[q] = Some(i);
-                }
-            }
-            Instruction::Conditional { targets, .. } => {
-                last_non1q_pos = Some(i);
-                for &q in targets.iter() {
-                    block_all[q] = Some(i);
-                    block_diag[q] = Some(i);
-                }
-            }
-        }
-    }
-    false
 }
 
 /// Reorder single-qubit gates as early as possible in the instruction stream.
@@ -466,12 +339,8 @@ fn has_reorder_opportunity(circuit: &Circuit) -> bool {
 /// This groups 1q gates together, maximizing batching opportunities for the
 /// subsequent `fuse_multi_1q_gates()` pass.
 ///
-/// Returns `Cow::Borrowed` when no reordering is possible.
+/// Returns the input unchanged when no gate moves.
 pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
-    if !has_reorder_opportunity(&circuit) {
-        return circuit;
-    }
-
     let n = circuit.num_qubits;
     // block_all[q] / block_diag[q]: index into non_1q of the last blocker
     let mut block_all: Vec<usize> = vec![usize::MAX; n];
@@ -479,6 +348,7 @@ pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     let mut last_1q_slot: Vec<usize> = vec![0; n];
     let mut non_1q: Vec<&Instruction> = Vec::new();
     let mut slots: Vec<Vec<Instruction>> = vec![Vec::new()];
+    let mut changed = false;
 
     for inst in &circuit.instructions {
         match inst {
@@ -495,6 +365,9 @@ pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     blocker + 1
                 };
                 let slot = dep_slot.max(last_1q_slot[q]);
+                if slot < non_1q.len() {
+                    changed = true;
+                }
                 slots[slot].push(inst.clone());
                 last_1q_slot[q] = slot;
             }
@@ -528,18 +401,8 @@ pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                             }
                         }
                     },
-                    Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                        block_all[*qubit] = idx;
-                        block_diag[*qubit] = idx;
-                    }
-                    Instruction::Barrier { qubits } => {
-                        for &q in qubits.iter() {
-                            block_all[q] = idx;
-                            block_diag[q] = idx;
-                        }
-                    }
-                    Instruction::Conditional { targets, .. } => {
-                        for &q in targets.iter() {
+                    _ => {
+                        for &q in inst_qubits(inst) {
                             block_all[q] = idx;
                             block_diag[q] = idx;
                         }
@@ -549,6 +412,10 @@ pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
         }
     }
 
+    if !changed {
+        return circuit;
+    }
+
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
     for (i, non_1q_inst) in non_1q.iter().enumerate() {
         output.append(&mut slots[i]);
@@ -556,11 +423,7 @@ pub(crate) fn reorder_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     }
     output.append(&mut slots[non_1q.len()]);
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
+    Cow::Owned(circuit.with_instructions(output))
 }
 
 /// Fuse single-qubit gates on distinct qubits into `Gate::MultiFused`.
@@ -601,11 +464,7 @@ pub(crate) fn fuse_multi_1q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
     }
     flush_all_pending(&mut pending, &mut pending_count, &mut output);
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
+    Cow::Owned(circuit.with_instructions(output))
 }
 
 #[inline]
@@ -643,9 +502,7 @@ fn flush_all_pending(
                 gates.push((q, mat));
             }
         }
-        let all_diagonal = gates
-            .iter()
-            .all(|(_, m)| m[0][1].norm() < IDENTITY_EPS && m[1][0].norm() < IDENTITY_EPS);
+        let all_diagonal = gates.iter().all(|(_, m)| is_diagonal_2x2(m));
         let targets: SmallVec<[usize; 4]> = gates.iter().map(|&(t, _)| t).collect();
         output.push(Instruction::Gate {
             gate: Gate::MultiFused(Box::new(MultiFusedData {
@@ -691,16 +548,13 @@ fn has_multi_1q_run(circuit: &Circuit) -> bool {
 /// Algorithm: greedy forward pass, absorbing pre-gates only. Post-gates of one
 /// 2q gate become pre-gates of the next, so most HEA-style patterns are captured.
 ///
-/// Returns `Cow::Borrowed` when no fusion opportunities exist.
+/// Returns the input unchanged when no absorption happens.
 pub(crate) fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
-    if !has_2q_fusion_opportunity(&circuit) {
-        return circuit;
-    }
-
     let identity_2x2 = Gate::Id.matrix_2x2();
     let n = circuit.num_qubits;
     let mut pending_1q: Vec<Option<[[Complex64; 2]; 2]>> = vec![None; n];
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
+    let mut changed = false;
 
     for inst in &circuit.instructions {
         match inst {
@@ -730,26 +584,11 @@ pub(crate) fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                         gate: Gate::Fused2q(Box::new(fused)),
                         targets: smallvec![q0, q1],
                     });
+                    changed = true;
                 }
             }
-            Instruction::Gate { targets, .. } => {
-                for &q in targets.iter() {
-                    flush_indexed_1q(q, &mut pending_1q, &mut output);
-                }
-                output.push(inst.clone());
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                flush_indexed_1q(*qubit, &mut pending_1q, &mut output);
-                output.push(inst.clone());
-            }
-            Instruction::Barrier { qubits } => {
-                for &q in qubits.iter() {
-                    flush_indexed_1q(q, &mut pending_1q, &mut output);
-                }
-                output.push(inst.clone());
-            }
-            Instruction::Conditional { targets, .. } => {
-                for &q in targets.iter() {
+            _ => {
+                for &q in inst_qubits(inst) {
                     flush_indexed_1q(q, &mut pending_1q, &mut output);
                 }
                 output.push(inst.clone());
@@ -761,52 +600,11 @@ pub(crate) fn fuse_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
         flush_indexed_1q(q, &mut pending_1q, &mut output);
     }
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
-}
-
-/// Check whether the circuit has any CX/CZ gate preceded by a 1q gate on the same qubit.
-fn has_2q_fusion_opportunity(circuit: &Circuit) -> bool {
-    let mut has_pending_1q = vec![false; circuit.num_qubits];
-    for inst in &circuit.instructions {
-        match inst {
-            Instruction::Gate { gate, targets } if gate.num_qubits() == 1 => {
-                has_pending_1q[targets[0]] = true;
-            }
-            Instruction::Gate {
-                gate: Gate::Cx | Gate::Cz,
-                targets,
-            } => {
-                if has_pending_1q[targets[0]] || has_pending_1q[targets[1]] {
-                    return true;
-                }
-                has_pending_1q[targets[0]] = false;
-                has_pending_1q[targets[1]] = false;
-            }
-            Instruction::Gate { targets, .. } => {
-                for &q in targets.iter() {
-                    has_pending_1q[q] = false;
-                }
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                has_pending_1q[*qubit] = false;
-            }
-            Instruction::Barrier { qubits } => {
-                for &q in qubits.iter() {
-                    has_pending_1q[q] = false;
-                }
-            }
-            Instruction::Conditional { targets, .. } => {
-                for &q in targets.iter() {
-                    has_pending_1q[q] = false;
-                }
-            }
-        }
+    if changed {
+        Cow::Owned(circuit.with_instructions(output))
+    } else {
+        circuit
     }
-    false
 }
 
 /// Cache-tier classification for 2q gates based on max target qubit.
@@ -836,18 +634,6 @@ fn classify_2q_tier(q0: usize, q1: usize) -> Tier2q {
 fn swap_order_4x4(mat: &[[Complex64; 4]; 4]) -> [[Complex64; 4]; 4] {
     let swap = Gate::Swap.matrix_4x4();
     mat_mul_4x4(&swap, &mat_mul_4x4(mat, &swap))
-}
-
-#[inline]
-fn is_diagonal_4x4(mat: &[[Complex64; 4]; 4]) -> bool {
-    for (r, row) in mat.iter().enumerate() {
-        for (c, value) in row.iter().enumerate() {
-            if r != c && value.norm() >= IDENTITY_EPS {
-                return false;
-            }
-        }
-    }
-    true
 }
 
 #[inline]
@@ -996,11 +782,7 @@ fn fuse_same_pair_2q_blocks(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     flush_pair_run(&mut run, &mut output, &mut changed);
 
     if changed {
-        Cow::Owned(Circuit {
-            num_qubits: circuit.num_qubits,
-            num_classical_bits: circuit.num_classical_bits,
-            instructions: output,
-        })
+        Cow::Owned(circuit.with_instructions(output))
     } else {
         input
     }
@@ -1045,11 +827,7 @@ pub(crate) fn reorder_disjoint_fused2q(input: Cow<'_, Circuit>) -> Cow<'_, Circu
     flush_disjoint_window(&mut window, &mut window_qubits, &mut output, &mut changed);
 
     if changed {
-        Cow::Owned(Circuit {
-            num_qubits: circuit.num_qubits,
-            num_classical_bits: circuit.num_classical_bits,
-            instructions: output,
-        })
+        Cow::Owned(circuit.with_instructions(output))
     } else {
         input
     }
@@ -1090,19 +868,17 @@ fn flush_disjoint_window(
 /// gate that the statevector backend applies in a tiled pass. Individual-tier
 /// gates (max qubit > 16) are left as-is.
 ///
-/// Returns `Cow::Borrowed` when no batching opportunities exist.
+/// Returns the input unchanged when no batch forms.
 pub(crate) fn fuse_multi_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
-    if !has_multi_2q_opportunity(&circuit) {
-        return circuit;
-    }
-
     let mut output: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len());
     let mut pending: Vec<(usize, usize, [[Complex64; 4]; 4])> = Vec::new();
     let mut current_tier: Option<Tier2q> = None;
+    let mut changed = false;
 
     let flush = |pending: &mut Vec<(usize, usize, [[Complex64; 4]; 4])>,
                  tier: &mut Option<Tier2q>,
-                 output: &mut Vec<Instruction>| {
+                 output: &mut Vec<Instruction>,
+                 changed: &mut bool| {
         if pending.is_empty() {
             return;
         }
@@ -1117,12 +893,8 @@ pub(crate) fn fuse_multi_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
         } else {
             let mut all_qubits: SmallVec<[usize; 4]> = SmallVec::new();
             for &(q0, q1, _) in pending.iter() {
-                if !all_qubits.contains(&q0) {
-                    all_qubits.push(q0);
-                }
-                if !all_qubits.contains(&q1) {
-                    all_qubits.push(q1);
-                }
+                push_unique(&mut all_qubits, q0);
+                push_unique(&mut all_qubits, q1);
             }
             all_qubits.sort_unstable();
             output.push(Instruction::Gate {
@@ -1131,6 +903,7 @@ pub(crate) fn fuse_multi_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
                 })),
                 targets: all_qubits,
             });
+            *changed = true;
         }
     };
 
@@ -1146,7 +919,7 @@ pub(crate) fn fuse_multi_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
 
                 if let Some(ct) = current_tier {
                     if ct != tier {
-                        flush(&mut pending, &mut current_tier, &mut output);
+                        flush(&mut pending, &mut current_tier, &mut output, &mut changed);
                     }
                 }
                 if current_tier.is_none() {
@@ -1155,90 +928,17 @@ pub(crate) fn fuse_multi_2q_gates(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
                 pending.push((q0, q1, **mat));
             }
             _ => {
-                flush(&mut pending, &mut current_tier, &mut output);
+                flush(&mut pending, &mut current_tier, &mut output, &mut changed);
                 output.push(inst.clone());
             }
         }
     }
-    flush(&mut pending, &mut current_tier, &mut output);
+    flush(&mut pending, &mut current_tier, &mut output, &mut changed);
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
-}
-
-/// Check if the circuit has ≥2 consecutive Fused2q gates in a tileable tier.
-fn has_multi_2q_opportunity(circuit: &Circuit) -> bool {
-    let mut consecutive = 0usize;
-    for inst in &circuit.instructions {
-        if let Instruction::Gate {
-            gate: Gate::Fused2q(_),
-            targets,
-        } = inst
-        {
-            let tier = classify_2q_tier(targets[0], targets[1]);
-            if tier != Tier2q::Individual {
-                consecutive += 1;
-                if consecutive >= MIN_MULTI_2Q_BATCH {
-                    return true;
-                }
-                continue;
-            }
-        }
-        consecutive = 0;
-    }
-    false
-}
-
-/// Returns true if `gate` is a diagonal gate that can be absorbed into a DiagonalBatch.
-fn is_diag_batchable(gate: &Gate) -> bool {
-    match gate {
-        Gate::Cz | Gate::Rzz(_) => true,
-        _ if gate.is_diagonal_1q() => true,
-        _ if gate.controlled_phase().is_some() => true,
-        _ => false,
-    }
-}
-
-/// Convert a gate to one or more DiagEntry values.
-fn gate_to_diag_entries(gate: &Gate, targets: &[usize]) -> SmallVec<[DiagEntry; 2]> {
-    match gate {
-        Gate::Cz => {
-            smallvec![DiagEntry::Phase2q {
-                q0: targets[0],
-                q1: targets[1],
-                phase: Complex64::new(-1.0, 0.0),
-            }]
-        }
-        Gate::Rzz(theta) => {
-            let half = theta / 2.0;
-            let same = Complex64::new((-half).cos(), (-half).sin()); // e^{-iθ/2}
-            let diff = Complex64::new(half.cos(), half.sin()); // e^{iθ/2}
-            smallvec![DiagEntry::Parity2q {
-                q0: targets[0],
-                q1: targets[1],
-                same,
-                diff,
-            }]
-        }
-        _ if gate.controlled_phase().is_some() => {
-            let phase = gate.controlled_phase().unwrap();
-            smallvec![DiagEntry::Phase2q {
-                q0: targets[0],
-                q1: targets[1],
-                phase,
-            }]
-        }
-        _ => {
-            let mat = gate.matrix_2x2();
-            smallvec![DiagEntry::Phase1q {
-                qubit: targets[0],
-                d0: mat[0][0],
-                d1: mat[1][1],
-            }]
-        }
+    if changed {
+        Cow::Owned(circuit.with_instructions(output))
+    } else {
+        circuit
     }
 }
 
@@ -1257,7 +957,7 @@ fn fuse_diagonal_batch(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
 
     let diag_count = insts
         .iter()
-        .filter(|i| matches!(i, Instruction::Gate { gate, .. } if is_diag_batchable(gate)))
+        .filter(|i| matches!(i, Instruction::Gate { gate, .. } if gate.is_diag_batchable()))
         .count();
     if diag_count < 2 {
         return input;
@@ -1298,8 +998,8 @@ fn fuse_diagonal_batch(input: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
 
     for inst in insts {
         if let Instruction::Gate { gate, targets } = inst {
-            if is_diag_batchable(gate) {
-                let new_entries = gate_to_diag_entries(gate, targets);
+            if gate.is_diag_batchable() {
+                let new_entries = gate.diag_entries(targets);
                 for t in targets.iter() {
                     run_qubits[*t] = true;
                 }
@@ -2479,6 +2179,49 @@ mod tests {
 
         assert_eq!(before, 2);
         assert_eq!(after, 2, "all-diagonal Fused2q runs should stay split");
+    }
+
+    #[test]
+    fn fuse_1q_returns_borrowed_without_consecutive_pair() {
+        let mut c = Circuit::new(12, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Rx(0.3), &[0]);
+        assert!(matches!(fuse_single_qubit_gates(&c), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn fuse_2q_returns_borrowed_without_absorbable_1q() {
+        let mut c = Circuit::new(12, 0);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cz, &[1, 2]);
+        assert!(matches!(fuse_2q_gates(Cow::Borrowed(&c)), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn fuse_multi_2q_returns_borrowed_without_tileable_run() {
+        let mut c = Circuit::new(20, 0);
+        c.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, 1]);
+        c.add_gate(Gate::H, &[2]);
+        c.add_gate(Gate::Fused2q(Box::new(Gate::Cz.matrix_4x4())), &[2, 3]);
+        assert!(matches!(
+            fuse_multi_2q_gates(Cow::Borrowed(&c)),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn fuse_controlled_phases_returns_borrowed_without_batchable_chain() {
+        let one = Complex64::new(1.0, 0.0);
+        let zero = Complex64::new(0.0, 0.0);
+        let phase = Complex64::new(0.0, 1.0);
+        let mut c = Circuit::new(20, 0);
+        c.add_gate(Gate::cu([[one, zero], [zero, phase]]), &[0, 1]);
+        c.add_gate(Gate::Cx, &[2, 3]);
+        assert!(matches!(
+            fuse_controlled_phases(Cow::Borrowed(&c)),
+            Cow::Borrowed(_)
+        ));
     }
 
     #[test]

--- a/src/circuit/fusion_phase.rs
+++ b/src/circuit/fusion_phase.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 use num_complex::Complex64;
 
 use super::{Circuit, Instruction, SmallVec, smallvec};
-use crate::gates::{BatchPhaseData, Gate, MultiFusedData};
+use crate::gates::{BatchPhaseData, Gate, MultiFusedData, is_diagonal_2x2};
 
-use super::fusion::IDENTITY_EPS;
+use super::fusion::push_unique;
 
 const MIN_BATCH_PHASES: usize = 2;
 
@@ -25,12 +25,18 @@ fn remove_target_user(target_users: &mut [TargetUserVec], target: usize, control
     target_users[target].retain(|c| *c != control);
 }
 
-fn emit_phase_chain(control: usize, phases: PhaseVec, output: &mut Vec<Instruction>) {
+fn emit_phase_chain(
+    control: usize,
+    phases: PhaseVec,
+    output: &mut Vec<Instruction>,
+    changed: &mut bool,
+) {
     if phases.len() >= MIN_BATCH_PHASES {
         output.push(Instruction::Gate {
             gate: Gate::BatchPhase(Box::new(BatchPhaseData { phases })),
             targets: smallvec![control],
         });
+        *changed = true;
         return;
     }
 
@@ -49,6 +55,7 @@ fn flush_phase_control(
     pending: &mut [Option<PhaseVec>],
     target_users: &mut [TargetUserVec],
     output: &mut Vec<Instruction>,
+    changed: &mut bool,
 ) {
     let Some(phases) = pending[control].take() else {
         return;
@@ -56,7 +63,7 @@ fn flush_phase_control(
     for &(target, _) in &phases {
         remove_target_user(target_users, target, control);
     }
-    emit_phase_chain(control, phases, output);
+    emit_phase_chain(control, phases, output, changed);
 }
 
 fn push_pending_phase(
@@ -84,6 +91,7 @@ fn flush_phase_target_conflicts(
     pending: &mut [Option<PhaseVec>],
     target_users: &mut [TargetUserVec],
     output: &mut Vec<Instruction>,
+    changed: &mut bool,
 ) {
     let controls = std::mem::take(&mut target_users[target]);
     if controls.is_empty() {
@@ -109,7 +117,7 @@ fn flush_phase_target_conflicts(
     }
 
     if !re_rooted.is_empty() {
-        emit_phase_chain(target, re_rooted, output);
+        emit_phase_chain(target, re_rooted, output, changed);
     }
 }
 
@@ -119,20 +127,22 @@ fn flush_phase_qubits_in_use(
     pending: &mut [Option<PhaseVec>],
     target_users: &mut [TargetUserVec],
     output: &mut Vec<Instruction>,
+    changed: &mut bool,
 ) {
     for &q in qs {
-        flush_phase_control(q, pending, target_users, output);
+        flush_phase_control(q, pending, target_users, output, changed);
     }
     if diagonal_only {
         return;
     }
     for &q in qs {
-        flush_phase_target_conflicts(q, pending, target_users, output);
+        flush_phase_target_conflicts(q, pending, target_users, output, changed);
     }
 }
 
+/// Returns the input unchanged unless at least one `BatchPhase` is emitted.
 pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
-    if !has_batchable_phases(&circuit) {
+    if !circuit.instructions.iter().any(is_controlled_phase_2q) {
         return circuit;
     }
 
@@ -140,6 +150,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     let n = circuit.num_qubits;
     let mut pending: PendingPhaseVec = (0..n).map(|_| None).collect();
     let mut target_users: Vec<TargetUserVec> = (0..n).map(|_| SmallVec::new()).collect();
+    let mut changed = false;
 
     for inst in &circuit.instructions {
         match inst {
@@ -157,6 +168,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                             &mut pending,
                             &mut target_users,
                             &mut output,
+                            &mut changed,
                         );
                         push_pending_phase(control, target, phase, &mut pending, &mut target_users);
                         continue;
@@ -169,6 +181,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     &mut pending,
                     &mut target_users,
                     &mut output,
+                    &mut changed,
                 );
                 output.push(inst.clone());
             }
@@ -179,6 +192,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     &mut pending,
                     &mut target_users,
                     &mut output,
+                    &mut changed,
                 );
                 output.push(inst.clone());
             }
@@ -189,6 +203,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     &mut pending,
                     &mut target_users,
                     &mut output,
+                    &mut changed,
                 );
                 output.push(inst.clone());
             }
@@ -199,6 +214,7 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
                     &mut pending,
                     &mut target_users,
                     &mut output,
+                    &mut changed,
                 );
                 output.push(inst.clone());
             }
@@ -206,148 +222,20 @@ pub fn fuse_controlled_phases(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit> {
     }
 
     for q in 0..n {
-        flush_phase_control(q, &mut pending, &mut target_users, &mut output);
+        flush_phase_control(
+            q,
+            &mut pending,
+            &mut target_users,
+            &mut output,
+            &mut changed,
+        );
     }
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
-}
-
-fn has_batchable_phases(circuit: &Circuit) -> bool {
-    type PendingTargets = SmallVec<[usize; 8]>;
-
-    if !circuit.instructions.iter().any(is_controlled_phase_2q) {
-        return false;
+    if changed {
+        Cow::Owned(circuit.with_instructions(output))
+    } else {
+        circuit
     }
-
-    fn push_pending_target(
-        control: usize,
-        target: usize,
-        pending: &mut [PendingTargets],
-        target_users: &mut [TargetUserVec],
-    ) {
-        if !pending[control].contains(&target) {
-            target_users[target].push(control);
-        }
-        pending[control].push(target);
-    }
-
-    fn flush_control(
-        q: usize,
-        pending: &mut [PendingTargets],
-        target_users: &mut [TargetUserVec],
-    ) -> bool {
-        let len = pending[q].len();
-        for target in pending[q].drain(..) {
-            remove_target_user(target_users, target, q);
-        }
-        len >= MIN_BATCH_PHASES
-    }
-
-    fn flush_target_conflicts(
-        target: usize,
-        pending: &mut [PendingTargets],
-        target_users: &mut [TargetUserVec],
-    ) -> bool {
-        let controls = std::mem::take(&mut target_users[target]);
-        let mut re_rooted = 0usize;
-        for control in controls {
-            let mut kept: PendingTargets = SmallVec::new();
-            for pending_target in pending[control].drain(..) {
-                if pending_target == target {
-                    re_rooted += 1;
-                } else {
-                    kept.push(pending_target);
-                }
-            }
-            pending[control] = kept;
-        }
-        re_rooted >= MIN_BATCH_PHASES
-    }
-
-    fn flush_qubits_in_use(
-        qs: &[usize],
-        diagonal_only: bool,
-        pending: &mut [PendingTargets],
-        target_users: &mut [TargetUserVec],
-    ) -> bool {
-        for &q in qs {
-            if flush_control(q, pending, target_users) {
-                return true;
-            }
-        }
-        if diagonal_only {
-            return false;
-        }
-        for &q in qs {
-            if flush_target_conflicts(q, pending, target_users) {
-                return true;
-            }
-        }
-        false
-    }
-
-    let mut pending: Vec<PendingTargets> =
-        (0..circuit.num_qubits).map(|_| SmallVec::new()).collect();
-    let mut target_users: Vec<TargetUserVec> =
-        (0..circuit.num_qubits).map(|_| SmallVec::new()).collect();
-    for inst in &circuit.instructions {
-        match inst {
-            Instruction::Gate { gate, targets } => {
-                if gate.controlled_phase().is_some() && gate.num_qubits() == 2 {
-                    let control = targets[0];
-                    let target = targets[1];
-                    if flush_qubits_in_use(
-                        std::slice::from_ref(&target),
-                        true,
-                        &mut pending,
-                        &mut target_users,
-                    ) {
-                        return true;
-                    }
-                    if pending[control].len() + 1 >= MIN_BATCH_PHASES {
-                        return true;
-                    }
-                    push_pending_target(control, target, &mut pending, &mut target_users);
-                } else {
-                    let diagonal_only = gate.num_qubits() == 1 && gate.is_diagonal_1q();
-                    if flush_qubits_in_use(targets, diagonal_only, &mut pending, &mut target_users)
-                    {
-                        return true;
-                    }
-                }
-            }
-            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                if flush_qubits_in_use(
-                    std::slice::from_ref(qubit),
-                    false,
-                    &mut pending,
-                    &mut target_users,
-                ) {
-                    return true;
-                }
-            }
-            Instruction::Barrier { qubits } => {
-                if flush_qubits_in_use(qubits, false, &mut pending, &mut target_users) {
-                    return true;
-                }
-            }
-            Instruction::Conditional { targets, .. } => {
-                if flush_qubits_in_use(targets, false, &mut pending, &mut target_users) {
-                    return true;
-                }
-            }
-        }
-    }
-    for q in 0..circuit.num_qubits {
-        if flush_control(q, &mut pending, &mut target_users) {
-            return true;
-        }
-    }
-    false
 }
 
 fn is_batchable_1q(inst: &Instruction) -> bool {
@@ -381,14 +269,10 @@ pub(super) fn batch_post_phase_1q(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
         if pending.len() >= 2 {
             let mut targets: SmallVec<[usize; 4]> = SmallVec::new();
             for &(q, _) in pending.iter() {
-                if !targets.contains(&q) {
-                    targets.push(q);
-                }
+                push_unique(&mut targets, q);
             }
             targets.sort_unstable();
-            let all_diagonal = pending
-                .iter()
-                .all(|(_, m)| m[0][1].norm() < IDENTITY_EPS && m[1][0].norm() < IDENTITY_EPS);
+            let all_diagonal = pending.iter().all(|(_, m)| is_diagonal_2x2(m));
             output.push(Instruction::Gate {
                 gate: Gate::MultiFused(Box::new(MultiFusedData {
                     gates: std::mem::take(pending),
@@ -419,9 +303,5 @@ pub(super) fn batch_post_phase_1q(circuit: Cow<'_, Circuit>) -> Cow<'_, Circuit>
 
     flush(&mut pending, &mut output);
 
-    Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: output,
-    })
+    Cow::Owned(circuit.with_instructions(output))
 }

--- a/src/circuit/fusion_rzz.rs
+++ b/src/circuit/fusion_rzz.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use super::fusion::push_unique;
 use super::{Circuit, Instruction, SmallVec, smallvec};
 use crate::gates::{BatchRzzData, Gate};
 
@@ -47,11 +48,7 @@ pub(super) fn fuse_rzz(circuit: &Circuit) -> Cow<'_, Circuit> {
     }
 
     match out {
-        Some(new_insts) => {
-            let mut c = Circuit::new(circuit.num_qubits, circuit.num_classical_bits);
-            c.instructions = new_insts;
-            Cow::Owned(c)
-        }
+        Some(new_insts) => Cow::Owned(circuit.with_instructions(new_insts)),
         None => Cow::Borrowed(circuit),
     }
 }
@@ -115,9 +112,7 @@ pub(super) fn fuse_batch_rzz(circuit: &Circuit) -> Cow<'_, Circuit> {
 
     flush_rzz_run(&mut output, &mut rzz_run, &mut deferred, &mut rzz_qubits);
 
-    let mut c = Circuit::new(circuit.num_qubits, circuit.num_classical_bits);
-    c.instructions = output;
-    Cow::Owned(c)
+    Cow::Owned(circuit.with_instructions(output))
 }
 
 fn flush_rzz_run(
@@ -129,12 +124,8 @@ fn flush_rzz_run(
     if rzz_run.len() >= 2 {
         let mut tgts: SmallVec<[usize; 4]> = SmallVec::new();
         for &(q0, q1, _) in rzz_run.iter() {
-            if !tgts.contains(&q0) {
-                tgts.push(q0);
-            }
-            if !tgts.contains(&q1) {
-                tgts.push(q1);
-            }
+            push_unique(&mut tgts, q0);
+            push_unique(&mut tgts, q1);
         }
         output.push(Instruction::Gate {
             gate: Gate::BatchRzz(Box::new(BatchRzzData {

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -725,36 +725,67 @@ impl Circuit {
         Some((prefix, tail))
     }
 
+    /// Same register shape as `self` with a replacement instruction list.
+    ///
+    /// The rebuild form every fusion pass uses to emit its rewritten circuit.
+    pub(crate) fn with_instructions(&self, instructions: Vec<Instruction>) -> Circuit {
+        Circuit {
+            num_qubits: self.num_qubits,
+            num_classical_bits: self.num_classical_bits,
+            instructions,
+        }
+    }
+
     /// Circuit depth via greedy layer assignment.
     ///
     /// Each gate occupies the earliest layer where all its qubits are free.
     /// Measurements count as depth-1 operations. Barriers synchronize qubits
     /// to the same layer without adding depth.
     pub fn depth(&self) -> usize {
-        if self.instructions.is_empty() {
-            return 0;
-        }
-        let mut qubit_depth = vec![0usize; self.num_qubits];
-        for inst in &self.instructions {
-            match inst {
-                Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
-                    let max_d = targets.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
-                    for &q in targets {
-                        qubit_depth[q] = max_d + 1;
-                    }
+        let mut depth = 0usize;
+        for_each_placement(&self.instructions, self.num_qubits, |inst, layer| {
+            if !matches!(inst, Instruction::Barrier { .. }) {
+                depth = depth.max(layer + 1);
+            }
+        });
+        depth
+    }
+}
+
+/// Walk instructions in greedy layer order, calling `visit(inst, layer)` with
+/// the earliest layer where every touched qubit is free. Gates and
+/// conditionals advance their qubits past the layer, measurements and resets
+/// advance one step, and barriers synchronize their qubits to the layer
+/// without occupying it. Shared by [`Circuit::depth`] and the drawing
+/// moment assignment.
+fn for_each_placement(
+    instructions: &[Instruction],
+    num_qubits: usize,
+    mut visit: impl FnMut(&Instruction, usize),
+) {
+    let mut qubit_depth = vec![0usize; num_qubits];
+    for inst in instructions {
+        match inst {
+            Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
+                let d = targets.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
+                visit(inst, d);
+                for &q in targets.iter() {
+                    qubit_depth[q] = d + 1;
                 }
-                Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
-                    qubit_depth[*qubit] += 1;
-                }
-                Instruction::Barrier { qubits } => {
-                    let max_d = qubits.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
-                    for &q in qubits {
-                        qubit_depth[q] = max_d;
-                    }
+            }
+            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
+                let d = qubit_depth[*qubit];
+                visit(inst, d);
+                qubit_depth[*qubit] = d + 1;
+            }
+            Instruction::Barrier { qubits } => {
+                let d = qubits.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
+                visit(inst, d);
+                for &q in qubits.iter() {
+                    qubit_depth[q] = d;
                 }
             }
         }
-        qubit_depth.into_iter().max().unwrap_or(0)
     }
 }
 
@@ -840,11 +871,7 @@ pub fn expand_qft_blocks(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
         }
     }
 
-    std::borrow::Cow::Owned(Circuit {
-        num_qubits: circuit.num_qubits,
-        num_classical_bits: circuit.num_classical_bits,
-        instructions: out,
-    })
+    std::borrow::Cow::Owned(circuit.with_instructions(out))
 }
 
 /// Condition for classically-controlled gate execution.

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -2040,6 +2040,14 @@ impl<'a> Parser<'a> {
     /// Returns `Ok(None)` if the gate name is not a decomposed gate (caller
     /// should fall through to `resolve_gate`). Returns `Ok(Some(instrs))` for
     /// gates that expand to multiple instructions.
+    /// Decomposition-body shorthand for a gate instruction.
+    fn ig(gate: Gate, targets: &[usize]) -> Instruction {
+        Instruction::Gate {
+            gate,
+            targets: SmallVec::from_slice(targets),
+        }
+    }
+
     fn resolve_decomposed_gate(
         name: &str,
         params: &[f64],
@@ -2064,10 +2072,10 @@ impl<'a> Parser<'a> {
                         ),
                     });
                 }
-                Ok(Some(vec![Instruction::Gate {
-                    gate: Gate::mcu(Gate::X.matrix_2x2(), controls as u8),
-                    targets: SmallVec::from_slice(qubits),
-                }]))
+                Ok(Some(vec![Self::ig(
+                    Gate::mcu(Gate::X.matrix_2x2(), controls as u8),
+                    qubits,
+                )]))
             }
             "rccx" => {
                 Self::check_arity(name, qubits, 3)?;
@@ -2075,42 +2083,15 @@ impl<'a> Parser<'a> {
                 let c1 = qubits[1];
                 let target = qubits[2];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c1, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c0, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c1, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
+                    Self::ig(Gate::H, &[target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c1, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::Cx, &[c0, target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c1, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::H, &[target]),
                 ]))
             }
             "rc3x" | "rcccx" => {
@@ -2120,78 +2101,24 @@ impl<'a> Parser<'a> {
                 let c2 = qubits[2];
                 let target = qubits[3];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c2, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c0, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c1, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c0, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c1, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::T,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![c2, target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Tdg,
-                        targets: smallvec![target],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![target],
-                    },
+                    Self::ig(Gate::H, &[target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c2, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::H, &[target]),
+                    Self::ig(Gate::Cx, &[c0, target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c1, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::Cx, &[c0, target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c1, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::H, &[target]),
+                    Self::ig(Gate::T, &[target]),
+                    Self::ig(Gate::Cx, &[c2, target]),
+                    Self::ig(Gate::Tdg, &[target]),
+                    Self::ig(Gate::H, &[target]),
                 ]))
             }
             "cswap" | "fredkin" => {
@@ -2200,18 +2127,9 @@ impl<'a> Parser<'a> {
                 let t1 = qubits[1];
                 let t2 = qubits[2];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![t2, t1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::mcu(Gate::X.matrix_2x2(), 2),
-                        targets: smallvec![ctrl, t1, t2],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![t2, t1],
-                    },
+                    Self::ig(Gate::Cx, &[t2, t1]),
+                    Self::ig(Gate::mcu(Gate::X.matrix_2x2(), 2), &[ctrl, t1, t2]),
+                    Self::ig(Gate::Cx, &[t2, t1]),
                 ]))
             }
             "rxx" => {
@@ -2220,34 +2138,13 @@ impl<'a> Parser<'a> {
                 let q0 = qubits[0];
                 let q1 = qubits[1];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rz(params[0]),
-                        targets: smallvec![q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q1],
-                    },
+                    Self::ig(Gate::H, &[q0]),
+                    Self::ig(Gate::H, &[q1]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::Rz(params[0]), &[q1]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::H, &[q0]),
+                    Self::ig(Gate::H, &[q1]),
                 ]))
             }
             "ryy" => {
@@ -2257,34 +2154,13 @@ impl<'a> Parser<'a> {
                 let q1 = qubits[1];
                 let half_pi = std::f64::consts::FRAC_PI_2;
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::Rx(half_pi),
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rx(half_pi),
-                        targets: smallvec![q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rz(params[0]),
-                        targets: smallvec![q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rx(-half_pi),
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rx(-half_pi),
-                        targets: smallvec![q1],
-                    },
+                    Self::ig(Gate::Rx(half_pi), &[q0]),
+                    Self::ig(Gate::Rx(half_pi), &[q1]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::Rz(params[0]), &[q1]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::Rx(-half_pi), &[q0]),
+                    Self::ig(Gate::Rx(-half_pi), &[q1]),
                 ]))
             }
             "ecr" => {
@@ -2292,22 +2168,10 @@ impl<'a> Parser<'a> {
                 let q0 = qubits[0];
                 let q1 = qubits[1];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::Rz(std::f64::consts::FRAC_PI_4),
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Rx(std::f64::consts::FRAC_PI_2),
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::X,
-                        targets: smallvec![q0],
-                    },
+                    Self::ig(Gate::Rz(std::f64::consts::FRAC_PI_4), &[q0]),
+                    Self::ig(Gate::Rx(std::f64::consts::FRAC_PI_2), &[q0]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::X, &[q0]),
                 ]))
             }
             "iswap" => {
@@ -2315,30 +2179,12 @@ impl<'a> Parser<'a> {
                 let q0 = qubits[0];
                 let q1 = qubits[1];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::S,
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::S,
-                        targets: smallvec![q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q1, q0],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::H,
-                        targets: smallvec![q1],
-                    },
+                    Self::ig(Gate::S, &[q0]),
+                    Self::ig(Gate::S, &[q1]),
+                    Self::ig(Gate::H, &[q0]),
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::Cx, &[q1, q0]),
+                    Self::ig(Gate::H, &[q1]),
                 ]))
             }
             "dcx" => {
@@ -2346,23 +2192,14 @@ impl<'a> Parser<'a> {
                 let q0 = qubits[0];
                 let q1 = qubits[1];
                 Ok(Some(vec![
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q0, q1],
-                    },
-                    Instruction::Gate {
-                        gate: Gate::Cx,
-                        targets: smallvec![q1, q0],
-                    },
+                    Self::ig(Gate::Cx, &[q0, q1]),
+                    Self::ig(Gate::Cx, &[q1, q0]),
                 ]))
             }
             "u1" => {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Self::check_arity(name, qubits, 1)?;
-                Ok(Some(vec![Instruction::Gate {
-                    gate: Gate::P(params[0]),
-                    targets: smallvec![qubits[0]],
-                }]))
+                Ok(Some(vec![Self::ig(Gate::P(params[0]), &[qubits[0]])]))
             }
             "u2" => {
                 Self::expect_param_count(name, params, 2, line_num)?;
@@ -2378,10 +2215,10 @@ impl<'a> Parser<'a> {
                         Complex64::from_polar(isqrt2, phi + lam),
                     ],
                 ];
-                Ok(Some(vec![Instruction::Gate {
-                    gate: Gate::Fused(Box::new(mat)),
-                    targets: smallvec![qubits[0]],
-                }]))
+                Ok(Some(vec![Self::ig(
+                    Gate::Fused(Box::new(mat)),
+                    &[qubits[0]],
+                )]))
             }
             "u3" | "u" | "U" => {
                 Self::expect_param_count(name, params, 3, line_num)?;
@@ -2390,10 +2227,10 @@ impl<'a> Parser<'a> {
                 let phi = params[1];
                 let lam = params[2];
                 let mat = Self::u_matrix(theta, phi, lam);
-                Ok(Some(vec![Instruction::Gate {
-                    gate: Gate::Fused(Box::new(mat)),
-                    targets: smallvec![qubits[0]],
-                }]))
+                Ok(Some(vec![Self::ig(
+                    Gate::Fused(Box::new(mat)),
+                    &[qubits[0]],
+                )]))
             }
             _ => Ok(None),
         }

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -2591,3 +2591,42 @@ fn if_bit_compare_against_two_rejected() {
     let err = parse(qasm).unwrap_err();
     assert!(matches!(err, PrismError::Parse { .. }));
 }
+
+#[test]
+fn gate_names_round_trip_through_resolve_gate() {
+    let named = [
+        Gate::Id,
+        Gate::X,
+        Gate::Y,
+        Gate::Z,
+        Gate::H,
+        Gate::S,
+        Gate::Sdg,
+        Gate::T,
+        Gate::Tdg,
+        Gate::SX,
+        Gate::SXdg,
+        Gate::Rx(0.3),
+        Gate::Ry(0.4),
+        Gate::Rz(0.5),
+        Gate::P(0.6),
+        Gate::Rzz(0.7),
+        Gate::Cx,
+        Gate::Cz,
+        Gate::Swap,
+    ];
+    for gate in named {
+        let params: Vec<f64> = match &gate {
+            Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::P(t) | Gate::Rzz(t) => vec![*t],
+            _ => vec![],
+        };
+        let resolved = Parser::resolve_gate(gate.name(), &params, 0)
+            .unwrap_or_else(|e| panic!("`{}` did not resolve: {e}", gate.name()));
+        assert_eq!(
+            resolved,
+            gate,
+            "`{}` resolved to a different variant",
+            gate.name()
+        );
+    }
+}

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -707,8 +707,61 @@ impl Gate {
             | Gate::Tdg
             | Gate::Rz(_)
             | Gate::P(_) => true,
-            Gate::Fused(m) => m[0][1].norm() < IDENTITY_EPS && m[1][0].norm() < IDENTITY_EPS,
+            Gate::Fused(m) => is_diagonal_2x2(m),
             _ => false,
+        }
+    }
+
+    /// True if this gate can be absorbed into a `DiagonalBatch`.
+    #[inline]
+    pub(crate) fn is_diag_batchable(&self) -> bool {
+        match self {
+            Gate::Cz | Gate::Rzz(_) => true,
+            _ if self.is_diagonal_1q() => true,
+            _ if self.controlled_phase().is_some() => true,
+            _ => false,
+        }
+    }
+
+    /// The `DiagEntry` values equivalent to this gate applied on `targets`.
+    ///
+    /// Only valid for gates where `is_diag_batchable()` returns true.
+    pub(crate) fn diag_entries(&self, targets: &[usize]) -> SmallVec<[DiagEntry; 2]> {
+        match self {
+            Gate::Cz => {
+                smallvec::smallvec![DiagEntry::Phase2q {
+                    q0: targets[0],
+                    q1: targets[1],
+                    phase: Complex64::new(-1.0, 0.0),
+                }]
+            }
+            Gate::Rzz(theta) => {
+                let half = theta / 2.0;
+                let same = Complex64::new((-half).cos(), (-half).sin()); // e^{-iθ/2}
+                let diff = Complex64::new(half.cos(), half.sin()); // e^{iθ/2}
+                smallvec::smallvec![DiagEntry::Parity2q {
+                    q0: targets[0],
+                    q1: targets[1],
+                    same,
+                    diff,
+                }]
+            }
+            _ if self.controlled_phase().is_some() => {
+                let phase = self.controlled_phase().unwrap();
+                smallvec::smallvec![DiagEntry::Phase2q {
+                    q0: targets[0],
+                    q1: targets[1],
+                    phase,
+                }]
+            }
+            _ => {
+                let mat = self.matrix_2x2();
+                smallvec::smallvec![DiagEntry::Phase1q {
+                    qubit: targets[0],
+                    d0: mat[0][0],
+                    d1: mat[1][1],
+                }]
+            }
         }
     }
 
@@ -813,6 +866,25 @@ impl Gate {
                 | Gate::Swap
         )
     }
+}
+
+/// Whether a 2x2 matrix is diagonal (both off-diagonal norms below `IDENTITY_EPS`).
+#[inline]
+pub(crate) fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
+    mat[0][1].norm() < IDENTITY_EPS && mat[1][0].norm() < IDENTITY_EPS
+}
+
+/// Whether a 4x4 matrix is diagonal (all off-diagonal norms below `IDENTITY_EPS`).
+#[inline]
+pub(crate) fn is_diagonal_4x4(mat: &[[Complex64; 4]; 4]) -> bool {
+    for (r, row) in mat.iter().enumerate() {
+        for (c, value) in row.iter().enumerate() {
+            if r != c && value.norm() >= IDENTITY_EPS {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Check if two 2x2 unitary matrices are equal up to a global phase factor.

--- a/src/gpu/kernels/bts.rs
+++ b/src/gpu/kernels/bts.rs
@@ -20,7 +20,7 @@ use crate::sim::compiled::rng::Xoshiro256PlusPlus;
 use crate::sim::compiled::shot_tail_mask;
 
 use super::super::GpuContext;
-use super::{div_ceil_grid, launch_err, require_i32, require_u32};
+use super::{div_ceil_grid, launch_err, linear_cfg, require_i32, require_u32, stream_and_fn};
 
 const SAMPLE_BLOCK_SIZE: u32 = 128;
 const NOISE_BLOCK_SIZE: u32 = 128;
@@ -156,6 +156,58 @@ extern "C" __global__ void bts_popcount_rows(
     }
 }
 
+
+// Open-addressing insert-or-increment for a 3-state (empty / claiming / ready)
+// hash table. Spins on slots mid-claim, linear-probes on collision, and sets
+// `overflow` when a full sweep finds no usable slot.
+__device__ __forceinline__ void hash_insert_count(
+    const unsigned long long *key,
+    int m_words,
+    unsigned long long *slot_keys,
+    unsigned long long *slot_counts,
+    unsigned int *slot_states,
+    unsigned int table_mask,
+    unsigned int *overflow
+) {
+    unsigned long long hash = hash_words(key, m_words);
+    unsigned int slot = (unsigned int)hash & table_mask;
+
+    for (unsigned int probe = 0; probe <= table_mask; ++probe) {
+        unsigned int state = load_state(slot_states + slot);
+        unsigned long long *slot_key =
+            slot_keys + (unsigned long long)slot * (unsigned long long)m_words;
+
+        if (state == 2U) {
+            if (keys_equal(slot_key, key, m_words)) {
+                atomicAdd(slot_counts + slot, 1ULL);
+                return;
+            }
+        } else if (state == 0U) {
+            if (atomicCAS(slot_states + slot, 0U, 1U) == 0U) {
+                for (int mw = 0; mw < m_words; ++mw) {
+                    slot_key[mw] = key[mw];
+                }
+                slot_counts[slot] = 1ULL;
+                __threadfence();
+                atomicExch(slot_states + slot, 2U);
+                return;
+            }
+            continue;
+        } else {
+            while ((state = load_state(slot_states + slot)) == 1U) {
+            }
+            if (state == 2U && keys_equal(slot_key, key, m_words)) {
+                atomicAdd(slot_counts + slot, 1ULL);
+                return;
+            }
+        }
+
+        slot = (slot + 1U) & table_mask;
+    }
+
+    atomicExch(overflow, 1U);
+}
+
 extern "C" __global__ void bts_count_meas_major_upto8(
     const unsigned long long *meas_major,
     int num_meas,
@@ -215,42 +267,7 @@ extern "C" __global__ void bts_count_meas_major_upto8(
         key[mw] = shot_words[lane][mw];
     }
 
-    unsigned long long hash = hash_words(key, m_words);
-    unsigned int slot = (unsigned int)hash & table_mask;
-
-    for (unsigned int probe = 0; probe <= table_mask; ++probe) {
-        unsigned int state = load_state(slot_states + slot);
-        unsigned long long *slot_key = slot_keys + (unsigned long long)slot * (unsigned long long)m_words;
-
-        if (state == 2U) {
-            if (keys_equal(slot_key, key, m_words)) {
-                atomicAdd(slot_counts + slot, 1ULL);
-                return;
-            }
-        } else if (state == 0U) {
-            if (atomicCAS(slot_states + slot, 0U, 1U) == 0U) {
-                for (int mw = 0; mw < m_words; ++mw) {
-                    slot_key[mw] = key[mw];
-                }
-                slot_counts[slot] = 1ULL;
-                __threadfence();
-                atomicExch(slot_states + slot, 2U);
-                return;
-            }
-            continue;
-        } else {
-            while ((state = load_state(slot_states + slot)) == 1U) {
-            }
-            if (state == 2U && keys_equal(slot_key, key, m_words)) {
-                atomicAdd(slot_counts + slot, 1ULL);
-                return;
-            }
-        }
-
-        slot = (slot + 1U) & table_mask;
-    }
-
-    atomicExch(overflow, 1U);
+    hash_insert_count(key, m_words, slot_keys, slot_counts, slot_states, table_mask, overflow);
 }
 
 extern "C" __global__ void bts_count_shot_major_upto8(
@@ -281,43 +298,7 @@ extern "C" __global__ void bts_count_shot_major_upto8(
         }
     }
 
-    unsigned long long hash = hash_words(key, m_words);
-    unsigned int slot = (unsigned int)hash & table_mask;
-
-    for (unsigned int probe = 0; probe <= table_mask; ++probe) {
-        unsigned int state = load_state(slot_states + slot);
-        unsigned long long *slot_key =
-            slot_keys + (unsigned long long)slot * (unsigned long long)m_words;
-
-        if (state == 2U) {
-            if (keys_equal(slot_key, key, m_words)) {
-                atomicAdd(slot_counts + slot, 1ULL);
-                return;
-            }
-        } else if (state == 0U) {
-            if (atomicCAS(slot_states + slot, 0U, 1U) == 0U) {
-                for (int mw = 0; mw < m_words; ++mw) {
-                    slot_key[mw] = key[mw];
-                }
-                slot_counts[slot] = 1ULL;
-                __threadfence();
-                atomicExch(slot_states + slot, 2U);
-                return;
-            }
-            continue;
-        } else {
-            while ((state = load_state(slot_states + slot)) == 1U) {
-            }
-            if (state == 2U && keys_equal(slot_key, key, m_words)) {
-                atomicAdd(slot_counts + slot, 1ULL);
-                return;
-            }
-        }
-
-        slot = (slot + 1U) & table_mask;
-    }
-
-    atomicExch(overflow, 1U);
+    hash_insert_count(key, m_words, slot_keys, slot_counts, slot_states, table_mask, overflow);
 }
 
 extern "C" __global__ void bts_count_used_slots(
@@ -844,9 +825,7 @@ pub(crate) fn launch_bts_sample(
         return Ok(vec![0u64; num_meas * s_words]);
     }
 
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_sample_meas_major")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_sample_meas_major")?;
 
     let mut output = vec![0u64; num_meas * s_words];
     let mut shots_done = 0usize;
@@ -958,8 +937,7 @@ pub(crate) fn launch_bts_sample_device(
     }
 
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_sample_meas_major")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_sample_meas_major")?;
     let mut output_dev = GpuBuffer::<u64>::alloc_zeros(device, output_len.max(1))?;
 
     let mut shots_done = 0usize;
@@ -1147,9 +1125,7 @@ pub(crate) fn generate_and_apply_noise_masks_meas_major_by_row(
         return Ok(());
     }
 
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_generate_and_apply_noise_meas_major_by_row")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_generate_and_apply_noise_meas_major_by_row")?;
     let num_meas_i = require_i32(
         "bts_generate_and_apply_noise_meas_major_by_row",
         "num_meas",
@@ -1235,9 +1211,7 @@ pub(crate) fn apply_noise_masks_meas_major(
         return Ok(());
     }
 
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_apply_noise_masks_meas_major")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_apply_noise_masks_meas_major")?;
     let num_meas_i = require_i32("bts_apply_noise_masks_meas_major", "num_meas", num_meas)?;
     let s_words_i = require_i32("bts_apply_noise_masks_meas_major", "s_words", s_words)?;
     let word_offset_i = require_i32(
@@ -1330,8 +1304,7 @@ pub(crate) fn count_meas_major_marginals(
     }
 
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_popcount_rows")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_popcount_rows")?;
     let mut row_counts = GpuBuffer::<u64>::alloc_zeros(device, num_meas.max(1))?;
     let mut host_counts = vec![0u64; num_meas];
 
@@ -1339,11 +1312,7 @@ pub(crate) fn count_meas_major_marginals(
     let s_words_i = require_i32("bts_popcount_rows", "s_words", s_words)?;
     let num_meas_grid = require_u32("bts_popcount_rows", "num_meas", num_meas)?;
     let tail_mask_u64 = shot_tail_mask(num_shots);
-    let cfg = LaunchConfig {
-        grid_dim: (num_meas_grid, 1, 1),
-        block_dim: (POPCOUNT_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(POPCOUNT_BLOCK_SIZE, num_meas_grid);
 
     let mut builder = stream.launch_builder(&func);
     builder
@@ -1373,8 +1342,7 @@ fn count_used_slots(
     }
 
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("bts_count_used_slots")?;
+    let (stream, func) = stream_and_fn(ctx, "bts_count_used_slots")?;
     let mut used_out = GpuBuffer::<u32>::alloc_zeros(device, 1)?;
     let table_capacity_i = require_i32("bts_count_used_slots", "table_slots", table_slots)?;
     let blocks = div_ceil_grid(
@@ -1383,11 +1351,7 @@ fn count_used_slots(
         table_slots,
         COUNT_HASH_BLOCK_SIZE,
     )?;
-    let cfg = LaunchConfig {
-        grid_dim: (blocks, 1, 1),
-        block_dim: (COUNT_HASH_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(COUNT_HASH_BLOCK_SIZE, blocks);
 
     let mut builder = stream.launch_builder(&func);
     builder
@@ -1442,11 +1406,7 @@ fn compact_count_table(
         table_slots,
         COUNT_COMPACT_BLOCK_SIZE,
     )?;
-    let compact_cfg = LaunchConfig {
-        grid_dim: (compact_blocks, 1, 1),
-        block_dim: (COUNT_COMPACT_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let compact_cfg = linear_cfg(COUNT_COMPACT_BLOCK_SIZE, compact_blocks);
 
     let mut compact_builder = stream.launch_builder(&compact_func);
     compact_builder
@@ -1523,11 +1483,7 @@ pub(crate) fn try_count_shot_major(
         num_shots,
         COUNT_HASH_BLOCK_SIZE,
     )?;
-    let cfg = LaunchConfig {
-        grid_dim: (blocks, 1, 1),
-        block_dim: (COUNT_HASH_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(COUNT_HASH_BLOCK_SIZE, blocks);
 
     let mut builder = stream.launch_builder(&func);
     builder
@@ -1605,11 +1561,7 @@ fn try_count_meas_major_direct(
         num_shots,
         COUNT_MEAS_BATCH_SIZE,
     )?;
-    let cfg = LaunchConfig {
-        grid_dim: (batches.max(1), 1, 1),
-        block_dim: (COUNT_MEAS_BATCH_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(COUNT_MEAS_BATCH_SIZE, batches.max(1));
 
     let mut builder = stream.launch_builder(&func);
     builder

--- a/src/gpu/kernels/dense.rs
+++ b/src/gpu/kernels/dense.rs
@@ -24,7 +24,7 @@ use num_complex::Complex64;
 use crate::error::{PrismError, Result};
 
 use super::super::{GpuContext, GpuState};
-use super::launch_err;
+use super::{launch_err, linear_cfg, stream_and_fn};
 
 const BLOCK_SIZE: u32 = 256;
 
@@ -42,6 +42,30 @@ const KERNEL_SOURCE_TEMPLATE: &str = r#"
 #define BR_GROUP_SIZE   {{BR_GROUP_SIZE}}
 #define DB_TABLE_SIZE   {{DB_TABLE_SIZE}}
 #define DB_MAX_QUBITS   {{DB_MAX_QUBITS}}
+
+// ============================================================================
+// Shared device helpers
+// ============================================================================
+
+__device__ __forceinline__ void apply2x2(double2 *state,
+    unsigned long long i0, unsigned long long i1,
+    double m00r, double m00i, double m01r, double m01i,
+    double m10r, double m10i, double m11r, double m11i)
+{
+    double2 a = state[i0];
+    double2 b = state[i1];
+    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
+    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
+    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
+    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+}
+
+__device__ __forceinline__ void apply_phase(double2 *state, unsigned long long i, double pr, double pi)
+{
+    double2 a = state[i];
+    state[i].x = pr*a.x - pi*a.y;
+    state[i].y = pr*a.y + pi*a.x;
+}
 
 // ============================================================================
 // Initialisation
@@ -71,12 +95,7 @@ extern "C" __global__ void apply_gate_1q(
     unsigned long long i0 = ((k & ~mask) << 1) | (k & mask);
     unsigned long long i1 = i0 | (1ULL << target);
 
-    double2 a = state[i0];
-    double2 b = state[i1];
-    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
-    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
-    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
-    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+    apply2x2(state, i0, i1, m00r, m00i, m01r, m01i, m10r, m10i, m11r, m11i);
 }
 
 // Diagonal 2x2 specialisation.
@@ -93,12 +112,8 @@ extern "C" __global__ void apply_diagonal_1q(
     unsigned long long i0 = ((k & ~mask) << 1) | (k & mask);
     unsigned long long i1 = i0 | (1ULL << target);
 
-    double2 a = state[i0];
-    double2 b = state[i1];
-    state[i0].x = d0r*a.x - d0i*a.y;
-    state[i0].y = d0r*a.y + d0i*a.x;
-    state[i1].x = d1r*b.x - d1i*b.y;
-    state[i1].y = d1r*b.y + d1i*b.x;
+    apply_phase(state, i0, d0r, d0i);
+    apply_phase(state, i1, d1r, d1i);
 }
 
 // ============================================================================
@@ -177,9 +192,7 @@ extern "C" __global__ void apply_parity_phase(
     unsigned long long parity = ((i >> q0) ^ (i >> q1)) & 1ULL;
     double pr = parity ? diff_r : same_r;
     double pi = parity ? diff_i : same_i;
-    double2 a = state[i];
-    state[i].x = pr*a.x - pi*a.y;
-    state[i].y = pr*a.y + pi*a.x;
+    apply_phase(state, i, pr, pi);
 }
 
 // ============================================================================
@@ -199,12 +212,7 @@ extern "C" __global__ void apply_cu(
     unsigned long long i0 = idx | (1ULL << control);
     unsigned long long i1 = i0 | (1ULL << target);
 
-    double2 a = state[i0];
-    double2 b = state[i1];
-    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
-    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
-    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
-    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+    apply2x2(state, i0, i1, m00r, m00i, m01r, m01i, m10r, m10i, m11r, m11i);
 }
 
 // Controlled-phase optimisation: state[both_set] *= phase.
@@ -220,9 +228,7 @@ extern "C" __global__ void apply_cu_phase(
     int hi_q = control < target ? target : control;
     unsigned long long idx = expand_2q(k, lo_q, hi_q);
     unsigned long long i = idx | (1ULL << control) | (1ULL << target);
-    double2 a = state[i];
-    state[i].x = pr*a.x - pi*a.y;
-    state[i].y = pr*a.y + pi*a.x;
+    apply_phase(state, i, pr, pi);
 }
 
 // Multi-controlled unitary. `sorted` contains all controls + target, sorted ascending.
@@ -250,12 +256,7 @@ extern "C" __global__ void apply_mcu(
     unsigned long long i0 = idx | ctrl_mask;
     unsigned long long i1 = i0 | tgt_mask;
 
-    double2 a = state[i0];
-    double2 b = state[i1];
-    state[i0].x = m00r*a.x - m00i*a.y + m01r*b.x - m01i*b.y;
-    state[i0].y = m00r*a.y + m00i*a.x + m01r*b.y + m01i*b.x;
-    state[i1].x = m10r*a.x - m10i*a.y + m11r*b.x - m11i*b.y;
-    state[i1].y = m10r*a.y + m10i*a.x + m11r*b.y + m11i*b.x;
+    apply2x2(state, i0, i1, m00r, m00i, m01r, m01i, m10r, m10i, m11r, m11i);
 }
 
 extern "C" __global__ void apply_mcu_phase(
@@ -275,9 +276,7 @@ extern "C" __global__ void apply_mcu_phase(
         idx = (hi << (bit + 1)) | lo;
     }
     unsigned long long i = idx | all_mask;
-    double2 a = state[i];
-    state[i].x = pr*a.x - pi*a.y;
-    state[i].y = pr*a.y + pi*a.x;
+    apply_phase(state, i, pr, pi);
 }
 
 // ============================================================================
@@ -403,18 +402,6 @@ extern "C" __global__ void compute_probabilities(
     out[i] = (a.x * a.x + a.y * a.y) * norm_sq;
 }
 
-// scale_state: state[i] *= s. Used to fold deferred pending_norm into the device buffer before
-// export. Launched over 2^n threads.
-
-extern "C" __global__ void scale_state(
-    double2 *state, unsigned long long dim, double s)
-{
-    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= dim) return;
-    state[i].x *= s;
-    state[i].y *= s;
-}
-
 // apply_multi_fused_tiled: batched non-diagonal MultiFused via shared-memory tiles.
 //
 // Each block loads a TILE_SIZE slice of amplitudes into shared memory, then applies every
@@ -458,9 +445,6 @@ extern "C" __global__ void apply_multi_fused_tiled(
         int i0 = ((k & ~mask) << 1) | (k & mask);
         int i1 = i0 | (1 << t);
 
-        double2 a = tile[i0];
-        double2 b = tile[i1];
-
         double2 m00 = matrices[g * 4 + 0];
         double2 m01 = matrices[g * 4 + 1];
         double2 m10 = matrices[g * 4 + 2];
@@ -471,10 +455,7 @@ extern "C" __global__ void apply_multi_fused_tiled(
         // index mapping partitions [0, TILE_SIZE)). The trailing sync below
         // serialises writes across gate boundaries, which is the only hazard.
 
-        tile[i0].x = m00.x * a.x - m00.y * a.y + m01.x * b.x - m01.y * b.y;
-        tile[i0].y = m00.x * a.y + m00.y * a.x + m01.x * b.y + m01.y * b.x;
-        tile[i1].x = m10.x * a.x - m10.y * a.y + m11.x * b.x - m11.y * b.y;
-        tile[i1].y = m10.x * a.y + m10.y * a.x + m11.x * b.y + m11.y * b.x;
+        apply2x2(tile, i0, i1, m00.x, m00.y, m01.x, m01.y, m10.x, m10.y, m11.x, m11.y);
         __syncthreads();
     }
 
@@ -516,9 +497,7 @@ extern "C" __global__ void apply_diagonal_batch(
         ci = ni;
     }
 
-    double2 a = state[i];
-    state[i].x = cr * a.x - ci * a.y;
-    state[i].y = cr * a.y + ci * a.x;
+    apply_phase(state, i, cr, ci);
 }
 
 // apply_batch_rzz: applies a batch of Rzz gates via precomputed parity-phase LUTs (built
@@ -558,9 +537,7 @@ extern "C" __global__ void apply_batch_rzz(
         ci = ni;
     }
 
-    double2 a = state[i];
-    state[i].x = cr * a.x - ci * a.y;
-    state[i].y = cr * a.y + ci * a.x;
+    apply_phase(state, i, cr, ci);
 }
 
 // apply_batch_phase: applies a batch of controlled-phase gates sharing a control qubit via
@@ -600,9 +577,7 @@ extern "C" __global__ void apply_batch_phase(
         ci = ni;
     }
 
-    double2 a = state[idx];
-    state[idx].x = cr * a.x - ci * a.y;
-    state[idx].y = cr * a.y + ci * a.x;
+    apply_phase(state, idx, cr, ci);
 }
 
 // apply_multi_fused_diagonal: batch of diagonal 1q gates in a single pass. Replaces the
@@ -683,14 +658,8 @@ fn grid_for(count: u64) -> u32 {
 }
 
 pub(crate) fn launch_set_initial_state(ctx: &GpuContext, state: &mut GpuState) -> Result<()> {
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("set_initial_state")?;
-    let cfg = LaunchConfig {
-        grid_dim: (1, 1, 1),
-        block_dim: (1, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "set_initial_state")?;
+    let cfg = linear_cfg(1, 1);
     let mut builder = stream.launch_builder(&func);
     let buffer = state.buffer_mut().raw_mut();
     builder.arg(buffer);
@@ -708,13 +677,8 @@ pub(crate) fn launch_compute_probabilities(ctx: &GpuContext, state: &GpuState) -
     let n = state.num_qubits();
     let dim: u64 = 1u64 << n;
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("compute_probabilities")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "compute_probabilities")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
 
     // Reuse the cached scratch buffer when large enough; grow if num_qubits increased.
     let mut scratch_slot = state.probs_scratch();
@@ -739,30 +703,6 @@ pub(crate) fn launch_compute_probabilities(ctx: &GpuContext, state: &GpuState) -
     Ok(host)
 }
 
-#[allow(dead_code)]
-pub(crate) fn launch_scale_state(ctx: &GpuContext, state: &mut GpuState, s: f64) -> Result<()> {
-    let n = state.num_qubits();
-    let dim: u64 = 1u64 << n;
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("scale_state")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
-    let mut builder = stream.launch_builder(&func);
-    let buffer = state.buffer_mut().raw_mut();
-    builder.arg(buffer).arg(&dim).arg(&s);
-    // SAFETY: signature matches; grid covers dim.
-    unsafe {
-        builder
-            .launch(cfg)
-            .map_err(|e| launch_err("scale_state", e))?;
-    }
-    Ok(())
-}
-
 pub(crate) fn launch_apply_gate_1q(
     ctx: &GpuContext,
     state: &mut GpuState,
@@ -777,14 +717,8 @@ pub(crate) fn launch_apply_gate_1q(
         });
     }
     let pair_count: u64 = 1u64 << (n - 1);
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_gate_1q")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_gate_1q")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let m00r = matrix[0][0].re;
     let m00i = matrix[0][0].im;
     let m01r = matrix[0][1].re;
@@ -832,14 +766,8 @@ pub(crate) fn launch_apply_diagonal_1q(
         });
     }
     let pair_count: u64 = 1u64 << (n - 1);
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_diagonal_1q")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_diagonal_1q")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let target_i = target as i32;
     let d0r = d0.re;
     let d0i = d0.im;
@@ -882,11 +810,7 @@ fn launch_2q(
     let device = ctx.device();
     let stream = device.stream()?;
     let func = device.function(kernel)?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let q0_i = q0 as i32;
     let q1_i = q1 as i32;
     let mut builder = stream.launch_builder(&func);
@@ -942,14 +866,8 @@ pub(crate) fn launch_apply_parity_phase(
         });
     }
     let dim: u64 = 1u64 << n;
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_parity_phase")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_parity_phase")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
     let q0_i = q0 as i32;
     let q1_i = q1 as i32;
     let sr = same.re;
@@ -1007,14 +925,8 @@ pub(crate) fn launch_apply_cu(
         });
     }
     let pair_count: u64 = 1u64 << (n - 2);
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_cu")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_cu")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let ctrl_i = control as i32;
     let tgt_i = target as i32;
     let m00r = matrix[0][0].re;
@@ -1062,14 +974,8 @@ pub(crate) fn launch_apply_cu_phase(
         });
     }
     let pair_count: u64 = 1u64 << (n - 2);
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_cu_phase")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_cu_phase")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let ctrl_i = control as i32;
     let tgt_i = target as i32;
     let pr = phase.re;
@@ -1136,13 +1042,8 @@ pub(crate) fn launch_apply_mcu(
     let tgt_mask: u64 = 1u64 << target;
 
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_mcu")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(iter_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_mcu")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(iter_count));
     let mut scratch = ctx.launcher_scratch();
     let sorted_buf = super::ensure_scratch(&mut scratch.u32_a, device, &sorted)?;
     let m00r = matrix[0][0].re;
@@ -1197,13 +1098,8 @@ pub(crate) fn launch_apply_mcu_phase(
     }
 
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_mcu_phase")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(iter_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_mcu_phase")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(iter_count));
     let mut scratch = ctx.launcher_scratch();
     let sorted_buf = super::ensure_scratch(&mut scratch.u32_a, device, &sorted)?;
     let pr = phase.re;
@@ -1243,13 +1139,8 @@ pub(crate) fn launch_apply_fused_2q(
     }
     let pair_count: u64 = 1u64 << (n - 2);
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_fused_2q")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(pair_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_fused_2q")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(pair_count));
     let mut flat = [0.0_f64; 32];
     for row in 0..4 {
         for col in 0..4 {
@@ -1370,14 +1261,8 @@ pub(crate) fn measure_collapse(
         });
     }
     let dim: u64 = 1u64 << n;
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("measure_collapse")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "measure_collapse")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
     let qubit_i = qubit as i32;
     let outcome_i: i32 = if outcome { 1 } else { 0 };
     let mut builder = stream.launch_builder(&func);
@@ -1426,13 +1311,8 @@ pub(crate) fn launch_apply_multi_fused_diagonal(
 
     let dim: u64 = 1u64 << n;
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_multi_fused_diagonal")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_multi_fused_diagonal")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
 
     let mut scratch = ctx.launcher_scratch();
     let scratch = &mut *scratch;
@@ -1521,13 +1401,8 @@ pub(crate) fn launch_apply_batch_phase(
 
     let half_count: u64 = 1u64 << (n - 1);
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_batch_phase")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(half_count), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_batch_phase")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(half_count));
 
     let mut scratch = ctx.launcher_scratch();
     let scratch = &mut *scratch;
@@ -1609,13 +1484,8 @@ pub(crate) fn launch_apply_batch_rzz(
 
     let dim: u64 = 1u64 << n;
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_batch_rzz")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_batch_rzz")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
 
     let mut scratch = ctx.launcher_scratch();
     let scratch = &mut *scratch;
@@ -1715,13 +1585,8 @@ pub(crate) fn launch_apply_diagonal_batch(
     let n = state.num_qubits();
     let dim: u64 = 1u64 << n;
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_diagonal_batch")?;
-    let cfg = LaunchConfig {
-        grid_dim: (grid_for(dim), 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_diagonal_batch")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(dim));
 
     let mut scratch = ctx.launcher_scratch();
     let scratch = &mut *scratch;
@@ -1833,13 +1698,8 @@ pub(crate) fn launch_apply_multi_fused_nondiag(
     let dim: u64 = 1u64 << n;
     let num_tiles = dim / MULTI_FUSED_TILE_SIZE;
     let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("apply_multi_fused_tiled")?;
-    let cfg = LaunchConfig {
-        grid_dim: (num_tiles as u32, 1, 1),
-        block_dim: (MULTI_FUSED_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let (stream, func) = stream_and_fn(ctx, "apply_multi_fused_tiled")?;
+    let cfg = linear_cfg(MULTI_FUSED_BLOCK_SIZE, num_tiles as u32);
 
     let num_gates_i = tile_targets.len() as i32;
     {

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -10,11 +10,30 @@ pub(crate) mod bts;
 pub(crate) mod dense;
 pub(crate) mod stabilizer;
 
-use cudarc::driver::{DeviceRepr, ValidAsZeroBits};
+use std::sync::Arc;
+
+use cudarc::driver::{CudaFunction, CudaStream, DeviceRepr, LaunchConfig, ValidAsZeroBits};
 
 use crate::error::{PrismError, Result};
+use crate::gpu::GpuContext;
 use crate::gpu::device::GpuDevice;
 use crate::gpu::memory::GpuBuffer;
+
+pub(super) fn stream_and_fn<'a>(
+    ctx: &'a GpuContext,
+    name: &'static str,
+) -> Result<(&'a Arc<CudaStream>, CudaFunction)> {
+    let device = ctx.device();
+    Ok((device.stream()?, device.function(name)?))
+}
+
+pub(super) fn linear_cfg(block_size: u32, grid_blocks: u32) -> LaunchConfig {
+    LaunchConfig {
+        grid_dim: (grid_blocks, 1, 1),
+        block_dim: (block_size, 1, 1),
+        shared_mem_bytes: 0,
+    }
+}
 
 pub(super) fn launch_err(op: &str, err: impl std::fmt::Display) -> PrismError {
     PrismError::BackendUnsupported {
@@ -145,7 +164,6 @@ pub(crate) const KERNEL_NAMES: &[&str] = &[
     "measure_prob_one_finalize",
     "measure_collapse",
     "compute_probabilities",
-    "scale_state",
     "apply_multi_fused_diagonal",
     "apply_batch_phase",
     "apply_batch_rzz",

--- a/src/gpu/kernels/stabilizer.rs
+++ b/src/gpu/kernels/stabilizer.rs
@@ -45,12 +45,12 @@
 //! serialises rowmul's of stabilisers whose paired destabilisers anticommute
 //! with Z_q into the scratch row and reads its phase.
 
-use cudarc::driver::{CudaSlice, LaunchConfig, PushKernelArg};
+use cudarc::driver::{CudaSlice, PushKernelArg};
 
 use crate::error::Result;
 
 use super::super::{GpuContext, GpuTableau};
-use super::{div_ceil_grid, launch_err, require_i32, require_u32};
+use super::{div_ceil_grid, launch_err, linear_cfg, require_i32, require_u32, stream_and_fn};
 
 const BLOCK_SIZE: u32 = 128;
 
@@ -618,9 +618,7 @@ pub(crate) fn kernel_source() -> String {
 /// Assumes `xz` and `phase` were allocated via `GpuBuffer::alloc_zeros` (so everything
 /// else is already zero); this kernel only writes the identity bits.
 pub(crate) fn launch_set_initial_tableau(ctx: &GpuContext, tableau: &mut GpuTableau) -> Result<()> {
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_set_initial_tableau")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_set_initial_tableau")?;
 
     let n_usize = tableau.num_qubits();
     if n_usize == 0 {
@@ -634,11 +632,7 @@ pub(crate) fn launch_set_initial_tableau(ctx: &GpuContext, tableau: &mut GpuTabl
         n_usize,
         BLOCK_SIZE,
     )?;
-    let cfg = LaunchConfig {
-        grid_dim: (blocks, 1, 1),
-        block_dim: (BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(BLOCK_SIZE, blocks);
 
     let mut builder = stream.launch_builder(&func);
     let xz = tableau.xz_mut().raw_mut();
@@ -873,9 +867,7 @@ fn launch_word_grouped_kernel(
     let num_rows = require_i32("stab_apply_word_grouped", "num_rows", num_rows_usize)?;
     let num_words_i = require_i32("stab_apply_word_grouped", "num_words", tableau.num_words())?;
 
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_apply_word_grouped")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_apply_word_grouped")?;
 
     let group_words_src: &[u32] = if scratch.group_words.is_empty() {
         &ZERO_U32
@@ -968,11 +960,7 @@ fn launch_word_grouped_kernel(
         .next_power_of_two()
         .clamp(32, BLOCK_SIZE as usize) as u32;
     let num_rows_grid = require_u32("stab_apply_word_grouped", "num_rows", num_rows_usize)?;
-    let cfg = LaunchConfig {
-        grid_dim: (num_rows_grid, 1, 1),
-        block_dim: (block_threads, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(block_threads, num_rows_grid);
 
     let group_words_dev = scratch
         .group_words_dev
@@ -1034,9 +1022,7 @@ pub(crate) fn launch_rowmul_words(
     src_row: usize,
     dst_row: usize,
 ) -> Result<()> {
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_rowmul_words")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_rowmul_words")?;
 
     let nw_usize = tableau.num_words();
     if nw_usize == 0 {
@@ -1045,11 +1031,7 @@ pub(crate) fn launch_rowmul_words(
     let nw = require_i32("stab_rowmul_words", "num_words", nw_usize)?;
     let src_i = require_i32("stab_rowmul_words", "src_row", src_row)?;
     let dst_i = require_i32("stab_rowmul_words", "dst_row", dst_row)?;
-    let cfg = LaunchConfig {
-        grid_dim: (1, 1, 1),
-        block_dim: (ROWMUL_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(ROWMUL_BLOCK_SIZE, 1);
 
     let mut builder = stream.launch_builder(&func);
     let (xz_buf, phase_buf) = tableau.xz_phase_mut();
@@ -1087,9 +1069,7 @@ pub(crate) fn launch_measure_find_pivot(
     if n == 0 {
         return Ok(None);
     }
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_measure_find_pivot")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_measure_find_pivot")?;
 
     let sentinel = require_i32(
         "stab_measure_find_pivot",
@@ -1105,11 +1085,7 @@ pub(crate) fn launch_measure_find_pivot(
         n,
         MEASURE_BLOCK_SIZE,
     )?;
-    let cfg = LaunchConfig {
-        grid_dim: (blocks, 1, 1),
-        block_dim: (MEASURE_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(MEASURE_BLOCK_SIZE, blocks);
 
     let mut host_pivot = [0_i32; 1];
     {
@@ -1158,20 +1134,14 @@ pub(crate) fn launch_measure_cascade(
     if n == 0 {
         return Ok(());
     }
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_measure_cascade")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_measure_cascade")?;
 
     let num_qubits_i = require_i32("stab_measure_cascade", "num_qubits", n)?;
     let nw = require_i32("stab_measure_cascade", "num_words", tableau.num_words())?;
     let target_i = require_i32("stab_measure_cascade", "target", target)?;
     let pivot_i = require_i32("stab_measure_cascade", "pivot_row", pivot_row)?;
     let blocks = require_u32("stab_measure_cascade", "num_rows", 2usize.saturating_mul(n))?;
-    let cfg = LaunchConfig {
-        grid_dim: (blocks, 1, 1),
-        block_dim: (MEASURE_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(MEASURE_BLOCK_SIZE, blocks);
 
     let mut builder = stream.launch_builder(&func);
     let (xz_buf, phase_buf) = tableau.xz_phase_mut();
@@ -1209,20 +1179,14 @@ pub(crate) fn launch_measure_fixup(
     if n == 0 {
         return Ok(());
     }
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_measure_fixup")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_measure_fixup")?;
 
     let num_qubits_i = require_i32("stab_measure_fixup", "num_qubits", n)?;
     let nw = require_i32("stab_measure_fixup", "num_words", tableau.num_words())?;
     let target_i = require_i32("stab_measure_fixup", "target", target)?;
     let pivot_i = require_i32("stab_measure_fixup", "pivot_row", pivot_row)?;
     let outcome_u8: u8 = outcome as u8;
-    let cfg = LaunchConfig {
-        grid_dim: (1, 1, 1),
-        block_dim: (MEASURE_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(MEASURE_BLOCK_SIZE, 1);
 
     let mut builder = stream.launch_builder(&func);
     let (xz_buf, phase_buf) = tableau.xz_phase_mut();
@@ -1259,9 +1223,7 @@ pub(crate) fn launch_measure_deterministic(
     if n == 0 {
         return Ok(false);
     }
-    let device = ctx.device();
-    let stream = device.stream()?;
-    let func = device.function("stab_measure_deterministic")?;
+    let (stream, func) = stream_and_fn(ctx, "stab_measure_deterministic")?;
 
     let num_qubits_i = require_i32("stab_measure_deterministic", "num_qubits", n)?;
     let nw = require_i32(
@@ -1270,11 +1232,7 @@ pub(crate) fn launch_measure_deterministic(
         tableau.num_words(),
     )?;
     let target_i = require_i32("stab_measure_deterministic", "target", target)?;
-    let cfg = LaunchConfig {
-        grid_dim: (1, 1, 1),
-        block_dim: (MEASURE_BLOCK_SIZE, 1, 1),
-        shared_mem_bytes: 0,
-    };
+    let cfg = linear_cfg(MEASURE_BLOCK_SIZE, 1);
 
     let mut host_out = [0u8; 1];
     {

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -668,63 +668,67 @@ impl QecProgram {
         })
     }
 
+    /// Walk the ops with a running count of measurement records emitted so
+    /// far. Record-referencing ops resolve relative offsets against that
+    /// count; the row-resolver methods below share this walk.
+    fn visit_ops_with_measurement_count(
+        &self,
+        mut visit: impl FnMut(&QecOp, usize) -> Result<()>,
+    ) -> Result<()> {
+        let mut next_measurement = 0;
+        for op in &self.ops {
+            if matches!(
+                op,
+                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. }
+            ) {
+                next_measurement += 1;
+                continue;
+            }
+            visit(op, next_measurement)?;
+        }
+        Ok(())
+    }
+
     /// Resolve detector rows to absolute measurement record indices.
     pub fn detector_rows(&self) -> Result<Vec<Vec<usize>>> {
         let mut rows = Vec::new();
-        let mut next_measurement = 0;
-        for op in &self.ops {
-            match op {
-                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
-                    next_measurement += 1;
-                }
-                QecOp::Detector { records, .. } => {
-                    rows.push(resolve_records(records, next_measurement)?);
-                }
-                _ => {}
+        self.visit_ops_with_measurement_count(|op, next_measurement| {
+            if let QecOp::Detector { records, .. } = op {
+                rows.push(resolve_records(records, next_measurement)?);
             }
-        }
+            Ok(())
+        })?;
         Ok(rows)
     }
 
     /// Resolve observable rows to absolute measurement record indices.
     pub fn observable_rows(&self) -> Result<Vec<Vec<usize>>> {
-        let mut rows = Vec::new();
-        let mut next_measurement = 0;
-        for op in &self.ops {
-            match op {
-                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
-                    next_measurement += 1;
+        let mut rows: Vec<Vec<usize>> = Vec::new();
+        self.visit_ops_with_measurement_count(|op, next_measurement| {
+            if let QecOp::ObservableInclude {
+                observable,
+                records,
+            } = op
+            {
+                if rows.len() <= *observable {
+                    rows.resize_with(*observable + 1, Vec::new);
                 }
-                QecOp::ObservableInclude {
-                    observable,
-                    records,
-                } => {
-                    if rows.len() <= *observable {
-                        rows.resize_with(*observable + 1, Vec::new);
-                    }
-                    rows[*observable].extend(resolve_records(records, next_measurement)?);
-                }
-                _ => {}
+                rows[*observable].extend(resolve_records(records, next_measurement)?);
             }
-        }
+            Ok(())
+        })?;
         Ok(rows)
     }
 
     /// Resolve postselection rows to absolute measurement record indices.
     pub fn postselection_rows(&self) -> Result<Vec<(Vec<usize>, bool)>> {
         let mut rows = Vec::new();
-        let mut next_measurement = 0;
-        for op in &self.ops {
-            match op {
-                QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
-                    next_measurement += 1;
-                }
-                QecOp::Postselect { records, expected } => {
-                    rows.push((resolve_records(records, next_measurement)?, *expected));
-                }
-                _ => {}
+        self.visit_ops_with_measurement_count(|op, next_measurement| {
+            if let QecOp::Postselect { records, expected } = op {
+                rows.push((resolve_records(records, next_measurement)?, *expected));
             }
-        }
+            Ok(())
+        })?;
         Ok(rows)
     }
 
@@ -890,6 +894,51 @@ pub(super) fn append_z_to_basis_rotation(circuit: &mut Circuit, basis: QecBasis,
         }
         QecBasis::Z => {}
     }
+}
+
+/// Lower a Pauli-product measurement onto a scratch qubit: rotate each term
+/// into the Z basis, accumulate parity on the scratch via CX, then undo the
+/// rotations in reverse order. The caller measures the scratch afterward.
+pub(super) fn append_mpp_parity_rotations(
+    circuit: &mut Circuit,
+    terms: &[QecPauli],
+    scratch: usize,
+) {
+    for term in terms {
+        append_basis_to_z_rotation(circuit, term.basis, term.qubit);
+    }
+    for term in terms {
+        circuit.add_gate(Gate::Cx, &[term.qubit, scratch]);
+    }
+    for term in terms.iter().rev() {
+        append_z_to_basis_rotation(circuit, term.basis, term.qubit);
+    }
+}
+
+pub(super) fn qec_non_clifford_error(gate: &Gate) -> PrismError {
+    PrismError::IncompatibleBackend {
+        backend: "QEC compiled runner".to_string(),
+        reason: format!(
+            "compiled QEC runner requires Clifford gates, got `{}`",
+            gate.name()
+        ),
+    }
+}
+
+pub(super) fn ensure_lowered_record_count(
+    program: &QecProgram,
+    produced: usize,
+    stage: &str,
+) -> Result<()> {
+    if produced != program.num_measurements() {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "QEC {stage} lowering produced {produced} records, expected {}",
+                program.num_measurements()
+            ),
+        });
+    }
+    Ok(())
 }
 
 fn resolve_records(records: &[QecRecordRef], next_measurement: usize) -> Result<Vec<usize>> {

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -1,9 +1,9 @@
 use super::{
-    QecNoise, QecOp, QecPauli, QecProgram, append_basis_to_z_rotation, append_z_to_basis_rotation,
+    QecNoise, QecOp, QecPauli, QecProgram, append_basis_to_z_rotation, append_mpp_parity_rotations,
+    append_z_to_basis_rotation, ensure_lowered_record_count, qec_non_clifford_error,
 };
 use crate::circuit::{Circuit, Instruction, SmallVec};
 use crate::error::{PrismError, Result};
-use crate::gates::Gate;
 use crate::sim::compiled::{
     CompiledSampler, PackedShots, batch_propagate_backward, compile_measurements,
     rng::Xoshiro256PlusPlus, xor_words,
@@ -260,13 +260,7 @@ fn lower_qec_program_to_deferred_circuit_inner(
         match op {
             QecOp::Gate { gate, targets } => {
                 if !allow_non_clifford && !gate.is_clifford() {
-                    return Err(PrismError::IncompatibleBackend {
-                        backend: "QEC compiled runner".to_string(),
-                        reason: format!(
-                            "compiled QEC runner requires Clifford gates, got `{}`",
-                            gate.name()
-                        ),
-                    });
+                    return Err(qec_non_clifford_error(gate));
                 }
                 let mapped = map_qec_deferred_targets(targets, &aliases, &measured_aliases)?;
                 circuit.add_gate(gate.clone(), mapped.as_slice());
@@ -302,15 +296,7 @@ fn lower_qec_program_to_deferred_circuit_inner(
                     mapped_terms.push(QecPauli::new(term.basis, alias));
                 }
 
-                for term in &mapped_terms {
-                    append_basis_to_z_rotation(&mut circuit, term.basis, term.qubit);
-                }
-                for term in &mapped_terms {
-                    circuit.add_gate(Gate::Cx, &[term.qubit, scratch_alias]);
-                }
-                for term in mapped_terms.iter().rev() {
-                    append_z_to_basis_rotation(&mut circuit, term.basis, term.qubit);
-                }
+                append_mpp_parity_rotations(&mut circuit, &mapped_terms, scratch_alias);
 
                 deferred_measurements.push((scratch_alias, next_record));
                 measured_aliases[scratch_alias] = true;
@@ -351,14 +337,7 @@ fn lower_qec_program_to_deferred_circuit_inner(
         }
     }
 
-    if next_record != program.num_measurements() {
-        return Err(PrismError::InvalidParameter {
-            message: format!(
-                "QEC deferred lowering produced {next_record} records, expected {}",
-                program.num_measurements()
-            ),
-        });
-    }
+    ensure_lowered_record_count(program, next_record, "deferred")?;
 
     let mut measurement_qubits = Vec::with_capacity(deferred_measurements.len());
     for (qubit, classical_bit) in deferred_measurements {

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -3,7 +3,8 @@ use super::noise::QecCompiledNoiseSampler;
 use super::noise::compile_qec_noisy_sampler;
 use super::{
     QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram, QecSampleResult,
-    append_basis_to_z_rotation, append_z_to_basis_rotation,
+    append_basis_to_z_rotation, append_mpp_parity_rotations, append_z_to_basis_rotation,
+    ensure_lowered_record_count, qec_non_clifford_error,
 };
 use crate::backend::{Backend, statevector::StatevectorBackend};
 use crate::circuit::{Circuit, Instruction, SmallVec};
@@ -850,13 +851,7 @@ fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit
         match op {
             QecOp::Gate { gate, targets } => {
                 if !gate.is_clifford() {
-                    return Err(PrismError::IncompatibleBackend {
-                        backend: "QEC compiled runner".to_string(),
-                        reason: format!(
-                            "compiled QEC runner requires Clifford gates, got `{}`",
-                            gate.name()
-                        ),
-                    });
+                    return Err(qec_non_clifford_error(gate));
                 }
                 circuit.add_gate(gate.clone(), targets);
             }
@@ -874,15 +869,7 @@ fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit
                 if scratch_needs_reset {
                     circuit.add_reset(scratch_qubit);
                 }
-                for term in terms {
-                    append_basis_to_z_rotation(&mut circuit, term.basis, term.qubit);
-                }
-                for term in terms {
-                    circuit.add_gate(Gate::Cx, &[term.qubit, scratch_qubit]);
-                }
-                for term in terms.iter().rev() {
-                    append_z_to_basis_rotation(&mut circuit, term.basis, term.qubit);
-                }
+                append_mpp_parity_rotations(&mut circuit, terms, scratch_qubit);
                 circuit.add_measure(scratch_qubit, next_record);
                 next_record += 1;
                 scratch_needs_reset = true;
@@ -917,14 +904,7 @@ fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit
         }
     }
 
-    if next_record != program.num_measurements() {
-        return Err(PrismError::InvalidParameter {
-            message: format!(
-                "QEC compiled lowering produced {next_record} records, expected {}",
-                program.num_measurements()
-            ),
-        });
-    }
+    ensure_lowered_record_count(program, next_record, "compiled")?;
     Ok(circuit)
 }
 

--- a/src/qec/t_sampler.rs
+++ b/src/qec/t_sampler.rs
@@ -540,6 +540,76 @@ fn packed_observable_records_from_logical_errors(
     PackedShots::from_meas_major(data, total_shots, num_observables)
 }
 
+struct LoweredPauliObservables {
+    circuit: Circuit,
+    record_to_qubit: Vec<usize>,
+    observable_terms_list: Vec<Vec<PauliTerm>>,
+    postsel_rows: Vec<(Vec<usize>, bool)>,
+}
+
+/// Shared lowering prelude for the analytical strategies: the restricted
+/// Clifford+T circuit, the record-to-qubit map, per-observable Pauli terms,
+/// and the unresolved postselection rows.
+fn lower_pauli_observables(program: &QecProgram) -> Result<LoweredPauliObservables> {
+    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let observable_rows = program.observable_rows()?;
+    let postsel_rows = program.postselection_rows()?;
+    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
+    for row in observable_rows.iter() {
+        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
+    }
+    Ok(LoweredPauliObservables {
+        circuit,
+        record_to_qubit,
+        observable_terms_list,
+        postsel_rows,
+    })
+}
+
+/// Shared result assembly for the analytical strategies. Evaluates each
+/// observable through `eval`, reporting unconditional means directly or
+/// routing through the conditional-expectation combiner when postselection
+/// rows exist. `discarded_sq` from `eval` lands in
+/// `QecObservableEstimate::variance` on both paths.
+fn evaluate_observable_program<F>(
+    program: &QecProgram,
+    lowered: &LoweredPauliObservables,
+    mut eval: F,
+) -> Result<QecSampleResult>
+where
+    F: FnMut(&[PauliTerm]) -> Result<ConditionalEval>,
+{
+    if lowered.postsel_rows.is_empty() {
+        let mut means = Vec::with_capacity(lowered.observable_terms_list.len());
+        let mut estimates = Vec::with_capacity(lowered.observable_terms_list.len());
+        for terms in &lowered.observable_terms_list {
+            let eval_result = eval(terms)?;
+            means.push(eval_result.mean);
+            estimates.push(QecObservableEstimate {
+                mean: eval_result.mean,
+                variance: eval_result.discarded_sq,
+                num_shots: program.options().shots,
+            });
+        }
+        return build_qec_result_from_observable_means(program, means, estimates);
+    }
+
+    let postsel = lower_postselection_rows(&lowered.postsel_rows, &lowered.record_to_qubit)?;
+    let (means, obs_discarded, accept_rate) =
+        evaluate_conditional_expectations(&lowered.observable_terms_list, &postsel, eval)?;
+    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
+    let estimates: Vec<_> = means
+        .iter()
+        .zip(obs_discarded.iter())
+        .map(|(&mean, &discarded_sq)| QecObservableEstimate {
+            mean,
+            variance: discarded_sq,
+            num_shots: estimate_shots,
+        })
+        .collect();
+    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+}
+
 /// Default MPS bond-dimension cap for CAMPS. Matches the
 /// auto-dispatch ceiling used elsewhere in PRISM-Q (`MPS(256)` in
 /// `sim/dispatch.rs`).
@@ -557,9 +627,8 @@ fn run_qec_program_camps(program: &QecProgram) -> Result<QecSampleResult> {
     };
     use crate::circuit::Instruction;
 
-    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
-    let observable_rows = program.observable_rows()?;
-    let postsel_rows = program.postselection_rows()?;
+    let lowered = lower_pauli_observables(program)?;
+    let circuit = &lowered.circuit;
 
     let mut backend = MpsBackend::new(program.options().seed, QEC_CAMPS_MAX_BOND_DIM);
     backend.init(circuit.num_qubits, 0)?;
@@ -590,105 +659,31 @@ fn run_qec_program_camps(program: &QecProgram) -> Result<QecSampleResult> {
         }
     }
 
-    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
-    for row in observable_rows.iter() {
-        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
-    }
-
     // Clifford gates are absorbed into a [`SignedCliffordPrefix`]; T/Tdg
     // gates dispatch through [`apply_t_via_camps`] (Liu & Clark
     // Algorithm 1 OFD). The observable `⟨ψ|Π Z_q|ψ⟩` is evaluated as
     // `⟨ϕ| C†(Π Z_q) C |ϕ⟩` by composing twisted Pauli rows and calling
     // [`crate::backend::mps::MpsBackend::pauli_expectation`].
-    let eval = |terms: &[PauliTerm]| -> Result<f64> {
+    evaluate_observable_program(program, &lowered, |terms| {
         let qubits: Vec<usize> = terms.iter().map(|t| t.qubit).collect();
-        evaluate_z_observable_camps(&prefix, &backend, &qubits)
-    };
-
-    if postsel_rows.is_empty() {
-        let mut means = Vec::with_capacity(observable_terms_list.len());
-        let mut estimates = Vec::with_capacity(observable_terms_list.len());
-        for terms in &observable_terms_list {
-            let mean = eval(terms)?;
-            means.push(mean);
-            estimates.push(QecObservableEstimate {
-                mean,
-                variance: 0.0,
-                num_shots: program.options().shots,
-            });
-        }
-        return build_qec_result_from_observable_means(program, means, estimates);
-    }
-
-    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
-    let (means, _obs_discarded, accept_rate) =
-        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
-            Ok(ConditionalEval {
-                mean: eval(terms)?,
-                discarded_sq: 0.0,
-            })
-        })?;
-    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
-    let estimates: Vec<_> = means
-        .iter()
-        .map(|&m| QecObservableEstimate {
-            mean: m,
-            variance: 0.0,
-            num_shots: estimate_shots,
+        Ok(ConditionalEval {
+            mean: evaluate_z_observable_camps(&prefix, &backend, &qubits)?,
+            discarded_sq: 0.0,
         })
-        .collect();
-    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+    })
 }
 
 // Private exact fallback for Auto. Contracts each scalar observable directly
 // as <0| U^dagger P U |0> and does not materialize a dense statevector.
 fn run_qec_program_tensor_network_observable(program: &QecProgram) -> Result<QecSampleResult> {
-    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
-    let observable_rows = program.observable_rows()?;
-    let postsel_rows = program.postselection_rows()?;
-
-    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
-    for row in observable_rows.iter() {
-        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
-    }
-
-    let eval = |terms: &[PauliTerm]| -> Result<f64> {
-        crate::backend::tensornetwork::expectation_zero_state(&circuit, terms)
-    };
-
-    if postsel_rows.is_empty() {
-        let mut means = Vec::with_capacity(observable_terms_list.len());
-        let mut estimates = Vec::with_capacity(observable_terms_list.len());
-        for terms in &observable_terms_list {
-            let mean = eval(terms)?;
-            means.push(mean);
-            estimates.push(QecObservableEstimate {
-                mean,
-                variance: 0.0,
-                num_shots: program.options().shots,
-            });
-        }
-        return build_qec_result_from_observable_means(program, means, estimates);
-    }
-
-    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
-    let (means, _obs_discarded, accept_rate) =
-        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
-            Ok(ConditionalEval {
-                mean: eval(terms)?,
-                discarded_sq: 0.0,
-            })
-        })?;
-    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
-    let estimates: Vec<_> = means
-        .iter()
-        .map(|&mean| QecObservableEstimate {
-            mean,
-            variance: 0.0,
-            num_shots: estimate_shots,
+    let lowered = lower_pauli_observables(program)?;
+    let circuit = &lowered.circuit;
+    evaluate_observable_program(program, &lowered, |terms| {
+        Ok(ConditionalEval {
+            mean: crate::backend::tensornetwork::expectation_zero_state(circuit, terms)?,
+            discarded_sq: 0.0,
         })
-        .collect();
-    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+    })
 }
 
 /// Tolerance on `⟨ψ|S|ψ⟩ = +1` for a rerouting stabilizer.
@@ -731,9 +726,12 @@ pub fn run_qec_program_spd_rerouted(
     program: &QecProgram,
     reroutes: &[QecObservableReroute],
 ) -> Result<QecSampleResult> {
-    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
-    let observable_rows = program.observable_rows()?;
-    let postsel_rows = program.postselection_rows()?;
+    let LoweredPauliObservables {
+        circuit,
+        observable_terms_list,
+        postsel_rows,
+        ..
+    } = lower_pauli_observables(program)?;
     if !postsel_rows.is_empty() {
         return Err(PrismError::IncompatibleBackend {
             backend: "QEC SPD rerouted".to_string(),
@@ -761,7 +759,7 @@ pub fn run_qec_program_spd_rerouted(
     }
 
     let mut reroute_by_observable: Vec<Option<&QecObservableReroute>> =
-        vec![None; observable_rows.len()];
+        vec![None; observable_terms_list.len()];
     for reroute in reroutes {
         let slot = reroute_by_observable
             .get_mut(reroute.observable)
@@ -769,7 +767,7 @@ pub fn run_qec_program_spd_rerouted(
                 message: format!(
                     "reroute references observable {} but program has {} observables",
                     reroute.observable,
-                    observable_rows.len()
+                    observable_terms_list.len()
                 ),
             })?;
         if slot.is_some() {
@@ -781,10 +779,10 @@ pub fn run_qec_program_spd_rerouted(
         *slot = Some(reroute);
     }
 
-    let mut means = Vec::with_capacity(observable_rows.len());
-    let mut estimates = Vec::with_capacity(observable_rows.len());
-    for (observable, row) in observable_rows.iter().enumerate() {
-        let mut terms = observable_row_to_pauli_terms(row, &record_to_qubit)?;
+    let mut means = Vec::with_capacity(observable_terms_list.len());
+    let mut estimates = Vec::with_capacity(observable_terms_list.len());
+    for (observable, terms) in observable_terms_list.iter().enumerate() {
+        let mut terms = terms.clone();
         if let Some(reroute) = reroute_by_observable[observable] {
             let support: Vec<usize> = terms.iter().map(|term| term.qubit).collect();
             let route = min_cone_z_representative(&circuit, &support, &reroute.stabilizers)?;
@@ -817,51 +815,16 @@ pub fn run_qec_program_spd_rerouted(
 /// the diagonal sum on `|0^n⟩` per observable. Truncation error is
 /// reported via `QecObservableEstimate::variance = total_discarded²`.
 fn run_qec_program_spd(program: &QecProgram) -> Result<QecSampleResult> {
-    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
-    let observable_rows = program.observable_rows()?;
-    let postsel_rows = program.postselection_rows()?;
-    let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
-    for row in observable_rows.iter() {
-        observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
-    }
-
-    if postsel_rows.is_empty() {
-        let mut means = Vec::with_capacity(observable_terms_list.len());
-        let mut estimates = Vec::with_capacity(observable_terms_list.len());
-        for terms in &observable_terms_list {
-            let result =
-                run_spd_observable_light_cone(&circuit, terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
-            means.push(result.mean);
-            estimates.push(QecObservableEstimate {
-                mean: result.mean,
-                variance: result.total_discarded * result.total_discarded,
-                num_shots: program.options().shots,
-            });
-        }
-        return build_qec_result_from_observable_means(program, means, estimates);
-    }
-
-    let postsel = lower_postselection_rows(&postsel_rows, &record_to_qubit)?;
-    let (means, obs_discarded, accept_rate) =
-        evaluate_conditional_expectations(&observable_terms_list, &postsel, |terms| {
-            let result =
-                run_spd_observable_light_cone(&circuit, terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
-            Ok(ConditionalEval {
-                mean: result.mean,
-                discarded_sq: result.total_discarded * result.total_discarded,
-            })
-        })?;
-    let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
-    let estimates: Vec<_> = means
-        .iter()
-        .zip(obs_discarded.iter())
-        .map(|(&m, &discarded_sq)| QecObservableEstimate {
-            mean: m,
-            variance: discarded_sq,
-            num_shots: estimate_shots,
+    let lowered = lower_pauli_observables(program)?;
+    let circuit = &lowered.circuit;
+    evaluate_observable_program(program, &lowered, |terms| {
+        let result =
+            run_spd_observable_light_cone(circuit, terms, QEC_SPD_EPSILON, QEC_SPD_MAX_TERMS)?;
+        Ok(ConditionalEval {
+            mean: result.mean,
+            discarded_sq: result.total_discarded * result.total_discarded,
         })
-        .collect();
-    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+    })
 }
 
 #[cfg(test)]

--- a/src/sim/compiled/accumulator.rs
+++ b/src/sim/compiled/accumulator.rs
@@ -23,6 +23,36 @@ pub fn default_chunk_size(num_meas: usize) -> usize {
     optimal_chunk_size(num_meas, DEFAULT_TARGET_BYTES)
 }
 
+pub(crate) fn for_each_chunk(
+    total_shots: usize,
+    chunk_size: usize,
+    mut sample_chunk: impl FnMut(usize),
+) {
+    let mut remaining = total_shots;
+    while remaining > 0 {
+        let batch = remaining.min(chunk_size);
+        sample_chunk(batch);
+        remaining -= batch;
+    }
+}
+
+pub(crate) fn counts_from_chunks(
+    sample_chunked: impl FnOnce(&mut HistogramAccumulator),
+) -> HashMap<Vec<u64>, u64> {
+    let mut acc = HistogramAccumulator::new();
+    sample_chunked(&mut acc);
+    acc.into_counts()
+}
+
+pub(crate) fn marginals_from_chunks(
+    num_measurements: usize,
+    sample_chunked: impl FnOnce(&mut MarginalsAccumulator),
+) -> Vec<f64> {
+    let mut acc = MarginalsAccumulator::new(num_measurements);
+    sample_chunked(&mut acc);
+    acc.marginals()
+}
+
 struct FxHasher {
     hash: u64,
 }

--- a/src/sim/compiled/mod.rs
+++ b/src/sim/compiled/mod.rs
@@ -25,6 +25,7 @@ pub use accumulator::{
     CorrelatorAccumulator, HistogramAccumulator, MarginalsAccumulator, NullAccumulator,
     PauliExpectationAccumulator, ShotAccumulator, default_chunk_size, optimal_chunk_size,
 };
+pub(crate) use accumulator::{counts_from_chunks, for_each_chunk, marginals_from_chunks};
 pub use parity::ParityStats;
 pub(crate) use parity::{ParityBlock, ParityBlocks, SparseParity, XorDag};
 use parity::{build_parity_blocks_if_useful, build_xor_dag_if_useful, minimize_flip_row_weight};
@@ -1073,13 +1074,10 @@ impl CompiledSampler {
         chunk_size: usize,
         acc: &mut A,
     ) {
-        let mut remaining = total_shots;
-        while remaining > 0 {
-            let this_batch = remaining.min(chunk_size);
-            let packed = self.sample_bulk_packed(this_batch);
+        for_each_chunk(total_shots, chunk_size, |batch| {
+            let packed = self.sample_bulk_packed(batch);
             acc.accumulate(&packed);
-            remaining -= this_batch;
-        }
+        });
     }
 
     pub fn sample_counts(
@@ -1123,9 +1121,7 @@ impl CompiledSampler {
                 return self.sample_counts_rank_space(total_shots);
             }
         }
-        let mut acc = HistogramAccumulator::new();
-        self.sample_chunked(total_shots, &mut acc);
-        acc.into_counts()
+        counts_from_chunks(|acc| self.sample_chunked(total_shots, acc))
     }
 
     fn sample_counts_multinomial(
@@ -1311,9 +1307,9 @@ impl CompiledSampler {
     }
 
     fn sample_marginals_cpu(&mut self, total_shots: usize) -> Vec<f64> {
-        let mut acc = MarginalsAccumulator::new(self.num_measurements);
-        self.sample_chunked(total_shots, &mut acc);
-        acc.marginals()
+        marginals_from_chunks(self.num_measurements, |acc| {
+            self.sample_chunked(total_shots, acc)
+        })
     }
 
     pub fn sample_detection_events(
@@ -1473,64 +1469,33 @@ impl CompiledSampler {
         }
         report
     }
-
-    pub fn detection_event_report(&self, pairs: &[(usize, usize)]) -> String {
-        let sparse = match &self.sparse {
-            Some(s) => s,
-            None => return "No sparse parity matrix available\n".to_string(),
-        };
-        let det_sparse = sparse.compile_detection_events(pairs);
-        let meas_stats = sparse.stats();
-        let det_stats = det_sparse.stats();
-
-        let mut report = format!(
-            "Detection events: {} pairs\n\
-             Measurement parity: total_weight={}, mean={:.2}\n\
-             Detection parity:   total_weight={}, mean={:.2}\n",
-            pairs.len(),
-            meas_stats.total_weight,
-            meas_stats.mean_weight,
-            det_stats.total_weight,
-            det_stats.mean_weight,
-        );
-
-        if meas_stats.total_weight > 0 {
-            let reduction = 1.0 - det_stats.total_weight as f64 / meas_stats.total_weight as f64;
-            report.push_str(&format!(
-                "Weight reduction: {:.1}% ({:.1}x less work)\n",
-                reduction * 100.0,
-                if det_stats.total_weight > 0 {
-                    meas_stats.total_weight as f64 / det_stats.total_weight as f64
-                } else {
-                    f64::INFINITY
-                },
-            ));
-        }
-
-        let mut histogram = [0usize; 8];
-        for m in 0..det_sparse.num_rows {
-            let w = det_sparse.row_weight(m);
-            histogram[w.min(7)] += 1;
-        }
-        report.push_str("Detection weight histogram: ");
-        for (i, &count) in histogram.iter().enumerate() {
-            if count > 0 {
-                if i < 7 {
-                    report.push_str(&format!("w{}={} ", i, count));
-                } else {
-                    report.push_str(&format!("w7+={} ", count));
-                }
-            }
-        }
-        report.push('\n');
-        report
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShotLayout {
     ShotMajor,
     MeasMajor,
+}
+
+/// XOR `mask` into every shot of a shot-major packed buffer.
+pub(crate) fn xor_mask_shot_major(
+    accum: &mut [u64],
+    num_shots: usize,
+    m_words: usize,
+    mask: &[u64],
+) {
+    #[cfg(feature = "parallel")]
+    if num_shots >= 256 {
+        use rayon::prelude::*;
+        accum[..num_shots * m_words]
+            .par_chunks_mut(m_words)
+            .for_each(|shot| xor_words(shot, mask));
+        return;
+    }
+    for s in 0..num_shots {
+        let base = s * m_words;
+        xor_words(&mut accum[base..base + m_words], mask);
+    }
 }
 
 #[inline]
@@ -3057,10 +3022,10 @@ pub fn compile_measurements(circuit: &Circuit, seed: u64) -> Result<CompiledSamp
 pub fn run_shots_compiled(circuit: &Circuit, num_shots: usize, seed: u64) -> Result<ShotsResult> {
     let mut sampler = compile_measurements(circuit, seed)?;
     let packed = sampler.sample_bulk_packed(num_shots);
-    Ok(ShotsResult {
-        shots: packed.to_shots(),
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(
+        packed.to_shots(),
+        circuit.num_classical_bits,
+    ))
 }
 
 /// Like [`run_shots_compiled`] but routes BTS sampling through the GPU when the
@@ -3078,8 +3043,8 @@ pub fn run_shots_compiled_with_gpu(
 ) -> Result<ShotsResult> {
     let mut sampler = compile_measurements(circuit, seed)?.with_gpu(context);
     let packed = sampler.sample_bulk_packed(num_shots);
-    Ok(ShotsResult {
-        shots: packed.to_shots(),
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(
+        packed.to_shots(),
+        circuit.num_classical_bits,
+    ))
 }

--- a/src/sim/homological.rs
+++ b/src/sim/homological.rs
@@ -721,20 +721,16 @@ impl HomologicalSampler {
 
     pub fn sample_chunked<A: ShotAccumulator>(&mut self, total_shots: usize, acc: &mut A) {
         let chunk_size = default_chunk_size(self.compiled.num_measurements());
-        let mut remaining = total_shots;
-        while remaining > 0 {
-            let batch = remaining.min(chunk_size);
+        crate::sim::compiled::for_each_chunk(total_shots, chunk_size, |batch| {
             let packed = self.sample_packed(batch);
             acc.accumulate(&packed);
-            remaining -= batch;
-        }
+        });
     }
 
     pub fn sample_marginals(&mut self, total_shots: usize) -> Vec<f64> {
-        let mut acc =
-            crate::sim::compiled::MarginalsAccumulator::new(self.compiled.num_measurements());
-        self.sample_chunked(total_shots, &mut acc);
-        acc.marginals()
+        crate::sim::compiled::marginals_from_chunks(self.compiled.num_measurements(), |acc| {
+            self.sample_chunked(total_shots, acc)
+        })
     }
 }
 
@@ -780,10 +776,7 @@ pub(crate) fn run_shots_homological_inner(
         shots.push(out);
     }
 
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 /// Compute exact noisy marginals analytically. No sampling, no rank limit.

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -24,9 +24,10 @@ use dispatch::{
     AUTO_APPROX_MAX_TERMS, AUTO_SPD_MAX_TERMS, BackendPlan, ExecutionPlan, Family,
     MAX_AUTO_T_COUNT_APPROX, MAX_AUTO_T_COUNT_EXACT, MAX_AUTO_T_COUNT_SHOTS,
     MAX_STABILIZER_RANK_QUBITS, MIN_BLOCK_FOR_FACTORED_STAB, MIN_FACTORED_STABILIZER_QUBITS,
-    MIN_QUBITS_FOR_SPD_AUTO, accel_for, auto_selects_cpu_statevector, build_statevector,
-    has_temporal_clifford_opportunity, plan_for_family, plan_temporal_clifford, resolve,
-    resolve_backend, run_temporal_clifford, stabilizer_rank_budget, validate_explicit_backend,
+    MIN_QUBITS_FOR_SPD_AUTO, TemporalCliffordPlan, accel_for, auto_selects_cpu_statevector,
+    build_statevector, has_temporal_clifford_opportunity, plan_for_family, plan_temporal_clifford,
+    resolve, resolve_backend, run_temporal_clifford, stabilizer_rank_budget,
+    validate_explicit_backend,
 };
 pub use probability::{FactoredBlock, Probabilities, ProbabilitiesIter};
 pub use shots::{ShotsResult, bitstring};
@@ -345,14 +346,8 @@ fn run_with_internal(
         let mut backend = resolve_backend(&kind, circuit, false).build(seed);
         return execute(&mut *backend, circuit, &opts);
     }
-    let (decompose, has_partial_independence) = analyze_independence(circuit);
-    if let Some(components) = decompose {
-        let max_block = components.iter().map(|c| c.len()).max().unwrap_or(0);
-        if kind.is_auto()
-            && circuit.is_clifford_only()
-            && circuit.num_qubits >= MIN_FACTORED_STABILIZER_QUBITS
-            && max_block >= MIN_BLOCK_FOR_FACTORED_STAB
-        {
+    match plan_probability_route(&kind, circuit) {
+        ProbabilityRoute::FactoredStabilizer => {
             let mut backend =
                 crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed);
             let fs_opts = if circuit.num_qubits > 64 {
@@ -362,59 +357,52 @@ fn run_with_internal(
             } else {
                 opts
             };
-            return execute(&mut backend, circuit, &fs_opts);
+            execute(&mut backend, circuit, &fs_opts)
         }
-        return run_decomposed(&kind, &components, circuit, seed, &opts);
-    }
-    if kind.is_auto() && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS {
-        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
-            if t <= MAX_AUTO_T_COUNT_APPROX
-                && t <= sr_budget
-                && !has_nonunitary_or_classical_ops(circuit)
-            {
-                let sr = if t <= MAX_AUTO_T_COUNT_EXACT {
-                    stabilizer_rank::run_stabilizer_rank(circuit, seed)?
-                } else {
-                    stabilizer_rank::run_stabilizer_rank_approx(
-                        circuit,
-                        AUTO_APPROX_MAX_TERMS,
-                        seed,
-                    )?
-                };
-                return Ok(probs_only_result(sr.probabilities));
-            }
+        ProbabilityRoute::Decomposed(components) => {
+            run_decomposed(&kind, &components, circuit, seed, &opts)
         }
-    }
-    if let Some(tc) = plan_temporal_clifford(&kind, circuit) {
-        return run_temporal_clifford(&tc, seed, opts.probabilities);
-    }
-    match resolve(&kind, circuit, has_partial_independence) {
-        ExecutionPlan::Backend(plan) => {
-            let mut backend = plan.build(seed);
-            execute(&mut *backend, circuit, &opts)
-        }
-        ExecutionPlan::StabilizerRank => {
-            let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
+        ProbabilityRoute::StabilizerRank { t_count } => {
+            let sr = if t_count <= MAX_AUTO_T_COUNT_EXACT {
+                stabilizer_rank::run_stabilizer_rank(circuit, seed)?
+            } else {
+                stabilizer_rank::run_stabilizer_rank_approx(circuit, AUTO_APPROX_MAX_TERMS, seed)?
+            };
             Ok(probs_only_result(sr.probabilities))
         }
-        ExecutionPlan::StochasticPauli { num_samples } => {
-            Err(crate::error::PrismError::IncompatibleBackend {
-                backend: format!(
-                    "{:?}",
-                    BackendKind::StochasticPauli { num_samples }
-                ),
-                reason: "StochasticPauli produces marginal estimates only; use `simulate(...).marginals()`".into(),
-            })
+        ProbabilityRoute::TemporalClifford(tc) => {
+            run_temporal_clifford(&tc, seed, opts.probabilities)
         }
-        ExecutionPlan::DeterministicPauli { epsilon, max_terms } => {
-            Err(crate::error::PrismError::IncompatibleBackend {
-                backend: format!(
-                    "{:?}",
-                    BackendKind::DeterministicPauli { epsilon, max_terms }
-                ),
-                reason: "DeterministicPauli produces marginals only; use `simulate(...).marginals()`".into(),
-            })
-        }
+        ProbabilityRoute::Direct {
+            has_partial_independence,
+        } => match resolve(&kind, circuit, has_partial_independence) {
+            ExecutionPlan::Backend(plan) => {
+                let mut backend = plan.build(seed);
+                execute(&mut *backend, circuit, &opts)
+            }
+            ExecutionPlan::StabilizerRank => {
+                let sr = stabilizer_rank::run_stabilizer_rank(circuit, seed)?;
+                Ok(probs_only_result(sr.probabilities))
+            }
+            ExecutionPlan::StochasticPauli { num_samples } => {
+                Err(crate::error::PrismError::IncompatibleBackend {
+                    backend: format!(
+                        "{:?}",
+                        BackendKind::StochasticPauli { num_samples }
+                    ),
+                    reason: "StochasticPauli produces marginal estimates only; use `simulate(...).marginals()`".into(),
+                })
+            }
+            ExecutionPlan::DeterministicPauli { epsilon, max_terms } => {
+                Err(crate::error::PrismError::IncompatibleBackend {
+                    backend: format!(
+                        "{:?}",
+                        BackendKind::DeterministicPauli { epsilon, max_terms }
+                    ),
+                    reason: "DeterministicPauli produces marginals only; use `simulate(...).marginals()`".into(),
+                })
+            }
+        },
     }
 }
 
@@ -539,29 +527,66 @@ fn auto_clifford_t_budget(circuit: &Circuit) -> Option<(usize, usize)> {
     })
 }
 
-/// Mirrors the routing precedence of `run_with_internal` (decomposition, then
-/// Clifford+T stabilizer rank, then temporal Clifford, then family choice)
-/// through the shared predicates. Keep the check order aligned when either
-/// side changes.
-fn auto_terminal_statevector_candidate(circuit: &Circuit) -> bool {
+/// Auto-dispatch gate for the Clifford+T stabilizer-rank shortcut: the T
+/// count must fit both the caller's ceiling and the size-derived
+/// stabilizer-rank budget. Returns the T count when the shortcut applies.
+fn auto_stabilizer_rank_t_count(circuit: &Circuit, max_t: usize) -> Option<usize> {
+    let (t, sr_budget) = auto_clifford_t_budget(circuit)?;
+    (t <= max_t && t <= sr_budget).then_some(t)
+}
+
+/// Routing precedence for the probability path: decomposition (with the
+/// large sparse-Clifford factored-stabilizer override), then the Clifford+T
+/// stabilizer-rank shortcut, then temporal Clifford, then direct family
+/// resolution. `run_with_internal` executes this plan and
+/// `auto_terminal_statevector_candidate` consults it, so the two cannot
+/// drift apart.
+enum ProbabilityRoute {
+    FactoredStabilizer,
+    Decomposed(Vec<Vec<usize>>),
+    StabilizerRank { t_count: usize },
+    TemporalClifford(TemporalCliffordPlan),
+    Direct { has_partial_independence: bool },
+}
+
+fn plan_probability_route(kind: &BackendKind, circuit: &Circuit) -> ProbabilityRoute {
     let (decompose, has_partial_independence) = analyze_independence(circuit);
-    if decompose.is_some() {
-        return false;
+    if let Some(components) = decompose {
+        let max_block = components.iter().map(|c| c.len()).max().unwrap_or(0);
+        if kind.is_auto()
+            && circuit.is_clifford_only()
+            && circuit.num_qubits >= MIN_FACTORED_STABILIZER_QUBITS
+            && max_block >= MIN_BLOCK_FOR_FACTORED_STAB
+        {
+            return ProbabilityRoute::FactoredStabilizer;
+        }
+        return ProbabilityRoute::Decomposed(components);
     }
-
-    if !auto_selects_cpu_statevector(circuit, has_partial_independence) {
-        return false;
-    }
-
-    if circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS {
-        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
-            if t <= MAX_AUTO_T_COUNT_APPROX && t <= sr_budget {
-                return false;
-            }
+    if kind.is_auto()
+        && circuit.num_qubits <= MAX_STABILIZER_RANK_QUBITS
+        && !has_nonunitary_or_classical_ops(circuit)
+    {
+        if let Some(t_count) = auto_stabilizer_rank_t_count(circuit, MAX_AUTO_T_COUNT_APPROX) {
+            return ProbabilityRoute::StabilizerRank { t_count };
         }
     }
+    if let Some(tc) = plan_temporal_clifford(kind, circuit) {
+        return ProbabilityRoute::TemporalClifford(tc);
+    }
+    ProbabilityRoute::Direct {
+        has_partial_independence,
+    }
+}
 
-    !has_temporal_clifford_opportunity(&BackendKind::Auto, circuit)
+/// True when the auto probability route falls through to direct family
+/// resolution and that resolver picks the CPU statevector.
+fn auto_terminal_statevector_candidate(circuit: &Circuit) -> bool {
+    match plan_probability_route(&BackendKind::Auto, circuit) {
+        ProbabilityRoute::Direct {
+            has_partial_independence,
+        } => auto_selects_cpu_statevector(circuit, has_partial_independence),
+        _ => false,
+    }
 }
 
 fn terminal_statevector_candidate(kind: &BackendKind, circuit: &Circuit) -> bool {
@@ -692,7 +717,7 @@ fn run_marginals_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result
     run_marginals_result_with(kind, circuit, seed).map(MarginalsResult::into_vec)
 }
 
-fn expectations_to_marginals(expectations: &[f64]) -> Vec<(f64, f64)> {
+pub(crate) fn expectations_to_marginals(expectations: &[f64]) -> Vec<(f64, f64)> {
     expectations
         .iter()
         .map(|ez| {
@@ -1014,10 +1039,10 @@ fn run_shots_distributed(
         // errors instead of fabricated output.
         let mut backend = DistributedStatevectorBackend::new(context, seed);
         backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
-        return Ok(ShotsResult {
-            shots: vec![vec![false; circuit.num_classical_bits]; num_shots],
-            num_classical_bits: circuit.num_classical_bits,
-        });
+        return Ok(ShotsResult::from_shots(
+            vec![vec![false; circuit.num_classical_bits]; num_shots],
+            circuit.num_classical_bits,
+        ));
     }
 
     if circuit.has_terminal_measurements_only() {
@@ -1035,10 +1060,7 @@ fn run_shots_distributed(
                 shot
             })
             .collect();
-        return Ok(ShotsResult {
-            shots,
-            num_classical_bits: circuit.num_classical_bits,
-        });
+        return Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits));
     }
 
     let probe = DistributedStatevectorBackend::new(context.clone(), seed);
@@ -1056,10 +1078,7 @@ fn run_shots_distributed(
         let result = execute_circuit(&mut backend, &fused, &opts)?;
         shots.push(result.classical_bits);
     }
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 /// Execute a circuit multiple times with explicit backend selection.
@@ -1087,10 +1106,10 @@ pub(crate) fn run_shots_with(
         let mut sampler = compile_measurements_for_kind(&kind, circuit, seed)?;
         let packed = sampler.try_sample_bulk_packed(num_shots)?;
         let meas_map = circuit.measurement_map();
-        return Ok(ShotsResult {
-            shots: packed_shots_to_classical_bits(&packed, &meas_map, circuit.num_classical_bits),
-            num_classical_bits: circuit.num_classical_bits,
-        });
+        return Ok(ShotsResult::from_shots(
+            packed_shots_to_classical_bits(&packed, &meas_map, circuit.num_classical_bits),
+            circuit.num_classical_bits,
+        ));
     }
 
     if should_use_deferred_clifford_sampling(&kind, circuit, num_shots) {
@@ -1098,14 +1117,10 @@ pub(crate) fn run_shots_with(
             let mut sampler = compile_measurements_for_kind(&kind, &deferred, seed)?;
             let packed = sampler.try_sample_bulk_packed(num_shots)?;
             let meas_map = deferred.measurement_map();
-            return Ok(ShotsResult {
-                shots: packed_shots_to_classical_bits(
-                    &packed,
-                    &meas_map,
-                    circuit.num_classical_bits,
-                ),
-                num_classical_bits: circuit.num_classical_bits,
-            });
+            return Ok(ShotsResult::from_shots(
+                packed_shots_to_classical_bits(&packed, &meas_map, circuit.num_classical_bits),
+                circuit.num_classical_bits,
+            ));
         }
     }
 
@@ -1129,10 +1144,7 @@ pub(crate) fn run_shots_with(
                 seed,
             )
         };
-        return Ok(ShotsResult {
-            shots,
-            num_classical_bits: circuit.num_classical_bits,
-        });
+        return Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits));
     }
 
     if matches!(kind, BackendKind::StabilizerRank) && circuit.has_t_gates() {
@@ -1141,12 +1153,9 @@ pub(crate) fn run_shots_with(
     if kind.is_auto()
         && circuit.has_terminal_measurements_only()
         && circuit.num_qubits > MAX_STABILIZER_RANK_QUBITS
+        && auto_stabilizer_rank_t_count(circuit, MAX_AUTO_T_COUNT_SHOTS).is_some()
     {
-        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
-            if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
-                return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
-            }
-        }
+        return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
     }
 
     if circuit.has_terminal_measurements_only() {
@@ -1161,10 +1170,7 @@ pub(crate) fn run_shots_with(
                 num_shots,
                 seed,
             );
-            return Ok(ShotsResult {
-                shots,
-                num_classical_bits: circuit.num_classical_bits,
-            });
+            return Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits));
         }
     }
 
@@ -1188,12 +1194,8 @@ pub(crate) fn run_shots_with(
             reason: "Pauli propagation backends do not support mid-circuit measurements".into(),
         });
     }
-    if kind.is_auto() {
-        if let Some((t, sr_budget)) = auto_clifford_t_budget(circuit) {
-            if t <= MAX_AUTO_T_COUNT_SHOTS && t <= sr_budget {
-                return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
-            }
-        }
+    if kind.is_auto() && auto_stabilizer_rank_t_count(circuit, MAX_AUTO_T_COUNT_SHOTS).is_some() {
+        return stabilizer_rank::run_stabilizer_rank_shots(circuit, num_shots, seed);
     }
 
     if has_temporal_clifford_opportunity(&kind, circuit) {
@@ -1267,10 +1269,7 @@ fn collect_shots(
     for i in 0..num_shots {
         shots.push(shot(seed.wrapping_add(i as u64))?);
     }
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 /// Family choice for auto-routed non-Pauli noise trajectories. Restricted to
@@ -1429,6 +1428,51 @@ mod tests {
         c.add_gate(Gate::Cx, &[1, 2]);
         c.add_gate(Gate::S, &[0]);
         c
+    }
+
+    /// The probability-route planner is the single source of the auto routing
+    /// precedence; every entry point (run, shots, counts via the terminal
+    /// candidate) consults it. Pin the route for representative circuits so a
+    /// precedence change is a deliberate edit here, not silent drift.
+    #[test]
+    fn probability_route_precedence_is_pinned() {
+        let ghz = make_clifford_circuit();
+        assert!(matches!(
+            plan_probability_route(&BackendKind::Auto, &ghz),
+            ProbabilityRoute::Direct { .. }
+        ));
+
+        let mut clifford_t = Circuit::new(16, 0);
+        clifford_t.add_gate(Gate::H, &[0]);
+        for i in 0..15 {
+            clifford_t.add_gate(Gate::Cx, &[i, i + 1]);
+        }
+        clifford_t.add_gate(Gate::T, &[1]);
+        assert!(matches!(
+            plan_probability_route(&BackendKind::Auto, &clifford_t),
+            ProbabilityRoute::StabilizerRank { t_count: 1 }
+        ));
+
+        let mut general = Circuit::new(4, 0);
+        general.add_gate(Gate::H, &[0]);
+        general.add_gate(Gate::Rx(0.3), &[1]);
+        general.add_gate(Gate::Cx, &[0, 1]);
+        assert!(matches!(
+            plan_probability_route(&BackendKind::Auto, &general),
+            ProbabilityRoute::Direct { .. }
+        ));
+
+        let candidate_is_direct = |c: &Circuit| {
+            matches!(
+                plan_probability_route(&BackendKind::Auto, c),
+                ProbabilityRoute::Direct { .. }
+            )
+        };
+        for circuit in [&ghz, &clifford_t, &general] {
+            if auto_terminal_statevector_candidate(circuit) {
+                assert!(candidate_is_direct(circuit));
+            }
+        }
     }
 
     fn make_product_circuit() -> Circuit {
@@ -2373,11 +2417,7 @@ mod tests {
         let probs = reference.probabilities.unwrap();
         let expected_shots =
             shots::sample_shots(&probs, &c.measurement_map(), c.num_classical_bits, 512, 7);
-        let expected = ShotsResult {
-            shots: expected_shots,
-            num_classical_bits: c.num_classical_bits,
-        }
-        .counts();
+        let expected = ShotsResult::from_shots(expected_shots, c.num_classical_bits).counts();
 
         let actual = run_counts_with(BackendKind::Statevector, &c, 512, 7).unwrap();
         assert_eq!(actual, expected);

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -1282,16 +1282,13 @@ impl NoisyCompiledSampler {
                 .noiseless
                 .should_use_gpu_bts(total_shots.min(chunk_size.max(1)))
         {
-            let mut remaining = total_shots;
-            while remaining > 0 {
-                let this_batch = remaining.min(chunk_size);
+            crate::sim::compiled::for_each_chunk(total_shots, chunk_size, |this_batch| {
                 let packed = match self.try_sample_bulk_packed_with_gpu_context(this_batch) {
                     Ok(packed) => packed,
                     Err(_) => self.sample_bulk_packed_cpu(this_batch),
                 };
                 acc.accumulate(&packed);
-                remaining -= this_batch;
-            }
+            });
             return;
         }
 
@@ -1299,9 +1296,7 @@ impl NoisyCompiledSampler {
         let mut accum_buf: Vec<u64> = Vec::new();
         let mut rand_buf: Vec<u8> = Vec::new();
         let ref_bits_packed = self.noiseless.ref_bits_packed().to_vec();
-        let mut remaining = total_shots;
-        while remaining > 0 {
-            let this_batch = remaining.min(chunk_size);
+        crate::sim::compiled::for_each_chunk(total_shots, chunk_size, |this_batch| {
             self.noiseless.sample_bulk_words_shot_major_reuse(
                 &mut accum_buf,
                 &mut rand_buf,
@@ -1310,37 +1305,18 @@ impl NoisyCompiledSampler {
 
             self.apply_noise_bulk(&mut accum_buf, this_batch, m_words);
 
-            #[cfg(feature = "parallel")]
-            if this_batch >= 256 {
-                use rayon::prelude::*;
-                accum_buf[..this_batch * m_words]
-                    .par_chunks_mut(m_words)
-                    .for_each(|shot| xor_words(shot, &ref_bits_packed));
-            } else {
-                for s in 0..this_batch {
-                    let shot_base = s * m_words;
-                    xor_words(
-                        &mut accum_buf[shot_base..shot_base + m_words],
-                        &ref_bits_packed,
-                    );
-                }
-            }
-
-            #[cfg(not(feature = "parallel"))]
-            for s in 0..this_batch {
-                let shot_base = s * m_words;
-                xor_words(
-                    &mut accum_buf[shot_base..shot_base + m_words],
-                    &ref_bits_packed,
-                );
-            }
+            crate::sim::compiled::xor_mask_shot_major(
+                &mut accum_buf,
+                this_batch,
+                m_words,
+                &ref_bits_packed,
+            );
 
             let data = std::mem::take(&mut accum_buf);
             let packed = PackedShots::from_shot_major(data, this_batch, self.num_measurements);
             acc.accumulate(&packed);
             accum_buf = packed.into_data();
-            remaining -= this_batch;
-        }
+        });
     }
 
     /// Sample noisy outcomes and return exact packed counts.
@@ -1370,9 +1346,7 @@ impl NoisyCompiledSampler {
         &mut self,
         total_shots: usize,
     ) -> std::collections::HashMap<Vec<u64>, u64> {
-        let mut acc = crate::sim::compiled::HistogramAccumulator::new();
-        self.sample_chunked(total_shots, &mut acc);
-        acc.into_counts()
+        crate::sim::compiled::counts_from_chunks(|acc| self.sample_chunked(total_shots, acc))
     }
 
     /// Sample noisy outcomes and return per-measurement `P(bit = 1)`.
@@ -1393,9 +1367,9 @@ impl NoisyCompiledSampler {
     }
 
     fn sample_marginals_cpu(&mut self, total_shots: usize) -> Vec<f64> {
-        let mut acc = crate::sim::compiled::MarginalsAccumulator::new(self.num_measurements);
-        self.sample_chunked(total_shots, &mut acc);
-        acc.marginals()
+        crate::sim::compiled::marginals_from_chunks(self.num_measurements, |acc| {
+            self.sample_chunked(total_shots, acc)
+        })
     }
 
     #[cfg(test)]
@@ -2141,10 +2115,7 @@ fn run_shots_noisy_frame(
         num_classical,
     );
 
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 /// Sample a Pauli-noisy Clifford circuit through the compiled noisy sampler,
@@ -2229,10 +2200,7 @@ fn finish_noisy_compiled_run(
     let packed = sampler.try_sample_bulk_packed(num_shots)?;
     let shots = unpack_and_remap_packed(&packed, num_shots, &classical_bit_order, num_classical);
 
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 fn run_shots_noisy_compiled(
@@ -2347,10 +2315,7 @@ pub(crate) fn run_shots_noisy_brute_with(
         shots.push(backend.classical_results().to_vec());
     }
 
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 #[cfg(test)]

--- a/src/sim/shots.rs
+++ b/src/sim/shots.rs
@@ -17,6 +17,13 @@ pub struct ShotsResult {
 }
 
 impl ShotsResult {
+    pub(crate) fn from_shots(shots: Vec<Vec<bool>>, num_classical_bits: usize) -> Self {
+        Self {
+            shots,
+            num_classical_bits,
+        }
+    }
+
     /// Build a frequency histogram of measurement outcomes.
     ///
     /// Keys are packed `Vec<u64>` where bit `i` of word `i/64` corresponds

--- a/src/sim/stabilizer_rank.rs
+++ b/src/sim/stabilizer_rank.rs
@@ -337,26 +337,7 @@ const MIN_TERMS_FOR_PAR: usize = 16;
 /// via T = α·I + β·Z decomposition. n ≤ 25, total terms ≤ 2²⁰.
 pub fn run_stabilizer_rank(circuit: &Circuit, seed: u64) -> Result<StabRankResult> {
     let n = circuit.num_qubits;
-    let nc = circuit.num_classical_bits;
-
-    if n > MAX_STATEVECTOR_QUBITS {
-        return Err(PrismError::BackendUnsupported {
-            backend: "stabilizer_rank".into(),
-            operation: format!(
-                "exact probabilities for {} qubits (max {})",
-                n, MAX_STATEVECTOR_QUBITS
-            ),
-        });
-    }
-    validate_stabilizer_rank_circuit(circuit)?;
-
-    let mut backend = StabilizerBackend::new(seed);
-    backend.init(n, nc)?;
-
-    let mut branches: Vec<WeightedBranch> = vec![WeightedBranch {
-        weight: Complex64::new(1.0, 0.0),
-        offset: SignedPauli::identity(n),
-    }];
+    let (mut backend, mut branches) = stabilizer_rank_setup(circuit, seed)?;
 
     let mut t_count = 0usize;
 
@@ -388,6 +369,33 @@ pub fn run_stabilizer_rank(circuit: &Circuit, seed: u64) -> Result<StabRankResul
         t_count,
         pruned_count: 0,
     })
+}
+
+/// Shared entry validation and initial state for the exact and approximate runners.
+fn stabilizer_rank_setup(
+    circuit: &Circuit,
+    seed: u64,
+) -> Result<(StabilizerBackend, Vec<WeightedBranch>)> {
+    let n = circuit.num_qubits;
+    if n > MAX_STATEVECTOR_QUBITS {
+        return Err(PrismError::BackendUnsupported {
+            backend: "stabilizer_rank".into(),
+            operation: format!(
+                "exact probabilities for {} qubits (max {})",
+                n, MAX_STATEVECTOR_QUBITS
+            ),
+        });
+    }
+    validate_stabilizer_rank_circuit(circuit)?;
+
+    let mut backend = StabilizerBackend::new(seed);
+    backend.init(n, circuit.num_classical_bits)?;
+
+    let branches = vec![WeightedBranch {
+        weight: Complex64::new(1.0, 0.0),
+        offset: SignedPauli::identity(n),
+    }];
+    Ok((backend, branches))
 }
 
 fn conjugate_all(branches: &mut [WeightedBranch], gate: &Gate, targets: &[usize]) -> Result<()> {
@@ -471,26 +479,7 @@ fn expand_t(branches: &mut Vec<WeightedBranch>, qubit: usize, is_dagger: bool) -
         });
     }
 
-    let (alpha, beta) = if is_dagger {
-        tdg_coefficients()
-    } else {
-        t_coefficients()
-    };
-
-    let orig_len = branches.len();
-    let mut new_branches = Vec::with_capacity(orig_len);
-
-    for b in branches.iter_mut() {
-        let mut z_offset = b.offset.clone();
-        z_offset.mul_z_on_left(qubit);
-        new_branches.push(WeightedBranch {
-            weight: b.weight * beta,
-            offset: z_offset,
-        });
-        b.weight *= alpha;
-    }
-
-    branches.extend(new_branches);
+    expand_t_unbounded(branches, qubit, is_dagger);
     Ok(())
 }
 
@@ -505,29 +494,10 @@ pub fn run_stabilizer_rank_approx(
     seed: u64,
 ) -> Result<StabRankResult> {
     let n = circuit.num_qubits;
-    let nc = circuit.num_classical_bits;
-
-    if n > MAX_STATEVECTOR_QUBITS {
-        return Err(PrismError::BackendUnsupported {
-            backend: "stabilizer_rank".into(),
-            operation: format!(
-                "exact probabilities for {} qubits (max {})",
-                n, MAX_STATEVECTOR_QUBITS
-            ),
-        });
-    }
-    validate_stabilizer_rank_circuit(circuit)?;
+    let (mut backend, mut branches) = stabilizer_rank_setup(circuit, seed)?;
 
     let max_terms = max_terms.max(2);
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-
-    let mut backend = StabilizerBackend::new(seed);
-    backend.init(n, nc)?;
-
-    let mut branches: Vec<WeightedBranch> = vec![WeightedBranch {
-        weight: Complex64::new(1.0, 0.0),
-        offset: SignedPauli::identity(n),
-    }];
 
     let mut t_count = 0usize;
     let mut pruned_total = 0usize;
@@ -1032,10 +1002,10 @@ fn sample_terminal_mps_branches(
         }
         shots.push(classical_bits);
     }
-    Ok(super::ShotsResult {
+    Ok(super::ShotsResult::from_shots(
         shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+        circuit.num_classical_bits,
+    ))
 }
 
 fn sample_mps_branches_online(
@@ -1054,10 +1024,10 @@ fn sample_mps_branches_online(
         }
         shots.push(classical_bits);
     }
-    Ok(super::ShotsResult {
+    Ok(super::ShotsResult::from_shots(
         shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+        circuit.num_classical_bits,
+    ))
 }
 
 /// Shot sampling on a Clifford+T circuit.

--- a/src/sim/terminal_sampling.rs
+++ b/src/sim/terminal_sampling.rs
@@ -153,9 +153,9 @@ fn extract_masked_bits(index: usize, mask: u64) -> usize {
     result
 }
 
-fn build_state_outcome_distribution(
-    state: &[Complex64],
-    norm_sq: f64,
+fn build_outcome_distribution<T: Sync>(
+    items: &[T],
+    weight: impl Fn(&T) -> f64 + Send + Sync,
     map: &CompactMeasurementMap,
     max_dense_bits: usize,
 ) -> Option<Vec<f64>> {
@@ -167,27 +167,27 @@ fn build_state_outcome_distribution(
 
     #[cfg(feature = "parallel")]
     {
-        if map.direct_state_key(state.len()) {
+        if map.direct_state_key(items.len()) {
             let mut probs = vec![0.0f64; outcomes];
             probs
                 .par_iter_mut()
-                .zip(state.par_iter())
-                .for_each(|(p, amp)| {
-                    *p = amp.norm_sqr() * norm_sq;
+                .zip(items.par_iter())
+                .for_each(|(p, item)| {
+                    *p = weight(item);
                 });
             return Some(probs);
         }
 
-        if state.len() >= crate::backend::MIN_PAR_ELEMS && outcomes <= (1usize << 16) {
-            let probs = state
+        if items.len() >= crate::backend::MIN_PAR_ELEMS && outcomes <= (1usize << 16) {
+            let probs = items
                 .par_chunks(crate::backend::MIN_PAR_ELEMS)
                 .enumerate()
                 .map(|(chunk_idx, chunk)| {
                     let mut local = vec![0.0f64; outcomes];
                     let base = chunk_idx * crate::backend::MIN_PAR_ELEMS;
-                    for (offset, amp) in chunk.iter().enumerate() {
+                    for (offset, item) in chunk.iter().enumerate() {
                         let key = map.compact_key(base + offset);
-                        local[key] += amp.norm_sqr() * norm_sq;
+                        local[key] += weight(item);
                     }
                     local
                 })
@@ -205,14 +205,14 @@ fn build_state_outcome_distribution(
     }
 
     let mut probs = vec![0.0f64; outcomes];
-    if map.direct_state_key(state.len()) {
-        for (idx, amp) in state.iter().enumerate() {
-            probs[idx] = amp.norm_sqr() * norm_sq;
+    if map.direct_state_key(items.len()) {
+        for (idx, item) in items.iter().enumerate() {
+            probs[idx] = weight(item);
         }
     } else {
-        for (idx, amp) in state.iter().enumerate() {
+        for (idx, item) in items.iter().enumerate() {
             let key = map.compact_key(idx);
-            probs[key] += amp.norm_sqr() * norm_sq;
+            probs[key] += weight(item);
         }
     }
     Some(probs)
@@ -284,9 +284,9 @@ fn sorted_thresholds(num_shots: usize, seed: u64) -> Vec<(f64, usize)> {
     thresholds
 }
 
-fn sample_shots_streaming_from_state(
-    state: &[Complex64],
-    norm_sq: f64,
+fn streaming_shots<T>(
+    items: &[T],
+    weight: impl Fn(&T) -> f64,
     map: &CompactMeasurementMap,
     num_classical_bits: usize,
     num_shots: usize,
@@ -297,8 +297,8 @@ fn sample_shots_streaming_from_state(
     let mut cumulative = 0.0f64;
     let mut next = 0usize;
 
-    for (state_idx, amp) in state.iter().enumerate() {
-        cumulative += amp.norm_sqr() * norm_sq;
+    for (state_idx, item) in items.iter().enumerate() {
+        cumulative += weight(item);
         while next < thresholds.len() && thresholds[next].0 <= cumulative {
             let shot_idx = thresholds[next].1;
             map.fill_shot_from_state_index(state_idx, &mut shots[shot_idx]);
@@ -306,7 +306,7 @@ fn sample_shots_streaming_from_state(
         }
     }
 
-    let fallback_idx = state.len().saturating_sub(1);
+    let fallback_idx = items.len().saturating_sub(1);
     while next < thresholds.len() {
         let shot_idx = thresholds[next].1;
         map.fill_shot_from_state_index(fallback_idx, &mut shots[shot_idx]);
@@ -316,9 +316,9 @@ fn sample_shots_streaming_from_state(
     shots
 }
 
-fn sample_counts_streaming_from_state(
-    state: &[Complex64],
-    norm_sq: f64,
+fn streaming_counts<T>(
+    items: &[T],
+    weight: impl Fn(&T) -> f64,
     map: &CompactMeasurementMap,
     num_classical_bits: usize,
     num_shots: usize,
@@ -326,12 +326,12 @@ fn sample_counts_streaming_from_state(
 ) -> HashMap<Vec<u64>, u64> {
     let thresholds = sorted_thresholds(num_shots, seed);
     let m_words = num_classical_bits.div_ceil(64).max(1);
-    let mut counts = HashMap::with_capacity(num_shots.min(state.len()));
+    let mut counts = HashMap::with_capacity(num_shots.min(items.len()));
     let mut cumulative = 0.0f64;
     let mut next = 0usize;
 
-    for (state_idx, amp) in state.iter().enumerate() {
-        cumulative += amp.norm_sqr() * norm_sq;
+    for (state_idx, item) in items.iter().enumerate() {
+        cumulative += weight(item);
         let start = next;
         while next < thresholds.len() && thresholds[next].0 <= cumulative {
             next += 1;
@@ -343,118 +343,7 @@ fn sample_counts_streaming_from_state(
         }
     }
 
-    let fallback_idx = state.len().saturating_sub(1);
-    let fallback_hits = thresholds.len() - next;
-    if fallback_hits != 0 {
-        let packed = map.packed_key_from_state_index(fallback_idx, m_words);
-        *counts.entry(packed).or_insert(0) += fallback_hits as u64;
-    }
-
-    counts
-}
-
-fn build_probs_outcome_distribution(
-    probs: &[f64],
-    map: &CompactMeasurementMap,
-    max_dense_bits: usize,
-) -> Option<Vec<f64>> {
-    if map.num_bits() > max_dense_bits {
-        return None;
-    }
-
-    let outcomes = 1usize << map.num_bits();
-
-    #[cfg(feature = "parallel")]
-    if probs.len() >= crate::backend::MIN_PAR_ELEMS && outcomes <= (1usize << 16) {
-        let out = probs
-            .par_chunks(crate::backend::MIN_PAR_ELEMS)
-            .enumerate()
-            .map(|(chunk_idx, chunk)| {
-                let mut local = vec![0.0f64; outcomes];
-                let base = chunk_idx * crate::backend::MIN_PAR_ELEMS;
-                for (offset, &p) in chunk.iter().enumerate() {
-                    let key = map.compact_key(base + offset);
-                    local[key] += p;
-                }
-                local
-            })
-            .reduce(
-                || vec![0.0f64; outcomes],
-                |mut a, b| {
-                    for (dst, src) in a.iter_mut().zip(b) {
-                        *dst += src;
-                    }
-                    a
-                },
-            );
-        return Some(out);
-    }
-
-    let mut out = vec![0.0f64; outcomes];
-    for (idx, &p) in probs.iter().enumerate() {
-        out[map.compact_key(idx)] += p;
-    }
-    Some(out)
-}
-
-fn sample_shots_streaming_from_probs(
-    probs: &[f64],
-    map: &CompactMeasurementMap,
-    num_classical_bits: usize,
-    num_shots: usize,
-    seed: u64,
-) -> Vec<Vec<bool>> {
-    let thresholds = sorted_thresholds(num_shots, seed);
-    let mut shots = vec![vec![false; num_classical_bits]; num_shots];
-    let mut cumulative = 0.0f64;
-    let mut next = 0usize;
-
-    for (state_idx, &p) in probs.iter().enumerate() {
-        cumulative += p;
-        while next < thresholds.len() && thresholds[next].0 <= cumulative {
-            let shot_idx = thresholds[next].1;
-            map.fill_shot_from_state_index(state_idx, &mut shots[shot_idx]);
-            next += 1;
-        }
-    }
-
-    let fallback_idx = probs.len().saturating_sub(1);
-    while next < thresholds.len() {
-        let shot_idx = thresholds[next].1;
-        map.fill_shot_from_state_index(fallback_idx, &mut shots[shot_idx]);
-        next += 1;
-    }
-
-    shots
-}
-
-fn sample_counts_streaming_from_probs(
-    probs: &[f64],
-    map: &CompactMeasurementMap,
-    num_classical_bits: usize,
-    num_shots: usize,
-    seed: u64,
-) -> HashMap<Vec<u64>, u64> {
-    let thresholds = sorted_thresholds(num_shots, seed);
-    let m_words = num_classical_bits.div_ceil(64).max(1);
-    let mut counts = HashMap::with_capacity(num_shots.min(probs.len()));
-    let mut cumulative = 0.0f64;
-    let mut next = 0usize;
-
-    for (state_idx, &p) in probs.iter().enumerate() {
-        cumulative += p;
-        let start = next;
-        while next < thresholds.len() && thresholds[next].0 <= cumulative {
-            next += 1;
-        }
-        let hits = next - start;
-        if hits != 0 {
-            let packed = map.packed_key_from_state_index(state_idx, m_words);
-            *counts.entry(packed).or_insert(0) += hits as u64;
-        }
-    }
-
-    let fallback_idx = probs.len().saturating_sub(1);
+    let fallback_idx = items.len().saturating_sub(1);
     let fallback_hits = thresholds.len() - next;
     if fallback_hits != 0 {
         let packed = map.packed_key_from_state_index(fallback_idx, m_words);
@@ -480,7 +369,7 @@ pub(super) fn sample_shots_from_probs(
         return vec![vec![false; num_classical_bits]; num_shots];
     }
 
-    sample_shots_streaming_from_probs(probs, &map, num_classical_bits, num_shots, seed)
+    streaming_shots(probs, |&p| p, &map, num_classical_bits, num_shots, seed)
 }
 
 pub(super) fn sample_counts_from_probs(
@@ -536,10 +425,10 @@ fn sample_counts_from_probs_capped(
         );
     }
 
-    if let Some(outcome) = build_probs_outcome_distribution(probs, &map, max_dense_bits) {
+    if let Some(outcome) = build_outcome_distribution(probs, |&p| p, &map, max_dense_bits) {
         sample_counts_from_outcome_distribution(&outcome, &map, num_classical_bits, num_shots, seed)
     } else {
-        sample_counts_streaming_from_probs(probs, &map, num_classical_bits, num_shots, seed)
+        streaming_counts(probs, |&p| p, &map, num_classical_bits, num_shots, seed)
     }
 }
 
@@ -560,7 +449,14 @@ pub(super) fn sample_shots_from_state(
         return vec![vec![false; num_classical_bits]; num_shots];
     }
 
-    sample_shots_streaming_from_state(state, norm_sq, &map, num_classical_bits, num_shots, seed)
+    streaming_shots(
+        state,
+        |amp| amp.norm_sqr() * norm_sq,
+        &map,
+        num_classical_bits,
+        num_shots,
+        seed,
+    )
 }
 
 pub(super) fn sample_counts_from_state(
@@ -589,17 +485,17 @@ pub(super) fn sample_counts_from_state(
         return counts;
     }
 
-    if let Some(probs) = build_state_outcome_distribution(
+    if let Some(probs) = build_outcome_distribution(
         state,
-        norm_sq,
+        |amp| amp.norm_sqr() * norm_sq,
         &map,
         crate::backend::max_dense_outcome_bits(),
     ) {
         sample_counts_from_outcome_distribution(&probs, &map, num_classical_bits, num_shots, seed)
     } else {
-        sample_counts_streaming_from_state(
+        streaming_counts(
             state,
-            norm_sq,
+            |amp| amp.norm_sqr() * norm_sq,
             &map,
             num_classical_bits,
             num_shots,
@@ -631,7 +527,7 @@ mod tests {
         assert!(map.direct_state_key(len));
 
         let above_cap = sample_counts_from_probs_capped(&probs, &meas_map, bits, 300, 42, bits - 1);
-        let via_streaming = sample_counts_streaming_from_probs(&probs, &map, bits, 300, 42);
+        let via_streaming = streaming_counts(&probs, |&p| p, &map, bits, 300, 42);
         assert_eq!(above_cap, via_streaming);
 
         let below_cap = sample_counts_from_probs_capped(&probs, &meas_map, bits, 300, 42, bits);

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -390,10 +390,7 @@ pub(crate) fn run_trajectories(
         shots.push(result);
     }
 
-    Ok(ShotsResult {
-        shots,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
 #[cfg(feature = "parallel")]
@@ -414,10 +411,7 @@ fn run_trajectories_par(
         })
         .collect();
 
-    Ok(ShotsResult {
-        shots: shots?,
-        num_classical_bits: circuit.num_classical_bits,
-    })
+    Ok(ShotsResult::from_shots(shots?, circuit.num_classical_bits))
 }
 
 #[cfg(test)]

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -440,13 +440,9 @@ pub fn run_spp(circuit: &Circuit, num_samples: usize, seed: u64) -> Result<SppRe
 
 #[cfg(test)]
 fn spp_to_probabilities(result: &SppResult) -> Vec<f64> {
-    result
-        .expectations
-        .iter()
-        .flat_map(|ez| {
-            let p0 = (1.0 + ez) / 2.0;
-            [p0.clamp(0.0, 1.0), (1.0 - ez).clamp(0.0, 2.0) / 2.0]
-        })
+    super::expectations_to_marginals(&result.expectations)
+        .into_iter()
+        .flat_map(|(p0, p1)| [p0, p1])
         .collect()
 }
 
@@ -826,13 +822,9 @@ pub fn run_spd_observable_light_cone(
 
 #[cfg(test)]
 fn spd_to_probabilities(result: &SpdResult) -> Vec<f64> {
-    result
-        .expectations
-        .iter()
-        .flat_map(|ez| {
-            let p0 = (1.0 + ez) / 2.0;
-            [p0.clamp(0.0, 1.0), (1.0 - p0).clamp(0.0, 1.0)]
-        })
+    super::expectations_to_marginals(&result.expectations)
+        .into_iter()
+        .flat_map(|(p0, p1)| [p0, p1])
         .collect()
 }
 

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -1,6 +1,8 @@
 //! Public API coverage for `run_expectation_values` and
 //! `Simulate::expectation_values`.
 
+mod common;
+
 use prism_q::gates::Gate;
 use prism_q::{BackendKind, Circuit, PauliAxis, PauliTerm, run_expectation_values, simulate};
 
@@ -14,10 +16,7 @@ fn bell() -> Circuit {
 }
 
 fn assert_close(got: &[f64], want: &[f64], tol: f64) {
-    assert_eq!(got.len(), want.len());
-    for (g, w) in got.iter().zip(want) {
-        assert!((g - w).abs() < tol, "got {g}, want {w}");
-    }
+    common::assert_probs_close(got, want, tol, "expectation");
 }
 
 #[test]

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -8,6 +8,9 @@
 
 #![cfg(feature = "gpu")]
 
+mod common;
+
+use common::assert_probs_close;
 use num_complex::Complex64;
 
 use prism_q::StatevectorBackend;
@@ -37,21 +40,40 @@ impl Fixture {
     }
 
     fn compare(&self, num_qubits: usize, instructions: &[Instruction]) {
+        self.compare_eps(num_qubits, instructions, EPS);
+    }
+
+    fn compare_eps(&self, num_qubits: usize, instructions: &[Instruction], eps: f64) {
+        self.compare_with_classical(num_qubits, 0, instructions, eps);
+    }
+
+    fn compare_with_classical(
+        &self,
+        num_qubits: usize,
+        num_classical: usize,
+        instructions: &[Instruction],
+        eps: f64,
+    ) {
         let mut cpu = StatevectorBackend::new(42);
-        cpu.init(num_qubits, 0).unwrap();
+        cpu.init(num_qubits, num_classical).unwrap();
         let mut gpu = StatevectorBackend::new(42).with_gpu(self.ctx.clone());
-        gpu.init(num_qubits, 0).unwrap();
+        gpu.init(num_qubits, num_classical).unwrap();
         for inst in instructions {
             cpu.apply(inst).unwrap();
             gpu.apply(inst).unwrap();
         }
+        assert_eq!(
+            cpu.classical_results(),
+            gpu.classical_results(),
+            "classical bits mismatch"
+        );
         let cpu_sv = cpu.export_statevector().unwrap();
         let gpu_sv = gpu.export_statevector().unwrap();
         assert_eq!(cpu_sv.len(), gpu_sv.len());
         for (i, (c, g)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
             let diff = (c - g).norm();
             assert!(
-                diff < EPS,
+                diff < eps,
                 "amplitude mismatch at index {i}: cpu={c:?}, gpu={g:?}, |diff|={diff}"
             );
         }
@@ -469,70 +491,28 @@ fn diagonal_batch_all_entry_kinds() {
 fn measurement_deterministic_with_fixed_seed() {
     let Some(f) = Fixture::try_new() else { return };
     let n = 3;
-    let mut cpu = StatevectorBackend::new(42);
-    cpu.init(n, n).unwrap();
-    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
-    gpu.init(n, n).unwrap();
-
-    let prep = [g(Gate::H, &[0]), g(Gate::Cx, &[0, 1]), g(Gate::H, &[2])];
-    for inst in &prep {
-        cpu.apply(inst).unwrap();
-        gpu.apply(inst).unwrap();
-    }
+    let mut insts = vec![g(Gate::H, &[0]), g(Gate::Cx, &[0, 1]), g(Gate::H, &[2])];
     for q in 0..n {
-        cpu.apply(&Instruction::Measure {
+        insts.push(Instruction::Measure {
             qubit: q,
             classical_bit: q,
-        })
-        .unwrap();
-        gpu.apply(&Instruction::Measure {
-            qubit: q,
-            classical_bit: q,
-        })
-        .unwrap();
+        });
     }
-    assert_eq!(cpu.classical_results(), gpu.classical_results());
-    // Export statevectors and verify residual state matches (post-collapse).
-    let cpu_sv = cpu.export_statevector().unwrap();
-    let gpu_sv = gpu.export_statevector().unwrap();
-    for (i, (c, g_)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
-        let diff = (c - g_).norm();
-        assert!(
-            diff < EPS,
-            "post-measurement amplitude mismatch at {i}: {c:?} vs {g_:?}"
-        );
-    }
+    f.compare_with_classical(n, n, &insts, EPS);
 }
 
 #[test]
 fn reset_to_zero() {
     let Some(f) = Fixture::try_new() else { return };
-    let n = 3;
-    let mut cpu = StatevectorBackend::new(42);
-    cpu.init(n, 0).unwrap();
-    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
-    gpu.init(n, 0).unwrap();
-
     // Put the register into |1⟩|+⟩|1⟩, then reset q0 and q2.
-    let prep = [g(Gate::X, &[0]), g(Gate::H, &[1]), g(Gate::X, &[2])];
-    for inst in &prep {
-        cpu.apply(inst).unwrap();
-        gpu.apply(inst).unwrap();
-    }
-    cpu.apply(&Instruction::Reset { qubit: 0 }).unwrap();
-    gpu.apply(&Instruction::Reset { qubit: 0 }).unwrap();
-    cpu.apply(&Instruction::Reset { qubit: 2 }).unwrap();
-    gpu.apply(&Instruction::Reset { qubit: 2 }).unwrap();
-
-    let cpu_sv = cpu.export_statevector().unwrap();
-    let gpu_sv = gpu.export_statevector().unwrap();
-    for (i, (c, g_)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
-        let diff = (c - g_).norm();
-        assert!(
-            diff < EPS,
-            "reset amplitude mismatch at {i}: {c:?} vs {g_:?}"
-        );
-    }
+    let insts = [
+        g(Gate::X, &[0]),
+        g(Gate::H, &[1]),
+        g(Gate::X, &[2]),
+        Instruction::Reset { qubit: 0 },
+        Instruction::Reset { qubit: 2 },
+    ];
+    f.compare(3, &insts);
 }
 
 // ============================================================================
@@ -586,55 +566,45 @@ fn batch_rzz_14q_qaoa_matches_cpu() {
     // CPU LUT kernel.
     let Some(f) = Fixture::try_new() else { return };
     let circuit = prism_q::circuits::qaoa_circuit(14, 2, 42);
-
-    let mut cpu = StatevectorBackend::new(42);
-    cpu.init(14, 0).unwrap();
-    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
-    gpu.init(14, 0).unwrap();
-    for inst in &circuit.instructions {
-        cpu.apply(inst).unwrap();
-        gpu.apply(inst).unwrap();
-    }
-    let cpu_sv = cpu.export_statevector().unwrap();
-    let gpu_sv = gpu.export_statevector().unwrap();
-    let eps = 1e-10;
-    for (i, (c, g)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
-        let diff = (c - g).norm();
-        assert!(
-            diff < eps,
-            "qaoa_14q mismatch at {i}: cpu={c:?} gpu={g:?} |diff|={diff}"
-        );
-    }
+    f.compare_eps(14, &circuit.instructions, 1e-10);
 }
 
 #[test]
 fn batch_phase_16q_matches_cpu() {
-    // QFT at 16q exercises the `fuse_controlled_phases` pass which emits
-    // `Gate::BatchPhase`. The batched GPU kernel must match the CPU tiled kernel
-    // within tolerance. The test drives through `simulate(...).run()` so fusion fires
-    // normally, then compares probabilities between plain statevector and GPU statevector.
+    // `qft_circuit` emits a single `Gate::QftBlock`, so exercising the batched
+    // phase kernel requires expanding to textbook gates first and running the
+    // fusion pipeline, which re-batches the controlled phases into
+    // `Gate::BatchPhase` at 16q. The batched GPU kernel must match the CPU
+    // tiled kernel within tolerance.
     let Some(f) = Fixture::try_new() else { return };
 
     let circuit = prism_q::circuits::qft_circuit(16);
+    let expanded = prism_q::circuit::expand_qft_blocks(&circuit);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&expanded, true);
+    assert!(
+        fused.instructions.iter().any(|inst| matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::BatchPhase(_),
+                ..
+            }
+        )),
+        "expanded 16q QFT must fuse to at least one BatchPhase"
+    );
+    // Looser than the default 1e-12: 16q with ~130 gates accumulates rounding.
+    f.compare_eps(16, &fused.instructions, 1e-10);
+}
 
-    let mut cpu = StatevectorBackend::new(42);
-    cpu.init(16, 0).unwrap();
-    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
-    gpu.init(16, 0).unwrap();
-    for inst in &circuit.instructions {
-        cpu.apply(inst).unwrap();
-        gpu.apply(inst).unwrap();
-    }
-    let cpu_sv = cpu.export_statevector().unwrap();
-    let gpu_sv = gpu.export_statevector().unwrap();
-    let eps = 1e-10; // looser than default 1e-12 for 16q × ~130 gates
-    for (i, (c, g)) in cpu_sv.iter().zip(gpu_sv.iter()).enumerate() {
-        let diff = (c - g).norm();
-        assert!(
-            diff < eps,
-            "qft_16q mismatch at {i}: cpu={c:?} gpu={g:?} |diff|={diff}"
-        );
-    }
+#[test]
+fn qft_block_native_and_expanded_match_cpu() {
+    // Native: the raw `Gate::QftBlock` instruction, CPU FFT path vs the GPU
+    // textbook-step decomposition. Expanded: both backends run the textbook
+    // gate list produced by `expand_qft_blocks`.
+    let Some(f) = Fixture::try_new() else { return };
+    let circuit = prism_q::circuits::qft_circuit(16);
+    f.compare_eps(16, &circuit.instructions, 1e-10);
+    let expanded = prism_q::circuit::expand_qft_blocks(&circuit);
+    f.compare_eps(16, &expanded.instructions, 1e-10);
 }
 
 #[test]
@@ -729,13 +699,7 @@ fn probabilities_match_cpu_on_random_circuit() {
     }
     let cpu_p = cpu.probabilities().unwrap();
     let gpu_p = gpu.probabilities().unwrap();
-    assert_eq!(cpu_p.len(), gpu_p.len());
-    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
-        assert!(
-            (c - g_).abs() < EPS,
-            "prob[{i}] mismatch: cpu={c}, gpu={g_}"
-        );
-    }
+    assert_probs_close(&gpu_p, &cpu_p, EPS, "gpu/random_6q");
 }
 
 // ============================================================================
@@ -768,14 +732,7 @@ fn statevector_gpu_builder_matches_cpu_random() {
 
     let cpu_p = cpu.probabilities.expect("cpu probs missing").to_vec();
     let gpu_p = gpu.probabilities.expect("gpu probs missing").to_vec();
-    assert_eq!(cpu_p.len(), gpu_p.len());
-    for (i, (c, g_)) in cpu_p.iter().zip(gpu_p.iter()).enumerate() {
-        assert!(
-            (c - g_).abs() < 1e-10,
-            "prob[{i}] cpu={c}, gpu={g_}, diff={}",
-            (c - g_).abs()
-        );
-    }
+    assert_probs_close(&gpu_p, &cpu_p, 1e-10, "gpu/dispatch_random_14q");
 }
 
 /// A mid-circuit measurement forces the per-shot slow path. With

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -3,6 +3,9 @@
 //! Each test constructs a circuit programmatically (not via QASM) and checks
 //! the resulting state vector or probabilities against hand-computed values.
 
+mod common;
+
+use common::assert_probs_close;
 use num_complex::Complex64;
 use prism_q::Instruction;
 use prism_q::backend::Backend;
@@ -39,10 +42,7 @@ fn run_and_state(circuit: &Circuit) -> Vec<Complex64> {
 }
 
 fn assert_probs(actual: &[f64], expected: &[f64]) {
-    assert_eq!(actual.len(), expected.len(), "length mismatch");
-    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
-        assert!((a - e).abs() < EPS, "prob[{i}]: expected {e}, got {a}");
-    }
+    assert_probs_close(actual, expected, EPS, "golden");
 }
 
 fn assert_amplitude(actual: Complex64, expected: Complex64, label: &str) {
@@ -473,10 +473,7 @@ fn run_mps_probs(circuit: &Circuit) -> Vec<f64> {
 }
 
 fn assert_probs_mps(actual: &[f64], expected: &[f64]) {
-    assert_eq!(actual.len(), expected.len(), "length mismatch");
-    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
-        assert!((a - e).abs() < MPS_EPS, "prob[{i}]: expected {e}, got {a}");
-    }
+    assert_probs_close(actual, expected, MPS_EPS, "mps");
 }
 
 #[test]
@@ -814,10 +811,7 @@ fn run_tn_probs(circuit: &Circuit) -> Vec<f64> {
 }
 
 fn assert_probs_tn(actual: &[f64], expected: &[f64]) {
-    assert_eq!(actual.len(), expected.len(), "length mismatch");
-    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
-        assert!((a - e).abs() < TN_EPS, "prob[{i}]: expected {e}, got {a}");
-    }
+    assert_probs_close(actual, expected, TN_EPS, "tn");
 }
 
 #[test]
@@ -884,13 +878,7 @@ fn tn_complex_circuit_matches_statevector() {
 const PAR_EPS: f64 = 1e-10;
 
 fn assert_probs_par(actual: &[f64], expected: &[f64], label: &str) {
-    assert_eq!(actual.len(), expected.len(), "{label}: length mismatch");
-    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
-        assert!(
-            (a - e).abs() < PAR_EPS,
-            "{label} prob[{i}]: expected {e}, got {a}"
-        );
-    }
+    assert_probs_close(actual, expected, PAR_EPS, label);
 }
 
 #[test]

--- a/tests/qec_common/mod.rs
+++ b/tests/qec_common/mod.rs
@@ -1,0 +1,19 @@
+//! Shared helpers for the QEC test targets.
+
+#![allow(dead_code)]
+
+use prism_q::{QecOptions, QecTStrategy};
+
+pub const SEED: u64 = 0xDEAD_BEEF;
+
+pub const ANALYTICAL_STRATEGIES: [QecTStrategy; 3] =
+    [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+
+pub fn qec_options(shots: usize, chunk_size: usize, keep_measurements: bool) -> QecOptions {
+    QecOptions {
+        shots,
+        seed: SEED,
+        chunk_size: Some(chunk_size),
+        keep_measurements,
+    }
+}

--- a/tests/qec_noisy_validation.rs
+++ b/tests/qec_noisy_validation.rs
@@ -5,16 +5,12 @@ use prism_q::{
     run_qec_program, run_qec_program_reference,
 };
 
-const SEED: u64 = 0xDEAD_BEEF;
+mod qec_common;
+
 const STAT_SHOTS: usize = 20_000;
 
 fn qec_options(shots: usize, keep_measurements: bool) -> QecOptions {
-    QecOptions {
-        shots,
-        seed: SEED,
-        chunk_size: Some(4096),
-        keep_measurements,
-    }
+    qec_common::qec_options(shots, 4096, keep_measurements)
 }
 
 fn bit_rate(shots: &PackedShots, column: usize) -> f64 {

--- a/tests/qec_t_correctness.rs
+++ b/tests/qec_t_correctness.rs
@@ -4,21 +4,18 @@
 //! [`QecTStrategy::Reference`] within statistical tolerance on a small
 //! Clifford+T fixture.
 
+mod qec_common;
+
 use prism_q::{
     Gate, QecObservableReroute, QecOptions, QecProgram, QecRecordRef, QecTStrategy,
     run_qec_program_reference, run_qec_program_spd_rerouted, run_qec_program_with_strategy,
 };
+use qec_common::ANALYTICAL_STRATEGIES;
 
-const SEED: u64 = 0xDEAD_BEEF;
 const STAT_SHOTS: usize = 4_000;
 
 fn options(shots: usize) -> QecOptions {
-    QecOptions {
-        shots,
-        seed: SEED,
-        chunk_size: Some(2048),
-        keep_measurements: false,
-    }
+    qec_common::qec_options(shots, 2048, false)
 }
 
 fn small_clifford_t_program() -> QecProgram {
@@ -239,7 +236,7 @@ fn t_chain_program(shots: usize, t_count: usize) -> QecProgram {
 #[test]
 fn analytical_t_count_scaling_correctness() {
     let t_counts: &[usize] = &[1, 2, 4, 8, 12];
-    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    let strategies = ANALYTICAL_STRATEGIES;
     run_strategy_sweep(
         "T-count scaling sweep",
         t_counts,
@@ -296,7 +293,7 @@ fn entangled_t_xor_program(shots: usize, n: usize) -> QecProgram {
 #[test]
 fn camps_matches_reference_on_entangled_multi_qubit_t() {
     let qubit_counts: &[usize] = &[2, 3, 4, 5, 6];
-    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    let strategies = ANALYTICAL_STRATEGIES;
     run_strategy_sweep(
         "multi-qubit GHZ-chain correctness sweep",
         qubit_counts,
@@ -344,7 +341,7 @@ fn entangled_two_t_xor_program(shots: usize, n: usize) -> QecProgram {
 #[test]
 fn camps_matches_reference_on_two_t_multi_qubit() {
     let qubit_counts: &[usize] = &[2, 3, 4, 5, 6];
-    let strategies = [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps];
+    let strategies = ANALYTICAL_STRATEGIES;
     run_strategy_sweep(
         "two-T multi-qubit correctness sweep",
         qubit_counts,
@@ -487,7 +484,7 @@ fn analytical_strategies_handle_reset() {
 
     let reference = run_qec_program_reference(&program).unwrap();
     let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
-    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+    for strategy in ANALYTICAL_STRATEGIES {
         let result = run_qec_program_with_strategy(&program, strategy).unwrap();
         let denom = result.accepted_shots.max(1) as f64;
         let rate = result.logical_errors[0] as f64 / denom;
@@ -516,7 +513,7 @@ fn analytical_strategies_handle_x_basis_measurement() {
 
     let reference = run_qec_program_reference(&program).unwrap();
     let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
-    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+    for strategy in ANALYTICAL_STRATEGIES {
         let result = run_qec_program_with_strategy(&program, strategy).unwrap();
         let denom = result.accepted_shots.max(1) as f64;
         let rate = result.logical_errors[0] as f64 / denom;
@@ -550,7 +547,7 @@ fn analytical_strategies_handle_postselection() {
 
     let reference = run_qec_program_reference(&program).unwrap();
     let ref_rate = reference.logical_errors[0] as f64 / reference.accepted_shots as f64;
-    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+    for strategy in ANALYTICAL_STRATEGIES {
         let result = run_qec_program_with_strategy(&program, strategy).unwrap();
         let denom = result.accepted_shots.max(1) as f64;
         let rate = result.logical_errors[0] as f64 / denom;
@@ -629,7 +626,7 @@ fn analytical_strategies_reject_active_noise_route_to_reference() {
         .observable_include(0, &[QecRecordRef::absolute(m0)])
         .unwrap();
 
-    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+    for strategy in ANALYTICAL_STRATEGIES {
         let err = run_qec_program_with_strategy(&program, strategy)
             .expect_err("analytical strategies must reject active noise channels");
         let msg = format!("{err:?}");
@@ -654,7 +651,7 @@ fn analytical_strategies_reject_detectors() {
         .observable_include(0, &[QecRecordRef::absolute(m0)])
         .unwrap();
 
-    for strategy in [QecTStrategy::Auto, QecTStrategy::Spd, QecTStrategy::Camps] {
+    for strategy in ANALYTICAL_STRATEGIES {
         let err = run_qec_program_with_strategy(&program, strategy)
             .expect_err("analytical strategy must reject detector records");
         let msg = format!("{err:?}");

--- a/tests/smoke_openqasm.rs
+++ b/tests/smoke_openqasm.rs
@@ -1,5 +1,7 @@
 //! Smoke tests: OpenQASM 3.0 parsing → statevector simulation round-trips.
 
+mod common;
+
 use prism_q::backend::Backend;
 use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::circuit::openqasm;
@@ -18,13 +20,7 @@ fn run_shots(
 }
 
 fn assert_probs(probs: &[f64], expected: &[f64], eps: f64) {
-    assert_eq!(probs.len(), expected.len());
-    for (i, (a, e)) in probs.iter().zip(expected).enumerate() {
-        assert!(
-            (a - e).abs() < eps,
-            "prob[{i}]: expected {e:.6}, got {a:.6}"
-        );
-    }
+    common::assert_probs_close(probs, expected, eps, "openqasm");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Consolidation umbrella: fold repeated setup, dispatch, and reduction logic across
`sim`, `fusion`, the GPU kernels, and the CPU backends behind single-source helpers.
No change to simulation results, public API, or dispatch decisions. Net -1,352 lines
(+1,987 / -3,339) across 49 files.

## Scope

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Run on a quiet GPU host (GTX 1080 Ti) with `--features "parallel gpu"`. The GPU kernel
consolidation is the only hot-path change; the CPU helpers are `#[inline(always)]` and
compile to identical code. Representative rows:

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| gpu/qft_textbook/16 | 1.267 ms | 1.249 ms | -1.5% | Yes (improved) |
| gpu/qaoa_l3/16 | 1.145 ms | 1.128 ms | -1.5% | Yes (improved) |
| gpu/direct/random_d10/16 | 2.09 ms | 2.055 ms | -1.7% | Yes (improved) |
| gpu/qft_textbook/14 | 799 µs | 811 µs | +1.5% | Yes |
| gpu/bell_pairs/8 (16 µs, launch-bound) | 16.05 µs | 16.29 µs | +1.6% | Yes |
| gpu/random_d10/10 (46 µs, launch-bound) | 43.6 µs | 46.7 µs | +7.3% | No, wide CI |

Regression verdict: PASS (with the exclusions noted below)

If WAIVER, explain why the regression is acceptable and what future work will recover it.

- `gpu_bts_device_counts/n1024_r12/1000000` (+7.9%): the `_cpu` sibling, which does not
  touch the new `hash_insert_count` device helper, regressed +9.9% in the same run,
  identifying host/machine noise rather than the refactor.
- The remaining >0% rows (`bell_pairs`, `random_d10/10`) are 16-46 µs launch-overhead
  kernels with wide confidence intervals; the full sweep was neutral-or-improved after
  the `__forceinline__` fix.

## Correctness

- [x] `cargo test --all-features` passes locally (full suite under `--features "parallel gpu"`, plus doctests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [x] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

No new gate, backend, or fusion pass was added; existing golden coverage applies.
Added test coverage: gate-name round-trip through `resolve_gate`, and the QftBlock
native + expanded fusion paths (closing a gap where the BatchPhase kernel was no longer
exercised).

## Hotspot notes

GPU dense/bts/stabilizer kernels: launch scaffolding moved to `stream_and_fn` /
`linear_cfg`; the per-amplitude math moved to `__device__ __forceinline__` helpers
(`apply2x2`, `apply_phase`, `hash_insert_count`). `__forceinline__` is load-bearing:
plain `inline` left NVRTC calls in the inner loop and cost +5-28% until corrected.
CPU-side shared helpers (`for_each_placement`, tableau row kernels, `rdm_block_sums`,
`chunk_min_len`) are inline and off the innermost apply loops; `fuse_circuit` is not on
the hot path.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No structural change; helpers replace duplicated logic with the same control flow.

## Breaking changes

None. Public API, gate semantics, backend dispatch, and simulation outputs are unchanged.

## Risks and rollback

Low blast radius: behavior-preserving consolidation verified by the full suite and
golden_gpu. The GPU device-helper extraction is the highest-risk piece; it is gated by
`golden_gpu` amplitude equivalence (1e-10) and the bench sweep. Any single commit can be
reverted independently; the branch is a sequence of self-contained refactors.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
