### PR TITLE
feat(sim): adjoint-method expectation-value gradients

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -9,7 +9,10 @@ use prism_q::circuit::{Circuit, SmallVec};
 use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::sim;
-use prism_q::{BackendKind, ClassicalCondition, Instruction, MpsBackend};
+use prism_q::{
+    BackendKind, ClassicalCondition, Instruction, MpsBackend, ParameterMap, PauliTerm,
+    run_expectation_gradient, run_expectation_values,
+};
 use rand::RngExt;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -953,6 +956,166 @@ fn bench_decomposition(c: &mut Criterion) {
     group.finish();
 }
 
+// ---- Adjoint gradient benchmarks ----
+
+/// Mark every analytically differentiable gate as its own trainable slot.
+fn all_rotations_trainable(circuit: &Circuit) -> ParameterMap {
+    let mut params = ParameterMap::new();
+    let mut slot = 0;
+    for (i, inst) in circuit.instructions.iter().enumerate() {
+        if let Instruction::Gate { gate, .. } = inst {
+            if gate.pauli_generator().is_some() {
+                params.push(i, slot);
+                slot += 1;
+            }
+        }
+    }
+    params
+}
+
+/// A small weighted Z-chain Hamiltonian over the first few qubits.
+fn z_chain_hamiltonian(n: usize) -> Vec<(f64, Vec<PauliTerm>)> {
+    (0..n - 1)
+        .map(|q| (1.0, vec![PauliTerm::z(q), PauliTerm::z(q + 1)]))
+        .collect()
+}
+
+/// Add `delta` to the angle of every gate bound to parameter `slot`.
+fn shift_slot(circuit: &Circuit, params: &ParameterMap, slot: usize, delta: f64) -> Circuit {
+    let mut out = circuit.clone();
+    for link in params.links().iter().filter(|l| l.param == slot) {
+        if let Instruction::Gate {
+            gate: Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::Rzz(t) | Gate::P(t),
+            ..
+        } = &mut out.instructions[link.instruction]
+        {
+            *t += delta;
+        }
+    }
+    out
+}
+
+/// Central finite-difference gradient over all parameters, the current user
+/// alternative to the adjoint method (two forward expectation runs per slot).
+fn finite_diff_gradient(
+    circuit: &Circuit,
+    hamiltonian: &[(f64, Vec<PauliTerm>)],
+    params: &ParameterMap,
+) -> Vec<f64> {
+    let observables: Vec<Vec<PauliTerm>> = hamiltonian.iter().map(|(_, p)| p.clone()).collect();
+    let eps = 1e-5;
+    let expval = |c: &Circuit| -> f64 {
+        let per_term = run_expectation_values(c, &observables, 42).unwrap();
+        hamiltonian
+            .iter()
+            .zip(per_term)
+            .map(|((coeff, _), v)| coeff * v)
+            .sum()
+    };
+    (0..params.num_params())
+        .map(|slot| {
+            let plus = expval(&shift_slot(circuit, params, slot, eps));
+            let minus = expval(&shift_slot(circuit, params, slot, -eps));
+            (plus - minus) / (2.0 * eps)
+        })
+        .collect()
+}
+
+fn bench_gradient(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gradient/hea_l2");
+    configure_group(&mut group);
+
+    for &n in &[14, 18, 20, 22] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, SEED);
+        let params = all_rotations_trainable(&circuit);
+        let ham = z_chain_hamiltonian(n);
+
+        group.bench_with_input(BenchmarkId::new("adjoint", n), &circuit, |b, circ| {
+            b.iter(|| black_box(run_expectation_gradient(circ, &ham, &params, 42).unwrap()));
+        });
+        group.bench_with_input(BenchmarkId::new("finitediff", n), &circuit, |b, circ| {
+            b.iter(|| black_box(finite_diff_gradient(circ, &ham, &params)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_gradient_qaoa(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gradient/qaoa_l1");
+    configure_group(&mut group);
+
+    for &n in &[14, 18, 20] {
+        let circuit = circuits::qaoa_circuit(n, 1, SEED);
+        let params = all_rotations_trainable(&circuit);
+        let ham = z_chain_hamiltonian(n);
+
+        group.bench_with_input(BenchmarkId::new("adjoint", n), &circuit, |b, circ| {
+            b.iter(|| black_box(run_expectation_gradient(circ, &ham, &params, 42).unwrap()));
+        });
+        group.bench_with_input(BenchmarkId::new("finitediff", n), &circuit, |b, circ| {
+            b.iter(|| black_box(finite_diff_gradient(circ, &ham, &params)));
+        });
+    }
+
+    group.finish();
+}
+
+/// A fixed entangling prefix (non-trainable) followed by a trainable
+/// single-qubit-rotation layer, with a local single-qubit observable. Exercises
+/// the backward-sweep early termination (prefix skipped) and light-cone
+/// sandwich pruning (only the in-cone trainable gate contributes).
+fn prefix_local_circuit(n: usize, prefix_layers: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for layer in 0..prefix_layers {
+        for q in 0..n {
+            c.add_gate(Gate::H, &[q]);
+        }
+        for q in (layer % 2..n - 1).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.1 + 0.01 * q as f64), &[q]);
+    }
+    c
+}
+
+fn bench_gradient_prefix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gradient/prefix_local");
+    configure_group(&mut group);
+
+    for &n in &[16, 18, 20] {
+        let circuit = prefix_local_circuit(n, 6);
+        let params = all_rotations_trainable(&circuit);
+        let ham = vec![(1.0, vec![PauliTerm::z(0)])];
+
+        group.bench_with_input(BenchmarkId::new("adjoint", n), &circuit, |b, circ| {
+            b.iter(|| black_box(run_expectation_gradient(circ, &ham, &params, 42).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_expectation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("expectation/pauli_sum");
+    configure_group(&mut group);
+
+    for &n in &[14, 16, 18, 20] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, SEED);
+        let observables: Vec<Vec<PauliTerm>> = (0..n - 1)
+            .map(|q| vec![PauliTerm::z(q), PauliTerm::z(q + 1)])
+            .collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| black_box(run_expectation_values(circ, &observables, 42).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
 // ---- Factored backend benchmarks ----
 
 fn bench_factored_random(c: &mut Criterion) {
@@ -1517,6 +1680,12 @@ criterion_group!(
     bench_compare_general,
     // Decomposition
     bench_decomposition,
+    // Adjoint gradient (adjoint vs finite-difference per parameter)
+    bench_gradient,
+    bench_gradient_qaoa,
+    bench_gradient_prefix,
+    // Forward Pauli-sum expectation (parallel-sandwich neutrality)
+    bench_expectation,
     // Factored backend
     bench_factored_random,
     bench_factored_independent,

--- a/bindings/python/src/circuit.rs
+++ b/bindings/python/src/circuit.rs
@@ -253,6 +253,81 @@ impl PyCircuitBuilder {
         Ok(slf)
     }
 
+    /// Append `Rx(theta0)` on `q`, recording it as trainable parameter `slot`
+    /// for `Simulation.expectation_gradient`.
+    fn rx_param(
+        mut slf: PyRefMut<'_, Self>,
+        slot: usize,
+        theta0: f64,
+        q: usize,
+    ) -> PyPrismResult<PyRefMut<'_, Self>> {
+        check_qubit(slf.inner.circuit().num_qubits, q, "qubit")?;
+        slf.inner.rx_param(slot, theta0, q);
+        Ok(slf)
+    }
+
+    /// Append `Ry(theta0)` on `q`, recording it as trainable parameter `slot`.
+    fn ry_param(
+        mut slf: PyRefMut<'_, Self>,
+        slot: usize,
+        theta0: f64,
+        q: usize,
+    ) -> PyPrismResult<PyRefMut<'_, Self>> {
+        check_qubit(slf.inner.circuit().num_qubits, q, "qubit")?;
+        slf.inner.ry_param(slot, theta0, q);
+        Ok(slf)
+    }
+
+    /// Append `Rz(theta0)` on `q`, recording it as trainable parameter `slot`.
+    fn rz_param(
+        mut slf: PyRefMut<'_, Self>,
+        slot: usize,
+        theta0: f64,
+        q: usize,
+    ) -> PyPrismResult<PyRefMut<'_, Self>> {
+        check_qubit(slf.inner.circuit().num_qubits, q, "qubit")?;
+        slf.inner.rz_param(slot, theta0, q);
+        Ok(slf)
+    }
+
+    /// Append `P(theta0)` on `q`, recording it as trainable parameter `slot`.
+    fn p_param(
+        mut slf: PyRefMut<'_, Self>,
+        slot: usize,
+        theta0: f64,
+        q: usize,
+    ) -> PyPrismResult<PyRefMut<'_, Self>> {
+        check_qubit(slf.inner.circuit().num_qubits, q, "qubit")?;
+        slf.inner.p_param(slot, theta0, q);
+        Ok(slf)
+    }
+
+    /// Append `Rzz(theta0)` on `q0, q1`, recording it as trainable parameter `slot`.
+    fn rzz_param(
+        mut slf: PyRefMut<'_, Self>,
+        slot: usize,
+        theta0: f64,
+        q0: usize,
+        q1: usize,
+    ) -> PyPrismResult<PyRefMut<'_, Self>> {
+        let num_qubits = slf.inner.circuit().num_qubits;
+        check_qubit(num_qubits, q0, "q0")?;
+        check_qubit(num_qubits, q1, "q1")?;
+        slf.inner.rzz_param(slot, theta0, q0, q1);
+        Ok(slf)
+    }
+
+    /// The `(instruction_index, parameter_slot)` links recorded by the
+    /// `*_param` methods, for passing to `Simulation.expectation_gradient`.
+    fn parameter_links(&self) -> Vec<(usize, usize)> {
+        self.inner
+            .parameter_map()
+            .links()
+            .iter()
+            .map(|l| (l.instruction, l.param))
+            .collect()
+    }
+
     fn cx(
         mut slf: PyRefMut<'_, Self>,
         control: usize,

--- a/bindings/python/src/sim.rs
+++ b/bindings/python/src/sim.rs
@@ -11,8 +11,9 @@ use num_complex::Complex64;
 use numpy::PyArray1;
 use prism_q::backend::Backend;
 use prism_q::{
-    BackendKind, Circuit, CountsResult, MarginalsResult, NoiseModel, RunOutcome, ShotsResult,
-    StatevectorBackend, bitstring, simulate as core_simulate,
+    BackendKind, Circuit, CountsResult, MarginalsResult, NoiseModel, ParamLink, ParameterMap,
+    PauliAxis, PauliTerm, RunOutcome, ShotsResult, StatevectorBackend, bitstring,
+    simulate as core_simulate,
 };
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -151,6 +152,63 @@ impl PySimulation {
             backend.export_statevector()
         })?;
         Ok(complex_array(py, amps))
+    }
+
+    /// Compute `⟨H⟩` and its exact gradient with respect to the trainable
+    /// parameters via the adjoint method, returning `(value, gradient)` with
+    /// the gradient as a `float64` array.
+    ///
+    /// `hamiltonian` is a list of `(coefficient, [(qubit, axis), ...])` terms,
+    /// where `axis` is one of `"X"`, `"Y"`, `"Z"` (identity factors omitted).
+    /// `parameters` is a list of `(instruction_index, parameter_slot)` links,
+    /// as returned by `CircuitBuilder.parameter_links()`. Runs on the
+    /// statevector backend; the circuit must be unitary.
+    #[pyo3(signature = (hamiltonian, parameters))]
+    fn expectation_gradient<'py>(
+        &self,
+        py: Python<'py>,
+        hamiltonian: Vec<(f64, Vec<(usize, String)>)>,
+        parameters: Vec<(usize, usize)>,
+    ) -> PyPrismResult<(f64, Bound<'py, PyArray1<f64>>)> {
+        if self.noise.is_some() {
+            return Err(invalid("expectation_gradient() does not support noise"));
+        }
+        let mut terms: Vec<(f64, Vec<PauliTerm>)> = Vec::with_capacity(hamiltonian.len());
+        for (coeff, factors) in hamiltonian {
+            let mut string = Vec::with_capacity(factors.len());
+            for (qubit, axis) in factors {
+                string.push(PauliTerm::new(qubit, parse_axis(&axis)?));
+            }
+            terms.push((coeff, string));
+        }
+        let params = ParameterMap::from_links(
+            parameters
+                .into_iter()
+                .map(|(instruction, param)| ParamLink { instruction, param })
+                .collect(),
+        );
+        let seed = self.seed.unwrap_or(DEFAULT_SEED);
+        let kind = self.kind.clone();
+        let circuit = &self.circuit;
+        let result = py.detach(|| {
+            let mut sim = core_simulate(circuit);
+            if let Some(k) = &kind {
+                sim = sim.backend(k.clone());
+            }
+            sim.seed(seed).expectation_gradient(&terms, &params)
+        })?;
+        Ok((result.value, f64_array(py, result.gradient)))
+    }
+}
+
+fn parse_axis(axis: &str) -> PyPrismResult<PauliAxis> {
+    match axis.to_ascii_uppercase().as_str() {
+        "X" => Ok(PauliAxis::X),
+        "Y" => Ok(PauliAxis::Y),
+        "Z" => Ok(PauliAxis::Z),
+        other => Err(invalid(format!(
+            "Pauli axis must be one of \"X\", \"Y\", \"Z\"; got {other:?}"
+        ))),
     }
 }
 

--- a/bindings/python/tests/test_gradient.py
+++ b/bindings/python/tests/test_gradient.py
@@ -1,0 +1,73 @@
+import math
+
+import numpy as np
+
+from prism_q import CircuitBuilder, simulate
+
+
+def test_single_rx_gradient_matches_analytic():
+    # Rx(theta)|0>, <Z> = cos theta, d/dtheta = -sin theta.
+    theta = 0.6
+    builder = CircuitBuilder(1)
+    builder.rx_param(0, theta, 0)
+    circuit = builder.build()
+    links = builder.parameter_links()
+
+    hamiltonian = [(1.0, [(0, "Z")])]
+    value, grad = simulate(circuit).seed(42).expectation_gradient(hamiltonian, links)
+
+    assert isinstance(grad, np.ndarray)
+    assert grad.dtype == np.float64
+    assert grad.shape == (1,)
+    assert math.isclose(value, math.cos(theta), abs_tol=1e-9)
+    assert math.isclose(grad[0], -math.sin(theta), abs_tol=1e-9)
+
+
+def test_two_parameter_circuit_matches_finite_difference():
+    builder = CircuitBuilder(2)
+    builder.h(0).rz_param(0, 0.9, 0).cx(0, 1).ry_param(1, 0.4, 1)
+    circuit = builder.build()
+    links = builder.parameter_links()
+    assert len(links) == 2
+
+    ham = [(1.0, [(0, "Z"), (1, "Z")])]
+    value, grad = simulate(circuit).seed(42).expectation_gradient(ham, links)
+    assert grad.shape == (2,)
+
+    # Central finite difference on each slot through the forward run().
+    def expval(shifted):
+        out = simulate(shifted).seed(42).state_vector()
+        # <Z0 Z1> from amplitudes: sign is (-1)^(bit0 xor bit1).
+        probs = np.abs(out) ** 2
+        signs = np.array([1.0 if bin(i).count("1") % 2 == 0 else -1.0 for i in range(len(out))])
+        return float(np.sum(probs * signs))
+
+    eps = 1e-5
+    for slot, (theta0, rebuild) in enumerate(
+        [
+            (0.9, lambda t: _build(t, 0.4)),
+            (0.4, lambda t: _build(0.9, t)),
+        ]
+    ):
+        plus = expval(rebuild(theta0 + eps))
+        minus = expval(rebuild(theta0 - eps))
+        fd = (plus - minus) / (2 * eps)
+        assert math.isclose(grad[slot], fd, abs_tol=1e-5)
+
+
+def _build(rz_theta, ry_theta):
+    b = CircuitBuilder(2)
+    b.h(0).rz(rz_theta, 0).cx(0, 1).ry(ry_theta, 1)
+    return b.build()
+
+
+def test_invalid_axis_is_rejected():
+    builder = CircuitBuilder(1)
+    builder.rx_param(0, 0.3, 0)
+    circuit = builder.build()
+    links = builder.parameter_links()
+    try:
+        simulate(circuit).seed(42).expectation_gradient([(1.0, [(0, "W")])], links)
+        assert False, "expected an error for invalid axis"
+    except Exception:
+        pass

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -35,6 +35,8 @@ Orchestration layer in `src/sim/mod.rs`.
 | `simulate(circuit).backend(kind).seed(seed).sample_counts(shots)` | Frequency histogram with backend selection |
 | `simulate(circuit).seed(seed).marginals()` | Auto-dispatched per-qubit marginal probabilities |
 | `simulate(circuit).backend(kind).seed(seed).marginals()` | Per-qubit marginal probabilities with backend selection |
+| `simulate(circuit).seed(seed).expectation_values(observables)` | `⟨P_k⟩` per Pauli string |
+| `simulate(circuit).seed(seed).expectation_gradient(hamiltonian, params)` | `⟨H⟩` and adjoint gradient |
 | `run_on(backend, circuit)` | Pre-constructed backend |
 | `run_qasm(qasm, seed)` | Parse + simulate |
 
@@ -77,6 +79,42 @@ Block-level Rayon parallelism when all blocks are <14 qubits (avoids oversubscri
 ## Temporal Clifford decomposition
 
 For Clifford+T circuits: Clifford prefix runs on the Stabilizer backend, state is exported to Statevector for the non-Clifford tail. Saves exponential memory for circuits with a long Clifford preamble.
+
+## Expectation-value gradients (adjoint method)
+
+`run_expectation_gradient(circuit, hamiltonian, params, seed)` and
+`simulate(circuit).seed(seed).expectation_gradient(hamiltonian, params)` compute
+`⟨H⟩` and the exact gradient `d⟨H⟩/dθ` for a weighted Pauli-sum Hamiltonian
+`H = Σ c_k P_k`, at a cost independent of the parameter count. Implementation in
+`src/sim/gradient.rs`.
+
+The method back-propagates two statevectors. With `U = U_L…U_1` and `|φ⟩ = U|0⟩`:
+
+1. Forward pass (unfused) keeps `|φ⟩`. Build `|λ⟩ = H|φ⟩`; the value is
+   `Re⟨φ|λ⟩`.
+2. Sweep `i = L…1`. For a trainable gate with generator `G_i`, accumulate
+   `Im⟨λ|G_i|φ⟩` (projector form for `P`), then step both states back through
+   `U_i†` (`Gate::inverse()`).
+
+The `⟨λ|G|φ⟩` sandwich generalizes the forward `pauli_expectation_from_masks`
+kernel to two vectors (`pauli_sandwich`, Rayon-parallel at 16+ qubits).
+
+Differentiable gates are `Rx`, `Ry`, `Rz`, `Rzz`, and `P` (identified by
+`Gate::pauli_generator`, a method, so `Gate` stays 16 bytes). Trainable links on
+other gates, non-unitary instructions, and `QftBlock` are rejected. Parameter
+identity is an index-based side table (`ParameterMap` of instruction→slot links,
+recorded by the `*_param` `CircuitBuilder` methods); many gates may share a slot.
+
+Differentiation runs on the unfused instruction stream so each gate keeps a 1:1
+correspondence with its generator (fusion would erase both the stored angle and
+that correspondence). Two prunings cut work without changing results: the sweep
+stops at the earliest in-cone trainable gate (a non-trainable prefix costs no
+inverse applications), and a trainable gate outside the Hamiltonian's inverse
+light cone has a provably zero gradient, so its sandwich is skipped.
+
+Memory is two statevectors, so the qubit ceiling is about one below a single
+run. Only the statevector backend is supported; stabilizer/MPS/factored/GPU
+gradients are not implemented.
 
 ## Backend dispatch variants
 

--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -16,6 +16,7 @@ use num_complex::Complex64;
 
 use super::{Circuit, ClassicalCondition, Instruction, SmallVec};
 use crate::gates::Gate;
+use crate::sim::gradient::ParameterMap;
 
 /// Fluent builder for quantum circuits.
 ///
@@ -23,8 +24,15 @@ use crate::gates::Gate;
 /// method returns `&mut Self`, allowing compact one-liner circuits.
 /// Call [`build`](Self::build) to extract the finished [`Circuit`], or
 /// use [`run`](Self::run) / [`run_with`](Self::run_with) for direct execution.
+///
+/// The `*_param` methods (e.g. [`rx_param`](Self::rx_param)) additionally record
+/// which instruction feeds which slot of a parameter vector, for use with the
+/// adjoint gradient. Retrieve the recorded map with
+/// [`parameter_map`](Self::parameter_map) or
+/// [`build_parametric`](Self::build_parametric).
 pub struct CircuitBuilder {
     circuit: Circuit,
+    params: ParameterMap,
 }
 
 macro_rules! gate_1q {
@@ -54,11 +62,24 @@ macro_rules! gate_2q {
     };
 }
 
+macro_rules! gate_1q_param_tracked {
+    ($name:ident, $variant:ident) => {
+        /// Append this single-qubit rotation on `q` with initial angle `theta0`,
+        /// recording it as trainable parameter `slot` for the adjoint gradient.
+        pub fn $name(&mut self, slot: usize, theta0: f64, q: usize) -> &mut Self {
+            self.params.push(self.circuit.instructions.len(), slot);
+            self.circuit.add_gate(Gate::$variant(theta0), &[q]);
+            self
+        }
+    };
+}
+
 impl CircuitBuilder {
     /// Create a builder for a circuit with `num_qubits` qubits and no classical bits.
     pub fn new(num_qubits: usize) -> Self {
         Self {
             circuit: Circuit::new(num_qubits, 0),
+            params: ParameterMap::new(),
         }
     }
 
@@ -66,6 +87,7 @@ impl CircuitBuilder {
     pub fn new_with_classical(num_qubits: usize, num_classical_bits: usize) -> Self {
         Self {
             circuit: Circuit::new(num_qubits, num_classical_bits),
+            params: ParameterMap::new(),
         }
     }
 
@@ -88,6 +110,18 @@ impl CircuitBuilder {
 
     pub fn rzz(&mut self, theta: f64, q0: usize, q1: usize) -> &mut Self {
         self.circuit.add_gate(Gate::Rzz(theta), &[q0, q1]);
+        self
+    }
+
+    gate_1q_param_tracked!(rx_param, Rx);
+    gate_1q_param_tracked!(ry_param, Ry);
+    gate_1q_param_tracked!(rz_param, Rz);
+    gate_1q_param_tracked!(p_param, P);
+
+    /// Append `Rzz(theta0)` on `q0, q1`, recording it as trainable parameter `slot`.
+    pub fn rzz_param(&mut self, slot: usize, theta0: f64, q0: usize, q1: usize) -> &mut Self {
+        self.params.push(self.circuit.instructions.len(), slot);
+        self.circuit.add_gate(Gate::Rzz(theta0), &[q0, q1]);
         self
     }
 
@@ -169,12 +203,26 @@ impl CircuitBuilder {
 
     /// Extract the finished circuit, replacing the builder's internal circuit with an empty one.
     pub fn build(&mut self) -> Circuit {
+        self.params = ParameterMap::new();
         std::mem::replace(&mut self.circuit, Circuit::new(0, 0))
+    }
+
+    /// Extract the finished circuit together with the recorded parameter map,
+    /// resetting the builder.
+    pub fn build_parametric(&mut self) -> (Circuit, ParameterMap) {
+        let circuit = std::mem::replace(&mut self.circuit, Circuit::new(0, 0));
+        let params = std::mem::take(&mut self.params);
+        (circuit, params)
     }
 
     /// Borrow the circuit without consuming the builder.
     pub fn circuit(&self) -> &Circuit {
         &self.circuit
+    }
+
+    /// Borrow the parameter map recorded by the `*_param` methods.
+    pub fn parameter_map(&self) -> &ParameterMap {
+        &self.params
     }
 
     /// Execute with automatic backend selection.

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -132,6 +132,28 @@ pub enum Gate {
     QftBlock { start: u8, num: u8 },
 }
 
+/// Analytic differentiation generator for a parametric gate.
+///
+/// Returned by [`Gate::pauli_generator`] and consumed by the adjoint gradient
+/// engine. `Gate` stays 16 bytes: this is produced on demand, never stored in
+/// the enum. Each rotation variant is `exp(-i θ/2 G)` with the named Pauli
+/// generator `G` acting on the gate's `targets` (in order); `Phase` is the
+/// non-Pauli phase gate `diag(1, e^{iθ})` whose generator is the projector
+/// `|1⟩⟨1|` on `targets[0]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeneratorKind {
+    /// `Rx(θ)`: generator `X` on `targets[0]`.
+    RotX,
+    /// `Ry(θ)`: generator `Y` on `targets[0]`.
+    RotY,
+    /// `Rz(θ)`: generator `Z` on `targets[0]`.
+    RotZ,
+    /// `Rzz(θ)`: generator `Z⊗Z` on `targets[0]` and `targets[1]`.
+    RotZz,
+    /// `P(θ)`: generator is the projector `|1⟩⟨1|` on `targets[0]`.
+    Phase,
+}
+
 /// Data for a multi-controlled unitary gate.
 #[derive(Debug, Clone, PartialEq)]
 pub struct McuData {
@@ -616,6 +638,23 @@ impl Gate {
                     .map(|&(q0, q1, ref mat)| (q0, q1, adjoint_4x4(mat)))
                     .collect(),
             })),
+        }
+    }
+
+    /// Return the analytic differentiation generator for a parametric gate,
+    /// or `None` if the gate has no defined generator (all non-parametric
+    /// gates, and parametric gates whose angle is not stored inline as `f64`,
+    /// e.g. controlled unitaries built from a boxed matrix). Used by the
+    /// adjoint gradient engine to decide which instructions are differentiable.
+    #[inline]
+    pub fn pauli_generator(&self) -> Option<GeneratorKind> {
+        match self {
+            Gate::Rx(_) => Some(GeneratorKind::RotX),
+            Gate::Ry(_) => Some(GeneratorKind::RotY),
+            Gate::Rz(_) => Some(GeneratorKind::RotZ),
+            Gate::Rzz(_) => Some(GeneratorKind::RotZz),
+            Gate::P(_) => Some(GeneratorKind::Phase),
+            _ => None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use distributed::MpiComm;
 #[cfg(feature = "distributed")]
 pub use distributed::{DistributedContext, RankComm, SerialComm};
 pub use error::{PrismError, Result};
-pub use gates::{BatchPhaseData, Gate, McuData, Multi2qData, MultiFusedData};
+pub use gates::{BatchPhaseData, Gate, GeneratorKind, McuData, Multi2qData, MultiFusedData};
 pub use qec::{
     QecBasis, QecCompiledRows, QecMeasurementRow, QecNoise, QecObservableEstimate,
     QecObservableReroute, QecOp, QecOptions, QecPauli, QecProgram, QecRecordRef, QecSampleResult,
@@ -89,6 +89,7 @@ pub use sim::compiled::{
     PauliExpectationAccumulator, ShotAccumulator, ShotLayout, compile_detector_sampler,
     compile_forward, compile_measurements, run_shots_compiled,
 };
+pub use sim::gradient::{ExpectationGradient, ParamLink, ParameterMap, run_expectation_gradient};
 pub use sim::homological::{
     ErrorChainComplex, HomologicalSampler, noisy_marginals_analytical, run_shots_homological,
 };

--- a/src/sim/gradient.rs
+++ b/src/sim/gradient.rs
@@ -1,0 +1,429 @@
+//! Adjoint-method gradients of expectation values.
+//!
+//! Computes the exact gradient of `⟨H⟩ = ⟨0|U†HU|0⟩` with respect to a vector
+//! of circuit parameters in a cost independent of the parameter count, by
+//! back-propagating two statevectors through the circuit. For `U = U_L…U_1`
+//! and a Hermitian Hamiltonian `H = Σ c_k P_k`:
+//!
+//! 1. Forward: apply `U` unfused, keep `|φ⟩ = U|0⟩`.
+//! 2. Build `|λ⟩ = H|φ⟩`; the value `⟨H⟩ = Re⟨φ|λ⟩`.
+//! 3. Backward `i = L…1`: for each trainable gate with generator `G_i`,
+//!    accumulate the gradient from `⟨λ|G_i|φ⟩` (with `|φ⟩` on the output side
+//!    of gate `i`), then step both states back through `U_i†`.
+//!
+//! Only the statevector backend is supported. The differentiated circuit must
+//! be unitary (no measurement, reset, or conditional). Differentiable gates are
+//! `Rx`, `Ry`, `Rz`, `Rzz`, and `P`; a trainable link on any other gate is an
+//! error.
+
+use num_complex::Complex64;
+
+use crate::backend::statevector::StatevectorBackend;
+use crate::backend::{Backend, max_statevector_qubits, reserve_dense_output};
+use crate::circuit::{Circuit, Instruction};
+use crate::error::{PrismError, Result};
+use crate::gates::{Gate, GeneratorKind};
+
+use super::unified_pauli::PauliTerm;
+use super::{i_pow, pauli_masks, pauli_sandwich};
+
+/// Binds one trainable gate instruction to a slot in the parameter vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParamLink {
+    /// Index into [`Circuit::instructions`].
+    pub instruction: usize,
+    /// Slot in the parameter (theta) vector this gate feeds.
+    pub param: usize,
+}
+
+/// Maps trainable gate instructions to parameter-vector slots for the adjoint
+/// gradient. Many instructions may share one slot (weight sharing); their
+/// contributions accumulate. Built by the parametric [`crate::CircuitBuilder`]
+/// methods or constructed directly.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParameterMap {
+    links: Vec<ParamLink>,
+}
+
+impl ParameterMap {
+    /// An empty map (no trainable parameters).
+    pub fn new() -> Self {
+        Self { links: Vec::new() }
+    }
+
+    /// Build a map from explicit instruction-to-slot links.
+    pub fn from_links(links: Vec<ParamLink>) -> Self {
+        Self { links }
+    }
+
+    /// Record that `instruction` feeds parameter slot `param`.
+    pub fn push(&mut self, instruction: usize, param: usize) {
+        self.links.push(ParamLink { instruction, param });
+    }
+
+    /// The recorded links.
+    pub fn links(&self) -> &[ParamLink] {
+        &self.links
+    }
+
+    /// True if no trainable parameters are recorded.
+    pub fn is_empty(&self) -> bool {
+        self.links.is_empty()
+    }
+
+    /// Number of distinct parameters, `max slot + 1` (0 if empty). The returned
+    /// gradient vector has this length.
+    pub fn num_params(&self) -> usize {
+        self.links.iter().map(|l| l.param + 1).max().unwrap_or(0)
+    }
+
+    fn validate(&self, circuit: &Circuit) -> Result<()> {
+        let n = circuit.instructions.len();
+        for link in &self.links {
+            if link.instruction >= n {
+                return Err(PrismError::InvalidParameter {
+                    message: format!(
+                        "parameter link references instruction {} but the circuit has {n} instructions",
+                        link.instruction
+                    ),
+                });
+            }
+            match &circuit.instructions[link.instruction] {
+                Instruction::Gate { gate, .. } if gate.pauli_generator().is_some() => {}
+                Instruction::Gate { gate, .. } => {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "instruction {} (`{}`) is not analytically differentiable; supported gates are rx, ry, rz, rzz, p",
+                            link.instruction,
+                            gate.name()
+                        ),
+                    });
+                }
+                _ => {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "parameter link references instruction {} which is not a gate",
+                            link.instruction
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Expectation value and its gradient with respect to each parameter slot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpectationGradient {
+    /// `⟨H⟩` at the circuit's current parameter values.
+    pub value: f64,
+    /// `d⟨H⟩/dθ`, one entry per parameter slot.
+    pub gradient: Vec<f64>,
+}
+
+/// Compute `⟨H⟩` and its exact gradient with respect to the trainable
+/// parameters using the adjoint method on the statevector backend.
+///
+/// `hamiltonian` is a weighted Pauli sum `Σ c_k P_k` with real coefficients;
+/// each `P_k` is a joint Pauli string (identity factors omitted). `params`
+/// declares which gate instructions are trainable and how they map to the
+/// gradient vector. The returned gradient has length `params.num_params()`.
+pub fn run_expectation_gradient(
+    circuit: &Circuit,
+    hamiltonian: &[(f64, Vec<PauliTerm>)],
+    params: &ParameterMap,
+    seed: u64,
+) -> Result<ExpectationGradient> {
+    if super::has_nonunitary_or_classical_ops(circuit) {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "Statevector".into(),
+            reason: "adjoint gradients require a unitary circuit without measurements, resets, or conditionals".into(),
+        });
+    }
+
+    if circuit.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::QftBlock { .. },
+                ..
+            }
+        )
+    }) {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "Statevector".into(),
+            reason: "adjoint gradients do not support QftBlock; expand it to primitive gates first"
+                .into(),
+        });
+    }
+
+    params.validate(circuit)?;
+
+    // Validate and reduce observables before the 2^n simulation.
+    let mut masked = Vec::with_capacity(hamiltonian.len());
+    for (coeff, terms) in hamiltonian {
+        let (xmask, zmask, num_y) = pauli_masks(terms, circuit.num_qubits)?;
+        masked.push((*coeff, xmask, zmask, num_y));
+    }
+
+    if circuit.num_qubits > max_statevector_qubits() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "Statevector".into(),
+            reason: format!(
+                "adjoint gradients for {} qubits exceed the statevector cap ({} qubits); the gradient path holds two statevectors",
+                circuit.num_qubits,
+                max_statevector_qubits()
+            ),
+        });
+    }
+
+    // Forward pass, unfused, to keep a 1:1 gate-to-generator correspondence.
+    let mut phi = StatevectorBackend::new(seed);
+    phi.init(circuit.num_qubits, circuit.num_classical_bits)?;
+    phi.apply_instructions(&circuit.instructions)?;
+
+    let (value, lambda_state) = build_lambda_and_value(phi.state_vector(), &masked)?;
+
+    let num_params = params.num_params();
+    let mut gradient = vec![0.0; num_params];
+    if params.is_empty() {
+        return Ok(ExpectationGradient { value, gradient });
+    }
+
+    // Inverse light cone of the Hamiltonian: a trainable gate outside it has a
+    // provably zero gradient (its generator commutes through the back-evolved
+    // observable), so its sandwich is skipped.
+    let in_cone = observable_light_cone(circuit, hamiltonian);
+
+    let mut slots_of: Vec<Vec<usize>> = vec![Vec::new(); circuit.instructions.len()];
+    for link in params.links() {
+        slots_of[link.instruction].push(link.param);
+    }
+
+    // Stop the backward sweep at the earliest in-cone trainable gate: nothing
+    // before it contributes, so a non-trainable (or out-of-cone) prefix costs
+    // no inverse applications. If no trainable gate reaches the observable, the
+    // gradient is zero everywhere.
+    let earliest = (0..circuit.instructions.len()).find(|&i| in_cone[i] && !slots_of[i].is_empty());
+    let Some(earliest) = earliest else {
+        return Ok(ExpectationGradient { value, gradient });
+    };
+
+    let mut lambda = StatevectorBackend::new(seed);
+    lambda.init_from_state(lambda_state, circuit.num_classical_bits)?;
+
+    for i in (earliest..circuit.instructions.len()).rev() {
+        let (gate, targets) = match &circuit.instructions[i] {
+            Instruction::Gate { gate, targets } => (gate, targets),
+            Instruction::Barrier { .. } => continue,
+            _ => unreachable!("non-unitary instructions rejected above"),
+        };
+
+        if in_cone[i] && !slots_of[i].is_empty() {
+            let kind = gate
+                .pauli_generator()
+                .expect("trainable instruction validated as differentiable");
+            let contrib =
+                gradient_contribution(kind, targets, lambda.state_vector(), phi.state_vector());
+            for &slot in &slots_of[i] {
+                gradient[slot] += contrib;
+            }
+        }
+
+        // The earliest in-cone trainable gate is the last one evaluated; its
+        // inverse and every gate before it can be skipped.
+        if i > earliest {
+            let inverse = Instruction::Gate {
+                gate: gate.inverse(),
+                targets: targets.clone(),
+            };
+            phi.apply(&inverse)?;
+            lambda.apply(&inverse)?;
+        }
+    }
+
+    Ok(ExpectationGradient { value, gradient })
+}
+
+/// Per-instruction flag: true if the gate lies in the Hamiltonian's inverse
+/// light cone (its support is connected to some observable term through the
+/// gates that follow it).
+fn observable_light_cone(circuit: &Circuit, hamiltonian: &[(f64, Vec<PauliTerm>)]) -> Vec<bool> {
+    let union: Vec<PauliTerm> = hamiltonian
+        .iter()
+        .flat_map(|(_, terms)| terms.iter().copied())
+        .collect();
+    super::unified_pauli::inverse_light_cone(circuit, &union)
+}
+
+/// Build `|λ⟩ = Σ c_k P_k|φ⟩` into a fresh buffer and return `(⟨H⟩, |λ⟩)`,
+/// where `⟨H⟩ = Re⟨φ|λ⟩`.
+fn build_lambda_and_value(
+    phi: &[Complex64],
+    masked: &[(f64, usize, usize, u32)],
+) -> Result<(f64, Vec<Complex64>)> {
+    let dim = phi.len();
+    let mut lambda: Vec<Complex64> = Vec::new();
+    reserve_dense_output(
+        &mut lambda,
+        dim,
+        "Statevector",
+        "adjoint gradient lambda state",
+    )?;
+    lambda.resize(dim, Complex64::new(0.0, 0.0));
+
+    for &(coeff, xmask, zmask, num_y) in masked {
+        let factor = Complex64::new(coeff, 0.0) * i_pow(num_y);
+        for (j, &amp) in phi.iter().enumerate() {
+            let sign = if (j & zmask).count_ones() & 1 == 1 {
+                -1.0
+            } else {
+                1.0
+            };
+            lambda[j ^ xmask] += factor * sign * amp;
+        }
+    }
+
+    let value: f64 = phi
+        .iter()
+        .zip(&lambda)
+        .map(|(p, l)| (p.conj() * l).re)
+        .sum();
+    Ok((value, lambda))
+}
+
+/// Gradient contribution `d⟨H⟩/dθ` of a single trainable gate, from the
+/// generator sandwich `⟨λ|G|φ⟩` with `|φ⟩` on the output side of the gate.
+fn gradient_contribution(
+    kind: GeneratorKind,
+    targets: &[usize],
+    lambda: &[Complex64],
+    phi: &[Complex64],
+) -> f64 {
+    match kind {
+        GeneratorKind::RotX => {
+            let x = 1usize << targets[0];
+            pauli_sandwich(lambda, phi, x, 0, 0).im
+        }
+        GeneratorKind::RotY => {
+            let b = 1usize << targets[0];
+            pauli_sandwich(lambda, phi, b, b, 1).im
+        }
+        GeneratorKind::RotZ => {
+            let z = 1usize << targets[0];
+            pauli_sandwich(lambda, phi, 0, z, 0).im
+        }
+        GeneratorKind::RotZz => {
+            let z = (1usize << targets[0]) | (1usize << targets[1]);
+            pauli_sandwich(lambda, phi, 0, z, 0).im
+        }
+        GeneratorKind::Phase => {
+            let bit = 1usize << targets[0];
+            let mut acc = Complex64::new(0.0, 0.0);
+            for (j, &amp) in phi.iter().enumerate() {
+                if j & bit != 0 {
+                    acc += lambda[j].conj() * amp;
+                }
+            }
+            -2.0 * acc.im
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim::unified_pauli::PauliTerm;
+
+    fn z_obs(qubit: usize) -> Vec<(f64, Vec<PauliTerm>)> {
+        vec![(1.0, vec![PauliTerm::z(qubit)])]
+    }
+
+    #[test]
+    fn single_rx_gradient_matches_analytic() {
+        // Rx(θ)|0>, <Z> = cos θ, d/dθ = -sin θ.
+        let theta = 0.7;
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::Rx(theta), &[0]);
+        let mut params = ParameterMap::new();
+        params.push(0, 0);
+
+        let g = run_expectation_gradient(&c, &z_obs(0), &params, 42).unwrap();
+        assert!((g.value - theta.cos()).abs() < 1e-12);
+        assert!((g.gradient[0] - (-theta.sin())).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ry_generator_carries_num_y() {
+        // Ry(θ)|0>, <Z> = cos θ, d/dθ = -sin θ. Generator Y has num_y = 1.
+        let theta = 1.3;
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::Ry(theta), &[0]);
+        let mut params = ParameterMap::new();
+        params.push(0, 0);
+
+        let g = run_expectation_gradient(&c, &z_obs(0), &params, 42).unwrap();
+        assert!((g.gradient[0] - (-theta.sin())).abs() < 1e-9);
+    }
+
+    #[test]
+    fn phase_projector_gradient() {
+        // H then P(θ): |ψ> = (|0> + e^{iθ}|1>)/√2, <X> = cos θ, d/dθ = -sin θ.
+        let theta = 0.9;
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::P(theta), &[0]);
+        let mut params = ParameterMap::new();
+        params.push(1, 0);
+
+        let obs = vec![(1.0, vec![PauliTerm::x(0)])];
+        let g = run_expectation_gradient(&c, &obs, &params, 42).unwrap();
+        assert!((g.value - theta.cos()).abs() < 1e-12);
+        assert!((g.gradient[0] - (-theta.sin())).abs() < 1e-9);
+    }
+
+    #[test]
+    fn shared_parameter_accumulates() {
+        // Two Rx gates on separate qubits sharing one slot; each contributes
+        // -sin θ to <Z0 + Z1>, so the shared gradient is -2 sin θ.
+        let theta = 0.4;
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::Rx(theta), &[0]);
+        c.add_gate(Gate::Rx(theta), &[1]);
+        let mut params = ParameterMap::new();
+        params.push(0, 0);
+        params.push(1, 0);
+
+        let obs = vec![(1.0, vec![PauliTerm::z(0)]), (1.0, vec![PauliTerm::z(1)])];
+        let g = run_expectation_gradient(&c, &obs, &params, 42).unwrap();
+        assert_eq!(g.gradient.len(), 1);
+        assert!((g.gradient[0] - (-2.0 * theta.sin())).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_params_returns_value_only() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::Rx(0.5), &[0]);
+        let g = run_expectation_gradient(&c, &z_obs(0), &ParameterMap::new(), 42).unwrap();
+        assert!(g.gradient.is_empty());
+        assert!((g.value - 0.5f64.cos()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn nondifferentiable_trainable_gate_is_rejected() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        let mut params = ParameterMap::new();
+        params.push(0, 0);
+        assert!(run_expectation_gradient(&c, &z_obs(0), &params, 42).is_err());
+    }
+
+    #[test]
+    fn nonunitary_circuit_is_rejected() {
+        let mut c = Circuit::new(1, 1);
+        c.add_gate(Gate::Rx(0.3), &[0]);
+        c.add_measure(0, 0);
+        assert!(run_expectation_gradient(&c, &z_obs(0), &ParameterMap::new(), 42).is_err());
+    }
+}

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -6,6 +6,7 @@
 pub mod compiled;
 mod decomposed;
 mod dispatch;
+pub mod gradient;
 pub mod homological;
 pub mod noise;
 mod probability;
@@ -250,6 +251,38 @@ impl<'c> Simulate<'c, Seeded> {
             });
         }
         run_expectation_values_with(self.kind, self.circuit, observables, seed)
