### PR TITLE
feat(backend): add exact density-matrix simulator backend

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -1,0 +1,154 @@
+//! Exact density-matrix backend.
+//!
+//! Stores the full density operator `rho` for `n` qubits as a `2^(2n)` amplitude
+//! buffer laid out row-major: buffer index `(r << n) | c` holds `<r|rho|c>`. That
+//! layout is isomorphic to a `2n`-qubit statevector whose high `n` qubits index
+//! the ket (row `r`) and whose low `n` qubits index the bra (column `c`). Gate
+//! application therefore reuses the validated statevector kernels directly: a
+//! unitary `U` on the ket register yields the left product `U rho`, and the same
+//! `U` applied to the bra register on a conjugated buffer yields the right product
+//! `rho U^dagger`, giving `U rho U^dagger` with no gate math of its own.
+//!
+//! Memory is `16 * 4^n` bytes (`4^n` `Complex64` entries), so the practical
+//! ceiling is about 14 qubits on a 16 GiB host and 15 on a 32 GiB host. CPU only.
+//! This backend is explicit-dispatch only and is never chosen by `Auto`.
+//!
+//! This is the initial core: exact unitary evolution, basis-state probabilities,
+//! and the one-qubit reduced density matrix. Measurement, reset, conditionals,
+//! and exact noise channels arrive in later milestones. Fusion is disabled
+//! (`supports_fused_gates` returns `false`) so every instruction reaching the
+//! backend is a primitive whose qubits live in the instruction targets.
+
+use num_complex::Complex64;
+use smallvec::SmallVec;
+
+use crate::backend::Backend;
+use crate::backend::statevector::StatevectorBackend;
+use crate::circuit::Instruction;
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+
+/// Exact density-matrix simulator. See the module docs for the state layout.
+pub struct DensityMatrixBackend {
+    num_qubits: usize,
+    classical_bits: Vec<bool>,
+    sv: StatevectorBackend,
+}
+
+impl DensityMatrixBackend {
+    /// Create a new density-matrix backend with the given RNG seed.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            num_qubits: 0,
+            classical_bits: Vec::new(),
+            sv: StatevectorBackend::new(seed),
+        }
+    }
+
+    /// Purity `Tr(rho^2)`, equal to `1` for a pure state and less otherwise.
+    pub fn purity(&self) -> f64 {
+        self.sv.state.iter().map(Complex64::norm_sqr).sum()
+    }
+
+    #[inline]
+    fn dim(&self) -> usize {
+        1usize << self.num_qubits
+    }
+
+    fn conjugate_buffer(&mut self) {
+        for amp in self.sv.state.iter_mut() {
+            *amp = amp.conj();
+        }
+    }
+
+    /// Evolve `rho -> U rho U^dagger` for the unitary `gate` on `targets`.
+    ///
+    /// `U` on the ket register (targets offset by `n`) is the left product
+    /// `U rho`; the same `U` on the bra register (original targets) sandwiched
+    /// between two whole-buffer conjugations applies `conj(U)`, giving the right
+    /// product `rho U^dagger`.
+    fn apply_unitary(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
+        let n = self.num_qubits;
+        let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
+        self.sv.apply(&Instruction::Gate {
+            gate: gate.clone(),
+            targets: ket_targets,
+        })?;
+
+        self.conjugate_buffer();
+        let bra_targets: SmallVec<[usize; 4]> = targets.iter().copied().collect();
+        self.sv.apply(&Instruction::Gate {
+            gate: gate.clone(),
+            targets: bra_targets,
+        })?;
+        self.conjugate_buffer();
+        Ok(())
+    }
+}
+
+impl Backend for DensityMatrixBackend {
+    fn name(&self) -> &'static str {
+        "density_matrix"
+    }
+
+    fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        self.num_qubits = num_qubits;
+        self.classical_bits = vec![false; num_classical_bits];
+        self.sv.init(2 * num_qubits, 0)
+    }
+
+    fn apply(&mut self, instruction: &Instruction) -> Result<()> {
+        match instruction {
+            Instruction::Gate { gate, targets } => self.apply_unitary(gate, targets),
+            Instruction::Barrier { .. } => Ok(()),
+            Instruction::Measure { .. }
+            | Instruction::Reset { .. }
+            | Instruction::Conditional { .. } => Err(PrismError::BackendUnsupported {
+                backend: self.name().to_string(),
+                operation: "measurement, reset, and conditionals (later density-matrix milestone)"
+                    .to_string(),
+            }),
+        }
+    }
+
+    fn classical_results(&self) -> &[bool] {
+        &self.classical_bits
+    }
+
+    fn probabilities(&self) -> Result<Vec<f64>> {
+        let d = self.dim();
+        let mut probs = vec![0.0f64; d];
+        for (k, p) in probs.iter_mut().enumerate() {
+            *p = self.sv.state[k * d + k].re.max(0.0);
+        }
+        Ok(probs)
+    }
+
+    fn num_qubits(&self) -> usize {
+        self.num_qubits
+    }
+
+    fn supports_fused_gates(&self) -> bool {
+        false
+    }
+
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        let n = self.num_qubits;
+        let d = self.dim();
+        let bit = 1usize << qubit;
+        let others = 1usize << (n - 1);
+        let mut r00 = Complex64::new(0.0, 0.0);
+        let mut r01 = Complex64::new(0.0, 0.0);
+        let mut r10 = Complex64::new(0.0, 0.0);
+        let mut r11 = Complex64::new(0.0, 0.0);
+        for m in 0..others {
+            let base = (m & (bit - 1)) | ((m >> qubit) << (qubit + 1));
+            let i1 = base | bit;
+            r00 += self.sv.state[base * d + base];
+            r01 += self.sv.state[base * d + i1];
+            r10 += self.sv.state[i1 * d + base];
+            r11 += self.sv.state[i1 * d + i1];
+        }
+        Ok([[r00, r01], [r10, r11]])
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -22,6 +22,7 @@
 //! Implement the [`Backend`] trait below, following the contract and
 //! performance requirements above.
 
