### PR TITLE
feat(backend): add measurement, noise, and expectation to the density matrix backend

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -5,6 +5,7 @@
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
 use prism_q::circuit::{Circuit, SmallVec};
 use prism_q::circuits;
 use prism_q::gates::Gate;
@@ -1617,6 +1618,50 @@ fn bench_coalesce_baseline(c: &mut Criterion) {
     group.finish();
 }
 
+// ---- Density matrix (explicit backend, constructed directly) ----
+
+fn run_dm_apply_only(circuit: &Circuit) {
+    let mut backend = DensityMatrixBackend::new(42);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    backend.apply_instructions(&circuit.instructions).unwrap();
+    black_box(backend.probabilities().unwrap());
+}
+
+fn bench_density_matrix_unitary_layers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/unitary_layers");
+    configure_group(&mut group);
+
+    for &n in &[4, 8, 10, 12] {
+        let circuit = circuits::random_circuit(n, 10, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_dm_apply_only(circ);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Neutrality row: an untouched statevector row re-run under a density-matrix
+/// group name. The density-matrix backend shares no kernels with the
+/// statevector path, so this must stay within the 5% regression gate.
+fn bench_density_matrix_neutrality(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/neutrality");
+    configure_group(&mut group);
+
+    let circuit = circuits::qft_circuit(22);
+    group.bench_with_input(BenchmarkId::from_parameter(22), &circuit, |b, circ| {
+        b.iter(|| {
+            run_with(BackendKind::Statevector, circ, 42).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     // Statevector sweeps
@@ -1693,5 +1738,8 @@ criterion_group!(
     bench_spp,
     // Coalescing baseline (interleaved Clifford+T)
     bench_coalesce_baseline,
+    // Density matrix (explicit backend)
+    bench_density_matrix_unitary_layers,
+    bench_density_matrix_neutrality,
 );
 criterion_main!(benches);

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -1,8 +1,9 @@
 # Backends
 
-PRISM-Q ships eight CPU backends plus an optional CUDA path. The
-[simulation engine](./engine.md) picks one automatically, or you can select explicitly.
-For a task-oriented version of this material, see the
+PRISM-Q ships eight CPU backends plus an optional CUDA path, and an explicit-only
+density-matrix backend for exact mixed-state evolution. The
+[simulation engine](./engine.md) picks one of the eight automatically, or you can select
+explicitly. For a task-oriented version of this material, see the
 [Backends Deep Dive guide](../guides/backends.md).
 
 The diagrams below are rendered directly from PRISM-Q's own SVG circuit renderer.
@@ -55,5 +56,19 @@ Deferred contraction with a greedy min-size heuristic. Gates append tensors; con
 ## Factored
 
 Dynamic split-state simulation. Starts with n independent 1-qubit states, merges via tensor product only when 2q gates bridge groups. Parallel kernels match statevector patterns for sub-states ≥14 qubits. Selected when subsystem decomposition detects partial independence.
+
+## Density Matrix
+
+Exact mixed-state evolution. Stores the full density operator `rho` for `n` qubits as a
+`4^n` `Complex64` buffer laid out row-major: index `(r << n) | c` holds `⟨r|rho|c⟩`. That
+layout is isomorphic to a `2n`-qubit statevector whose high `n` qubits index the ket (row)
+and low `n` qubits index the bra (column), so gate application reuses the statevector
+kernels with no new gate math. A unitary `U` on the ket register gives the left product
+`U rho`; the same `U` on the bra register of a conjugated buffer gives the right product
+`rho U^dagger`, so `U rho U^dagger` costs two statevector passes and two conjugations.
+
+Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host and 15 on
+32 GiB (`PRISM_MAX_DM_QUBITS` overrides). This backend is CPU-only and explicit-dispatch
+only; `Auto` never selects it.
 
 The [GPU backend](../guides/gpu.md) is documented as a user guide.

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -13,25 +13,31 @@
 //! ceiling is about 14 qubits on a 16 GiB host and 15 on a 32 GiB host. CPU only.
 //! This backend is explicit-dispatch only and is never chosen by `Auto`.
 //!
-//! This is the initial core: exact unitary evolution, basis-state probabilities,
-//! and the one-qubit reduced density matrix. Measurement, reset, conditionals,
-//! and exact noise channels arrive in later milestones. Fusion is disabled
+//! Supported: exact unitary evolution, basis-state probabilities, the one-qubit
+//! reduced density matrix, projective measurement with stochastic collapse,
+//! reset, classically-conditioned gates, exact one-qubit Kraus channels
+//! (`apply_1q_kraus`), two-qubit depolarizing (`apply_2q_depolarizing`), and
+//! exact `Tr(rho P)` expectation (`expectation_pauli`). Fusion is disabled
 //! (`supports_fused_gates` returns `false`) so every instruction reaching the
 //! backend is a primitive whose qubits live in the instruction targets.
 
 use num_complex::Complex64;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
-use crate::backend::Backend;
-use crate::backend::statevector::StatevectorBackend;
-use crate::circuit::Instruction;
-use crate::error::{PrismError, Result};
+use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
+use crate::backend::{Backend, NORM_CLAMP_MIN};
+use crate::circuit::{ClassicalCondition, Instruction};
+use crate::error::Result;
 use crate::gates::Gate;
+use crate::sim::i_pow;
 
 /// Exact density-matrix simulator. See the module docs for the state layout.
 pub struct DensityMatrixBackend {
     num_qubits: usize,
     classical_bits: Vec<bool>,
+    rng: ChaCha8Rng,
     sv: StatevectorBackend,
 }
 
@@ -41,6 +47,7 @@ impl DensityMatrixBackend {
         Self {
             num_qubits: 0,
             classical_bits: Vec::new(),
+            rng: ChaCha8Rng::seed_from_u64(seed),
             sv: StatevectorBackend::new(seed),
         }
     }
@@ -56,6 +63,17 @@ impl DensityMatrixBackend {
     }
 
     fn conjugate_buffer(&mut self) {
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
+            if self.sv.state.len() >= (1 << crate::backend::PARALLEL_THRESHOLD_QUBITS) {
+                self.sv
+                    .state
+                    .par_iter_mut()
+                    .for_each(|amp| *amp = amp.conj());
+                return;
+            }
+        }
         for amp in self.sv.state.iter_mut() {
             *amp = amp.conj();
         }
@@ -84,6 +102,230 @@ impl DensityMatrixBackend {
         self.conjugate_buffer();
         Ok(())
     }
+
+    /// `P(qubit = |1>) = Tr(P_1 rho)`, the sum of the diagonal `rho` entries
+    /// whose row index has `qubit` set.
+    fn prob_one(&self, qubit: usize) -> f64 {
+        let d = self.dim();
+        let bit = 1usize << qubit;
+        let mut p1 = 0.0;
+        for r in 0..d {
+            if r & bit != 0 {
+                p1 += self.sv.state[r * d + r].re;
+            }
+        }
+        p1.clamp(0.0, 1.0)
+    }
+
+    /// Sample and project qubit `qubit`, recording the outcome in
+    /// `classical_bit`. Collapses `rho -> P_m rho P_m / p_m`, which in the
+    /// embedded layout zeroes every entry whose row or column disagrees with
+    /// the outcome on `qubit` and rescales the survivors to unit trace.
+    fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
+        let p1 = self.prob_one(qubit);
+        let u: f64 = self.rng.random();
+        let outcome = u < p1;
+        self.classical_bits[classical_bit] = outcome;
+        let p = if outcome { p1 } else { 1.0 - p1 };
+        self.project(qubit, outcome, p);
+    }
+
+    /// Deterministic reset `rho -> |0><0| (x) tr_q rho`: fold the block with
+    /// `qubit` set on both row and column into the block with it clear on both,
+    /// then zero the three sibling entries that still touch `qubit`. One pass
+    /// over the `d*d/4` block bases.
+    fn apply_reset(&mut self, qubit: usize) {
+        let n = self.num_qubits;
+        let d = self.dim();
+        let rmask = 1usize << (qubit + n);
+        let cmask = 1usize << qubit;
+        let both = rmask | cmask;
+        let zero = Complex64::new(0.0, 0.0);
+        for m in 0..((d * d) >> 2) {
+            let base = insert_zero_bit(insert_zero_bit(m, qubit), qubit + n);
+            let folded = self.sv.state[base | both];
+            self.sv.state[base] += folded;
+            self.sv.state[base | rmask] = zero;
+            self.sv.state[base | cmask] = zero;
+            self.sv.state[base | both] = zero;
+        }
+    }
+
+    /// Project `rho` onto the `outcome` subspace of `qubit` with outcome
+    /// probability `p`, renormalizing the survivors to unit trace.
+    fn project(&mut self, qubit: usize, outcome: bool, p: f64) {
+        let n = self.num_qubits;
+        let d = self.dim();
+        let rmask = 1usize << (qubit + n);
+        let cmask = 1usize << qubit;
+        let keep = if outcome { rmask | cmask } else { 0 };
+        let inv = 1.0 / p.clamp(NORM_CLAMP_MIN, 1.0);
+        for idx in 0..d * d {
+            if idx & (rmask | cmask) == keep {
+                self.sv.state[idx] *= inv;
+            } else {
+                self.sv.state[idx] = Complex64::new(0.0, 0.0);
+            }
+        }
+    }
+
+    fn apply_conditional(
+        &mut self,
+        condition: &ClassicalCondition,
+        gate: &Gate,
+        targets: &[usize],
+    ) -> Result<()> {
+        if condition.evaluate(&self.classical_bits) {
+            self.apply_unitary(gate, targets)?;
+        }
+        Ok(())
+    }
+
+    /// Apply a general single-qubit channel `rho -> sum_k K_k rho K_k^dagger`
+    /// on `qubit`. The Kraus set is compiled once into a 4x4 block
+    /// superoperator acting on each `(row-bit, col-bit)` block of `rho`, so the
+    /// buffer is swept once with no per-element allocation.
+    ///
+    /// Block index `i = 2*a + b` orders `(row-bit a, col-bit b)`; the
+    /// superoperator is `S[2a+b][2a'+b'] = sum_k K_k[a][a'] * conj(K_k[b][b'])`.
+    pub fn apply_1q_kraus(&mut self, qubit: usize, kraus: &[[[Complex64; 2]; 2]]) {
+        let n = self.num_qubits;
+        let d = self.dim();
+        let rmask = 1usize << (qubit + n);
+        let cmask = 1usize << qubit;
+
+        let mut s = [[Complex64::new(0.0, 0.0); 4]; 4];
+        for k in kraus {
+            for a in 0..2 {
+                for b in 0..2 {
+                    for ap in 0..2 {
+                        for bp in 0..2 {
+                            s[2 * a + b][2 * ap + bp] += k[a][ap] * k[b][bp].conj();
+                        }
+                    }
+                }
+            }
+        }
+
+        for m in 0..((d * d) >> 2) {
+            let base = insert_zero_bit(insert_zero_bit(m, qubit), qubit + n);
+            let idx = [base, base | cmask, base | rmask, base | rmask | cmask];
+            let v = [
+                self.sv.state[idx[0]],
+                self.sv.state[idx[1]],
+                self.sv.state[idx[2]],
+                self.sv.state[idx[3]],
+            ];
+            for i in 0..4 {
+                let mut acc = Complex64::new(0.0, 0.0);
+                for j in 0..4 {
+                    acc += s[i][j] * v[j];
+                }
+                self.sv.state[idx[i]] = acc;
+            }
+        }
+    }
+
+    /// Apply symmetric two-qubit depolarizing on `(q0, q1)`:
+    /// `rho -> (1-p) rho + (p/15) sum_{P != I(x)I} P rho P`, summed over the 15
+    /// non-identity two-qubit Paulis. The 16 two-qubit Pauli Kraus operators are
+    /// compiled once into a 16x16 block superoperator over the four-bit
+    /// `(q0-row, q1-row, q0-col, q1-col)` block, so the buffer is swept once.
+    ///
+    /// Block index `4*tr + tc` orders the two-qubit row value `tr` (bit 0 = q0,
+    /// bit 1 = q1) against the column value `tc`.
+    pub fn apply_2q_depolarizing(&mut self, q0: usize, q1: usize, p: f64) {
+        let c1 = Complex64::new(1.0, 0.0);
+        let c0 = Complex64::new(0.0, 0.0);
+        let ci = Complex64::new(0.0, 1.0);
+        let paulis: [[[Complex64; 2]; 2]; 4] = [
+            [[c1, c0], [c0, c1]],
+            [[c0, c1], [c1, c0]],
+            [[c0, -ci], [ci, c0]],
+            [[c1, c0], [c0, -c1]],
+        ];
+        // K_(a,b) = weight * (paulis[b] (x) paulis[a]) with q0 as the low bit;
+        // S[4*tr+tc][4*trp+tcp] = sum_(a,b) K[tr][trp] * conj(K[tc][tcp]).
+        let mut s = [[Complex64::new(0.0, 0.0); 16]; 16];
+        for a in 0..4 {
+            for b in 0..4 {
+                let w = if a == 0 && b == 0 {
+                    (1.0 - p).sqrt()
+                } else {
+                    (p / 15.0).sqrt()
+                };
+                let kentry = |t: usize, tp: usize| {
+                    Complex64::new(w, 0.0) * paulis[b][t >> 1][tp >> 1] * paulis[a][t & 1][tp & 1]
+                };
+                for tr in 0..4 {
+                    for trp in 0..4 {
+                        let kr = kentry(tr, trp);
+                        if kr == Complex64::new(0.0, 0.0) {
+                            continue;
+                        }
+                        for tc in 0..4 {
+                            for tcp in 0..4 {
+                                s[4 * tr + tc][4 * trp + tcp] += kr * kentry(tc, tcp).conj();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let n = self.num_qubits;
+        let d = self.dim();
+        let mut positions = [q0, q1, q0 + n, q1 + n];
+        positions.sort_unstable();
+        let flat_offset = |tr: usize, tc: usize| {
+            (if tr & 1 != 0 { 1usize << (q0 + n) } else { 0 })
+                | (if tr & 2 != 0 { 1usize << (q1 + n) } else { 0 })
+                | (if tc & 1 != 0 { 1usize << q0 } else { 0 })
+                | (if tc & 2 != 0 { 1usize << q1 } else { 0 })
+        };
+        let mut flats = [0usize; 16];
+        for tr in 0..4 {
+            for tc in 0..4 {
+                flats[4 * tr + tc] = flat_offset(tr, tc);
+            }
+        }
+
+        for m in 0..((d * d) >> 4) {
+            let mut base = m;
+            for &pos in &positions {
+                base = insert_zero_bit(base, pos);
+            }
+            let mut v = [Complex64::new(0.0, 0.0); 16];
+            for (k, &off) in flats.iter().enumerate() {
+                v[k] = self.sv.state[base | off];
+            }
+            for (i, &off) in flats.iter().enumerate() {
+                let mut acc = Complex64::new(0.0, 0.0);
+                for j in 0..16 {
+                    acc += s[i][j] * v[j];
+                }
+                self.sv.state[base | off] = acc;
+            }
+        }
+    }
+
+    /// Exact `Tr(rho P)` for the joint Pauli reduced to `(xmask, zmask, num_y)`,
+    /// where `P|j> = i^{num_y} * (-1)^{popcount(j & zmask)} * |j ^ xmask>`. The
+    /// trace collapses to a single diagonal-offset sweep:
+    /// `Tr(rho P) = i^{num_y} sum_j (-1)^{popcount(j & zmask)} rho[j][j ^ xmask]`.
+    pub fn expectation_pauli(&self, xmask: usize, zmask: usize, num_y: u32) -> f64 {
+        let d = self.dim();
+        let mut acc = Complex64::new(0.0, 0.0);
+        for j in 0..d {
+            let sign = if (j & zmask).count_ones() & 1 == 1 {
+                -1.0
+            } else {
+                1.0
+            };
+            acc += self.sv.state[j * d + (j ^ xmask)] * sign;
+        }
+        (acc * i_pow(num_y)).re
+    }
 }
 
 impl Backend for DensityMatrixBackend {
@@ -101,13 +343,22 @@ impl Backend for DensityMatrixBackend {
         match instruction {
             Instruction::Gate { gate, targets } => self.apply_unitary(gate, targets),
             Instruction::Barrier { .. } => Ok(()),
-            Instruction::Measure { .. }
-            | Instruction::Reset { .. }
-            | Instruction::Conditional { .. } => Err(PrismError::BackendUnsupported {
-                backend: self.name().to_string(),
-                operation: "measurement, reset, and conditionals (later density-matrix milestone)"
-                    .to_string(),
-            }),
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => {
+                self.apply_measure(*qubit, *classical_bit);
+                Ok(())
+            }
+            Instruction::Reset { qubit } => {
+                self.apply_reset(*qubit);
+                Ok(())
+            }
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => self.apply_conditional(condition, gate, targets),
         }
     }
 
@@ -130,6 +381,15 @@ impl Backend for DensityMatrixBackend {
 
     fn supports_fused_gates(&self) -> bool {
         false
+    }
+
+    fn qubit_probability(&self, qubit: usize) -> Result<f64> {
+        Ok(self.prob_one(qubit))
+    }
+
+    fn reset(&mut self, qubit: usize) -> Result<()> {
+        self.apply_reset(qubit);
+        Ok(())
     }
 
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -17,6 +17,23 @@ pub(crate) fn max_statevector_qubits() -> usize {
     })
 }
 
+/// Qubit cap for the exact density-matrix backend. Its state is `4^n`
+/// `Complex64` entries, the element count of a `2n`-qubit statevector, so the
+/// cap is `floor(cap_sv / 2)`: 14 on a 16 GiB host, 15 on 32 GiB.
+/// `PRISM_MAX_DM_QUBITS` overrides unconditionally.
+pub(crate) fn max_density_matrix_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        env_qubit_override("PRISM_MAX_DM_QUBITS").unwrap_or(max_statevector_qubits() / 2)
+    })
+}
+
+/// Read a qubit-cap override from `env_var`, returning `None` when unset or
+/// unparseable.
+fn env_qubit_override(env_var: &str) -> Option<usize> {
+    std::env::var(env_var).ok().and_then(|val| val.parse().ok())
+}
+
 pub(crate) fn max_dense_probability_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
@@ -69,10 +86,8 @@ fn configured_or_detected_dense_qubits(
     bytes_per_basis_state: usize,
     warning_label: &str,
 ) -> usize {
-    if let Ok(val) = std::env::var(env_var) {
-        if let Ok(n) = val.parse::<usize>() {
-            return n;
-        }
+    if let Some(n) = env_qubit_override(env_var) {
+        return n;
     }
     match detect_physical_memory_bytes().and_then(|bytes| {
         max_dense_qubits_for_budget(bytes / MEMORY_BUDGET_DIVISOR, bytes_per_basis_state)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -77,8 +77,9 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) use memory::{
-    dense_probability_len, dense_statevector_len, max_dense_outcome_bits, max_statevector_qubits,
-    reserve_dense_output, tensor_probability_len,
+    dense_probability_len, dense_statevector_len, max_dense_outcome_bits,
+    max_density_matrix_qubits, max_statevector_qubits, reserve_dense_output,
+    tensor_probability_len,
 };
 
 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use sim::homological::{
 };
 pub use sim::noise::{
     NoiseChannel, NoiseEvent, NoiseModel, NoisyCompiledSampler, ReadoutError, compile_noisy,
-    run_shots_noisy,
+    density_matrix_expectation_values, run_shots_noisy,
 };
 pub use sim::stabilizer_rank::{
     StabRankResult, run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_inner_product,

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -1,10 +1,11 @@
+use crate::backend::density_matrix::DensityMatrixBackend;
 use crate::backend::mps::MpsBackend;
 use crate::backend::product::ProductStateBackend;
 use crate::backend::sparse::SparseBackend;
 use crate::backend::stabilizer::StabilizerBackend;
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::tensornetwork::TensorNetworkBackend;
-use crate::backend::{Backend, max_statevector_qubits};
+use crate::backend::{Backend, max_density_matrix_qubits, max_statevector_qubits};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
@@ -80,6 +81,15 @@ pub enum BackendKind {
     Factored,
     StabilizerRank,
     FactoredStabilizer,
+    /// Exact density-matrix backend for mixed-state evolution.
+    ///
+    /// Explicit-dispatch only: [`BackendKind::Auto`] never selects it. Stores
+    /// `4^n` `Complex64` amplitudes, so the qubit ceiling is roughly half the
+    /// statevector cap (14 on a 16 GiB host); `PRISM_MAX_DM_QUBITS` overrides.
+    /// Fusion is skipped for this backend because batched and fused gate
+    /// variants carry qubit indices in their payload that the ket-register
+    /// offset cannot relocate.
+    DensityMatrix,
     StochasticPauli {
         num_samples: usize,
     },
@@ -176,6 +186,7 @@ impl BackendKind {
             BackendKind::StabilizerRank
                 | BackendKind::StochasticPauli { .. }
                 | BackendKind::DeterministicPauli { .. }
+                | BackendKind::DensityMatrix
         )
     }
 
@@ -241,6 +252,16 @@ pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -
                 reason: "circuit has no T gates; use Stabilizer instead".into(),
             });
         }
+        BackendKind::DensityMatrix if circuit.num_qubits > max_density_matrix_qubits() => {
+            return Err(PrismError::IncompatibleBackend {
+                backend: "density_matrix".into(),
+                reason: format!(
+                    "circuit has {} qubits, exceeding the density-matrix cap of {} on this machine (set PRISM_MAX_DM_QUBITS to override)",
+                    circuit.num_qubits,
+                    max_density_matrix_qubits()
+                ),
+            });
+        }
         _ => {}
     }
     Ok(())
@@ -258,6 +279,7 @@ pub(super) enum Family {
     FactoredStabilizer,
     TensorNetwork,
     Statevector,
+    DensityMatrix,
 }
 
 fn select_auto_backend_choice(circuit: &Circuit, has_partial_independence: bool) -> Family {
@@ -332,7 +354,8 @@ fn gpu_capability(family: Family) -> Option<GpuCapability> {
         | Family::Mps
         | Family::Factored
         | Family::FactoredStabilizer
-        | Family::TensorNetwork => None,
+        | Family::TensorNetwork
+        | Family::DensityMatrix => None,
     }
 }
 
@@ -452,6 +475,7 @@ pub(super) enum BackendPlan {
     Statevector {
         accel: Accel,
     },
+    DensityMatrix,
     #[cfg(feature = "distributed")]
     Distributed(Arc<DistributedContext>),
 }
@@ -469,6 +493,7 @@ impl BackendPlan {
             BackendPlan::Mps { max_bond_dim } => Box::new(MpsBackend::new(seed, *max_bond_dim)),
             BackendPlan::Stabilizer { accel } => Box::new(build_stabilizer(accel, seed)),
             BackendPlan::Statevector { accel } => Box::new(build_statevector(accel, seed)),
+            BackendPlan::DensityMatrix => Box::new(DensityMatrixBackend::new(seed)),
             #[cfg(feature = "distributed")]
             BackendPlan::Distributed(context) => {
                 Box::new(DistributedStatevectorBackend::new(context.clone(), seed))
@@ -491,7 +516,9 @@ impl BackendPlan {
     pub(super) fn supports_fused(&self) -> bool {
         !matches!(
             self,
-            BackendPlan::Stabilizer { .. } | BackendPlan::FactoredStabilizer
+            BackendPlan::Stabilizer { .. }
+                | BackendPlan::FactoredStabilizer
+                | BackendPlan::DensityMatrix
         )
     }
 
@@ -506,6 +533,7 @@ impl BackendPlan {
             BackendPlan::Mps { .. } => Family::Mps,
             BackendPlan::Stabilizer { .. } => Family::Stabilizer,
             BackendPlan::Statevector { .. } => Family::Statevector,
+            BackendPlan::DensityMatrix => Family::DensityMatrix,
             #[cfg(feature = "distributed")]
             BackendPlan::Distributed(_) => Family::Statevector,
         }
@@ -551,6 +579,7 @@ pub(super) fn plan_for_family(
         Family::Statevector => BackendPlan::Statevector {
             accel: accel_for(kind, Family::Statevector, num_qubits),
         },
+        Family::DensityMatrix => BackendPlan::DensityMatrix,
     }
 }
 
@@ -582,6 +611,7 @@ pub(super) fn resolve(
         BackendKind::TensorNetwork => Family::TensorNetwork,
         BackendKind::Factored => Family::Factored,
         BackendKind::FactoredStabilizer => Family::FactoredStabilizer,
+        BackendKind::DensityMatrix => Family::DensityMatrix,
         BackendKind::StabilizerRank => return ExecutionPlan::StabilizerRank,
         BackendKind::StochasticPauli { num_samples } => {
             return ExecutionPlan::StochasticPauli {
@@ -1238,6 +1268,39 @@ mod dispatch_matrix_tests {
                 max_terms: 3
             } if e == 0.5
         ));
+    }
+
+    #[test]
+    fn density_matrix_is_explicit_only() {
+        // Auto never routes to the density-matrix family, whatever the shape.
+        for circuit in [product(6), clifford(6), dense(6)] {
+            for hpi in [false, true] {
+                assert_ne!(
+                    resolved(&BackendKind::Auto, &circuit, hpi).family(),
+                    Family::DensityMatrix
+                );
+            }
+        }
+        // Explicit selection maps 1:1 onto the density-matrix plan, which skips
+        // fusion.
+        let plan = resolved(&BackendKind::DensityMatrix, &dense(6), false);
+        assert_eq!(plan.family(), Family::DensityMatrix);
+        assert!(!plan.supports_fused(), "density matrix must skip fusion");
+        assert!(matches!(plan.accel(), Accel::Cpu));
+    }
+
+    #[test]
+    fn density_matrix_rejects_over_cap() {
+        let cap = max_density_matrix_qubits();
+        if cap >= usize::BITS as usize {
+            eprintln!("SKIP: density-matrix cap disabled on this host");
+            return;
+        }
+        let circuit = dense(cap + 1);
+        let err = validate_explicit_backend(&BackendKind::DensityMatrix, &circuit).unwrap_err();
+        assert!(matches!(err, PrismError::IncompatibleBackend { .. }));
+        // At or below the cap the same shape validates.
+        assert!(validate_explicit_backend(&BackendKind::DensityMatrix, &dense(cap)).is_ok());
     }
 
     /// Explicit GPU kinds resolve hard device execution at their crossover

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -4,6 +4,7 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::smallvec;
 
 use crate::backend::Backend;
+use crate::backend::density_matrix::DensityMatrixBackend;
 use crate::backend::stabilizer::StabilizerBackend;
 use crate::circuit::{Circuit, Instruction, SmallVec};
 use crate::error::Result;
@@ -106,6 +107,11 @@ impl NoiseChannel {
                     return Err(crate::error::PrismError::InvalidParameter {
                         message: "thermal relaxation gate_time must be finite and non-negative"
                             .into(),
+                    });
+                }
+                if *t2 > 2.0 * *t1 * (1.0 + 1e-9) {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: "thermal relaxation requires t2 <= 2*t1".into(),
                     });
                 }
             }
@@ -2318,6 +2324,203 @@ pub(crate) fn run_shots_noisy_brute_with(
     Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits))
 }
 
+fn amplitude_damping_kraus(gamma: f64) -> [[[Complex64; 2]; 2]; 2] {
+    let s = (1.0 - gamma).max(0.0).sqrt();
+    let g = gamma.max(0.0).sqrt();
+    [
+        [
+            [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+            [Complex64::new(0.0, 0.0), Complex64::new(s, 0.0)],
+        ],
+        [
+            [Complex64::new(0.0, 0.0), Complex64::new(g, 0.0)],
+            [Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0)],
+        ],
+    ]
+}
+
+fn phase_damping_kraus(gamma: f64) -> [[[Complex64; 2]; 2]; 2] {
+    let s = (1.0 - gamma).max(0.0).sqrt();
+    let g = gamma.max(0.0).sqrt();
+    [
+        [
+            [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+            [Complex64::new(0.0, 0.0), Complex64::new(s, 0.0)],
+        ],
+        [
+            [Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0)],
+            [Complex64::new(0.0, 0.0), Complex64::new(g, 0.0)],
+        ],
+    ]
+}
+
+/// Lower a single-qubit noise channel to its Kraus operators for exact
+/// density-matrix evolution. Thermal relaxation (`t2 <= 2*t1`, zero
+/// temperature) is the amplitude-damping channel composed with a pure-dephasing
+/// channel chosen so populations decay as `exp(-t/t1)` and coherences as
+/// `exp(-t/t2)`.
+pub(crate) fn kraus_1q(channel: &NoiseChannel) -> Vec<[[Complex64; 2]; 2]> {
+    let id = [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+    ];
+    let x = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let y = [
+        [Complex64::new(0.0, 0.0), Complex64::new(0.0, -1.0)],
+        [Complex64::new(0.0, 1.0), Complex64::new(0.0, 0.0)],
+    ];
+    let z = [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(-1.0, 0.0)],
+    ];
+    let scale = |m: [[Complex64; 2]; 2], s: f64| {
+        let s = Complex64::new(s, 0.0);
+        [[m[0][0] * s, m[0][1] * s], [m[1][0] * s, m[1][1] * s]]
+    };
+    let pauli = |px: f64, py: f64, pz: f64| {
+        let pi = (1.0 - px - py - pz).max(0.0);
+        vec![
+            scale(id, pi.sqrt()),
+            scale(x, px.sqrt()),
+            scale(y, py.sqrt()),
+            scale(z, pz.sqrt()),
+        ]
+    };
+    match channel {
+        NoiseChannel::Pauli { px, py, pz } => pauli(*px, *py, *pz),
+        NoiseChannel::Depolarizing { p } => pauli(p / 3.0, p / 3.0, p / 3.0),
+        NoiseChannel::AmplitudeDamping { gamma } => amplitude_damping_kraus(*gamma).to_vec(),
+        NoiseChannel::PhaseDamping { gamma } => phase_damping_kraus(*gamma).to_vec(),
+        NoiseChannel::ThermalRelaxation { t1, t2, gate_time } => {
+            let gad = 1.0 - (-gate_time / t1).exp();
+            let gpd = (1.0 - (gate_time / t1 - 2.0 * gate_time / t2).exp()).clamp(0.0, 1.0);
+            let ad = amplitude_damping_kraus(gad);
+            let pd = phase_damping_kraus(gpd);
+            let mut out = Vec::with_capacity(4);
+            for a in &ad {
+                for p in &pd {
+                    out.push(crate::gates::mat_mul_2x2(a, p));
+                }
+            }
+            out
+        }
+        NoiseChannel::Custom { kraus } => kraus.clone(),
+        NoiseChannel::TwoQubitDepolarizing { .. } => {
+            unreachable!("two-qubit depolarizing has no single-qubit Kraus lowering")
+        }
+    }
+}
+
+/// Apply one noise event to a density-matrix backend exactly.
+pub(crate) fn apply_noise_event_dm(dm: &mut DensityMatrixBackend, event: &NoiseEvent) {
+    match &event.channel {
+        NoiseChannel::TwoQubitDepolarizing { p } => {
+            dm.apply_2q_depolarizing(event.qubits[0], event.qubits[1], *p);
+        }
+        other => {
+            let kraus = kraus_1q(other);
+            dm.apply_1q_kraus(event.qubits[0], &kraus);
+        }
+    }
+}
+
+/// Evolve a density-matrix backend through `circuit` and optional `noise`.
+///
+/// Measurements are not collapsed; observables and marginals are read off the
+/// final mixed state, so this assumes terminal (non-feedback) measurement. The
+/// circuit is checked against the density-matrix qubit cap and the noise model
+/// is validated before any allocation.
+fn evolve_density_matrix(
+    circuit: &Circuit,
+    noise: Option<&NoiseModel>,
+    seed: u64,
+) -> Result<DensityMatrixBackend> {
+    let cap = crate::backend::max_density_matrix_qubits();
+    if circuit.num_qubits > cap {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: "density_matrix".into(),
+            reason: format!(
+                "circuit has {} qubits, exceeding the density-matrix cap of {cap} on this machine (set PRISM_MAX_DM_QUBITS to override)",
+                circuit.num_qubits
+            ),
+        });
+    }
+    if let Some(noise) = noise {
+        if noise.after_gate.len() != circuit.instructions.len() {
+            return Err(crate::error::PrismError::InvalidParameter {
+                message: "noise model length does not match circuit instruction count".into(),
+            });
+        }
+        noise.validate()?;
+    }
+
+    let mut dm = DensityMatrixBackend::new(seed);
+    dm.init(circuit.num_qubits, circuit.num_classical_bits)?;
+    for (i, inst) in circuit.instructions.iter().enumerate() {
+        match inst {
+            Instruction::Measure { .. } => {}
+            other => dm.apply(other)?,
+        }
+        if let Some(noise) = noise {
+            for event in &noise.after_gate[i] {
+                apply_noise_event_dm(&mut dm, event);
+            }
+        }
+    }
+    Ok(dm)
+}
+
+/// Exact per-classical-bit measurement marginals under a noise model, evolved
+/// on the density-matrix backend. Measurements are read as `Tr(P_1 rho)` on the
+/// final state without collapse, so this assumes terminal (non-feedback)
+/// measurement, matching the domain of `noisy_marginals_analytical`.
+#[cfg(test)]
+pub(crate) fn dm_noisy_marginals(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    seed: u64,
+) -> Result<Vec<f64>> {
+    let dm = evolve_density_matrix(circuit, Some(noise), seed)?;
+    let mut result = vec![0.5f64; circuit.num_classical_bits];
+    for inst in &circuit.instructions {
+        if let Instruction::Measure {
+            qubit,
+            classical_bit,
+        } = inst
+        {
+            if *classical_bit < result.len() {
+                result[*classical_bit] = dm.qubit_probability(*qubit)?;
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Exact `Tr(rho P_k)` for each joint Pauli `P_k`, evolving the density-matrix
+/// backend through `circuit` and (optionally) `noise`. Measurements are read off
+/// the final mixed state without collapse, so this is the exact (zero-variance)
+/// analogue of trajectory-averaged expectation values. The circuit must fit the
+/// density-matrix qubit cap; observables reuse the same Pauli-mask reduction as
+/// [`run_expectation_values`](crate::sim::run_expectation_values).
+pub fn density_matrix_expectation_values(
+    circuit: &Circuit,
+    observables: &[Vec<crate::PauliTerm>],
+    noise: Option<&NoiseModel>,
+    seed: u64,
+) -> Result<Vec<f64>> {
+    let dm = evolve_density_matrix(circuit, noise, seed)?;
+    observables
+        .iter()
+        .map(|obs| {
+            let (xmask, zmask, num_y) = crate::sim::pauli_masks(obs, circuit.num_qubits)?;
+            Ok(dm.expectation_pauli(xmask, zmask, num_y))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2501,6 +2704,23 @@ mod tests {
             }
         }
 
+        // The density-matrix backend carries no sampling noise, so it sits far
+        // tighter to the analytic marginals than the sampled engines. The
+        // residual is a model gap, not statistics: the analytic reference is the
+        // Pauli-frame independent-error model (X and Y flips are independent
+        // Bernoulli events), while the density matrix evolves the exact
+        // depolarizing channel (mutually exclusive Paulis). The two agree to
+        // first order in p and differ at O(p^2); at p = 0.02 that gap is < 3e-4.
+        let dm_marginals = dm_noisy_marginals(&circuit, &noise, seed).unwrap();
+        let dm_tol = 3e-4;
+        for (bit, &expected) in analytic.iter().enumerate() {
+            assert!(
+                (dm_marginals[bit] - expected).abs() < dm_tol,
+                "density_matrix bit {bit}: marginal {:.12} vs analytic {expected:.12}",
+                dm_marginals[bit]
+            );
+        }
+
         let ghz_coherent = |result: &ShotsResult| -> f64 {
             result
                 .shots
@@ -2518,6 +2738,270 @@ mod tests {
                 "{name} GHZ coherence {value:.4} vs compiled {reference:.4}"
             );
         }
+    }
+
+    #[test]
+    fn dm_expectation_matches_run_expectation_values() {
+        use crate::{PauliAxis, PauliTerm};
+        let mut circuit = Circuit::new(3, 0);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Ry(0.7), &[1]);
+        circuit.add_gate(Gate::Cx, &[0, 1]);
+        circuit.add_gate(Gate::Rx(1.1), &[2]);
+        circuit.add_gate(Gate::Cz, &[1, 2]);
+        circuit.add_gate(Gate::T, &[0]);
+
+        let observables = vec![
+            vec![PauliTerm::new(0, PauliAxis::Z)],
+            vec![PauliTerm::new(2, PauliAxis::X)],
+            vec![
+                PauliTerm::new(0, PauliAxis::Z),
+                PauliTerm::new(1, PauliAxis::Z),
+            ],
+            vec![
+                PauliTerm::new(0, PauliAxis::Y),
+                PauliTerm::new(2, PauliAxis::X),
+            ],
+        ];
+
+        let reference = crate::sim::run_expectation_values(&circuit, &observables, 42).unwrap();
+        let dm = density_matrix_expectation_values(&circuit, &observables, None, 42).unwrap();
+        for (i, (a, b)) in dm.iter().zip(&reference).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-12,
+                "observable {i}: dm {a:.15} vs statevector {b:.15}"
+            );
+        }
+    }
+
+    #[test]
+    fn trajectory_expectations_converge_to_density_matrix_within_5_sigma() {
+        use crate::backend::statevector::StatevectorBackend;
+        use crate::sim::trajectory::run_trajectory_shot;
+        use crate::{PauliAxis, PauliTerm};
+
+        // Six-qubit seeded layered circuit with two noise layers.
+        let mut circuit = Circuit::new(6, 0);
+        for q in 0..6 {
+            circuit.add_gate(Gate::H, &[q]);
+        }
+        for q in 0..5 {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(0xDEAD_BEEF);
+        for q in 0..6 {
+            let theta: f64 = rand::RngExt::random::<f64>(&mut rng) * std::f64::consts::TAU;
+            circuit.add_gate(
+                if q % 2 == 0 {
+                    Gate::Rz(theta)
+                } else {
+                    Gate::Rx(theta)
+                },
+                &[q],
+            );
+        }
+
+        // Noise after layer 1 (the first H) and layer 2 (first CX).
+        let mut noise = NoiseModel {
+            after_gate: vec![Vec::new(); circuit.instructions.len()],
+            readout: vec![None; circuit.num_classical_bits],
+        };
+        for q in 0..6 {
+            noise.after_gate[q].push(NoiseEvent {
+                channel: NoiseChannel::Depolarizing { p: 0.02 },
+                qubits: smallvec![q],
+            });
+        }
+        for q in 0..6 {
+            noise.after_gate[6 + q.min(4)].push(NoiseEvent {
+                channel: NoiseChannel::AmplitudeDamping { gamma: 0.03 },
+                qubits: smallvec![q],
+            });
+        }
+
+        let observables = vec![
+            vec![
+                PauliTerm::new(0, PauliAxis::Z),
+                PauliTerm::new(1, PauliAxis::Z),
+            ],
+            vec![
+                PauliTerm::new(2, PauliAxis::X),
+                PauliTerm::new(3, PauliAxis::X),
+            ],
+            vec![
+                PauliTerm::new(4, PauliAxis::Z),
+                PauliTerm::new(5, PauliAxis::Z),
+            ],
+        ];
+        let weights = [0.5f64, 0.3, 0.2];
+
+        let mu_dm =
+            density_matrix_expectation_values(&circuit, &observables, Some(&noise), 42).unwrap();
+
+        // Trajectory estimates: each shot is a pure state; the observable value
+        // on that state is a sample whose mean converges to Tr(rho P).
+        let masks: Vec<_> = observables
+            .iter()
+            .map(|obs| crate::sim::pauli_masks(obs, circuit.num_qubits).unwrap())
+            .collect();
+        let shots = 20_000usize;
+        let mut sums = vec![0.0f64; observables.len()];
+        let mut sq_sums = vec![0.0f64; observables.len()];
+        let mut backend = StatevectorBackend::new(42);
+        for i in 0..shots {
+            let mut shot_rng = ChaCha8Rng::seed_from_u64(42u64.wrapping_add(i as u64));
+            run_trajectory_shot(&mut backend, &circuit, &noise, &mut shot_rng).unwrap();
+            let state = backend.state_vector();
+            let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+            for (k, &(x, z, y)) in masks.iter().enumerate() {
+                let v = crate::sim::pauli_expectation_from_masks(state, x, z, y, norm);
+                sums[k] += v;
+                sq_sums[k] += v * v;
+            }
+        }
+
+        for (k, &w) in weights.iter().enumerate() {
+            let mean = sums[k] / shots as f64;
+            let var = (sq_sums[k] / shots as f64 - mean * mean).max(0.0);
+            let sigma = (var / shots as f64).sqrt();
+            let diff = (mean - mu_dm[k]).abs();
+            if sigma < 1e-12 {
+                assert!(
+                    diff < 1e-10,
+                    "term {k} (w={w}): degenerate trajectory, mean {mean} vs dm {}",
+                    mu_dm[k]
+                );
+            } else {
+                let z_score = diff / sigma;
+                assert!(
+                    z_score < 5.0,
+                    "term {k} (w={w}): z={z_score:.2}, traj {mean:.6} vs dm {:.6}",
+                    mu_dm[k]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dm_named_channel_lowering_preserves_trace_and_decay() {
+        use crate::backend::density_matrix::DensityMatrixBackend;
+
+        let trace = |dm: &DensityMatrixBackend| -> f64 { dm.probabilities().unwrap().iter().sum() };
+        let identity = [
+            [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+            [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        ];
+        let channels = [
+            NoiseChannel::Pauli {
+                px: 0.1,
+                py: 0.05,
+                pz: 0.2,
+            },
+            NoiseChannel::Depolarizing { p: 0.3 },
+            NoiseChannel::AmplitudeDamping { gamma: 0.4 },
+            NoiseChannel::PhaseDamping { gamma: 0.35 },
+            NoiseChannel::ThermalRelaxation {
+                t1: 50.0,
+                t2: 40.0,
+                gate_time: 10.0,
+            },
+            NoiseChannel::Custom {
+                kraus: vec![identity],
+            },
+        ];
+        for ch in &channels {
+            let mut dm = DensityMatrixBackend::new(42);
+            dm.init(1, 0).unwrap();
+            dm.apply(&Instruction::Gate {
+                gate: Gate::H,
+                targets: smallvec![0],
+            })
+            .unwrap();
+            dm.apply_1q_kraus(0, &kraus_1q(ch));
+            assert!(
+                (trace(&dm) - 1.0).abs() < 1e-12,
+                "trace after {ch:?}: {}",
+                trace(&dm)
+            );
+        }
+
+        let (t1, t2, gt) = (50.0, 40.0, 10.0);
+        let thermal = NoiseChannel::ThermalRelaxation {
+            t1,
+            t2,
+            gate_time: gt,
+        };
+        let mut dm = DensityMatrixBackend::new(42);
+        dm.init(1, 0).unwrap();
+        dm.apply(&Instruction::Gate {
+            gate: Gate::X,
+            targets: smallvec![0],
+        })
+        .unwrap();
+        dm.apply_1q_kraus(0, &kraus_1q(&thermal));
+        let rho = dm.reduced_density_matrix_1q(0).unwrap();
+        assert!(
+            (rho[1][1].re - (-gt / t1).exp()).abs() < 1e-12,
+            "T1 population decay: {rho:?}"
+        );
+
+        let mut dm = DensityMatrixBackend::new(42);
+        dm.init(1, 0).unwrap();
+        dm.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: smallvec![0],
+        })
+        .unwrap();
+        dm.apply_1q_kraus(0, &kraus_1q(&thermal));
+        let rho = dm.reduced_density_matrix_1q(0).unwrap();
+        assert!(
+            (rho[0][1].norm() - 0.5 * (-gt / t2).exp()).abs() < 1e-12,
+            "T2 coherence decay: {rho:?}"
+        );
+
+        // Amplitude and phase damping lowerings drive the exact analytic channel
+        // through kraus_1q, not just trace preservation, on |+>.
+        let prep_plus = |ch: &NoiseChannel| -> [[Complex64; 2]; 2] {
+            let mut dm = DensityMatrixBackend::new(42);
+            dm.init(1, 0).unwrap();
+            dm.apply(&Instruction::Gate {
+                gate: Gate::H,
+                targets: smallvec![0],
+            })
+            .unwrap();
+            dm.apply_1q_kraus(0, &kraus_1q(ch));
+            dm.reduced_density_matrix_1q(0).unwrap()
+        };
+
+        let gamma = 0.4;
+        let rho = prep_plus(&NoiseChannel::AmplitudeDamping { gamma });
+        assert!(
+            (rho[0][0].re - (0.5 + 0.5 * gamma)).abs() < 1e-12,
+            "AD pop0: {rho:?}"
+        );
+        assert!(
+            (rho[1][1].re - 0.5 * (1.0 - gamma)).abs() < 1e-12,
+            "AD pop1: {rho:?}"
+        );
+        assert!(
+            (rho[0][1].norm() - 0.5 * (1.0 - gamma).sqrt()).abs() < 1e-12,
+            "AD coherence: {rho:?}"
+        );
+
+        let gamma = 0.35;
+        let rho = prep_plus(&NoiseChannel::PhaseDamping { gamma });
+        assert!(
+            (rho[0][0].re - 0.5).abs() < 1e-12,
+            "PD pop0 preserved: {rho:?}"
+        );
+        assert!(
+            (rho[1][1].re - 0.5).abs() < 1e-12,
+            "PD pop1 preserved: {rho:?}"
+        );
+        assert!(
+            (rho[0][1].norm() - 0.5 * (1.0 - gamma).sqrt()).abs() < 1e-12,
+            "PD coherence: {rho:?}"
+        );
     }
 
     #[test]

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -11,6 +11,58 @@ use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
 use prism_q::{circuits, sim};
 
+fn dm_backend(circuit: &Circuit, seed: u64) -> DensityMatrixBackend {
+    let mut backend = DensityMatrixBackend::new(seed);
+    sim::run_on(&mut backend, circuit).unwrap();
+    backend
+}
+
+use num_complex::Complex64;
+
+fn c(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// Build a one-qubit backend, prepare it with `prep`, apply Kraus set `kraus`,
+/// and return the resulting one-qubit density matrix and its trace.
+fn dm_after_channel(
+    prep: &[(Gate, usize)],
+    kraus: &[[[Complex64; 2]; 2]],
+) -> ([[Complex64; 2]; 2], f64) {
+    let mut backend = DensityMatrixBackend::new(42);
+    backend.init(1, 0).unwrap();
+    for (gate, q) in prep {
+        backend
+            .apply(&prism_q::circuit::Instruction::Gate {
+                gate: gate.clone(),
+                targets: [*q].into_iter().collect(),
+            })
+            .unwrap();
+    }
+    backend.apply_1q_kraus(0, kraus);
+    let rho = backend.reduced_density_matrix_1q(0).unwrap();
+    let trace = rho[0][0].re + rho[1][1].re;
+    (rho, trace)
+}
+
+fn amplitude_damping(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let s = (1.0 - gamma).sqrt();
+    let g = gamma.sqrt();
+    vec![
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(s, 0.0)]],
+        [[c(0.0, 0.0), c(g, 0.0)], [c(0.0, 0.0), c(0.0, 0.0)]],
+    ]
+}
+
+fn phase_damping(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let s = (1.0 - gamma).sqrt();
+    let g = gamma.sqrt();
+    vec![
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(s, 0.0)]],
+        [[c(0.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(g, 0.0)]],
+    ]
+}
+
 const DM_EPS: f64 = 1e-12;
 
 fn statevector_probs(circuit: &Circuit) -> Vec<f64> {
@@ -150,6 +202,241 @@ fn dm_probabilities_sum_to_one() {
         (total - 1.0).abs() < 1e-12,
         "probabilities must sum to 1, got {total}"
     );
+}
+
+fn depolarizing(p: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let pp = (p / 3.0).sqrt();
+    let pi = (1.0 - p).sqrt();
+    vec![
+        [[c(pi, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(pi, 0.0)]],
+        [[c(0.0, 0.0), c(pp, 0.0)], [c(pp, 0.0), c(0.0, 0.0)]],
+        [[c(0.0, 0.0), c(0.0, -pp)], [c(0.0, pp), c(0.0, 0.0)]],
+        [[c(pp, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-pp, 0.0)]],
+    ]
+}
+
+#[test]
+fn dm_explicit_dispatch_matches_statevector() {
+    use prism_q::BackendKind;
+    let c = circuits::random_circuit(4, 8, 0xDEAD_BEEF);
+    let outcome = sim::simulate(&c)
+        .backend(BackendKind::DensityMatrix)
+        .seed(42)
+        .run()
+        .unwrap();
+    let probs = outcome.probabilities.unwrap().to_vec();
+    assert_probs_close(&probs, &statevector_probs(&c), "explicit dispatch");
+}
+
+#[test]
+fn dm_noisy_shot_sampling_is_rejected() {
+    use prism_q::{BackendKind, NoiseModel};
+    // Density matrix is an exact backend, not a per-shot sampler. Noisy shot
+    // sampling must fail cleanly; exact noisy expectation goes through
+    // density_matrix_expectation_values instead.
+    let mut c = Circuit::new(2, 2);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.measure_all();
+    let noise = NoiseModel::uniform_depolarizing(&c, 0.01);
+    let result = sim::simulate(&c)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(42)
+        .shots(100);
+    assert!(result.is_err(), "noisy DM shot sampling should be rejected");
+}
+
+#[test]
+fn dm_amplitude_damping_analytic() {
+    let gamma = 0.3;
+    // Excited state relaxes: rho11 -> 1 - gamma, rho00 -> gamma.
+    let (rho, tr) = dm_after_channel(&[(Gate::X, 0)], &amplitude_damping(gamma));
+    assert!((tr - 1.0).abs() < DM_EPS, "trace preserved: {tr}");
+    assert!((rho[0][0].re - gamma).abs() < DM_EPS, "ground pop: {rho:?}");
+    assert!(
+        (rho[1][1].re - (1.0 - gamma)).abs() < DM_EPS,
+        "excited pop: {rho:?}"
+    );
+    // Coherence of |+> decays as sqrt(1-gamma).
+    let (rho, tr) = dm_after_channel(&[(Gate::H, 0)], &amplitude_damping(gamma));
+    assert!((tr - 1.0).abs() < DM_EPS, "trace preserved: {tr}");
+    assert!(
+        (rho[0][1].re - 0.5 * (1.0 - gamma).sqrt()).abs() < DM_EPS,
+        "coherence: {rho:?}"
+    );
+}
+
+#[test]
+fn dm_phase_damping_analytic() {
+    let gamma = 0.4;
+    // Populations preserved, off-diagonal decays as sqrt(1-gamma).
+    let (rho, tr) = dm_after_channel(&[(Gate::H, 0)], &phase_damping(gamma));
+    assert!((tr - 1.0).abs() < DM_EPS, "trace preserved: {tr}");
+    assert!(
+        (rho[0][0].re - 0.5).abs() < DM_EPS,
+        "pop0 preserved: {rho:?}"
+    );
+    assert!(
+        (rho[1][1].re - 0.5).abs() < DM_EPS,
+        "pop1 preserved: {rho:?}"
+    );
+    assert!(
+        (rho[0][1].re - 0.5 * (1.0 - gamma).sqrt()).abs() < DM_EPS,
+        "coherence: {rho:?}"
+    );
+    assert!(
+        rho[0][1].im.abs() < DM_EPS,
+        "no imaginary coherence: {rho:?}"
+    );
+}
+
+#[test]
+fn dm_depolarizing_fixed_point() {
+    // Depolarizing with p = 3/4 maps any single-qubit state to I/2.
+    for prep in [vec![(Gate::X, 0)], vec![(Gate::H, 0)], vec![(Gate::T, 0)]] {
+        let (rho, tr) = dm_after_channel(&prep, &depolarizing(0.75));
+        assert!((tr - 1.0).abs() < DM_EPS, "trace preserved: {tr}");
+        assert!(
+            (rho[0][0].re - 0.5).abs() < DM_EPS,
+            "maximally mixed pop0: {rho:?}"
+        );
+        assert!(
+            (rho[1][1].re - 0.5).abs() < DM_EPS,
+            "maximally mixed pop1: {rho:?}"
+        );
+        assert!(rho[0][1].norm() < DM_EPS, "no coherence: {rho:?}");
+    }
+}
+
+#[test]
+fn dm_custom_kraus_matches_amplitude_damping() {
+    // A Custom Kraus set equal to amplitude damping must reproduce it.
+    let gamma = 0.25;
+    let (rho, _) = dm_after_channel(&[(Gate::X, 0)], &amplitude_damping(gamma));
+    assert!(
+        (rho[1][1].re - (1.0 - gamma)).abs() < DM_EPS,
+        "custom == AD: {rho:?}"
+    );
+}
+
+#[test]
+fn dm_two_qubit_depolarizing_bell_analytic() {
+    // A Bell pair under symmetric two-qubit depolarizing with parameter p:
+    // rho' = (1 - p - p/15)|Phi+><Phi+| + (4p/15) I.
+    let p = 0.3;
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    let mut backend = DensityMatrixBackend::new(42);
+    sim::run_on(&mut backend, &c).unwrap();
+    backend.apply_2q_depolarizing(0, 1, p);
+
+    let probs = backend.probabilities().unwrap();
+    let diag_bell = (1.0 - p - p / 15.0) * 0.5 + 4.0 * p / 15.0;
+    let off_bell = 4.0 * p / 15.0;
+    assert!((probs[0] - diag_bell).abs() < DM_EPS, "p00: {probs:?}");
+    assert!((probs[3] - diag_bell).abs() < DM_EPS, "p11: {probs:?}");
+    assert!((probs[1] - off_bell).abs() < DM_EPS, "p01: {probs:?}");
+    assert!((probs[2] - off_bell).abs() < DM_EPS, "p10: {probs:?}");
+    let total: f64 = probs.iter().sum();
+    assert!((total - 1.0).abs() < DM_EPS, "trace preserved: {total}");
+}
+
+#[test]
+fn dm_measure_basis_state_deterministic() {
+    let mut c = Circuit::new(2, 2);
+    c.add_gate(Gate::X, &[0]);
+    c.add_measure(0, 0);
+    c.add_measure(1, 1);
+    let backend = dm_backend(&c, 42);
+    assert_eq!(backend.classical_results(), &[true, false]);
+    let probs = backend.probabilities().unwrap();
+    assert!(
+        (probs[1] - 1.0).abs() < DM_EPS,
+        "collapsed onto |01>: {probs:?}"
+    );
+}
+
+#[test]
+fn dm_reset_returns_qubit_to_zero() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::X, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_reset(0);
+    let backend = dm_backend(&c, 42);
+    let rdm0 = backend.reduced_density_matrix_1q(0).unwrap();
+    assert!(
+        (rdm0[0][0].re - 1.0).abs() < DM_EPS,
+        "reset qubit population: {rdm0:?}"
+    );
+    assert!(
+        rdm0[1][1].re.abs() < DM_EPS,
+        "reset qubit excited population: {rdm0:?}"
+    );
+    let total: f64 = backend.probabilities().unwrap().iter().sum();
+    assert!((total - 1.0).abs() < DM_EPS, "trace preserved: {total}");
+}
+
+#[test]
+fn dm_reset_from_superposition_gives_maximally_mixed_partial_trace() {
+    // A Bell pair reset on one qubit leaves the other maximally mixed.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_reset(0);
+    let backend = dm_backend(&c, 42);
+    let rdm1 = backend.reduced_density_matrix_1q(1).unwrap();
+    assert!((rdm1[0][0].re - 0.5).abs() < DM_EPS, "rdm1={rdm1:?}");
+    assert!((rdm1[1][1].re - 0.5).abs() < DM_EPS, "rdm1={rdm1:?}");
+    assert!(
+        rdm1[0][1].norm() < DM_EPS,
+        "off-diagonal coherence: {rdm1:?}"
+    );
+}
+
+#[test]
+fn dm_conditional_applies_on_measured_one() {
+    use prism_q::circuit::{ClassicalCondition, Instruction, SmallVec};
+    let mut c = Circuit::new(2, 1);
+    c.add_gate(Gate::X, &[0]);
+    c.add_measure(0, 0);
+    let targets: SmallVec<[usize; 4]> = [1usize].into_iter().collect();
+    c.instructions.push(Instruction::Conditional {
+        condition: ClassicalCondition::BitIsOne(0),
+        gate: Gate::X,
+        targets,
+    });
+    let backend = dm_backend(&c, 42);
+    let probs = backend.probabilities().unwrap();
+    assert!(
+        (probs[3] - 1.0).abs() < DM_EPS,
+        "both qubits flipped: {probs:?}"
+    );
+}
+
+#[test]
+fn dm_measurement_marginals_match_statevector() {
+    // Measuring a Bell pair yields 00 or 11 with probability 0.5 each; 01 and
+    // 10 never occur. The empirical frequency must match the statevector
+    // analytic marginals.
+    let mut c = Circuit::new(2, 2);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_measure(0, 0);
+    c.add_measure(1, 1);
+    let shots = 4000usize;
+    let mut counts = [0usize; 4];
+    for seed in 0..shots {
+        let backend = dm_backend(&c, seed as u64);
+        let bits = backend.classical_results();
+        let idx = usize::from(bits[0]) | (usize::from(bits[1]) << 1);
+        counts[idx] += 1;
+    }
+    assert_eq!(counts[1], 0, "01 forbidden by correlation");
+    assert_eq!(counts[2], 0, "10 forbidden by correlation");
+    let p00 = counts[0] as f64 / shots as f64;
+    assert!((p00 - 0.5).abs() < 0.05, "p00={p00}");
 }
 
 #[test]

--- a/tests/noise_validation.rs
+++ b/tests/noise_validation.rs
@@ -97,6 +97,26 @@ fn thermal_relaxation_validation() {
         .validate()
         .is_err()
     );
+    // t2 must not exceed 2*t1 (outside the amplitude-damping-then-dephasing
+    // decomposition's validity).
+    assert!(
+        NoiseChannel::ThermalRelaxation {
+            t1: 50.0,
+            t2: 150.0,
+            gate_time: 10.0,
+        }
+        .validate()
+        .is_err()
+    );
+    assert!(
+        NoiseChannel::ThermalRelaxation {
+            t1: 50.0,
+            t2: 100.0,
+            gate_time: 10.0,
+        }
+        .validate()
+        .is_ok()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Completes the exact CPU density-matrix backend: on top of the merged unitary core
it adds measurement/reset/conditionals, exact one- and two-qubit noise channels,
exact `Tr(rho O)` expectation values, and explicit-only dispatch with a memory
cap. This closes the exact mixed-state gap for small-`n` QEC and VQE oracle work
without touching any existing backend.

## Scope

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Run with `--features parallel` on a quiet machine. The density-matrix backend is
new, so `unitary_layers` rows have no prior baseline. The A/B rows isolate the
`conjugate_buffer` parallelization (the only new optimization `unitary_layers`
exercises); `neutrality/22` re-runs the unmodified statevector `qft_textbook` 22q
workload to prove shared kernels are untouched.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| density_matrix/unitary_layers/4 | n/a (new) | 24.7 µs | new | n/a |
| density_matrix/unitary_layers/8 | n/a (new) | 12.95 ms | new | n/a |
| density_matrix/unitary_layers/10 (serial vs parallel conj) | 558 ms | 511 ms | -8.4% | yes (improvement) |
| density_matrix/unitary_layers/12 (serial vs parallel conj) | 12.59 s | 12.26 s | -2.6% (p=0.14, n.s.) | yes |
| density_matrix/neutrality/22 (statevector qft_textbook 22q) | 142.5 ms | 142.5 ms | ~0% (same code path) | yes |

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (1736 tests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features parallel` passes with no warnings
- [x] `cargo test --doc --features parallel` passes
- [x] New public API has docstrings (`density_matrix_expectation_values`, backend methods)
- [x] New backend has golden tests against the statevector backend
- [ ] GPU-affecting change runs golden_gpu (N/A, CPU-only backend)

Note: validated with `--features parallel` (the benchmarked configuration) rather
than `--all-features`, and via `cargo-nextest` (doctests via `cargo test --doc`).

## Hotspot notes

The density-matrix kernels operate on a `4^n` buffer. Hot paths and their design:

- `apply_1q_kraus` and `apply_reset` enumerate the `d^2/4` block bases via
  `insert_zero_bit` bit-deposit (no 4x over-iteration).
- `apply_2q_depolarizing` is a single-pass 16x16 block superoperator (was ~200
  full-buffer sweeps).
- `conjugate_buffer` parallelizes above the 14-qubit element threshold.
- Gate application reuses the statevector kernels on the embedded 2n-qubit state,
  so it inherits their SIMD and Rayon paths.

## Architecture or design changes

- [x] `docs/architecture/backends.md` updated with a Density Matrix section and
      the 2n-qubit embedding layout.
- [x] Design note added for the new subsystem.

## Breaking changes

None. `BackendKind::DensityMatrix` is a new explicit-only variant; `Auto` routing,
existing backends, and all public result shapes are unchanged. The added
`t2 <= 2*t1` check in `NoiseChannel::validate` rejects a previously-accepted but
physically invalid parameter regime.

## Risks and rollback

Low blast radius. The backend is explicit-dispatch only and never selected by
`Auto`, so existing runs are unaffected. Fusion is disabled for it
(`supports_fused_gates` returns `false`), so every instruction arrives as a
primitive. Rollback is reverting the commit; no persisted state or config.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
