### PR TITLE
feat(qec): evaluate EXP_VAL end to end with final-state estimator semenatics

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -26,7 +26,7 @@ controlled-phase gates that the fusion pipeline batches:
 
 ## Stabilizer
 
-Aaronson-Gottesman bit-packed tableau for Clifford circuits. O(n²) time and space. Scales to thousands of qubits. Gate kernels use wordwise bitwise ops and `popcount` for phase computation. Supports H, S, Sdg, SX, SXdg, CX, CZ, SWAP, and measurement.
+Aaronson-Gottesman bit-packed tableau for Clifford circuits. O(n²) time and space. Scales to thousands of qubits. Gate kernels use wordwise bitwise ops and `popcount` for phase computation. Supports H, S, Sdg, SX, SXdg, X, Y, Z, Id, CX, CZ, SWAP, plus measurement, reset, and classical conditionals.
 
 Word-group batching fuses multiple 1q gate flushes into single tableau passes. Type-grouped masks apply all gates of the same Pauli type with one wordwise op instead of per-gate dispatch. Sparse Generator Indexing (SGI) tracks per-qubit active generator lists, enabling targeted row operations instead of full-tableau scans. Lazy destabilizer materialization defers destabilizer rows until probabilities are requested.
 

--- a/docs/architecture/qec-ir.md
+++ b/docs/architecture/qec-ir.md
@@ -35,8 +35,9 @@ absolute measurement-record indices. Detector, observable, and postselection
 projection uses `PackedShots::parity_rows`, so the QEC layer reuses the existing
 packed parity engine instead of maintaining a second one. This is a
 sampler-lowering artifact, not an execution engine. Gate, reset, and noise
-execution lives in `run_qec_program`; `EXP_VAL` remains unsupported in the
-packed runner until estimator semantics land.
+execution lives in `run_qec_program`; `EXP_VAL` has no packed-row
+representation, so the row compiler rejects it and `run_qec_program` routes
+such programs to the estimator paths described below.
 
 ## Execution
 
@@ -48,8 +49,9 @@ observables, postselection, Pauli-noise annotations, and optional
 raw-measurement retention. Noisy Clifford programs compile `X_ERROR`,
 `Z_ERROR`, `DEPOLARIZE1`, and correlated `DEPOLARIZE2` events into packed
 sensitivity rows, then XOR those rows into the packed measurement records.
-Non-Clifford gates and `EXP_VAL` reject clearly until their production
-strategies land.
+Non-Clifford gates reject clearly on the packed path; programs containing
+`EXP_VAL` route to the expectation-value paths below, which accept T gates
+via the analytical strategies.
 
 ```admonish note title="V1 reset requirement"
 V1 requires a reset before any later gate reuse of a measured qubit, because the
@@ -62,3 +64,45 @@ postselection, and logical-error accounting.
 `run_qec_program_reference` is the small-program correctness oracle. It runs one
 state-vector simulation per shot and supports Pauli-noise annotations, but it is
 not the production performance path.
+
+## Expectation values
+
+`EXP_VAL(c) P1*...*Pk` estimates `c * <P>` for the Pauli product `P` in the
+program's final state and returns one `QecObservableEstimate` per op, in op
+order, in `QecSampleResult::expectation_values`. Two placement rules make
+"final state" well defined on every path:
+
+- Terminal placement: no gate, measurement, reset, or active noise may follow
+  an `EXP_VAL` op. Detector, observable, postselection, and tick metadata may.
+- Live qubits only: a term may not reference a qubit that was
+  single-qubit-measured after its last reset. Under this rule the Pauli
+  commutes with every prior measurement projector, so the sampled
+  post-measurement average equals the measurement-stripped pure-state
+  expectation the analytical strategies compute. `MPP` does not affect
+  liveness: the deferred lowering measures a scratch alias, and the projected
+  cross terms cancel exactly.
+
+Estimator paths:
+
+| Path | Selection | `mean` | `variance` |
+| --- | --- | --- | --- |
+| Reference runner | `run_qec_program` with active noise, or as the detector-split fallback; `run_qec_program_reference` directly | per-shot exact `c * <P>` averaged over accepted shots | unbiased sample variance |
+| Analytical ladder (SPD, CAMPS, tensor network) | `run_qec_program` noiseless; `run_qec_program_with_strategy` | exact `c * <P>` on the lowered unitary | `c^2 *` squared SPD truncation weight; 0.0 for CAMPS and tensor network |
+
+Noiseless programs with detectors split into two runs: the packed compiled
+sampler executes the program without its `EXP_VAL` ops, producing real sampled
+measurement, detector, and observable records, while the analytical ladder
+executes it without its detectors, producing the estimates. Detectors are
+record metadata with no effect on the state, so the two halves compose into
+one result. When either half cannot run (non-Clifford gates on the packed
+half, or an analytical failure), the whole program falls back to the
+reference runner.
+
+CAMPS evaluates arbitrary X/Y/Z strings by conjugating each letter through the
+signed Clifford prefix (`Y = i * X * Z` composes the two inverse-tableau rows).
+Postselection composes on both paths: the reference runner averages over
+accepted shots, and the analytical combiner conditions via
+`<O * Pi> / <Pi>`, whose projector Z-strings live on measured aliases and so
+never overlap `EXP_VAL` terms. With noise annotations the reference runner's
+per-shot trajectories average to the mixed-state expectation `Tr(rho P)`. The
+stabilizer-rerouted SPD path does not support `EXP_VAL`.

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -29,7 +29,7 @@ state fits in RAM. The memory cap is derived from system RAM (overridable with
 
 ## Stabilizer
 
-If your circuit uses only Clifford gates (H, S, Sdg, SX, SXdg, CX, CZ, SWAP, measurement),
+If your circuit uses only Clifford gates (H, S, Sdg, SX, SXdg, X, Y, Z, Id, CX, CZ, SWAP, measurement),
 the stabilizer tableau simulates it in $O(n^2)$ and scales to thousands of qubits.
 Auto-dispatch selects it whenever the circuit is Clifford-only.
 

--- a/docs/guides/qec.md
+++ b/docs/guides/qec.md
@@ -51,10 +51,13 @@ programs.
 
 ```admonish info title="What QEC programs support"
 Clifford gates, basis resets and measurements, `MPP` Pauli-product measurements,