+pub mod density_matrix;
 #[cfg(feature = "distributed")]
 pub mod distributed_statevector;
 pub mod factored;

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1,0 +1,175 @@
+//! Cross-backend correctness for the density-matrix backend.
+//!
+//! On noiseless (unitary) circuits the density-matrix backend must reproduce the
+//! statevector backend's basis-state probabilities exactly, and a pure state must
+//! stay pure (`Tr(rho^2) == 1`).
+
+use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::backend::statevector::StatevectorBackend;
+use prism_q::circuit::Circuit;
+use prism_q::gates::Gate;
+use prism_q::{circuits, sim};
+
+const DM_EPS: f64 = 1e-12;
+
+fn statevector_probs(circuit: &Circuit) -> Vec<f64> {
+    let mut backend = StatevectorBackend::new(42);
+    sim::run_on(&mut backend, circuit).unwrap();
+    backend.probabilities().unwrap()
+}
+
+fn run_dm(circuit: &Circuit) -> DensityMatrixBackend {
+    let mut backend = DensityMatrixBackend::new(42);
+    sim::run_on(&mut backend, circuit).unwrap();
+    backend
+}
+
+fn dm_probs(circuit: &Circuit) -> Vec<f64> {
+    run_dm(circuit).probabilities().unwrap()
+}
+
+fn assert_probs_close(actual: &[f64], expected: &[f64], label: &str) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label}: probability vector length mismatch"
+    );
+    for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (a - e).abs() < DM_EPS,
+            "{label}: probability[{i}] mismatch: dm={a}, statevector={e}"
+        );
+    }
+}
+
+fn assert_matches_statevector(circuit: &Circuit, label: &str) {
+    assert_probs_close(&dm_probs(circuit), &statevector_probs(circuit), label);
+}
+
+#[test]
+fn dm_all_single_gates_match_statevector() {
+    let gates = [
+        Gate::Id,
+        Gate::X,
+        Gate::Y,
+        Gate::Z,
+        Gate::H,
+        Gate::S,
+        Gate::Sdg,
+        Gate::T,
+        Gate::Tdg,
+        Gate::SX,
+        Gate::SXdg,
+        Gate::Rx(0.7),
+        Gate::Ry(1.1),
+        Gate::Rz(0.3),
+        Gate::P(0.5),
+    ];
+    for gate in gates {
+        // The Hadamard sandwich converts phase-only differences into population,
+        // so the probability comparison is sensitive to a mishandled conjugation.
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(gate.clone(), &[0]);
+        c.add_gate(Gate::H, &[0]);
+        assert_matches_statevector(&c, &format!("single_gate {gate:?}"));
+    }
+}
+
+#[test]
+fn dm_two_qubit_gates_match_statevector() {
+    for gate in [Gate::Cx, Gate::Cz, Gate::Swap, Gate::Rzz(0.9)] {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Ry(0.6), &[1]);
+        c.add_gate(gate.clone(), &[0, 1]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        assert_matches_statevector(&c, &format!("two_qubit_gate {gate:?}"));
+    }
+}
+
+#[test]
+fn dm_bell_matches_statevector() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    assert_matches_statevector(&c, "bell");
+}
+
+#[test]
+fn dm_ghz4_matches_statevector() {
+    let c = circuits::ghz_circuit(4);
+    assert_matches_statevector(&c, "ghz4");
+}
+
+#[test]
+fn dm_complex_circuit_matches_statevector() {
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Rx(0.5), &[1]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::Ry(1.3), &[2]);
+    c.add_gate(Gate::Cz, &[1, 2]);
+    c.add_gate(Gate::Swap, &[0, 2]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::Rz(0.9), &[1]);
+    c.add_gate(Gate::Cx, &[2, 0]);
+    assert_matches_statevector(&c, "complex");
+}
+
+#[test]
+fn dm_qft_matches_statevector() {
+    let c = circuits::qft_circuit(5);
+    assert_matches_statevector(&c, "qft5");
+}
+
+#[test]
+fn dm_random_layers_match_statevector() {
+    let c = circuits::random_circuit(6, 10, 0xDEAD_BEEF);
+    assert_matches_statevector(&c, "random6");
+}
+
+#[test]
+fn dm_pure_state_stays_pure() {
+    let c = circuits::random_circuit(5, 8, 0xDEAD_BEEF);
+    let backend = run_dm(&c);
+    assert!(
+        (backend.purity() - 1.0).abs() < 1e-12,
+        "purity of a unitary-evolved state must be 1, got {}",
+        backend.purity()
+    );
+}
+
+#[test]
+fn dm_probabilities_sum_to_one() {
+    let c = circuits::random_circuit(5, 8, 0xDEAD_BEEF);
+    let total: f64 = dm_probs(&c).iter().sum();
+    assert!(
+        (total - 1.0).abs() < 1e-12,
+        "probabilities must sum to 1, got {total}"
+    );
+}
+
+#[test]
+fn dm_reduced_density_matrix_matches_statevector() {
+    let c = circuits::random_circuit(4, 8, 0xDEAD_BEEF);
+    let dm = run_dm(&c);
+    let mut sv = StatevectorBackend::new(42);
+    sim::run_on(&mut sv, &c).unwrap();
+    for q in 0..4 {
+        let a = dm.reduced_density_matrix_1q(q).unwrap();
+        let b = sv.reduced_density_matrix_1q(q).unwrap();
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (a[i][j] - b[i][j]).norm() < 1e-12,
+                    "rdm[{q}][{i}][{j}] mismatch: dm={}, sv={}",
+                    a[i][j],
+                    b[i][j]
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a CPU density-matrix backend that evolves the full density operator exactly,
producing exact mixed-state results that today's sampling engines (trajectory,
Pauli-frame, homological) only approximate. The density operator for n qubits is
stored as the amplitude buffer of an embedded 2n-qubit statevector, so gate
application reuses the existing, validated statevector kernels with no new gate
math. This is the core cut: exact unitary evolution, probabilities, the one-qubit
reduced density matrix, and purity. It lays the groundwork for exact Tr(rho O)
under noise as a small-n oracle.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes. The backend is a new, self-contained module that is not
wired into automatic dispatch and touches no shared kernels, so no existing
benchmark path is affected. A dedicated `density_matrix/*` Criterion group
(gate-apply and channel-apply rows plus a neutrality row) is planned as follow-up
work alongside the noise and dispatch milestones.

Regression verdict: PASS

## Correctness

- [x] Test suite passes locally (`cargo nextest run --features parallel`: 1719 passed;
      `--all-features` is not runnable here since it enables `gpu`, which needs the
      CUDA toolkit — CI covers the full feature matrix)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings` passes (no unsafe
      blocks in the new code)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features parallel` passes
- [x] New public API has docstrings
- [x] New backend has golden tests against the statevector backend
- [ ] GPU-affecting change runs golden_gpu (N/A, CPU-only backend)

## Hotspot notes

N/A. No hot paths touched.

## Architecture or design changes

- [ ] Architecture doc updated (follow-up: add the new backend's position and the
      2n-qubit state layout)
- [ ] Design note added (follow-up: the density-matrix scope/decision note)

## Breaking changes

None. Purely additive. The backend is explicit-only and is never chosen by
automatic dispatch, so existing behavior is unchanged.

## Risks and rollback

Low blast radius: additive new module, no existing code paths modified beyond the
module registration line. The backend is unreachable unless explicitly selected,
so it cannot affect existing users. Rollback is a plain revert of the single
commit. Known current limits (intended for follow-up, not defects): measurement,
reset, and conditionals return BackendUnsupported; fusion is disabled for
correctness because batched gate variants embed their qubit indices in the boxed
payload; memory is 16 * 4^n bytes, capping practical use near 14 qubits.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale (none added)
- [ ] CI is green (confirm after push)