+    }
+
+    /// Compute `⟨H⟩` and its exact gradient with respect to the trainable
+    /// parameters using the adjoint method.
+    ///
+    /// `hamiltonian` is a weighted Pauli sum `Σ c_k P_k` with real
+    /// coefficients. `params` declares which gate instructions are trainable.
+    /// Runs on the statevector backend; the selected backend must be `Auto` or
+    /// `Statevector`. The circuit must be unitary. See
+    /// [`gradient::run_expectation_gradient`].
+    #[inline]
+    pub fn expectation_gradient(
+        self,
+        hamiltonian: &[(f64, Vec<PauliTerm>)],
+        params: &gradient::ParameterMap,
+    ) -> Result<gradient::ExpectationGradient> {
+        let seed = self.seed_value();
+        if self.noise_model.is_some() {
+            return Err(PrismError::BackendUnsupported {
+                backend: format!("{:?}", self.kind),
+                operation: "expectation gradients with an inline noise model".into(),
+            });
+        }
+        if !(self.kind.is_auto() || matches!(self.kind, BackendKind::Statevector)) {
+            return Err(PrismError::IncompatibleBackend {
+                backend: format!("{:?}", self.kind),
+                reason:
+                    "adjoint gradients run on the statevector backend; select Auto or Statevector"
+                        .into(),
+            });
+        }
+        gradient::run_expectation_gradient(self.circuit, hamiltonian, params, seed)
     }
 }
 
