### PR TITLE
ci(release): switch release workflow to manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
The `feat` commits is creating too much noise. I am going to start reducing things to just manual releases for the time being.