-detectors, observables, postselection, and `X_ERROR` / `Z_ERROR` / `DEPOLARIZE1` /
-`DEPOLARIZE2` noise. Non-Clifford gates and `EXP_VAL` are rejected until their production
-strategies land. See the [QEC IR reference](../architecture/qec-ir.md) for the full
-grammar and the V1 reset requirement.
+detectors, observables, postselection, `X_ERROR` / `Z_ERROR` / `DEPOLARIZE1` /
+`DEPOLARIZE2` noise, and terminal `EXP_VAL` final-state expectation estimates
+(noiseless programs use the analytical T strategies, with any detector records
+still sampled by the packed runner; noisy programs use the per-shot reference
+runner). Non-Clifford gates are rejected on the packed sampling path.
+See the [QEC IR reference](../architecture/qec-ir.md) for the full
+grammar, the V1 reset requirement, and the `EXP_VAL` placement rules.
 ```
 
 ## Homological sampling

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -11,8 +11,9 @@
 //! # Gate support
 //!
 //! All single-qubit gates are applied as a 2×2 matrix-vector multiply on the
-//! per-qubit state. Two-qubit and multi-qubit gates return `BackendUnsupported`
-//! since product states cannot represent entanglement.
+//! per-qubit state; `MultiFused` batches and single-qubit `DiagonalBatch`
+//! entries apply the same way per target. Entangling gates return
+//! `BackendUnsupported` since product states cannot represent entanglement.
 //!
 //! # When to prefer this backend
 //!
@@ -260,8 +261,8 @@ impl Backend for ProductStateBackend {
         reserve_dense_output(&mut sv, dim, self.name(), "statevector export")?;
         sv.push(Complex64::new(1.0, 0.0));
         for q in 0..self.num_qubits {
-            let a = self.qubits[q][0]; // α = ⟨0|ψ_q⟩
-            let b = self.qubits[q][1]; // β = ⟨1|ψ_q⟩
+            let a = self.qubits[q][0];
+            let b = self.qubits[q][1];
             let len = sv.len();
             for i in 0..len {
                 sv.push(sv[i] * b);

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -1,7 +1,7 @@
 //! Stabilizer (Clifford) simulation backend.
 //!
-//! Uses the Gottesman-Knill theorem: Clifford circuits can be simulated in
-//! O(n²) time per gate using a stabilizer tableau of 2n Pauli strings.
+//! Uses the Gottesman-Knill theorem: Clifford circuits are simulated on a
+//! stabilizer tableau of 2n Pauli strings in O(n) time per gate.
 //!
 //! # Memory layout
 //!
@@ -15,7 +15,7 @@
 //!
 //! # Gate support
 //!
-//! Clifford gates only: H, S, Sdg, X, Y, Z, CX, CZ, SWAP, Id.
+//! Clifford gates only: H, S, Sdg, SX, SXdg, X, Y, Z, Id, CX, CZ, SWAP.
 //! Non-Clifford gates (T, Rx, Ry, Rz, Fused) return `BackendUnsupported`.
 //!
 //! # When to prefer this backend
@@ -59,7 +59,8 @@ use crate::gpu::kernels::stabilizer::CliffordBatchScratch;
 #[cfg(feature = "gpu")]
 use crate::gpu::{GpuContext, GpuTableau};
 
-/// Clifford-only O(n^2) stabilizer simulation (Aaronson-Gottesman tableau).
+/// Clifford-only stabilizer simulation on an Aaronson-Gottesman tableau,
+/// O(n²) space.
 ///
 /// Manually implements `Clone`: the CPU tableau fields (`xz`, `phase`, SGI
 /// buffers, etc.) clone element-for-element just like the old derived impl.
@@ -542,12 +543,20 @@ impl StabilizerBackend {
         }
     }
 
+    /// Create a backend that starts in lazy destabilizer mode (see
+    /// [`Self::enable_lazy_destab`]).
     pub fn new_lazy(seed: u64) -> Self {
         let mut s = Self::new(seed);
         s.lazy_destab = true;
         s
     }
 
+    /// Defer destabilizer rows: gates update only the n stabilizer rows until
+    /// a measurement or reset materializes the destabilizers via Gaussian
+    /// elimination. Halves gate cost for long Clifford prefixes with few
+    /// measurements. The per-instruction [`Backend::apply`] path switches back
+    /// to an eager tableau before the first gate; only the bulk apply paths
+    /// preserve laziness.
     pub fn enable_lazy_destab(&mut self) {
         if self.lazy_destab || self.n == 0 {
             return;
@@ -707,6 +716,10 @@ impl StabilizerBackend {
         (self.xz, self.phase, self.n, self.num_words)
     }
 
+    /// Apply gate and satisfied-conditional instructions, skipping
+    /// measurements, resets, and barriers. Routes through the SGI or
+    /// word-batch bulk paths at the same thresholds as
+    /// [`Backend::apply_instructions`].
     pub fn apply_gates_only(&mut self, instructions: &[Instruction]) -> Result<()> {
         let nw = self.num_words;
         if nw < MIN_WORDS_FOR_BATCH {
@@ -808,6 +821,14 @@ impl StabilizerBackend {
         }
     }
 
+    /// Measure a run of distinct qubits into distinct classical bits using one
+    /// tableau index pass instead of two strided full-tableau scans per
+    /// measurement.
+    ///
+    /// Bit-identical to applying the measurements sequentially: a random
+    /// outcome invalidates the index, which is rebuilt before continuing.
+    /// Returns, per measurement, whether the outcome was random, the X-support
+    /// of the pivot row for random outcomes, and the outcome bit.
     pub(crate) fn batch_measure_ref_info(
         &mut self,
         measurements: &[(usize, usize)],
@@ -978,11 +999,10 @@ impl StabilizerBackend {
         (is_random, random_x_support, outcomes)
     }
 
-    /// Export the stabilizer state as a dense statevector.
-    ///
-    /// Host-readable snapshot of the raw tableau: bit-packed `xz` and per-row
-    /// `phase`. When a GPU tableau is attached the data is copied back via
-    /// `GpuTableau::copy_to_host`; otherwise the host vectors are cloned.
+    /// Export a host-readable snapshot of the raw tableau: bit-packed `xz`
+    /// and per-row `phase`. When a GPU tableau is attached the data is copied
+    /// back via `GpuTableau::copy_to_host` with queued ops replayed; otherwise
+    /// the host vectors are cloned.
     ///
     /// Used by golden tests to compare GPU kernel output against the CPU
     /// reference byte for byte. Also gives user-facing diagnostics access to

--- a/src/qec/camps_prefix.rs
+++ b/src/qec/camps_prefix.rs
@@ -201,7 +201,6 @@ impl SignedCliffordPrefix {
         self.inv_z[q].clone()
     }
 
-    #[cfg(test)]
     pub fn conjugate_x(&self, q: usize) -> SignedPauli {
         self.inv_x[q].clone()
     }
@@ -686,12 +685,16 @@ pub(crate) fn build_ofds_disentangler(
     Some((anchor, cascade))
 }
 
-/// Evaluate `⟨ψ|Π_q Z_q|ψ⟩` for a CAMPS state `|ψ⟩ = C|ϕ⟩` where the
-/// Clifford prefix `C` is tracked by `prefix` and the MPS holds `|ϕ⟩`.
+/// Evaluate `⟨ψ|Π_k P_k|ψ⟩` for a general Pauli product over X/Y/Z terms
+/// on a CAMPS state `|ψ⟩ = C|ϕ⟩` where the Clifford prefix `C` is tracked
+/// by `prefix` and the MPS holds `|ϕ⟩`.
 ///
-/// Rewrites the observable as `⟨ϕ| C† (Π Z_q) C |ϕ⟩` by composing
-/// `Π_q (C† Z_q C)` via signed-Pauli multiplication, then evaluates
-/// the resulting Pauli string on the MPS via [`crate::backend::mps::MpsBackend::pauli_expectation`].
+/// Rewrites the observable as `⟨ϕ| C† (Π P_k) C |ϕ⟩` by composing the
+/// conjugated rows via signed-Pauli multiplication: `C† Z_q C` and
+/// `C† X_q C` come straight from the inverse tableau, and a Y term is
+/// `C† Y_q C = i · (C† X_q C)(C† Z_q C)`, with the `i` supplied as
+/// `extra_phase4 = 1` on that product. The result is evaluated on the MPS
+/// via [`crate::backend::mps::MpsBackend::pauli_expectation`].
 ///
 /// The composed string is canonicalized for the MPS evaluator: each
 /// qubit's `(x, z)` bit pattern is mapped to letter `I`/`X`/`Y`/`Z`,
@@ -699,16 +702,25 @@ pub(crate) fn build_ofds_disentangler(
 /// absorbed into the overall coefficient alongside the stored `i^phase4`.
 /// For a Hermitian observable (which `C† O C` is whenever `O` is
 /// Hermitian and `C` unitary) the coefficient lands at `±1`.
-pub(crate) fn evaluate_z_observable_camps(
+pub(crate) fn evaluate_pauli_observable_camps(
     prefix: &SignedCliffordPrefix,
     mps: &crate::backend::mps::MpsBackend,
-    z_qubits: &[usize],
+    terms: &[crate::sim::unified_pauli::PauliTerm],
 ) -> crate::error::Result<f64> {
+    use crate::sim::unified_pauli::PauliAxis;
     let n = prefix.num_qubits();
     let num_words = n.div_ceil(64).max(1);
     let mut combined = SignedPauli::zero(num_words);
-    for &q in z_qubits {
-        let row = prefix.conjugate_z(q);
+    for term in terms {
+        let row = match term.axis {
+            PauliAxis::Z => prefix.conjugate_z(term.qubit),
+            PauliAxis::X => prefix.conjugate_x(term.qubit),
+            PauliAxis::Y => {
+                let mut row = prefix.conjugate_x(term.qubit);
+                rowmul_into(&mut row, &prefix.inv_z[term.qubit], n, 1);
+                row
+            }
+        };
         rowmul_into(&mut combined, &row, n, 0);
     }
     let factors = combined.mps_factors(n);
@@ -943,6 +955,19 @@ mod tests {
     use crate::backend::statevector::StatevectorBackend;
     use crate::circuit::{Instruction, SmallVec};
     use num_complex::Complex64;
+
+    fn eval_z(
+        prefix: &SignedCliffordPrefix,
+        mps: &crate::backend::mps::MpsBackend,
+        qubits: &[usize],
+    ) -> f64 {
+        let terms: Vec<_> = qubits
+            .iter()
+            .copied()
+            .map(crate::sim::unified_pauli::PauliTerm::z)
+            .collect();
+        evaluate_pauli_observable_camps(prefix, mps, &terms).unwrap()
+    }
 
     fn pauli_action_on_basis(p: &SignedPauli, i: usize, n: usize) -> (Complex64, usize) {
         let mut j = i;
@@ -1430,7 +1455,7 @@ mod tests {
         apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
         prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
 
-        let z_camps = evaluate_z_observable_camps(&prefix, &mps, &[0]).unwrap();
+        let z_camps = eval_z(&prefix, &mps, &[0]);
         let direct = direct_state(
             n,
             &[(Gate::SX, vec![0]), (Gate::T, vec![0]), (Gate::H, vec![0])],
@@ -1448,6 +1473,60 @@ mod tests {
             (z_camps - z_direct).abs() < 1e-9,
             "single-Y twisted Pauli: camps={z_camps} direct={z_direct}"
         );
+    }
+
+    #[test]
+    fn general_pauli_observable_matches_statevector() {
+        use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
+        let n = 3;
+        let prep = [
+            (Gate::H, vec![0]),
+            (Gate::SX, vec![1]),
+            (Gate::Cx, vec![0, 1]),
+            (Gate::S, vec![1]),
+            (Gate::Cz, vec![1, 2]),
+            (Gate::SXdg, vec![2]),
+        ];
+        let mut prefix = SignedCliffordPrefix::identity(n);
+        for (g, t) in &prep {
+            prefix.apply_state_gate(g, t).unwrap();
+        }
+        let mut mps = crate::backend::mps::MpsBackend::new(42, 64);
+        mps.init(n, 0).unwrap();
+        apply_t_via_camps(&mut prefix, &mut mps, 0, false, 1e-10).unwrap();
+
+        let mut full_gates = prep.to_vec();
+        full_gates.push((Gate::T, vec![0]));
+        let direct = direct_state(n, &full_gates);
+
+        let cases: Vec<Vec<PauliTerm>> = vec![
+            vec![PauliTerm::x(0)],
+            vec![PauliTerm::y(1)],
+            vec![PauliTerm::z(2), PauliTerm::x(0)],
+            vec![PauliTerm::y(0), PauliTerm::y(2)],
+            vec![PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)],
+            vec![PauliTerm::y(0), PauliTerm::y(1), PauliTerm::y(2)],
+        ];
+        let num_words = n.div_ceil(64).max(1);
+        for terms in &cases {
+            let camps = evaluate_pauli_observable_camps(&prefix, &mps, terms).unwrap();
+            let mut p = SignedPauli::zero(num_words);
+            for t in terms {
+                match t.axis {
+                    PauliAxis::X => p.set_x(t.qubit, true),
+                    PauliAxis::Z => p.set_z(t.qubit, true),
+                    PauliAxis::Y => {
+                        p.set_x(t.qubit, true);
+                        p.set_z(t.qubit, true);
+                    }
+                }
+            }
+            let direct_val = pauli_string_expectation(&direct, n, &p).re;
+            assert!(
+                (camps - direct_val).abs() < 1e-9,
+                "general Pauli {terms:?}: camps={camps} direct={direct_val}"
+            );
+        }
     }
 
     #[test]
@@ -1964,7 +2043,7 @@ mod tests {
         for (g, t) in post_cliffords {
             prefix.apply_state_gate(g, t).unwrap();
         }
-        let zz_camps = evaluate_z_observable_camps(&prefix, &mps, &[0, 1]).unwrap();
+        let zz_camps = eval_z(&prefix, &mps, &[0, 1]);
         let mut gates: Vec<(Gate, Vec<usize>)> = vec![
             (Gate::H, vec![0]),
             (Gate::Cx, vec![0, 1]),
@@ -2031,7 +2110,7 @@ mod tests {
         prefix.apply_state_gate(&Gate::H, &[0]).unwrap();
         prefix.apply_state_gate(&Gate::H, &[1]).unwrap();
 
-        let zz_camps = evaluate_z_observable_camps(&prefix, &mps, &[0, 1]).unwrap();
+        let zz_camps = eval_z(&prefix, &mps, &[0, 1]);
 
         let direct = direct_state(
             n,
@@ -2249,7 +2328,7 @@ mod tests {
 
         let probs = sv.probabilities().unwrap();
         for q in 0..n {
-            let camps = evaluate_z_observable_camps(&prefix, &mps, &[q]).unwrap();
+            let camps = eval_z(&prefix, &mps, &[q]);
             let mask = 1usize << q;
             let direct: f64 = probs
                 .iter()

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -218,8 +218,13 @@ pub enum QecOp {
         observable: usize,
         records: Vec<QecRecordRef>,
     },
-    /// Expectation-value metadata. Both runners reject programs containing
-    /// this op until estimator semantics land.
+    /// Final-state expectation-value estimator: `coefficient * <P>` where
+    /// `P` is the Pauli product over `terms`, evaluated in the program's
+    /// final state. Must be terminal (no gate, measurement, reset, or
+    /// active noise may follow) and may only reference live qubits (not
+    /// single-qubit-measured since their last reset). Estimates are
+    /// returned in [`QecSampleResult::expectation_values`], one per op in
+    /// op order.
     ExpectationValue {
         terms: Vec<QecPauli>,
         coefficient: f64,
@@ -567,6 +572,27 @@ impl QecProgram {
             .map_or(0, |max_idx| max_idx + 1)
     }
 
+    /// Number of `EXP_VAL` ops.
+    pub fn num_expectation_values(&self) -> usize {
+        self.ops
+            .iter()
+            .filter(|op| matches!(op, QecOp::ExpectationValue { .. }))
+            .count()
+    }
+
+    /// The `EXP_VAL` ops in op order as `(terms, coefficient)`.
+    pub fn expectation_value_ops(&self) -> Vec<(&[QecPauli], f64)> {
+        self.ops
+            .iter()
+            .filter_map(|op| match op {
+                QecOp::ExpectationValue { terms, coefficient } => {
+                    Some((terms.as_slice(), *coefficient))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Append a validated operation.
     pub fn push_op(&mut self, op: QecOp) -> Result<()> {
         self.validate_op(&op, self.num_measurements())?;
@@ -838,7 +864,9 @@ pub fn compile_qec_program_rows(program: &QecProgram) -> Result<QecCompiledRows>
             QecOp::ExpectationValue { .. } => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "QEC row compiler".to_string(),
-                    reason: "QEC row compilation does not evaluate EXP_VAL yet".to_string(),
+                    reason: "QEC row compilation has no row representation for `EXP_VAL`; \
+                             use `run_qec_program`"
+                        .to_string(),
                 });
             }
             QecOp::Detector { .. }
@@ -872,6 +900,89 @@ pub fn compile_qec_program_rows(program: &QecProgram) -> Result<QecCompiledRows>
         postselection_rows,
         postselection_expected,
     })
+}
+
+pub(crate) fn qec_terms_to_pauli(terms: &[QecPauli]) -> Vec<crate::sim::unified_pauli::PauliTerm> {
+    use crate::sim::unified_pauli::PauliTerm;
+    terms
+        .iter()
+        .map(|t| match t.basis {
+            QecBasis::X => PauliTerm::x(t.qubit),
+            QecBasis::Y => PauliTerm::y(t.qubit),
+            QecBasis::Z => PauliTerm::z(t.qubit),
+        })
+        .collect()
+}
+
+/// Validate `EXP_VAL` placement for execution.
+///
+/// Terminality: no gate, measurement, reset, or active noise may follow an
+/// `EXP_VAL` op, so "final state" is well defined on every path.
+/// Liveness: an `EXP_VAL` term may not reference a qubit that was
+/// single-qubit-measured after its last reset. Liveness keeps the sampled
+/// post-measurement expectation equal to the measurement-stripped
+/// pure-state expectation the analytical strategies evaluate (the Pauli
+/// commutes with every measurement projector when their supports are
+/// disjoint). Pauli-product measurements do not affect liveness: the
+/// deferred lowering measures a scratch alias and the cross terms of the
+/// projected state cancel exactly.
+///
+/// No-op for programs without `EXP_VAL` ops.
+pub(crate) fn validate_qec_exp_val_placement(program: &QecProgram) -> Result<()> {
+    let terminal_violation = |op_name: &str| PrismError::InvalidParameter {
+        message: format!("`EXP_VAL` must be terminal: `{op_name}` appears after an `EXP_VAL` op"),
+    };
+    let mut seen_exp_val = false;
+    let mut measured_since_reset = vec![false; program.num_qubits()];
+    for op in program.ops() {
+        match op {
+            QecOp::ExpectationValue { terms, .. } => {
+                seen_exp_val = true;
+                if let Some(term) = terms.iter().find(|t| measured_since_reset[t.qubit]) {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "`EXP_VAL` term on qubit {}: qubit was measured after its last \
+                             reset; expectation values are defined only on live qubits",
+                            term.qubit
+                        ),
+                    });
+                }
+            }
+            QecOp::Gate { gate, .. } => {
+                if seen_exp_val {
+                    return Err(terminal_violation(gate.name()));
+                }
+            }
+            QecOp::Measure { qubit, .. } => {
+                if seen_exp_val {
+                    return Err(terminal_violation("M"));
+                }
+                measured_since_reset[*qubit] = true;
+            }
+            QecOp::MeasurePauliProduct { .. } => {
+                if seen_exp_val {
+                    return Err(terminal_violation("MPP"));
+                }
+            }
+            QecOp::Reset { qubit, .. } => {
+                if seen_exp_val {
+                    return Err(terminal_violation("R"));
+                }
+                measured_since_reset[*qubit] = false;
+            }
+            QecOp::Noise { channel, .. } if channel.probability() > 0.0 => {
+                if seen_exp_val {
+                    return Err(terminal_violation(channel.name()));
+                }
+            }
+            QecOp::Detector { .. }
+            | QecOp::ObservableInclude { .. }
+            | QecOp::Postselect { .. }
+            | QecOp::Noise { .. }
+            | QecOp::Tick => {}
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn append_basis_to_z_rotation(circuit: &mut Circuit, basis: QecBasis, qubit: usize) {
@@ -973,10 +1084,7 @@ fn validate_pauli_terms(terms: &[QecPauli], num_qubits: usize) -> Result<()> {
         validate_qubit(term.qubit, num_qubits)?;
         if terms[..idx].iter().any(|prior| prior.qubit == term.qubit) {
             return Err(PrismError::InvalidParameter {
-                message: format!(
-                    "Pauli-product measurement contains duplicate qubit {}",
-                    term.qubit
-                ),
+                message: format!("Pauli product contains duplicate qubit {}", term.qubit),
             });
         }
     }

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -22,6 +22,10 @@ pub(super) struct QecDeferredProgram {
     pub(super) circuit: Circuit,
     noise_events: Vec<QecDeferredNoiseEvent>,
     pub(super) measurement_qubits: Vec<usize>,
+    /// Final lowered-circuit alias of each program qubit. Resets reassign a
+    /// program qubit to a fresh alias, so ops that reference program qubits
+    /// at the end of the stream (`EXP_VAL`) must translate through this map.
+    pub(super) final_qubit_aliases: Vec<usize>,
 }
 
 pub(super) struct QecCompiledNoiseSampler {
@@ -324,13 +328,8 @@ fn lower_qec_program_to_deferred_circuit_inner(
                     )?;
                 }
             }
-            QecOp::ExpectationValue { .. } => {
-                return Err(PrismError::IncompatibleBackend {
-                    backend: "QEC compiled runner".to_string(),
-                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
-                });
-            }
-            QecOp::Detector { .. }
+            QecOp::ExpectationValue { .. }
+            | QecOp::Detector { .. }
             | QecOp::ObservableInclude { .. }
             | QecOp::Postselect { .. }
             | QecOp::Tick => {}
@@ -345,10 +344,12 @@ fn lower_qec_program_to_deferred_circuit_inner(
         circuit.add_measure(qubit, classical_bit);
     }
 
+    let final_qubit_aliases = aliases[..program.num_qubits()].to_vec();
     Ok(QecDeferredProgram {
         circuit,
         noise_events,
         measurement_qubits,
+        final_qubit_aliases,
     })
 }
 

--- a/src/qec/result.rs
+++ b/src/qec/result.rs
@@ -52,10 +52,19 @@ pub struct QecSampleResult {
     /// analytical or weighted T strategies where the observable expectation
     /// is not a simple ratio of bit counts.
     pub observable_expectations: Option<Vec<QecObservableEstimate>>,
+    /// Estimates for the program's `EXP_VAL` ops, one per op in op order,
+    /// each scaled by the op's coefficient. `None` when the program has no
+    /// `EXP_VAL` ops. The reference runner reports the per-shot sample mean
+    /// and unbiased sample variance over accepted shots; analytical
+    /// strategies report the exact expectation with `variance` carrying
+    /// squared truncation weight (0.0 when exact). Zero accepted shots
+    /// yield `{mean: 0.0, variance: 0.0, num_shots: 0}`.
+    pub expectation_values: Option<Vec<QecObservableEstimate>>,
 }
 
 /// Unbiased expectation estimate for one observable under a weighted
-/// shot strategy.
+/// shot strategy, or for one `EXP_VAL` op (see
+/// [`QecSampleResult::expectation_values`]).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct QecObservableEstimate {
     /// Empirical mean of `Re(weight · (1 - 2·parity))` over the shot
@@ -82,6 +91,7 @@ impl QecSampleResult {
             discarded_shots: 0,
             logical_errors: vec![0; num_observables],
             observable_expectations: None,
+            expectation_values: None,
         }
     }
 
@@ -165,6 +175,7 @@ impl QecSampleResult {
             discarded_shots,
             logical_errors,
             observable_expectations: None,
+            expectation_values: None,
         })
     }
 
@@ -186,6 +197,14 @@ impl QecSampleResult {
         }
         self.observable_expectations = Some(estimates);
         Ok(self)
+    }
+
+    /// Attach `EXP_VAL` estimates, one per `EXP_VAL` op in op order. There
+    /// is no packed row to validate against; callers supply one estimate
+    /// per op.
+    pub fn with_expectation_values(mut self, estimates: Vec<QecObservableEstimate>) -> Self {
+        self.expectation_values = Some(estimates);
+        self
     }
 
     /// Fraction of requested shots accepted after postselection.

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -2,9 +2,9 @@
 use super::noise::QecCompiledNoiseSampler;
 use super::noise::compile_qec_noisy_sampler;
 use super::{
-    QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram, QecSampleResult,
-    append_basis_to_z_rotation, append_mpp_parity_rotations, append_z_to_basis_rotation,
-    ensure_lowered_record_count, qec_non_clifford_error,
+    QecBasis, QecNoise, QecObservableEstimate, QecOp, QecOptions, QecPauli, QecProgram,
+    QecSampleResult, append_basis_to_z_rotation, append_mpp_parity_rotations,
+    append_z_to_basis_rotation, ensure_lowered_record_count, qec_non_clifford_error,
 };
 use crate::backend::{Backend, statevector::StatevectorBackend};
 use crate::circuit::{Circuit, Instruction, SmallVec};
@@ -26,8 +26,18 @@ use rand_chacha::ChaCha8Rng;
 /// `DEPOLARIZE2`) are compiled into packed sensitivity rows that are XORed
 /// into the noiseless measurement records.
 ///
+/// Programs containing `EXP_VAL` ops are routed instead of packed-sampled:
+/// with active noise they run through [`run_qec_program_reference`].
+/// Noiseless programs with detectors split into a packed sampling run for
+/// the measurement, detector, and observable records plus an analytical
+/// estimator run, falling back to the reference runner when either half
+/// cannot lower (for example non-Clifford gates on the packed half).
+/// Otherwise the analytical Auto T-strategy ladder evaluates the program.
+/// Estimates land in [`QecSampleResult::expectation_values`].
+///
 /// V1 limitations:
-/// - Non-Clifford gates and `EXP_VAL` are rejected.
+/// - Non-Clifford gates are rejected on the packed path (the `EXP_VAL`
+///   route accepts them via the analytical strategies).
 /// - A measured qubit must be `Reset` before any later gate reuses it; the
 ///   compiled lowering defers measurements to the terminal records of an
 ///   internal circuit.
@@ -35,6 +45,23 @@ use rand_chacha::ChaCha8Rng;
 ///   `chunk_size` together with `keep_measurements: false` keeps peak memory
 ///   at one chunk worth of measurement records.
 pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
+    if program.num_expectation_values() > 0 {
+        super::validate_qec_exp_val_placement(program)?;
+        let has_active_noise = program
+            .ops()
+            .iter()
+            .any(|op| matches!(op, QecOp::Noise { channel, .. } if channel.probability() > 0.0));
+        if has_active_noise {
+            return run_qec_program_reference(program);
+        }
+        if program.num_detectors() > 0 {
+            return run_qec_program_detectors_and_exp_val(program);
+        }
+        return super::t_sampler::run_qec_program_with_strategy(
+            program,
+            super::t_sampler::QecTStrategy::Auto,
+        );
+    }
     let has_noise = validate_qec_compiled_program(program)?;
     let chunk_size = qec_runner_chunk_size(program.options())?;
     if program.num_measurements() == 0 {
@@ -69,6 +96,47 @@ pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
         return qec_result_from_measurements(program, measurements);
     }
     qec_result_from_measurement_chunks(program, |chunk| sampler.sample_measurements_packed(chunk))
+}
+
+/// Split execution for noiseless `EXP_VAL` programs with detectors.
+///
+/// Detectors are record metadata and do not affect the state, so the two
+/// halves compose: the packed compiled sampler runs the program without its
+/// `EXP_VAL` ops (real sampled measurement, detector, and observable
+/// records), and the analytical ladder runs the program without its
+/// detectors (exact estimates). When either half cannot run, for example
+/// non-Clifford gates on the packed half, the whole program falls back to
+/// [`run_qec_program_reference`].
+fn run_qec_program_detectors_and_exp_val(program: &QecProgram) -> Result<QecSampleResult> {
+    let sampling_ops = program
+        .ops()
+        .iter()
+        .filter(|op| !matches!(op, QecOp::ExpectationValue { .. }))
+        .cloned()
+        .collect();
+    let estimator_ops = program
+        .ops()
+        .iter()
+        .filter(|op| !matches!(op, QecOp::Detector { .. }))
+        .cloned()
+        .collect();
+    let sampling_program =
+        QecProgram::from_ops(program.num_qubits(), program.options(), sampling_ops)?;
+    let estimator_program =
+        QecProgram::from_ops(program.num_qubits(), program.options(), estimator_ops)?;
+    let Ok(sampled) = run_qec_program(&sampling_program) else {
+        return run_qec_program_reference(program);
+    };
+    let Ok(estimated) = super::t_sampler::run_qec_program_with_strategy(
+        &estimator_program,
+        super::t_sampler::QecTStrategy::Auto,
+    ) else {
+        return run_qec_program_reference(program);
+    };
+    let estimates = estimated
+        .expectation_values
+        .expect("analytical ladder attaches estimates for EXP_VAL programs");
+    Ok(sampled.with_expectation_values(estimates))
 }
 
 /// Internal staged QEC sampler used by benchmark harnesses.
@@ -284,10 +352,18 @@ impl QecProfiledSampler {
 /// for small programs or to cross-check the compiled runner; cost is
 /// `O(shots * 2^n)`, so it is not the production performance path.
 ///
-/// `EXP_VAL` is rejected pending estimator semantics. [`QecOptions::chunk_size`]
-/// is validated for shape but not used to bound execution batches.
+/// `EXP_VAL` ops are evaluated exactly on each shot's final statevector and
+/// reported in [`QecSampleResult::expectation_values`] as the sample mean and
+/// unbiased sample variance over accepted shots. With noise annotations the
+/// per-shot trajectories average to the mixed-state expectation `Tr(rho P)`
+/// and the variance captures the noise-induced spread. The Pauli-mask
+/// reduction limits `EXP_VAL` here to programs of at most 64 qubits (larger
+/// programs are rejected up front); statevector memory binds far earlier.
+/// [`QecOptions::chunk_size`] is validated for shape but not used to bound
+/// execution batches.
 pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult> {
     qec_runner_chunk_size(program.options())?;
+    super::validate_qec_exp_val_placement(program)?;
     let shots = program.options().shots;
     let num_measurements = program.num_measurements();
     let has_mpp = program
@@ -300,6 +376,29 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
     let mut noise_rng = ChaCha8Rng::seed_from_u64(program.options().seed ^ 0xD1B5_4A32_D192_ED03);
     let m_words = num_measurements.div_ceil(64);
     let mut measurement_data = vec![0u64; shots.saturating_mul(m_words)];
+
+    if program.num_expectation_values() > 0 && backend_qubits > usize::BITS as usize {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC reference runner".to_string(),
+            reason: format!(
+                "`EXP_VAL` mask reduction supports at most {} qubits, program needs {}",
+                usize::BITS,
+                backend_qubits
+            ),
+        });
+    }
+    let exp_val_masks = program
+        .expectation_value_ops()
+        .into_iter()
+        .map(|(terms, coefficient)| {
+            let terms = super::qec_terms_to_pauli(terms);
+            crate::sim::pauli_masks(&terms, backend_qubits).map(|masks| (masks, coefficient))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let postselection_rows = program.postselection_rows()?;
+    let mut exp_val_sums = vec![0.0f64; exp_val_masks.len()];
+    let mut exp_val_sq_sums = vec![0.0f64; exp_val_masks.len()];
+    let mut exp_val_accepted = 0usize;
 
     for shot in 0..shots {
         backend.init(backend_qubits, num_measurements)?;
@@ -332,13 +431,8 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
                 QecOp::Noise { channel, targets } => {
                     apply_reference_noise(&mut backend, &mut noise_rng, *channel, targets)?;
                 }
-                QecOp::ExpectationValue { .. } => {
-                    return Err(PrismError::IncompatibleBackend {
-                        backend: "QEC reference runner".to_string(),
-                        reason: "QEC reference runner does not evaluate EXP_VAL yet".to_string(),
-                    });
-                }
-                QecOp::Detector { .. }
+                QecOp::ExpectationValue { .. }
+                | QecOp::Detector { .. }
                 | QecOp::ObservableInclude { .. }
                 | QecOp::Postselect { .. }
                 | QecOp::Tick => {}
@@ -352,10 +446,65 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
                 ),
             });
         }
+
+        if !exp_val_masks.is_empty() {
+            let accepted = postselection_rows.iter().all(|(row, expected)| {
+                let parity = row.iter().fold(false, |acc, &record| {
+                    let bit =
+                        (measurement_data[shot * m_words + record / 64] >> (record % 64)) & 1 == 1;
+                    acc ^ bit
+                });
+                parity == *expected
+            });
+            if accepted {
+                exp_val_accepted += 1;
+                let state = backend.state_vector();
+                let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+                for (slot, &((xmask, zmask, num_y), coefficient)) in
+                    exp_val_masks.iter().enumerate()
+                {
+                    let value = coefficient
+                        * crate::sim::pauli_expectation_from_masks(
+                            state, xmask, zmask, num_y, norm,
+                        );
+                    exp_val_sums[slot] += value;
+                    exp_val_sq_sums[slot] += value * value;
+                }
+            }
+        }
     }
 
     let measurements = PackedShots::from_shot_major(measurement_data, shots, num_measurements);
-    qec_result_from_measurements(program, measurements)
+    let result = qec_result_from_measurements(program, measurements)?;
+    if exp_val_masks.is_empty() {
+        return Ok(result);
+    }
+    let n = exp_val_accepted;
+    let estimates = exp_val_sums
+        .iter()
+        .zip(&exp_val_sq_sums)
+        .map(|(&sum, &sum_sq)| {
+            if n == 0 {
+                return QecObservableEstimate {
+                    mean: 0.0,
+                    variance: 0.0,
+                    num_shots: 0,
+                };
+            }
+            let mean = sum / n as f64;
+            let variance = if n >= 2 {
+                ((sum_sq - n as f64 * mean * mean) / (n as f64 - 1.0)).max(0.0)
+            } else {
+                0.0
+            };
+            QecObservableEstimate {
+                mean,
+                variance,
+                num_shots: n,
+            }
+        })
+        .collect();
+    Ok(result.with_expectation_values(estimates))
 }
 
 fn qec_result_from_measurements(
@@ -822,7 +971,10 @@ fn validate_qec_compiled_program(program: &QecProgram) -> Result<bool> {
             QecOp::ExpectationValue { .. } => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "QEC compiled runner".to_string(),
-                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
+                    reason: "compiled QEC sampler has no estimator stage for `EXP_VAL`; \
+                             `run_qec_program` routes such programs to the analytical or \
+                             reference runners"
+                        .to_string(),
                 });
             }
             QecOp::Noise { channel, .. } => {
@@ -894,7 +1046,10 @@ fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit
             QecOp::ExpectationValue { .. } => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "QEC compiled runner".to_string(),
-                    reason: "compiled QEC runner does not evaluate EXP_VAL yet".to_string(),
+                    reason: "compiled QEC sampler has no estimator stage for `EXP_VAL`; \
+                             `run_qec_program` routes such programs to the analytical or \
+                             reference runners"
+                        .to_string(),
                 });
             }
             QecOp::Detector { .. }

--- a/src/qec/t_sampler.rs
+++ b/src/qec/t_sampler.rs
@@ -102,7 +102,13 @@ mod auto_test_hooks {
 fn run_qec_program_spd_for_auto(program: &QecProgram) -> Result<QecSampleResult> {
     let mut result = run_qec_program_spd(program)?;
     if auto_test_hooks::force_spd_nonexact() {
-        if let Some(estimates) = result.observable_expectations.as_mut() {
+        for estimates in [
+            result.observable_expectations.as_mut(),
+            result.expectation_values.as_mut(),
+        ]
+        .into_iter()
+        .flatten()
+        {
             for estimate in estimates {
                 estimate.variance = estimate.variance.max(1.0);
             }
@@ -175,15 +181,16 @@ fn run_qec_program_auto_after_camps(
 const QEC_SPD_NEGLIGIBLE_VARIANCE: f64 = 1e-12;
 
 fn analytical_result_has_no_truncation(result: &QecSampleResult) -> bool {
-    result
-        .observable_expectations
-        .as_ref()
-        .map(|estimates| {
-            estimates
-                .iter()
-                .all(|estimate| estimate.variance <= QEC_SPD_NEGLIGIBLE_VARIANCE)
-        })
-        .unwrap_or(true)
+    let exact = |estimates: Option<&Vec<QecObservableEstimate>>| {
+        estimates
+            .map(|estimates| {
+                estimates
+                    .iter()
+                    .all(|estimate| estimate.variance <= QEC_SPD_NEGLIGIBLE_VARIANCE)
+            })
+            .unwrap_or(true)
+    };
+    exact(result.observable_expectations.as_ref()) && exact(result.expectation_values.as_ref())
 }
 
 /// Default truncation tolerance for SPD on QEC programs.
@@ -208,9 +215,16 @@ const QEC_SPD_MAX_TERMS: usize = 16_384;
 /// **Still rejected:**
 /// - Active `Noise` channels: SPD / CAMPS do not have an
 ///   `apply_noise_to_measurements`-style hook.
-/// - `ExpectationValue`: unmodified rejection.
 /// - `Detector`: analytical strategies do not emit detector rows yet.
-fn lower_qec_program_for_pauli_observable(program: &QecProgram) -> Result<(Circuit, Vec<usize>)> {
+///
+/// `ExpectationValue` ops are accepted: placement is validated (terminal,
+/// live qubits only) and their program-qubit terms are translated through
+/// the returned final-alias map, since resets reassign qubits to fresh
+/// aliases in the lowered circuit.
+fn lower_qec_program_for_pauli_observable(
+    program: &QecProgram,
+) -> Result<(Circuit, Vec<usize>, Vec<usize>)> {
+    super::validate_qec_exp_val_placement(program)?;
     for op in program.ops() {
         match op {
             QecOp::Noise { channel, .. } if channel.probability() > 0.0 => {
@@ -223,14 +237,6 @@ fn lower_qec_program_for_pauli_observable(program: &QecProgram) -> Result<(Circu
                          (statevector per shot with stochastic noise) or extend \
                          CAMPS to an `MPDO` density-matrix path"
                     ),
-                });
-            }
-            QecOp::ExpectationValue { .. } => {
-                return Err(PrismError::IncompatibleBackend {
-                    backend: "QEC SPD / CAMPS".to_string(),
-                    reason: "EXP_VAL op is reserved for the dedicated \
-                             expectation runner"
-                        .to_string(),
                 });
             }
             QecOp::Detector { .. } => {
@@ -254,7 +260,11 @@ fn lower_qec_program_for_pauli_observable(program: &QecProgram) -> Result<(Circu
             circuit.instructions.push(inst.clone());
         }
     }
-    Ok((circuit, deferred.measurement_qubits))
+    Ok((
+        circuit,
+        deferred.measurement_qubits,
+        deferred.final_qubit_aliases,
+    ))
 }
 
 /// Convert an observable-row record list into a joint Pauli observable.
@@ -335,6 +345,31 @@ fn lower_postselection_rows(
     Ok(out)
 }
 
+/// Merge a projector Z-string with an observable's Pauli terms. A Z
+/// observable term on a projector qubit cancels it (Z·Z = I), preserving
+/// the parity semantics of the legacy record-based observables. X/Y
+/// observable terms cannot share a projector qubit: projector strings live
+/// on measured aliases while `EXP_VAL` terms are restricted to live
+/// qubits, so the supports are disjoint by construction.
+fn merge_projector_with_observable(pi: &[PauliTerm], obs: &[PauliTerm]) -> Vec<PauliTerm> {
+    use crate::sim::unified_pauli::PauliAxis;
+    let mut out: Vec<PauliTerm> = obs.to_vec();
+    for pt in pi {
+        if let Some(pos) = out.iter().position(|t| t.qubit == pt.qubit) {
+            debug_assert!(
+                matches!(out[pos].axis, PauliAxis::Z),
+                "projector qubit {} overlaps a non-Z observable term",
+                pt.qubit
+            );
+            out.remove(pos);
+        } else {
+            out.push(*pt);
+        }
+    }
+    out.sort_by_key(|t| t.qubit);
+    out
+}
+
 /// XOR-merge a sequence of qubit lists into a sorted, deduplicated
 /// `Vec<PauliTerm>` of `Z` factors (each qubit appears with parity 1).
 fn merge_qubit_groups_into_z_terms<'a, I>(groups: I) -> Vec<PauliTerm>
@@ -402,14 +437,9 @@ where
     let mut obs_pi_sums = vec![0.0; observable_terms_list.len()];
     let mut obs_discarded = vec![0.0; observable_terms_list.len()];
 
-    let obs_qubits: Vec<Vec<usize>> = observable_terms_list
-        .iter()
-        .map(|terms| terms.iter().map(|t| t.qubit).collect())
-        .collect();
-
     for mask in 0..subset_count {
         let mut sign = 1.0;
-        let mut qubit_groups: Vec<&[usize]> = Vec::with_capacity(j + 1);
+        let mut qubit_groups: Vec<&[usize]> = Vec::with_capacity(j);
         for (j_idx, (qubits, eps)) in postsel.iter().enumerate() {
             if (mask >> j_idx) & 1 == 1 {
                 sign *= *eps;
@@ -420,10 +450,8 @@ where
         let pi_value = eval(&pi_pauli)?;
         pi_sum += sign * pi_value.mean;
 
-        for (obs_idx, obs_q) in obs_qubits.iter().enumerate() {
-            qubit_groups.push(obs_q.as_slice());
-            let combined_pauli = merge_qubit_groups_into_z_terms(qubit_groups.iter().copied());
-            qubit_groups.pop();
+        for (obs_idx, obs_terms) in observable_terms_list.iter().enumerate() {
+            let combined_pauli = merge_projector_with_observable(&pi_pauli, obs_terms);
             let outcome = eval(&combined_pauli)?;
             obs_pi_sums[obs_idx] += sign * outcome.mean;
             obs_discarded[obs_idx] += outcome.discarded_sq;
@@ -540,37 +568,61 @@ fn packed_observable_records_from_logical_errors(
     PackedShots::from_meas_major(data, total_shots, num_observables)
 }
 
+struct QecExpVal {
+    terms: Vec<PauliTerm>,
+    coefficient: f64,
+}
+
 struct LoweredPauliObservables {
     circuit: Circuit,
     record_to_qubit: Vec<usize>,
     observable_terms_list: Vec<Vec<PauliTerm>>,
     postsel_rows: Vec<(Vec<usize>, bool)>,
+    exp_vals: Vec<QecExpVal>,
 }
 
 /// Shared lowering prelude for the analytical strategies: the restricted
 /// Clifford+T circuit, the record-to-qubit map, per-observable Pauli terms,
-/// and the unresolved postselection rows.
+/// the unresolved postselection rows, and the `EXP_VAL` ops with their
+/// program-qubit terms translated to final lowered-circuit aliases.
 fn lower_pauli_observables(program: &QecProgram) -> Result<LoweredPauliObservables> {
-    let (circuit, record_to_qubit) = lower_qec_program_for_pauli_observable(program)?;
+    let (circuit, record_to_qubit, final_qubit_aliases) =
+        lower_qec_program_for_pauli_observable(program)?;
     let observable_rows = program.observable_rows()?;
     let postsel_rows = program.postselection_rows()?;
     let mut observable_terms_list = Vec::with_capacity(observable_rows.len());
     for row in observable_rows.iter() {
         observable_terms_list.push(observable_row_to_pauli_terms(row, &record_to_qubit)?);
     }
+    let exp_vals = program
+        .expectation_value_ops()
+        .into_iter()
+        .map(|(terms, coefficient)| {
+            let terms = super::qec_terms_to_pauli(terms)
+                .into_iter()
+                .map(|mut t| {
+                    t.qubit = final_qubit_aliases[t.qubit];
+                    t
+                })
+                .collect();
+            QecExpVal { terms, coefficient }
+        })
+        .collect();
     Ok(LoweredPauliObservables {
         circuit,
         record_to_qubit,
         observable_terms_list,
         postsel_rows,
+        exp_vals,
     })
 }
 
 /// Shared result assembly for the analytical strategies. Evaluates each
-/// observable through `eval`, reporting unconditional means directly or
-/// routing through the conditional-expectation combiner when postselection
-/// rows exist. `discarded_sq` from `eval` lands in
-/// `QecObservableEstimate::variance` on both paths.
+/// observable and `EXP_VAL` op through `eval`, reporting unconditional
+/// means directly or routing through the conditional-expectation combiner
+/// when postselection rows exist. `discarded_sq` from `eval` lands in
+/// `QecObservableEstimate::variance` on both paths; `EXP_VAL` estimates
+/// are scaled by the op coefficient (mean by `c`, variance by `c²`).
 fn evaluate_observable_program<F>(
     program: &QecProgram,
     lowered: &LoweredPauliObservables,
@@ -591,23 +643,57 @@ where
                 num_shots: program.options().shots,
             });
         }
-        return build_qec_result_from_observable_means(program, means, estimates);
+        let mut exp_estimates = Vec::with_capacity(lowered.exp_vals.len());
+        for ev in &lowered.exp_vals {
+            let eval_result = eval(&ev.terms)?;
+            exp_estimates.push(QecObservableEstimate {
+                mean: ev.coefficient * eval_result.mean,
+                variance: ev.coefficient * ev.coefficient * eval_result.discarded_sq,
+                num_shots: program.options().shots,
+            });
+        }
+        let result = build_qec_result_from_observable_means(program, means, estimates)?;
+        return Ok(if exp_estimates.is_empty() {
+            result
+        } else {
+            result.with_expectation_values(exp_estimates)
+        });
     }
 
     let postsel = lower_postselection_rows(&lowered.postsel_rows, &lowered.record_to_qubit)?;
-    let (means, obs_discarded, accept_rate) =
-        evaluate_conditional_expectations(&lowered.observable_terms_list, &postsel, eval)?;
+    let num_observables = lowered.observable_terms_list.len();
+    let mut all_terms: Vec<Vec<PauliTerm>> = lowered.observable_terms_list.clone();
+    all_terms.extend(lowered.exp_vals.iter().map(|ev| ev.terms.clone()));
+    let (mut means, mut discarded, accept_rate) =
+        evaluate_conditional_expectations(&all_terms, &postsel, eval)?;
+    let exp_means = means.split_off(num_observables);
+    let exp_discarded = discarded.split_off(num_observables);
     let estimate_shots = accepted_shots_for_rate(program.options().shots, accept_rate);
     let estimates: Vec<_> = means
         .iter()
-        .zip(obs_discarded.iter())
+        .zip(discarded.iter())
         .map(|(&mean, &discarded_sq)| QecObservableEstimate {
             mean,
             variance: discarded_sq,
             num_shots: estimate_shots,
         })
         .collect();
-    build_qec_result_with_acceptance(program, means, estimates, accept_rate)
+    let exp_estimates: Vec<_> = lowered
+        .exp_vals
+        .iter()
+        .zip(exp_means.iter().zip(exp_discarded.iter()))
+        .map(|(ev, (&mean, &discarded_sq))| QecObservableEstimate {
+            mean: ev.coefficient * mean,
+            variance: ev.coefficient * ev.coefficient * discarded_sq,
+            num_shots: estimate_shots,
+        })
+        .collect();
+    let result = build_qec_result_with_acceptance(program, means, estimates, accept_rate)?;
+    Ok(if exp_estimates.is_empty() {
+        result
+    } else {
+        result.with_expectation_values(exp_estimates)
+    })
 }
 
 /// Default MPS bond-dimension cap for CAMPS. Matches the
@@ -618,12 +704,13 @@ const QEC_CAMPS_MAX_BOND_DIM: usize = 256;
 /// CAMPS analytical path for QEC observables.
 ///
 /// Tracks the Clifford prefix separately from the MPS, applies T/Tdg through
-/// the CAMPS disentangler update, and evaluates Z-string observables directly
-/// from the MPS plus prefix. The path shares SPD's restricted lowering and
-/// Z-only observable scope.
+/// the CAMPS disentangler update, and evaluates Pauli-string observables
+/// directly from the MPS plus prefix: record-based observables lower to
+/// Z-strings, and `EXP_VAL` terms may carry any X/Y/Z letters. The path
+/// shares SPD's restricted lowering.
 fn run_qec_program_camps(program: &QecProgram) -> Result<QecSampleResult> {
     use super::camps_prefix::{
-        SignedCliffordPrefix, apply_t_via_camps, evaluate_z_observable_camps,
+        SignedCliffordPrefix, apply_t_via_camps, evaluate_pauli_observable_camps,
     };
     use crate::circuit::Instruction;
 
@@ -661,13 +748,12 @@ fn run_qec_program_camps(program: &QecProgram) -> Result<QecSampleResult> {
 
     // Clifford gates are absorbed into a [`SignedCliffordPrefix`]; T/Tdg
     // gates dispatch through [`apply_t_via_camps`] (Liu & Clark
-    // Algorithm 1 OFD). The observable `⟨ψ|Π Z_q|ψ⟩` is evaluated as
-    // `⟨ϕ| C†(Π Z_q) C |ϕ⟩` by composing twisted Pauli rows and calling
+    // Algorithm 1 OFD). The observable `⟨ψ|Π P_k|ψ⟩` is evaluated as
+    // `⟨ϕ| C†(Π P_k) C |ϕ⟩` by composing twisted Pauli rows and calling
     // [`crate::backend::mps::MpsBackend::pauli_expectation`].
     evaluate_observable_program(program, &lowered, |terms| {
-        let qubits: Vec<usize> = terms.iter().map(|t| t.qubit).collect();
         Ok(ConditionalEval {
-            mean: evaluate_z_observable_camps(&prefix, &backend, &qubits)?,
+            mean: evaluate_pauli_observable_camps(&prefix, &backend, terms)?,
             discarded_sq: 0.0,
         })
     })
@@ -726,6 +812,14 @@ pub fn run_qec_program_spd_rerouted(
     program: &QecProgram,
     reroutes: &[QecObservableReroute],
 ) -> Result<QecSampleResult> {
+    if program.num_expectation_values() > 0 {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "QEC SPD rerouted".to_string(),
+            reason: "stabilizer rerouting applies to record-based Z observables; `EXP_VAL` \
+                     is not supported on the rerouted path"
+                .to_string(),
+        });
+    }
     let LoweredPauliObservables {
         circuit,
         observable_terms_list,

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1075,7 +1075,7 @@ pub(crate) fn i_pow(num_y: u32) -> Complex64 {
 
 /// Exact `⟨ψ|P|ψ⟩` from the reduced observable masks. Normalization
 /// independent, so raw backend amplitudes are fine.
-fn pauli_expectation_from_masks(
+pub(crate) fn pauli_expectation_from_masks(
     state: &[Complex64],
     xmask: usize,
     zmask: usize,

--- a/tests/qec_e2e_d3.rs
+++ b/tests/qec_e2e_d3.rs
@@ -1,0 +1,161 @@
+//! End-to-end distance-3 repetition-code fixtures for the `EXP_VAL`
+//! estimator.
+//!
+//! `e2e-d3-t`: logical |+> encoding, one syndrome round with ancilla resets
+//! (exercising reset-alias translation of `EXP_VAL` terms), deterministic
+//! postselection, transversal T, and X/Y/Z logical expectation values with
+//! closed-form references. Runs the analytical ladder, the compiled-runner
+//! routing, and the sampled reference.
+//!
+//! `e2e-d3-s`: Clifford-only encoding under X noise with detectors,
+//! sampled through the compiled runner's reference route, compared against
+//! closed-form means within a 5-sigma band.
+
+mod qec_common;
+
+use prism_q::{
+    Gate, QecBasis, QecNoise, QecPauli, QecProgram, QecRecordRef, QecTStrategy, run_qec_program,
+    run_qec_program_reference, run_qec_program_with_strategy,
+};
+use qec_common::ANALYTICAL_STRATEGIES;
+
+const STAT_SHOTS: usize = 4_000;
+
+fn syndrome_round(program: &mut QecProgram) -> (usize, usize) {
+    program.push_gate(Gate::Cx, &[0, 3]).unwrap();
+    program.push_gate(Gate::Cx, &[1, 3]).unwrap();
+    program.push_gate(Gate::Cx, &[1, 4]).unwrap();
+    program.push_gate(Gate::Cx, &[2, 4]).unwrap();
+    let m0 = program.measure_z(3).unwrap();
+    let m1 = program.measure_z(4).unwrap();
+    (m0, m1)
+}
+
+fn e2e_d3_t_program() -> QecProgram {
+    let mut program = QecProgram::with_options(5, qec_common::qec_options(STAT_SHOTS, 2048, false));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 2]).unwrap();
+    let (m0, _m1) = syndrome_round(&mut program);
+    program.reset(QecBasis::Z, 3).unwrap();
+    program.reset(QecBasis::Z, 4).unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(m0)], false)
+        .unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::T, &[1]).unwrap();
+    program.push_gate(Gate::T, &[2]).unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::x(1), QecPauli::x(2)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::y(0), QecPauli::x(1), QecPauli::x(2)], -0.5)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], 1.0)
+        .unwrap();
+    program
+}
+
+// State after transversal T on the logical |+>: (|000> + e^{i3pi/4}|111>)/sqrt(2).
+// <X_L> = cos(3pi/4), <Y0 X1 X2> = sin(3pi/4) (scaled by -0.5), <Z0 Z1> = 1.
+fn e2e_d3_t_expected() -> [f64; 3] {
+    let theta = 3.0 * std::f64::consts::FRAC_PI_4;
+    [theta.cos(), -0.5 * theta.sin(), 1.0]
+}
+
+#[test]
+fn e2e_d3_t() {
+    let program = e2e_d3_t_program();
+    let expected = e2e_d3_t_expected();
+
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let estimates = result.expectation_values.expect("e2e-d3-t estimates");
+        assert_eq!(estimates.len(), 3, "e2e-d3-t: three EXP_VAL ops in order");
+        for (slot, (estimate, reference)) in estimates.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (estimate.mean - reference).abs() < 1e-6,
+                "e2e-d3-t strategy {strategy:?} slot {slot}: {:.8} vs closed form {reference:.8}",
+                estimate.mean
+            );
+        }
+    }
+
+    let routed = run_qec_program(&program).unwrap();
+    let auto = run_qec_program_with_strategy(&program, QecTStrategy::Auto).unwrap();
+    let routed_estimates = routed.expectation_values.expect("estimates");
+    let auto_estimates = auto.expectation_values.expect("estimates");
+    for (slot, (a, b)) in routed_estimates
+        .iter()
+        .zip(auto_estimates.iter())
+        .enumerate()
+    {
+        assert!(
+            (a.mean - b.mean).abs() < 1e-12,
+            "e2e-d3-t slot {slot}: compiled entry point must match the Auto ladder"
+        );
+    }
+
+    // The syndrome round is deterministic on the logical |+> state, so the
+    // sampled reference is exact shot for shot.
+    let reference = run_qec_program_reference(&program).unwrap();
+    assert_eq!(reference.accepted_shots, STAT_SHOTS);
+    let estimates = reference.expectation_values.expect("estimates");
+    for (slot, (estimate, expected)) in estimates.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (estimate.mean - expected).abs() < 1e-9,
+            "e2e-d3-t reference slot {slot}: {:.10} vs closed form {expected:.10}",
+            estimate.mean
+        );
+    }
+}
+
+#[test]
+fn e2e_d3_s() {
+    let p = 0.05;
+    let mut program = QecProgram::with_options(5, qec_common::qec_options(STAT_SHOTS, 2048, false));
+    program.noise(QecNoise::XError(p), &[0, 1, 2]).unwrap();
+    let (m0, m1) = syndrome_round(&mut program);
+    program.detector(&[QecRecordRef::absolute(m0)]).unwrap();
+    program.detector(&[QecRecordRef::absolute(m1)]).unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1), QecPauli::z(2)], 1.0)
+        .unwrap();
+    program.expectation_value(&[QecPauli::z(0)], 2.0).unwrap();
+
+    // Independent X flips with probability p on each data qubit:
+    // <Z0 Z1 Z2> = (1-2p)^3 and 2*<Z0> = 2*(1-2p).
+    let expected = [(1.0 - 2.0 * p).powi(3), 2.0 * (1.0 - 2.0 * p)];
+
+    let result = run_qec_program(&program).unwrap();
+    assert_eq!(result.total_shots, STAT_SHOTS);
+    let estimates = result.expectation_values.expect("e2e-d3-s estimates");
+    assert_eq!(estimates.len(), 2, "e2e-d3-s: two EXP_VAL ops in order");
+    for (slot, (estimate, reference)) in estimates.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            estimate.variance > 0.0,
+            "e2e-d3-s slot {slot}: sampled path must report nonzero variance"
+        );
+        assert_eq!(estimate.num_shots, STAT_SHOTS);
+        let tol = 5.0 * (estimate.variance / estimate.num_shots as f64).sqrt() + 0.02;
+        assert!(
+            (estimate.mean - reference).abs() < tol,
+            "e2e-d3-s slot {slot}: {:.4} vs closed form {reference:.4} (tol {tol:.4})",
+            estimate.mean
+        );
+    }
+
+    // Each detector fires when an odd number of its two data qubits flipped:
+    // rate 2p(1-p) = 0.095.
+    let detector_shots = result.detectors.to_shots();
+    assert_eq!(result.detectors.num_measurements(), 2);
+    for detector in 0..2 {
+        let fired = detector_shots.iter().filter(|shot| shot[detector]).count() as f64;
+        let rate = fired / STAT_SHOTS as f64;
+        assert!(
+            (0.05..0.15).contains(&rate),
+            "e2e-d3-s detector {detector}: firing rate {rate:.4} outside the plausible band"
+        );
+    }
+}

--- a/tests/qec_exp_val.rs
+++ b/tests/qec_exp_val.rs
@@ -1,0 +1,345 @@
+//! Semantics tests for the QEC `EXP_VAL` estimator: placement validation,
+//! coefficient scaling, reference-vs-analytic agreement, postselection
+//! composition, and entry-point routing.
+
+mod qec_common;
+
+use prism_q::{
+    Gate, QecBasis, QecNoise, QecPauli, QecProgram, QecRecordRef, QecTStrategy, run_qec_program,
+    run_qec_program_reference, run_qec_program_with_strategy,
+};
+use qec_common::ANALYTICAL_STRATEGIES;
+
+const STAT_SHOTS: usize = 4_000;
+
+fn program_with_shots(num_qubits: usize, shots: usize) -> QecProgram {
+    QecProgram::with_options(num_qubits, qec_common::qec_options(shots, 2048, false))
+}
+
+#[test]
+fn exp_val_requires_terminal_placement() {
+    let mut gate_after = program_with_shots(1, 16);
+    gate_after
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    gate_after.push_gate(Gate::X, &[0]).unwrap();
+
+    let mut measure_after = program_with_shots(1, 16);
+    measure_after
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    measure_after.measure_z(0).unwrap();
+
+    for program in [&gate_after, &measure_after] {
+        let err = run_qec_program(program).unwrap_err();
+        assert!(format!("{err}").contains("must be terminal"));
+        let err = run_qec_program_reference(program).unwrap_err();
+        assert!(format!("{err}").contains("must be terminal"));
+        for &strategy in &ANALYTICAL_STRATEGIES {
+            let err = run_qec_program_with_strategy(program, strategy).unwrap_err();
+            assert!(
+                format!("{err}").contains("must be terminal"),
+                "strategy {strategy:?} accepted a non-terminal EXP_VAL"
+            );
+        }
+    }
+}
+
+#[test]
+fn exp_val_rejects_measured_unreset_qubit() {
+    let mut measured = program_with_shots(1, 16);
+    measured.measure_z(0).unwrap();
+    measured.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
+    let err = run_qec_program_reference(&measured).unwrap_err();
+    assert!(format!("{err}").contains("live qubits"));
+
+    let mut reset_between = program_with_shots(1, 16);
+    reset_between.measure_z(0).unwrap();
+    reset_between.reset(QecBasis::Z, 0).unwrap();
+    reset_between
+        .expectation_value(&[QecPauli::x(0)], 1.0)
+        .unwrap();
+    let reference = run_qec_program_reference(&reset_between).unwrap();
+    let ref_mean = reference.expectation_values.expect("estimates")[0].mean;
+    assert!(ref_mean.abs() < 1e-12, "<X> on a reset qubit must be 0");
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&reset_between, strategy).unwrap();
+        let mean = result.expectation_values.expect("estimates")[0].mean;
+        assert!(
+            mean.abs() < 1e-9,
+            "strategy {strategy:?}: <X> on a reset qubit must be 0, got {mean}"
+        );
+    }
+}
+
+#[test]
+fn exp_val_reference_rejects_programs_beyond_mask_width() {
+    let mut program = program_with_shots(65, 4);
+    program.expectation_value(&[QecPauli::z(64)], 1.0).unwrap();
+    let err = run_qec_program_reference(&program).unwrap_err();
+    assert!(format!("{err}").contains("at most 64 qubits"));
+}
+
+#[test]
+fn exp_val_coefficient_scales_mean_and_variance() {
+    let build = |coefficient: f64| {
+        let mut program = program_with_shots(1, 512);
+        program.noise(QecNoise::XError(0.3), &[0]).unwrap();
+        program
+            .expectation_value(&[QecPauli::z(0)], coefficient)
+            .unwrap();
+        program
+    };
+    let unit = run_qec_program(&build(1.0)).unwrap();
+    let scaled = run_qec_program(&build(-0.5)).unwrap();
+    let unit = &unit.expectation_values.expect("estimates")[0];
+    let scaled = &scaled.expectation_values.expect("estimates")[0];
+    assert!((scaled.mean - (-0.5) * unit.mean).abs() < 1e-12);
+    assert!((scaled.variance - 0.25 * unit.variance).abs() < 1e-12);
+    assert!(unit.variance > 0.0, "noisy sampling must report spread");
+}
+
+#[test]
+fn exp_val_reference_matches_analytic_on_live_qubits_after_measurement() {
+    // GHZ on three qubits with a T phase, then a collapsing measurement of
+    // qubit 2. EXP_VAL terms live on the unmeasured qubits, so the
+    // trajectory-averaged post-measurement expectation must equal the
+    // measurement-stripped pure-state expectation. Z0 has genuine per-shot
+    // spread (+1 or -1 per collapse branch), X0*X1 and Z0*Z1 are
+    // deterministic.
+    let mut program = program_with_shots(3, STAT_SHOTS);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::Cx, &[1, 2]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.measure_z(2).unwrap();
+    program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::x(1)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], 1.0)
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_estimates = reference.expectation_values.expect("estimates");
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let estimates = result.expectation_values.expect("estimates");
+        assert_eq!(estimates.len(), 3);
+        for (slot, (analytic, sampled)) in estimates.iter().zip(ref_estimates.iter()).enumerate() {
+            let tol = 5.0 * (sampled.variance / sampled.num_shots.max(1) as f64).sqrt() + 0.01;
+            assert!(
+                (analytic.mean - sampled.mean).abs() < tol,
+                "strategy {strategy:?} slot {slot}: analytic {:.4} vs reference {:.4} (tol {tol:.4})",
+                analytic.mean,
+                sampled.mean
+            );
+        }
+    }
+}
+
+#[test]
+fn exp_val_after_mpp_matches_reference() {
+    // MPP measures a scratch alias, so data qubits stay live and an X-basis
+    // EXP_VAL on them stays exact: on a Bell pair Z0*Z1 measures +1
+    // deterministically and <X0*X1> remains +1.
+    let mut program = program_with_shots(2, 256);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program
+        .measure_pauli_product(&[QecPauli::z(0), QecPauli::z(1)])
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::x(1)], 1.0)
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_mean = reference.expectation_values.expect("estimates")[0].mean;
+    assert!((ref_mean - 1.0).abs() < 1e-12);
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let mean = result.expectation_values.expect("estimates")[0].mean;
+        assert!(
+            (mean - 1.0).abs() < 1e-9,
+            "strategy {strategy:?}: <X0*X1> after MPP should be 1, got {mean}"
+        );
+    }
+}
+
+#[test]
+fn exp_val_composes_with_postselection() {
+    // Bell pair, measure qubit 1, postselect on outcome 0. The accepted
+    // ensemble collapses qubit 0 to |0>, so the conditioned <Z0> is +1 on
+    // both paths, and num_shots reflects roughly half the shots surviving.
+    let mut program = program_with_shots(2, STAT_SHOTS);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    let record = program.measure_z(1).unwrap();
+    program
+        .postselect(&[QecRecordRef::absolute(record)], false)
+        .unwrap();
+    program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let sampled = &reference.expectation_values.expect("estimates")[0];
+    assert!((sampled.mean - 1.0).abs() < 1e-12);
+    assert_eq!(sampled.num_shots, reference.accepted_shots);
+    assert!(sampled.num_shots > STAT_SHOTS / 3 && sampled.num_shots < 2 * STAT_SHOTS / 3);
+
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let estimate = &result.expectation_values.expect("estimates")[0];
+        assert!(
+            (estimate.mean - 1.0).abs() < 1e-9,
+            "strategy {strategy:?}: conditioned <Z0> should be 1, got {}",
+            estimate.mean
+        );
+        assert_eq!(estimate.num_shots, STAT_SHOTS / 2);
+    }
+}
+
+#[test]
+fn exp_val_routing_pinned() {
+    let base = |num_qubits: usize| {
+        let mut program = program_with_shots(num_qubits, 256);
+        program.push_gate(Gate::H, &[0]).unwrap();
+        program.push_gate(Gate::T, &[0]).unwrap();
+        program
+    };
+
+    let mut noiseless = base(1);
+    noiseless.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
+    let routed = run_qec_program(&noiseless).unwrap();
+    let auto = run_qec_program_with_strategy(&noiseless, QecTStrategy::Auto).unwrap();
+    let routed_estimates = routed.expectation_values.expect("estimates");
+    let auto_estimates = auto.expectation_values.expect("estimates");
+    for (a, b) in routed_estimates.iter().zip(auto_estimates.iter()) {
+        assert!(
+            (a.mean - b.mean).abs() < 1e-12 && a.num_shots == b.num_shots,
+            "noiseless EXP_VAL programs must route to the analytical Auto ladder"
+        );
+    }
+
+    let mut noisy = base(1);
+    noisy.noise(QecNoise::XError(0.1), &[0]).unwrap();
+    noisy.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
+    let routed = run_qec_program(&noisy).unwrap();
+    let reference = run_qec_program_reference(&noisy).unwrap();
+    assert_eq!(
+        routed.expectation_values.expect("estimates"),
+        reference.expectation_values.expect("estimates"),
+        "noisy EXP_VAL programs must route to the reference runner"
+    );
+
+    let mut with_detector = base(2);
+    with_detector.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    with_detector.measure_z(1).unwrap();
+    with_detector
+        .detector(&[QecRecordRef::lookback(1).unwrap()])
+        .unwrap();
+    with_detector
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    let routed = run_qec_program(&with_detector).unwrap();
+    let reference = run_qec_program_reference(&with_detector).unwrap();
+    assert_eq!(
+        routed.expectation_values.expect("estimates"),
+        reference.expectation_values.expect("estimates"),
+        "non-Clifford EXP_VAL programs with detectors must fall back to the reference runner"
+    );
+    assert_eq!(routed.detectors.num_measurements(), 1);
+    assert_eq!(routed.detectors.num_shots(), 256);
+}
+
+#[test]
+fn exp_val_with_detectors_splits_clifford_programs() {
+    // GHZ on three qubits, measure qubit 2 with a detector on the record.
+    // The detector must come from real packed sampling (fires on the |111>
+    // branch, rate 1/2) while the estimates stay analytical and exact:
+    // stripped <Z0*Z1> = 1 (scaled by -2.0) and stripped <Z0> = 0.
+    let mut program = program_with_shots(3, STAT_SHOTS);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::Cx, &[1, 2]).unwrap();
+    program.measure_z(2).unwrap();
+    program
+        .detector(&[QecRecordRef::lookback(1).unwrap()])
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], -2.0)
+        .unwrap();
+    program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
+
+    let result = run_qec_program(&program).unwrap();
+    let estimates = result.expectation_values.expect("estimates");
+    assert_eq!(estimates.len(), 2);
+    assert!(
+        (estimates[0].mean - (-2.0)).abs() < 1e-9,
+        "split path slot 0: {} vs closed form -2.0",
+        estimates[0].mean
+    );
+    assert!(
+        estimates[0].variance <= 1e-12 && estimates[1].variance <= 1e-12,
+        "analytical estimates on a Clifford program must be exact"
+    );
+    assert!(estimates[1].mean.abs() < 1e-9);
+
+    assert_eq!(result.detectors.num_measurements(), 1);
+    assert_eq!(result.detectors.num_shots(), STAT_SHOTS);
+    let fired = result
+        .detectors
+        .to_shots()
+        .iter()
+        .filter(|shot| shot[0])
+        .count();
+    let rate = fired as f64 / STAT_SHOTS as f64;
+    assert!(
+        (0.4..0.6).contains(&rate),
+        "detector firing rate {rate:.4} outside the sampled band around 0.5"
+    );
+}
+
+#[test]
+fn exp_val_xy_strings_across_strategies() {
+    // Non-measuring Clifford+T fixture: the reference runner is exact per
+    // shot (zero variance), so every analytical strategy must reproduce its
+    // means for X-, Y-, and mixed strings. Pins the CAMPS X/Y extension
+    // end to end.
+    let mut program = program_with_shots(2, 64);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::T, &[1]).unwrap();
+    program.push_gate(Gate::H, &[1]).unwrap();
+    program.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
+    program.expectation_value(&[QecPauli::y(0)], 1.0).unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::y(1)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::x(1)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::y(0), QecPauli::y(1)], -2.0)
+        .unwrap();
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    let ref_estimates = reference.expectation_values.expect("estimates");
+    for estimate in ref_estimates.iter() {
+        assert!(estimate.variance < 1e-30, "identical shots leave no spread");
+    }
+    for &strategy in &ANALYTICAL_STRATEGIES {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let estimates = result.expectation_values.expect("estimates");
+        assert_eq!(estimates.len(), ref_estimates.len());
+        for (slot, (analytic, exact)) in estimates.iter().zip(ref_estimates.iter()).enumerate() {
+            assert!(
+                (analytic.mean - exact.mean).abs() < 1e-6,
+                "strategy {strategy:?} slot {slot}: {:.8} vs exact {:.8}",
+                analytic.mean,
+                exact.mean
+            );
+        }
+    }
+}

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -530,13 +530,16 @@ fn qec_compiled_runner_ignores_single_qubit_noise_after_measurement() {
 }
 
 #[test]
-fn qec_compiled_runner_rejects_exp_val_without_reference_fallback() {
+fn qec_compiled_runner_evaluates_noiseless_exp_val_via_analytic_route() {
     let mut exp_val_program = QecProgram::new(1);
     exp_val_program
         .expectation_value(&[QecPauli::z(0)], 1.0)
         .unwrap();
-    let err = run_qec_program(&exp_val_program).unwrap_err();
-    assert!(format!("{err}").contains("EXP_VAL"));
+    let result = run_qec_program(&exp_val_program).unwrap();
+    let estimates = result.expectation_values.expect("EXP_VAL estimates");
+    assert_eq!(estimates.len(), 1);
+    assert!((estimates[0].mean - 1.0).abs() < 1e-12);
+    assert!(estimates[0].variance <= 1e-12);
 }
 
 #[test]
@@ -616,12 +619,16 @@ fn qec_reference_runner_applies_pauli_noise() {
 }
 
 #[test]
-fn qec_reference_runner_rejects_exp_val_until_result_schema_lands() {
+fn qec_reference_runner_evaluates_exp_val_on_final_state() {
     let mut program = QecProgram::new(1);
     program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
 
-    let err = run_qec_program_reference(&program).unwrap_err();
-    assert!(format!("{err}").contains("does not evaluate EXP_VAL yet"));
+    let result = run_qec_program_reference(&program).unwrap();
+    let estimates = result.expectation_values.expect("EXP_VAL estimates");
+    assert_eq!(estimates.len(), 1);
+    assert!((estimates[0].mean - 1.0).abs() < 1e-12);
+    assert_eq!(estimates[0].variance, 0.0);
+    assert_eq!(estimates[0].num_shots, program.options().shots);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`EXP_VAL(c) P1*...*Pk` now executes end to end: it estimates `c * <P>` in the
program's final state and returns one coefficient-scaled estimate per op in
`QecSampleResult::expectation_values`, replacing the previous rejections in all
runners. Two placement rules (terminal placement, live qubits only) make the
sampled and analytical paths provably agree; `run_qec_program` routes noiseless
programs to the analytical T-strategy ladder, splits detector programs into a
packed sampling run plus an analytical estimator run, and sends noisy programs
to the per-shot reference runner. Also corrects stabilizer and product backend
doc claims (per-gate tableau cost is O(n), full Clifford gate list, product
backend `MultiFused` / single-qubit `DiagonalBatch` support).

## Scope

- [x] New feature
- [x] Documentation

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. No gate kernels, fusion passes, or packed-sampler
inner loops were touched; the `EXP_VAL` paths add per-program (not per-shot)
work and the packed path for programs without `EXP_VAL` is unchanged.

Regression verdict: PASS

## Correctness

- [x] `cargo test --all-features` passes locally (run as `cargo nextest run`
      with `--features "parallel serialization distributed"`; the CI host
      covers the CUDA/MPI feature matrix)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (same feature set as above)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --all-features` passes (same feature set as above)