@@ -948,7 +981,10 @@ fn expectation_values_statevector(
 
 /// Validate a joint Pauli observable and reduce it to `(Xmask, Zmask, #Y)`,
 /// where `Xmask` covers X and Y factors and `Zmask` covers Z and Y factors.
-fn pauli_masks(observable: &[PauliTerm], num_qubits: usize) -> Result<(usize, usize, u32)> {
+pub(crate) fn pauli_masks(
+    observable: &[PauliTerm],
+    num_qubits: usize,
+) -> Result<(usize, usize, u32)> {
     let mut xmask = 0usize;
     let mut zmask = 0usize;
     let mut num_y = 0u32;
@@ -983,8 +1019,61 @@ fn pauli_masks(observable: &[PauliTerm], num_qubits: usize) -> Result<(usize, us
     Ok((xmask, zmask, num_y))
 }
 
-/// Exact `⟨ψ|P|ψ⟩` from the reduced observable masks, where `P` acts as
-/// `P|j⟩ = i^{#Y}·(-1)^{popcount(j & Zmask)}·|j ⊕ Xmask⟩`. Normalization
+/// Complex Pauli sandwich `⟨λ|P|φ⟩`, where `P` acts as
+/// `P|j⟩ = i^{#Y}·(-1)^{popcount(j & Zmask)}·|j ⊕ Xmask⟩`. Returns the raw
+/// (unnormalized) complex value. The adjoint gradient engine uses this with
+/// distinct `λ` and `φ`; `pauli_expectation_from_masks` is the `λ = φ` case.
+pub(crate) fn pauli_sandwich(
+    lambda: &[Complex64],
+    phi: &[Complex64],
+    xmask: usize,
+    zmask: usize,
+    num_y: u32,
+) -> Complex64 {
+    let term = |j: usize, amp: Complex64| {
+        let partner = lambda[j ^ xmask];
+        let sign = if (j & zmask).count_ones() & 1 == 1 {
+            -1.0
+        } else {
+            1.0
+        };
+        partner.conj() * amp * sign
+    };
+
+    // Higher threshold than gate kernels: the sandwich is a single lightweight
+    // O(N) reduction, so Rayon fan-out only pays off past 2^16 elements. Below
+    // that (and for a multi-term Hamiltonian's many small reductions) the
+    // sequential path is faster.
+    #[cfg(feature = "parallel")]
+    const SANDWICH_MIN_PAR_QUBITS: usize = 16;
+    #[cfg(feature = "parallel")]
+    let acc: Complex64 = if phi.len() >= (1 << SANDWICH_MIN_PAR_QUBITS) {
+        use rayon::prelude::*;
+        phi.par_iter()
+            .enumerate()
+            .map(|(j, &amp)| term(j, amp))
+            .sum()
+    } else {
+        phi.iter().enumerate().map(|(j, &amp)| term(j, amp)).sum()
+    };
+    #[cfg(not(feature = "parallel"))]
+    let acc: Complex64 = phi.iter().enumerate().map(|(j, &amp)| term(j, amp)).sum();
+
+    acc * i_pow(num_y)
+}
+
+/// `i^{num_y}`, the phase a joint Pauli picks up from its Y factors.
+#[inline]
+pub(crate) fn i_pow(num_y: u32) -> Complex64 {
+    match num_y % 4 {
+        0 => Complex64::new(1.0, 0.0),
+        1 => Complex64::new(0.0, 1.0),
+        2 => Complex64::new(-1.0, 0.0),
+        _ => Complex64::new(0.0, -1.0),
+    }
+}
+
+/// Exact `⟨ψ|P|ψ⟩` from the reduced observable masks. Normalization
 /// independent, so raw backend amplitudes are fine.
 fn pauli_expectation_from_masks(
     state: &[Complex64],
@@ -996,25 +1085,7 @@ fn pauli_expectation_from_masks(
     if norm == 0.0 {
         return 0.0;
     }
-
-    let mut acc = Complex64::new(0.0, 0.0);
-    for (j, &amp) in state.iter().enumerate() {
-        let partner = state[j ^ xmask];
-        let sign = if (j & zmask).count_ones() & 1 == 1 {
-            -1.0
-        } else {
-            1.0
-        };
-        acc += partner.conj() * amp * sign;
-    }
-
-    let i_pow = match num_y % 4 {
-        0 => Complex64::new(1.0, 0.0),
-        1 => Complex64::new(0.0, 1.0),
-        2 => Complex64::new(-1.0, 0.0),
-        _ => Complex64::new(0.0, -1.0),
-    };
-    (acc * i_pow).re / norm
+    pauli_sandwich(state, state, xmask, zmask, num_y).re / norm
 }
 
 /// Multi-shot execution for the distributed statevector backend.

--- a/tests/expectation_gradient.rs
+++ b/tests/expectation_gradient.rs
@@ -1,0 +1,251 @@
+//! Adjoint-gradient correctness: `run_expectation_gradient` and
+//! `Simulate::expectation_gradient` validated against central finite
+//! differences and the parameter-shift rule, at fixed seed 42.
+
+use prism_q::circuits;
+use prism_q::{
+    Circuit, Gate, Instruction, ParameterMap, PauliTerm, run_expectation_gradient,
+    run_expectation_values, simulate,
+};
+
+const SEED: u64 = 42;
+
+type Hamiltonian = Vec<(f64, Vec<PauliTerm>)>;
+
+/// Weighted expectation value `Σ c_k ⟨P_k⟩` from the forward API.
+fn expval(circuit: &Circuit, hamiltonian: &Hamiltonian) -> f64 {
+    let observables: Vec<Vec<PauliTerm>> = hamiltonian.iter().map(|(_, p)| p.clone()).collect();
+    let per_term = run_expectation_values(circuit, &observables, SEED).unwrap();
+    hamiltonian
+        .iter()
+        .zip(per_term)
+        .map(|((c, _), v)| c * v)
+        .sum()
+}
+
+/// Return a copy of `circuit` with `delta` added to the angle of every gate
+/// bound to parameter `slot`.
+fn shift_slot(circuit: &Circuit, params: &ParameterMap, slot: usize, delta: f64) -> Circuit {
+    let mut out = circuit.clone();
+    for link in params.links().iter().filter(|l| l.param == slot) {
+        if let Instruction::Gate { gate, .. } = &mut out.instructions[link.instruction] {
+            *gate = shifted_gate(gate, delta);
+        }
+    }
+    out
+}
+
+fn shifted_gate(gate: &Gate, delta: f64) -> Gate {
+    match gate {
+        Gate::Rx(t) => Gate::Rx(t + delta),
+        Gate::Ry(t) => Gate::Ry(t + delta),
+        Gate::Rz(t) => Gate::Rz(t + delta),
+        Gate::Rzz(t) => Gate::Rzz(t + delta),
+        Gate::P(t) => Gate::P(t + delta),
+        other => panic!("gate {} is not differentiable", other.name()),
+    }
+}
+
+/// Central finite-difference gradient of `⟨H⟩` for one slot.
+fn finite_diff(
+    circuit: &Circuit,
+    hamiltonian: &Hamiltonian,
+    params: &ParameterMap,
+    slot: usize,
+) -> f64 {
+    let eps = 1e-5;
+    let plus = expval(&shift_slot(circuit, params, slot, eps), hamiltonian);
+    let minus = expval(&shift_slot(circuit, params, slot, -eps), hamiltonian);
+    (plus - minus) / (2.0 * eps)
+}
+
+/// Parameter-shift gradient of `⟨H⟩` for one slot. Valid for Rx/Ry/Rz/Rzz/P
+/// (generator eigenvalue gap 1, shift π/2, coefficient 1/2).
+fn param_shift(
+    circuit: &Circuit,
+    hamiltonian: &Hamiltonian,
+    params: &ParameterMap,
+    slot: usize,
+) -> f64 {
+    let s = std::f64::consts::FRAC_PI_2;
+    let plus = expval(&shift_slot(circuit, params, slot, s), hamiltonian);
+    let minus = expval(&shift_slot(circuit, params, slot, -s), hamiltonian);
+    (plus - minus) / 2.0
+}
+
+/// Mark every analytically differentiable gate as its own trainable slot.
+fn all_rotations_trainable(circuit: &Circuit) -> ParameterMap {
+    let mut params = ParameterMap::new();
+    let mut slot = 0;
+    for (i, inst) in circuit.instructions.iter().enumerate() {
+        if let Instruction::Gate { gate, .. } = inst {
+            if gate.pauli_generator().is_some() {
+                params.push(i, slot);
+                slot += 1;
+            }
+        }
+    }
+    params
+}
+
+#[test]
+fn single_rx_matches_analytic() {
+    let theta = 0.6;
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::Rx(theta), &[0]);
+    let mut params = ParameterMap::new();
+    params.push(0, 0);
+
+    let obs = vec![(1.0, vec![PauliTerm::z(0)])];
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    assert!((g.value - theta.cos()).abs() < 1e-12);
+    assert!((g.gradient[0] - (-theta.sin())).abs() < 1e-9);
+    assert!((g.gradient[0] - finite_diff(&c, &obs, &params, 0)).abs() < 1e-6);
+    assert!((g.gradient[0] - param_shift(&c, &obs, &params, 0)).abs() < 1e-9);
+}
+
+#[test]
+fn hea_multiterm_hamiltonian_all_params() {
+    let c = circuits::hardware_efficient_ansatz(4, 2, SEED);
+    let params = all_rotations_trainable(&c);
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (0.7, vec![PauliTerm::x(0)]),
+        (0.5, vec![PauliTerm::y(2)]),
+        (-0.3, vec![PauliTerm::z(3)]),
+    ];
+
+    let g = simulate(&c)
+        .seed(SEED)
+        .expectation_gradient(&obs, &params)
+        .unwrap();
+
+    assert!((g.value - expval(&c, &obs)).abs() < 1e-10);
+    assert_eq!(g.gradient.len(), params.num_params());
+    for slot in 0..params.num_params() {
+        let fd = finite_diff(&c, &obs, &params, slot);
+        let ps = param_shift(&c, &obs, &params, slot);
+        assert!(
+            (g.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: adjoint {} vs finite-diff {fd}",
+            g.gradient[slot]
+        );
+        assert!(
+            (g.gradient[slot] - ps).abs() < 1e-9,
+            "slot {slot}: adjoint {} vs param-shift {ps}",
+            g.gradient[slot]
+        );
+    }
+}
+
+#[test]
+fn qaoa_layer_rzz_and_rx() {
+    let c = circuits::qaoa_circuit(6, 1, SEED);
+    let params = all_rotations_trainable(&c);
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (1.0, vec![PauliTerm::z(2), PauliTerm::z(3)]),
+        (0.4, vec![PauliTerm::x(5)]),
+    ];
+
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    assert!((g.value - expval(&c, &obs)).abs() < 1e-10);
+    for slot in 0..params.num_params() {
+        let fd = finite_diff(&c, &obs, &params, slot);
+        assert!(
+            (g.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: adjoint {} vs finite-diff {fd}",
+            g.gradient[slot]
+        );
+    }
+}
+
+#[test]
+fn value_matches_forward_expectation() {
+    let c = circuits::hardware_efficient_ansatz(5, 3, SEED);
+    let params = all_rotations_trainable(&c);
+    let obs: Hamiltonian = vec![
+        (1.2, vec![PauliTerm::z(0)]),
+        (-0.5, vec![PauliTerm::x(1), PauliTerm::x(2)]),
+    ];
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    assert!((g.value - expval(&c, &obs)).abs() < 1e-10);
+}
+
+#[test]
+fn builder_records_and_differentiates() {
+    use prism_q::CircuitBuilder;
+    let theta = 0.9;
+    let mut b = CircuitBuilder::new(2);
+    b.h(0).rz_param(0, theta, 0).cx(0, 1).ry_param(1, 0.4, 1);
+    let (circuit, params) = b.build_parametric();
+
+    let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(0), PauliTerm::z(1)])];
+    let g = run_expectation_gradient(&circuit, &obs, &params, SEED).unwrap();
+    assert_eq!(g.gradient.len(), 2);
+    for slot in 0..2 {
+        let fd = finite_diff(&circuit, &obs, &params, slot);
+        assert!((g.gradient[slot] - fd).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn out_of_cone_gate_has_zero_gradient() {
+    // Observable Z0; an Rx on qubit 2 has no path to qubit 0, so its gradient
+    // is exactly zero (light-cone skip), while the in-cone Rx on qubit 0 is
+    // -sin(theta).
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::Rx(0.5), &[0]);
+    c.add_gate(Gate::Rx(0.7), &[2]);
+    let mut params = ParameterMap::new();
+    params.push(0, 0);
+    params.push(1, 1);
+
+    let obs = vec![(1.0, vec![PauliTerm::z(0)])];
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    assert!((g.gradient[0] - (-0.5f64.sin())).abs() < 1e-9);
+    assert_eq!(g.gradient[1], 0.0);
+    assert!((g.gradient[1] - finite_diff(&c, &obs, &params, 1)).abs() < 1e-6);
+}
+
+#[test]
+fn nontrainable_prefix_is_skipped_correctly() {
+    // A fixed entangling prefix (H, CX, CX) precedes the trainable ansatz. The
+    // backward sweep must stop at the earliest trainable gate; the gradient
+    // still matches finite differences.
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::Ry(0.6), &[0]);
+    c.add_gate(Gate::Rz(0.4), &[1]);
+    c.add_gate(Gate::Rx(0.9), &[2]);
+    let mut params = ParameterMap::new();
+    params.push(3, 0);
+    params.push(4, 1);
+    params.push(5, 2);
+
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(2)]),
+        (0.5, vec![PauliTerm::x(1)]),
+    ];
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    for slot in 0..3 {
+        let fd = finite_diff(&c, &obs, &params, slot);
+        assert!(
+            (g.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: adjoint {} vs finite-diff {fd}",
+            g.gradient[slot]
+        );
+    }
+}
+
+#[test]
+fn out_of_range_link_is_rejected() {
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::Rx(0.3), &[0]);
+    let mut params = ParameterMap::new();
+    params.push(5, 0);
+    let obs = vec![(1.0, vec![PauliTerm::z(0)])];
+    assert!(run_expectation_gradient(&c, &obs, &params, SEED).is_err());
+}


### PR DESCRIPTION
## Summary

Add adjoint-method expectation-value gradients. `run_expectation_gradient` and
`Simulate::expectation_gradient` compute `<H>` and the exact gradient `d<H>/dtheta`
for a weighted Pauli-sum Hamiltonian on the statevector backend, at a cost independent
of the parameter count. This replaces finite-differencing `run_expectation_values`
(two simulations per parameter, precision loss from cancellation) for VQE/QAOA/QML
workloads, and is reachable from Python. Builds on the Pauli expectation values from #90.

## Scope

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

The only shared hot path touched is the forward Pauli sandwich
(`pauli_expectation_from_masks` now calls `pauli_sandwich`, Rayon-parallel at 16+
qubits). Before = sequential (main); After = this PR. Host: i7-6700K,
`--features "parallel bench-fast"`, seed 42 sim / `0xDEAD_BEEF` circuit gen.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| expectation/pauli_sum/14 | 1.07 ms | 1.07 ms | ~0% (stays sequential) | Yes |
| expectation/pauli_sum/16 | 3.62 ms | 2.70 ms | -25% | Yes (improvement) |
| expectation/pauli_sum/18 | 13.1 ms | 8.01 ms | -39% | Yes (improvement) |
| expectation/pauli_sum/20 | 69.9 ms | 43.1 ms | -38% | Yes (improvement) |