- [x] New public API has docstrings
- [x] New gate, backend, or fusion pass has golden tests against the
      statevector backend: `tests/qec_exp_val.rs` pins every analytical
      strategy against the per-shot statevector reference runner, and
      `tests/qec_e2e_d3.rs` adds distance-3 fixtures with closed-form
      references
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu` (N/A, no GPU code touched)

## Hotspot notes

N/A.

## Architecture or design changes

- [x] `docs/architecture/`: `qec-ir.md` gains an "Expectation values" section
      (placement rules, estimator-path table, detector split); `backends.md`
      stabilizer claims corrected

## Breaking changes

`QecSampleResult` gains a public field `expectation_values`
(`Option<Vec<QecObservableEstimate>>`), which breaks exhaustive struct
literals. Behavioral: programs containing `EXP_VAL` previously errored in
every runner and now execute; `compile_qec_program_rows` and
`run_qec_program_spd_rerouted` keep explicit rejections.

## Risks and rollback

Blast radius is limited to programs containing `EXP_VAL` ops: routing is
gated on `num_expectation_values() > 0`, so existing sampling programs take
the unchanged packed path. The detector split falls back to the reference
runner whenever either half cannot run. The reference runner rejects
`EXP_VAL` programs wider than 64 qubits before mask construction instead of
wrapping the mask shift.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