Regression verdict: PASS

New capability (no prior baseline in this code path): adjoint gradient vs the
finite-difference alternative it replaces.

`gradient/hea_l2` (depth-2 HEA, z-chain Hamiltonian):

| n (params) | adjoint | finite-diff | speedup |
| --- | --- | --- | --- |
| 14 (56) | 12.9 ms | 147.6 ms | 11.4x |
| 18 (72) | 99.2 ms | 1.349 s | 13.6x |
| 20 (80) | 707.7 ms | 7.259 s | 10.3x |
| 22 (88) | 2.934 s | 37.38 s | 12.7x |

`gradient/qaoa_l1`:

| n | adjoint | finite-diff | speedup |
| --- | --- | --- | --- |
| 14 | 6.1 ms | 61.4 ms | 10.1x |
| 18 | 40.4 ms | 404 ms | 10.0x |
| 20 | 300 ms | 2.48 s | 8.3x |

Adjoint time scales with `2^n`, not with the parameter count, so the margin over
finite differencing grows linearly with the number of parameters.

Light-cone + early-termination pruning, measured on `gradient/prefix_local` (fixed
6-layer entangling prefix + trainable rotation layer, local Z0 observable), pruning
off vs on:

| Benchmark | Off | On | Change |
| --- | --- | --- | --- |
| gradient/prefix_local/16 | 16.3 ms | 6.3 ms | -61% |
| gradient/prefix_local/18 | 84.3 ms | 21.4 ms | -75% |
| gradient/prefix_local/20 | 777 ms | 282 ms | -64% |

On all-trainable, global-Hamiltonian ansatze (hea/qaoa) the prunings are no-ops, so
those rows are unchanged.

## Correctness

- [x] `cargo test --all-features` passes locally (run as `cargo nextest run --features parallel`, 1694 tests; `gpu`/`distributed` need CUDA/MPI toolchains not on this host)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (run with `--features parallel`; this change adds no `unsafe`)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes (run with `--features parallel`, `RUSTDOCFLAGS=-D warnings`)
- [x] New public API has docstrings
- [ ] New gate, backend, or fusion pass has golden tests against the statevector backend (N/A: no new gate/backend/fusion pass; the gradient engine is validated in `tests/expectation_gradient.rs` against central finite differences and the parameter-shift rule at seed 42)
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu` (N/A: no GPU change)

## Hotspot notes

Shared hot path: `pauli_expectation_from_masks` (`src/sim/mod.rs`) now delegates to the
new two-vector `pauli_sandwich`, which is Rayon-parallel at 16+ qubits
(`SANDWICH_MIN_PAR_QUBITS`) and sequential below, matching the `expectation/pauli_sum`
numbers above. New gradient path (`src/sim/gradient.rs`): `run_expectation_gradient` ->
`build_lambda_and_value`, the reverse sweep applying `Gate::inverse()` through
`Backend::apply` on both states, and `gradient_contribution` (the `pauli_sandwich`
generator sandwich per trainable gate). Coverage is the Criterion rows above; no
flamegraph attached.

## Architecture or design changes

- [x] `docs/architecture/` updated if the change is structural (`engine.md`: "Expectation-value gradients (adjoint method)" section plus the two new entry points)
- [ ] Design or research notes added where required for new subsystems (N/A: no new subsystem; extends the existing sim orchestration)

## Breaking changes

None. The public API is purely additive (`run_expectation_gradient`,
`ExpectationGradient`, `ParameterMap`, `ParamLink`, `GeneratorKind`,
`Simulate::expectation_gradient`, and the `*_param` `CircuitBuilder` methods). The
`pauli_expectation_from_masks` change is an internal refactor of a private function;
`run_expectation_values` results are unchanged.

## Risks and rollback

Small blast radius. The only change to an existing code path is parallelizing the
forward Pauli sandwich, gated at 16 qubits and numerically identical to the sequential
path (only summation order differs, well below the 1e-10 tolerances). The gradient
engine is new and reached only through new entry points, so it cannot affect existing
runs. There is no feature flag or dispatch guard; rollback is a straight revert of the
commit, and the sandwich parallelization can be reverted independently if it ever
regresses. Memory note: the gradient path holds two statevectors, lowering its qubit
ceiling by about one relative to a single run.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale (reuses `rayon`, `num-complex`, `smallvec`)
- [ ] CI is green (pending push)
