### PR TITLE
Feat/qec density matrix exp val

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Backends](./architecture/backends.md)
 - [Compiled Samplers](./architecture/samplers.md)
 - [Native QEC Program IR](./architecture/qec-ir.md)
+- [QEC Program Execution](./architecture/qec-programs.md)
 - [Threading, SIMD, and Memory Layout](./architecture/threading-simd.md)
 - [Error Model and Public API](./architecture/api-surface.md)
 

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -10,6 +10,22 @@ The diagrams below are rendered directly from PRISM-Q's own SVG circuit renderer
 
 ![GHZ state preparation circuit](../diagrams/ghz_5.svg)
 
+## Reset semantics
+
+`reset` is the channel `rho -> |0⟩⟨0| ⊗ tr_q rho` on every backend: the qubit is traced
+out and replaced by `|0⟩`, leaving the rest of the register in the mixture the trace
+produces. Projecting onto `|0⟩` and renormalizing is not equivalent. The two agree only
+when the reset qubit is unentangled; when it is entangled, projection also collapses its
+partners into the branch correlated with the `|0⟩` outcome. Resetting qubit 1 of a Bell
+pair leaves `⟨Z0⟩ = 0` under the channel and `⟨Z0⟩ = 1` under projection.
+
+A backend holding a single pure state cannot represent the resulting mixture, so it runs
+one trajectory of the channel: sample the measurement outcome, collapse onto it, and
+apply X when the outcome is 1. Averaged over shots that reproduces the channel, and a
+reset consumes one draw from the backend's RNG stream. The density-matrix backend holds
+the mixture and applies the channel directly, with no draw. `tests/reset_channel.rs`
+pins the contract across backends against the density-matrix oracle.
+
 ## Statevector
 
 Full-state simulation in a flat `Vec<Complex64>` of 2^n amplitudes. The primary backend for circuits up to ~28 qubits.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,6 +44,7 @@ flowchart TD
 The remaining pages in this section follow that flow: the
 [parser and circuit IR](./ir.md), the [fusion pipeline](./fusion.md), the
 [simulation engine and dispatch](./engine.md), the individual [backends](./backends.md),
-the [compiled samplers](./samplers.md), the [native QEC program IR](./qec-ir.md), the
+the [compiled samplers](./samplers.md), the [native QEC program IR](./qec-ir.md) and its
+[execution path](./qec-programs.md), the
 [threading, SIMD, and memory layout](./threading-simd.md), and the
 [error model and public API surface](./api-surface.md).

--- a/docs/architecture/qec-ir.md
+++ b/docs/architecture/qec-ir.md
@@ -41,68 +41,18 @@ such programs to the estimator paths described below.
 
 ## Execution
 
-`run_qec_program` is the scalable native QEC execution path. It lowers
-Clifford-compatible QEC programs into the existing packed compiled sampler, so
-sampling uses packed measurement records instead of dense amplitudes. It
-supports Clifford gates, basis resets and measurements, `MPP`, detectors,
-observables, postselection, Pauli-noise annotations, and optional
-raw-measurement retention. Noisy Clifford programs compile `X_ERROR`,
-`Z_ERROR`, `DEPOLARIZE1`, and correlated `DEPOLARIZE2` events into packed
-sensitivity rows, then XOR those rows into the packed measurement records.
-Non-Clifford gates reject clearly on the packed path; programs containing
-`EXP_VAL` route to the expectation-value paths below, which accept T gates
-via the analytical strategies.
-
-```admonish note title="V1 reset requirement"
-V1 requires a reset before any later gate reuse of a measured qubit, because the
-compiled lowering defers measurements to terminal records. `QecOptions::chunk_size`
-bounds compiled-runner shot batches. When raw measurements are omitted, chunking avoids
-materializing the full measurement record matrix before detector, observable,
-postselection, and logical-error accounting.
-```
-
-`run_qec_program_reference` is the small-program correctness oracle. It runs one
-state-vector simulation per shot and supports Pauli-noise annotations, but it is
-not the production performance path.
+`run_qec_program` lowers Clifford-compatible programs into the packed
+compiled sampler, compiles Pauli-noise annotations into sensitivity rows
+XORed into the records, and routes `EXP_VAL` programs to estimator paths.
+`run_qec_program_reference` is the per-shot state-vector correctness oracle.
+The runner routing, the compiled and noisy sampling paths, the circuit
+lowerings, and the result shape are covered in
+[QEC program execution](./qec-programs.md).
 
 ## Expectation values
 
 `EXP_VAL(c) P1*...*Pk` estimates `c * <P>` for the Pauli product `P` in the
 program's final state and returns one `QecObservableEstimate` per op, in op
-order, in `QecSampleResult::expectation_values`. Two placement rules make
-"final state" well defined on every path:
-
-- Terminal placement: no gate, measurement, reset, or active noise may follow
-  an `EXP_VAL` op. Detector, observable, postselection, and tick metadata may.
-- Live qubits only: a term may not reference a qubit that was
-  single-qubit-measured after its last reset. Under this rule the Pauli
-  commutes with every prior measurement projector, so the sampled
-  post-measurement average equals the measurement-stripped pure-state
-  expectation the analytical strategies compute. `MPP` does not affect
-  liveness: the deferred lowering measures a scratch alias, and the projected
-  cross terms cancel exactly.
-
-Estimator paths:
-
-| Path | Selection | `mean` | `variance` |
-| --- | --- | --- | --- |
-| Reference runner | `run_qec_program` with active noise, or as the detector-split fallback; `run_qec_program_reference` directly | per-shot exact `c * <P>` averaged over accepted shots | unbiased sample variance |
-| Analytical ladder (SPD, CAMPS, tensor network) | `run_qec_program` noiseless; `run_qec_program_with_strategy` | exact `c * <P>` on the lowered unitary | `c^2 *` squared SPD truncation weight; 0.0 for CAMPS and tensor network |
-
-Noiseless programs with detectors split into two runs: the packed compiled
-sampler executes the program without its `EXP_VAL` ops, producing real sampled
-measurement, detector, and observable records, while the analytical ladder
-executes it without its detectors, producing the estimates. Detectors are
-record metadata with no effect on the state, so the two halves compose into
-one result. When either half cannot run (non-Clifford gates on the packed
-half, or an analytical failure), the whole program falls back to the
-reference runner.
-
-CAMPS evaluates arbitrary X/Y/Z strings by conjugating each letter through the
-signed Clifford prefix (`Y = i * X * Z` composes the two inverse-tableau rows).
-Postselection composes on both paths: the reference runner averages over
-accepted shots, and the analytical combiner conditions via
-`<O * Pi> / <Pi>`, whose projector Z-strings live on measured aliases and so
-never overlap `EXP_VAL` terms. With noise annotations the reference runner's
-per-shot trajectories average to the mixed-state expectation `Tr(rho P)`. The
-stabilizer-rerouted SPD path does not support `EXP_VAL`.
+order, in `QecSampleResult::expectation_values`. The placement rules, the
+estimator paths, and the analytical strategy ladder are defined in
+[QEC program execution](./qec-programs.md).

--- a/docs/architecture/qec-programs.md
+++ b/docs/architecture/qec-programs.md
@@ -1,0 +1,285 @@
+# QEC Program Execution
+
+This page covers the execution architecture behind native QEC programs: the
+runner routing, the compiled row machinery, the circuit lowerings, the noisy
+data flow, the expectation-value estimator paths, and the result shape. The
+data model and text format are defined in the
+[native QEC program IR](./qec-ir.md) page; workflow examples live in the
+[noise and QEC guide](../guides/qec.md). The public entry points are
+`run_qec_program`, `run_qec_program_reference`,
+`run_qec_program_with_strategy`, `run_qec_program_spd_rerouted`, and
+`compile_qec_program_rows`.
+
+## Program, ops, and options
+
+`QecProgram` holds a qubit count, an ordered op list, and a `QecOptions`
+value. The typed builders (`push_gate`, `measure`, `measure_pauli_product`,
+`reset`, `detector`, `observable_include`, `expectation_value`, `postselect`,
+`noise`) validate each op as it is appended; `measure` and
+`measure_pauli_product` return the new measurement-record index, and
+`detector` returns the detector index. Validation covers gate arity, qubit
+bounds, finite coordinates, coefficients, and probabilities, record-reference
+scope, duplicate qubits in a Pauli product, and `DEPOLARIZE2` target pairing.
+
+| `QecOp` variant | Payload | Semantics |
+| --- | --- | --- |
+| `Gate` | `gate`, `targets` | Standard gate. The compiled runner requires Clifford gates; the reference runner accepts any gate the statevector backend supports. |
+| `Measure` | `basis`, `qubit` | Single-qubit measurement in the requested basis. One record. |
+| `MeasurePauliProduct` | `terms` | One record equal to the parity of the listed Pauli terms. |
+| `Reset` | `basis`, `qubit` | Reset to the `+1` eigenstate of the requested basis. |
+| `Detector` | `records`, `coords` | Parity over the listed records. `coords` is passthrough metadata with no effect on sampling. |
+| `ObservableInclude` | `observable`, `records` | Includes for the same observable index XOR into a single row. |
+| `ExpectationValue` | `terms`, `coefficient` | `coefficient * <P>` in the final state. Terminal placement, live qubits only. |
+| `Postselect` | `records`, `expected` | The shot is accepted only when the parity over `records` matches `expected`. |
+| `Noise` | `channel`, `targets` | Pauli-noise annotation. Zero probability is inactive. |
+| `Tick` | | Scheduling separator with no semantic effect. |
+
+Record references are `QecRecordRef::Absolute` indices or
+`QecRecordRef::Lookback` distances (distance 1 is the most recent record,
+distance 0 is rejected), resolved against the records that exist when the
+referencing op is appended. The text parser resolves `rec[-k]` references to
+absolute indices while parsing.
+
+| `QecOptions` field | Default | Effect |
+| --- | --- | --- |
+| `shots` | `1024` | Number of shots requested by the runner APIs. |
+| `seed` | `42` | RNG seed for stochastic samplers and Pauli-noise dispatch. |
+| `chunk_size` | `None` | Per-batch shot bound for the compiled runner. `None` is equivalent to `Some(shots)`; `Some(0)` is rejected. No effect on the reference runner. |
+| `keep_measurements` | `true` | When `false`, `QecSampleResult::measurements` is returned with zero shots (column count preserved). Detector and observable records are always populated. |
+
+## Runner routing
+
+`run_qec_program` picks one of five paths:
+
+```mermaid
+flowchart TD
+    A[run_qec_program] --> B{EXP_VAL ops present?}
+    B -- yes --> C[validate placement rules]
+    C --> D{active noise?}
+    D -- yes --> R[reference runner]
+    D -- no --> E{detectors present?}
+    E -- yes --> S[two-run split]
+    E -- no --> L[analytical Auto ladder]
+    S -- either half fails --> R
+    B -- no --> F{active noise?}
+    F -- yes --> N[noisy compiled sampler]
+    F -- no --> P[clean compiled sampler]
+```
+
+Programs containing `EXP_VAL` ops are routed instead of packed-sampled. The
+placement rules are validated first, then active noise sends the program to
+`run_qec_program_reference`, detectors send it to the two-run split, and the
+remaining noiseless case runs the analytical Auto ladder described under
+Expectation values.
+
+Programs without `EXP_VAL` ops take the packed compiled path. Validation
+rejects non-Clifford gates and reports whether active noise is present.
+Programs with no measurements return an empty record buffer without compiling
+a sampler. Noisy Clifford programs compile a noise-aware sampler; clean
+Clifford programs lower to a circuit and compile a detector sampler. Both
+honor `QecOptions::chunk_size`: sampling proceeds in batches of at most
+`chunk_size` shots, and detector, observable, postselection, and
+logical-error accounting runs per chunk, so peak memory stays at one chunk of
+measurement records when raw measurements are not kept.
+
+The two-run split serves noiseless `EXP_VAL` programs with detectors.
+Detectors are record metadata with no effect on the state, so the halves
+compose: the packed sampler runs the program without its `EXP_VAL` ops
+(real sampled measurement, detector, and observable records), and the
+analytical ladder runs the program without its detectors (exact estimates
+attached to the sampled result). When either half cannot run, for example
+non-Clifford gates on the packed half, the whole program falls back to the
+reference runner.
+
+`run_qec_program_reference` is the correctness oracle: one statevector
+simulation per shot, `O(shots * 2^n)`. It executes ops in order, samples
+Pauli noise stochastically from a dedicated RNG stream derived from the seed,
+lowers `MPP` onto one scratch qubit at index `num_qubits`, and evaluates
+postselection parities per shot.
+
+## Compiled rows
+
+`compile_qec_program_rows` is the public sampler-row primitive. It lowers
+basis measurements and `MPP` ops into `QecCompiledRows`: one packed X/Z Pauli
+row per measurement record (bitmask words over the qubits), plus detector,
+observable, and postselection rows carried as absolute record indices with
+their expected values. Parity projection delegates to
+`PackedShots::parity_rows`, so the QEC layer reuses the packed parity engine
+of the compiled sampler. The row compiler is a lowering artifact, not an
+execution path: it rejects programs containing gates, resets, active noise,
+or `EXP_VAL`.
+
+The clean compiled path builds its sampler from the lowered Clifford circuit
+instead. The compiled sampler backward-propagates each measurement observable
+through the circuit into a Pauli sensitivity row, reduces the rows by
+Gaussian elimination into a set of independent flip rows plus a deterministic
+reference outcome, and samples shots by XORing a random subset of flip rows
+into the reference bits. Detector and observable rows are applied afterward
+as parities over the sampled records. The propagation and sampling machinery
+is described on the [compiled samplers](./samplers.md) page.
+
+## Lowering
+
+Two lowerings turn a QEC program into a circuit the samplers accept, sharing
+the same helpers for basis rotations (`append_basis_to_z_rotation` and its
+inverse), `MPP` parity accumulation (`append_mpp_parity_rotations`: rotate
+each term into the Z basis, accumulate parity on a scratch qubit via `CX`,
+undo the rotations, measure the scratch), and a final record-count check that
+the lowering emitted exactly `num_measurements` records.
+
+The clean Clifford lowering emits measurements in place: rotate the measured
+qubit into the Z basis, measure into the next record, rotate back. `MPP` uses
+one scratch qubit at index `num_qubits`, reset between uses. Resets emit a
+reset followed by the basis rotation.
+
+The deferred lowering backs the noisy path and the analytical estimator
+prelude. A reset assigns the program qubit a fresh circuit alias, so every
+measurement can be deferred to a terminal record of the lowered circuit;
+reusing a measured qubit without a reset is rejected. The final alias of each
+program qubit is recorded so terminal `EXP_VAL` terms translate onto the
+lowered circuit. Noise ops are not applied to the circuit; they are recorded
+as positioned events for sensitivity compilation.
+
+```admonish note title="V1 reset requirement"
+A measured qubit must be reset before any later gate reuses it, because the
+compiled lowering defers measurements to terminal records.
+`QecOptions::chunk_size` bounds compiled-runner shot batches. When raw
+measurements are omitted, chunking avoids materializing the full
+measurement-record matrix before detector, observable, postselection, and
+logical-error accounting.
+```
+
+## Noisy data flow
+
+Noise never executes during compiled sampling; it compiles into record flips.
+
+At compile time, the deferred lowering produces the noiseless circuit plus
+the positioned noise events. Backward Pauli propagation then walks the
+circuit in reverse, carrying each measurement's observable to each event
+position, and converts every event into sensitivity rows: for each noise
+branch, the set of measurement records whose propagated Pauli anti-commutes
+with the injected error, packed as flip masks. The noiseless sampler is
+compiled on the deferred circuit.
+
+At sample time, the noiseless records are sampled first, then each noise
+event stochastically XORs its branch flip masks into the shot-major record
+buffer from a noise RNG stream derived from the seed. Small-probability
+events skip between firing shots with geometric sampling; dense events
+(probability at or above `0.5`, or fewer than 32 shots) iterate every shot.
+`DEPOLARIZE2` precomputes the flip masks of all 15 non-identity two-qubit
+Pauli branches and picks one uniformly per firing.
+
+Supported channels are `X_ERROR`, `Z_ERROR`, `DEPOLARIZE1`, and
+`DEPOLARIZE2`. Noise on an already-measured target is dropped (it can no
+longer affect any record), and a `DEPOLARIZE2` pair with one measured target
+degrades to `DEPOLARIZE1` at `p * 0.8` on the survivor, preserving the
+marginal error rate. The reference runner instead applies the same channels
+stochastically to the per-shot state. How the QEC noise path relates to the
+circuit-level noisy engines is covered by the noisy engine routing section of
+the [compiled samplers](./samplers.md) page.
+
+## Expectation values
+
+`EXP_VAL(c) P1*...*Pk` estimates `c * <P>` for the Pauli product `P` in the
+program's final state and returns one `QecObservableEstimate` per op, in op
+order, in `QecSampleResult::expectation_values`. Two placement rules make
+"final state" well defined on every path:
+
+- Terminal placement: no gate, measurement, reset, or active noise may follow
+  an `EXP_VAL` op. Detector, observable, postselection, and tick metadata
+  may.
+- Live qubits only: a term may not reference a qubit that was
+  single-qubit-measured after its last reset. Under this rule the Pauli
+  commutes with every prior measurement projector, so the sampled
+  post-measurement average equals the measurement-stripped pure-state
+  expectation the analytical strategies compute. `MPP` does not affect
+  liveness: the deferred lowering measures a scratch alias, and the projected
+  cross terms cancel exactly.
+
+Estimator paths:
+
+| Path | Selection | `mean` | `variance` |
+| --- | --- | --- | --- |
+| Reference runner | `run_qec_program` with active noise, or as the detector-split fallback; `run_qec_program_reference` directly | per-shot exact `c * <P>` averaged over accepted shots | unbiased sample variance |
+| Analytical ladder (SPD, CAMPS, tensor network) | `run_qec_program` noiseless; `run_qec_program_with_strategy` | exact `c * <P>` on the lowered unitary | `c^2 *` squared SPD truncation weight; `0.0` for CAMPS and tensor network |
+
+The reference runner precomputes Pauli masks per observable and evaluates
+`c * <P>` on the final statevector of every accepted shot, reporting the
+sample mean and unbiased sample variance with `num_shots` equal to the
+accepted count. Programs wider than 64 qubits (including the `MPP` scratch
+qubit) are rejected, since the mask reduction packs X and Z masks into
+64-bit words. With noise annotations the per-shot trajectories average to
+the mixed-state expectation `Tr(rho P)`.
+
+The analytical strategies evaluate `<0|U^dag P U|0>` on the deferred lowering
+with the trailing measurements stripped, translating record observables into
+Z strings and `EXP_VAL` terms through the final qubit aliases. They reject
+detectors and active noise; `run_qec_program` composes those cases through
+the split and reference routes instead. `QecTStrategy` selects the path:
+
+- `Auto`, the production ladder. Light-cone SPD runs first (truncation
+  tolerance `1e-10`, term cap `16384`) and its result is accepted when every
+  estimate reports no truncation; SPD encodes truncation as
+  `variance = total_discarded^2`, and variance at or below `1e-12` counts as
+  exact. Otherwise CAMPS runs (bond dimension cap `256`), which hard-errors
+  when SVD truncation discards weight above `1e-12` so the ladder falls
+  through to the exact tensor-network scalar fallback. When all three fail,
+  the combined error reports each stage's reason.
+- `Reference`, the per-shot oracle.
+- `Spd` and `Camps` run their stage directly.
+
+CAMPS evaluates arbitrary X/Y/Z strings by conjugating each letter through
+the signed Clifford prefix (`Y = i * X * Z` composes the two inverse-tableau
+rows). Postselection composes on both paths: the reference runner averages
+over accepted shots, and the analytical combiner conditions via
+`<O * Pi> / <Pi>` evaluated over the projector subsets, capped at 12
+postselection predicates; the projector Z strings live on measured aliases
+and so never overlap `EXP_VAL` terms.
+
+`run_qec_program_spd_rerouted` accepts caller-supplied Z stabilizers per
+observable and evaluates each rerouted observable on the XOR-equivalent
+support with the smallest inverse light cone, verifying first (via SPD) that
+the substituted stabilizer product holds `<S> = +1` in the lowered state;
+observables without a reroute evaluate on their original support. The path
+rejects `EXP_VAL` ops, postselection, and resets (resets relabel qubits,
+making stabilizer indices ambiguous).
+
+Routing and placement are pinned by `tests/qec_exp_val.rs`;
+`tests/qec_e2e_d3.rs` checks distance-3 repetition-code fixtures against
+closed-form expectations on the compiled, analytical, and reference paths.
+
+## Result shape
+
+Every runner returns a `QecSampleResult`. The type is `#[non_exhaustive]`:
+construct through `new`, `new_with_total_shots`, or `empty`, and match fields
+with a trailing `..`.
+
+| Field | Meaning |
+| --- | --- |
+| `total_shots` | Shots requested. `accepted_shots + discarded_shots == total_shots`. |
+| `measurements` | Raw measurement records, or a zero-shot buffer when `keep_measurements` is `false` (column count preserved). |
+| `detectors` | One bit per detector per shot. |
+| `observables` | One bit per observable per shot. Synthesized on the analytical path (below). |
+| `accepted_shots` | Shots accepted after postselection (`total_shots` without a predicate). |
+| `discarded_shots` | Shots rejected by postselection. |
+| `logical_errors` | Per observable, the count of accepted shots whose parity is 1. |
+| `observable_expectations` | Optional weighted-estimator expectation per observable; `None` when the strategy emits raw bit counts only. |
+| `expectation_values` | Estimates for the program's `EXP_VAL` ops, one per op in op order, coefficient-scaled; `None` when the program has none. |
+
+`QecObservableEstimate` carries `mean`, `variance`, and `num_shots` (the
+shots that contributed, excluding postselection rejections). Zero accepted
+shots yield `{mean: 0.0, variance: 0.0, num_shots: 0}`.
+
+Analytical strategies have no per-shot stream, so they synthesize the packed
+`observables` records to match the `logical_errors` counts: the one-bits
+occupy positions `[0, accepted_shots)` and the remainder is inert padding.
+Derive rates with `logical_error_rates` (denominator `accepted_shots`); do
+not align these rows shot-for-shot with detector rows on the analytical
+path.
+
+Record buffers reuse the measurement-major `PackedShots` layout of the
+compiled sampler: one contiguous bit row per record across all shots, shot
+`j` at bit `j % 64` of word `j / 64`. Detector, observable, and
+postselection parities XOR whole shot words of the referenced measurement
+rows. Summary statistics are available as `survivor_rate`,
+`logical_error_rates`, and their Wilson-interval variants.

--- a/docs/architecture/qec-programs.md
+++ b/docs/architecture/qec-programs.md
@@ -49,14 +49,17 @@ absolute indices while parsing.
 
 ## Runner routing
 
-`run_qec_program` picks one of five paths:
+`run_qec_program` picks one of six paths:
 
 ```mermaid
 flowchart TD
     A[run_qec_program] --> B{EXP_VAL ops present?}
     B -- yes --> C[validate placement rules]
     C --> D{active noise?}
-    D -- yes --> R[reference runner]
+    D -- yes --> M{density-matrix eligible?}
+    M -- yes --> X[density-matrix estimator]
+    M -- no --> R[reference runner]
+    X -- lowering or oracle rejects --> R
     D -- no --> E{detectors present?}
     E -- yes --> S[two-run split]
     E -- no --> L[analytical Auto ladder]
@@ -68,9 +71,9 @@ flowchart TD
 
 Programs containing `EXP_VAL` ops are routed instead of packed-sampled. The
 placement rules are validated first, then active noise sends the program to
-`run_qec_program_reference`, detectors send it to the two-run split, and the
-remaining noiseless case runs the analytical Auto ladder described under
-Expectation values.
+the density-matrix estimator or `run_qec_program_reference`, detectors send it
+to the two-run split, and the remaining noiseless case runs the analytical
+Auto ladder described under Expectation values.
 
 Programs without `EXP_VAL` ops take the packed compiled path. Validation
 rejects non-Clifford gates and reports whether active noise is present.
@@ -90,6 +93,32 @@ analytical ladder runs the program without its detectors (exact estimates
 attached to the sampled result). When either half cannot run, for example
 non-Clifford gates on the packed half, the whole program falls back to the
 reference runner.
+
+The density-matrix estimator serves noisy `EXP_VAL` programs whose noisy
+ensemble the mixed state can carry in full, where `Tr(rho P)` is the exact
+value the reference runner approximates by averaging per-shot statevector
+expectations. Eligibility:
+
+- No measurement records. `M` and `MPP` collapse the state per shot and feed
+  the measurement, detector, and observable rows of the result; the mixed
+  state holds no record stream, so those programs need real sampling.
+- No postselection predicate, which would condition the estimate on an
+  accepted subensemble that `Tr(rho P)` does not express.
+- Width within the density-matrix cap (`PRISM_MAX_DM_QUBITS`, default half
+  the statevector cap), since the backend stores `4^n` amplitudes.
+
+`R` is eligible. Both paths implement the reset channel
+`rho -> |0><0| (x) tr_q rho` per the reset contract on the
+[backends](./backends.md) page: the density matrix applies it directly, and
+the reference runner samples one trajectory of it per shot, so the shot mean
+still converges to `Tr(rho P)`.
+
+Gates and channels the density-matrix path rejects surface as an error from
+the lowering or the oracle, which also falls back to the reference runner. The
+lowering maps gates one to one, expands a basis reset into `Reset` plus its
+Z-to-basis rotation, and turns each Pauli-noise annotation into `NoiseModel`
+events on the instruction it follows, applied through the backend's exact
+one-qubit Kraus and two-qubit depolarizing channels.
 
 `run_qec_program_reference` is the correctness oracle: one statevector
 simulation per shot, `O(shots * 2^n)`. It executes ops in order, samples
@@ -174,9 +203,12 @@ Supported channels are `X_ERROR`, `Z_ERROR`, `DEPOLARIZE1`, and
 longer affect any record), and a `DEPOLARIZE2` pair with one measured target
 degrades to `DEPOLARIZE1` at `p * 0.8` on the survivor, preserving the
 marginal error rate. The reference runner instead applies the same channels
-stochastically to the per-shot state. How the QEC noise path relates to the
-circuit-level noisy engines is covered by the noisy engine routing section of
-the [compiled samplers](./samplers.md) page.
+stochastically to the per-shot state, and the density-matrix estimator
+applies them exactly: `X_ERROR` and `Z_ERROR` become one-axis Pauli channels,
+`DEPOLARIZE1` a symmetric one-qubit depolarizing channel, and `DEPOLARIZE2` a
+two-qubit depolarizing channel on each target pair. How the QEC noise path
+relates to the circuit-level noisy engines is covered by the noisy engine
+routing section of the [compiled samplers](./samplers.md) page.
 
 ## Expectation values
 
@@ -200,7 +232,8 @@ Estimator paths:
 
 | Path | Selection | `mean` | `variance` |
 | --- | --- | --- | --- |
-| Reference runner | `run_qec_program` with active noise, or as the detector-split fallback; `run_qec_program_reference` directly | per-shot exact `c * <P>` averaged over accepted shots | unbiased sample variance |
+| Density-matrix estimator | `run_qec_program` with active noise on an eligible program | exact `c * Tr(rho P)` | `0.0` |
+| Reference runner | `run_qec_program` with active noise on an ineligible program, or as the detector-split fallback; `run_qec_program_reference` directly | per-shot exact `c * <P>` averaged over accepted shots | unbiased sample variance |
 | Analytical ladder (SPD, CAMPS, tensor network) | `run_qec_program` noiseless; `run_qec_program_with_strategy` | exact `c * <P>` on the lowered unitary | `c^2 *` squared SPD truncation weight; `0.0` for CAMPS and tensor network |
 
 The reference runner precomputes Pauli masks per observable and evaluates

--- a/docs/guides/qec.md
+++ b/docs/guides/qec.md
@@ -57,7 +57,8 @@ detectors, observables, postselection, `X_ERROR` / `Z_ERROR` / `DEPOLARIZE1` /
 still sampled by the packed runner; noisy programs use the per-shot reference
 runner). Non-Clifford gates are rejected on the packed sampling path.
 See the [QEC IR reference](../architecture/qec-ir.md) for the full
-grammar, the V1 reset requirement, and the `EXP_VAL` placement rules.
+grammar, and [QEC program execution](../architecture/qec-programs.md) for the
+runner routing, the V1 reset requirement, and the `EXP_VAL` placement rules.
 ```
 
 ## Homological sampling

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1265,23 +1265,20 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Reset `qubit` to `|0>` using the statevector backend's projection
-    /// convention.
-    fn reset_dist(&mut self, qubit: usize) {
-        let qubit = self.physical_qubit(qubit);
-        let prob_zero = self.prob_outcome_global(qubit, false);
-        if prob_zero > 0.0 {
-            self.collapse(qubit, false);
-            self.inner.pending_norm *= 1.0 / prob_zero.sqrt();
-        } else {
-            simd::zero_slice(&mut self.inner.state);
-            if self.context.rank() == 0 {
-                if let Some(amp) = self.inner.state.get_mut(0) {
-                    *amp = Complex64::new(1.0, 0.0);
-                }
-            }
-            self.inner.pending_norm = 1.0;
+    /// Reset `qubit` to `|0>` as one trajectory of the reset channel: sample
+    /// the outcome, collapse onto it, then apply X when it is 1. The draw
+    /// comes from the rank-replicated measurement stream, so every rank
+    /// selects the same branch.
+    fn reset_dist(&mut self, qubit: usize) -> Result<()> {
+        let physical = self.physical_qubit(qubit);
+        let prob_one = self.prob_one_global(physical);
+        let outcome = self.meas_rng.random::<f64>() < prob_one;
+        self.collapse(physical, outcome);
+        self.inner.pending_norm *= measurement_inv_norm(outcome, prob_one);
+        if outcome {
+            self.apply_gate(&Gate::X, &[qubit])?;
         }
+        Ok(())
     }
 
     /// Route a gate to the local fast path or the distributed paths.
@@ -1410,10 +1407,7 @@ impl Backend for DistributedStatevectorBackend {
                 self.measure_dist(*qubit, *classical_bit);
                 Ok(())
             }
-            Instruction::Reset { qubit } => {
-                self.reset_dist(*qubit);
-                Ok(())
-            }
+            Instruction::Reset { qubit } => self.reset_dist(*qubit),
             Instruction::Barrier { .. } => Ok(()),
             Instruction::Conditional {
                 condition,
@@ -1463,7 +1457,6 @@ impl Backend for DistributedStatevectorBackend {
     }
 
     fn reset(&mut self, qubit: usize) -> Result<()> {
-        self.reset_dist(qubit);
-        Ok(())
+        self.reset_dist(qubit)
     }
 }

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -837,11 +837,34 @@ fn loopback_reset_clears_global_qubit() {
 }
 
 #[test]
+fn loopback_reset_of_entangled_partner_matches_statevector() {
+    relax_min_local_qubits();
+    // Reset samples a branch, so every rank has to draw the same outcome from
+    // the replicated measurement stream. A disagreement leaves ranks holding
+    // halves of different branches, which the statevector comparison catches.
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    b.h(0);
+    for q in 1..n {
+        b.cx(0, q);
+    }
+    let mut circuit = b.build();
+    circuit.add_reset(n - 1);
+
+    let expected = reference_probs(&circuit);
+    assert!(
+        (expected[0] + expected[(1 << (n - 1)) - 1] - 1.0).abs() < TOL,
+        "reset of a GHZ partner must land wholly on one branch, got {expected:?}"
+    );
+    assert_loopback_matches(&circuit, &[1, 2, 4]);
+}
+
+#[test]
 fn loopback_reset_empty_zero_branch_matches_statevector() {
     relax_min_local_qubits();
-    // Statevector reset projects onto the |0> branch. If that branch is empty,
-    // it reinitializes to |0...0>; distributed reset must not preserve other
-    // qubits by flipping the |1> branch.
+    // Resetting a qubit that holds |1> has no |0> branch to sample: the
+    // outcome is forced to 1, so the reset collapses there and flips it,
+    // leaving every other qubit untouched.
     let n = 5;
     let mut b = CircuitBuilder::new(n);
     b.x(0).x(n - 1);
@@ -850,8 +873,8 @@ fn loopback_reset_empty_zero_branch_matches_statevector() {
 
     let expected = reference_probs(&circuit);
     assert!(
-        (expected[0] - 1.0).abs() < TOL,
-        "statevector reset should reinitialize empty zero branch"
+        (expected[1] - 1.0).abs() < TOL,
+        "reset from |1> must clear only the reset qubit and leave qubit 0 set"
     );
     assert_loopback_matches(&circuit, &[1, 2, 4]);
 }

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -460,27 +460,23 @@ impl FactoredBackend {
         let n = sub.state.len();
         let zero = Complex64::new(0.0, 0.0);
 
-        let mut prob_zero = 0.0f64;
+        let mut prob_one = 0.0f64;
         for i in 0..n {
-            if (i & mask) == 0 {
-                prob_zero += sub.state[i].norm_sqr();
+            if (i & mask) != 0 {
+                prob_one += sub.state[i].norm_sqr();
             }
         }
 
-        if prob_zero > 0.0 {
-            let inv_norm = 1.0 / prob_zero.sqrt();
-            for i in 0..n {
-                if (i & mask) == 0 {
-                    sub.state[i] *= inv_norm;
-                } else {
-                    sub.state[i] = zero;
-                }
+        let outcome = self.rng.random::<f64>() < prob_one;
+        let inv_norm = measurement_inv_norm(outcome, prob_one);
+
+        for i in 0..n {
+            if (i & mask) != 0 {
+                continue;
             }
-        } else {
-            for amp in sub.state.iter_mut() {
-                *amp = zero;
-            }
-            sub.state[0] = Complex64::new(1.0, 0.0);
+            let source = if outcome { i | mask } else { i };
+            sub.state[i] = sub.state[source] * inv_norm;
+            sub.state[i | mask] = zero;
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -238,6 +238,21 @@ pub trait Backend {
     /// Destructive, non-unitary. Used by OpenQASM `reset` and as a primitive
     /// for thermal relaxation trajectory simulation. The default returns
     /// `BackendUnsupported`; backends override for their native representation.
+    ///
+    /// The contract is the reset channel `rho -> |0><0| (x) tr_q rho`: the
+    /// qubit is traced out and replaced by |0⟩, leaving the rest of the
+    /// register in the mixture the trace produces. Projecting onto |0⟩ and
+    /// renormalizing is **not** equivalent. The two agree only when the qubit
+    /// is unentangled; when it is entangled, projection also collapses its
+    /// partners into the branch correlated with the |0⟩ outcome. On a Bell
+    /// pair, resetting qubit 1 leaves ⟨Z0⟩ = 0 under the channel and
+    /// ⟨Z0⟩ = 1 under projection.
+    ///
+    /// A backend holding a single pure state cannot represent the mixture, so
+    /// it implements one trajectory of the channel: sample the measurement
+    /// outcome, collapse onto it, and apply X when the outcome is 1. Averaged
+    /// over shots that reproduces the channel. Backends holding a mixed state
+    /// (density matrix) apply the channel directly.
     fn reset(&mut self, _qubit: usize) -> Result<()> {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -1540,50 +1540,9 @@ impl MpsBackend {
     }
 
     fn apply_reset(&mut self, qubit: usize) {
-        let l_env = self.compute_left_env(qubit);
-        let r_env = self.compute_right_env(qubit);
-        let t = &self.sites[qubit];
-        let bl = t.bond_left;
-        let br = t.bond_right;
-
-        let mut prob_zero = 0.0f64;
-        for alpha in 0..bl {
-            for alpha_p in 0..bl {
-                let l_val = l_env[alpha * bl + alpha_p];
-                if l_val == ZERO {
-                    continue;
-                }
-                for beta in 0..br {
-                    for beta_p in 0..br {
-                        let r_val = r_env[beta * br + beta_p];
-                        if r_val == ZERO {
-                            continue;
-                        }
-                        prob_zero += (l_val
-                            * t.data[t.idx(alpha, 0, beta)]
-                            * t.data[t.idx(alpha_p, 0, beta_p)].conj()
-                            * r_val)
-                            .re;
-                    }
-                }
-            }
-        }
-
-        if prob_zero > NORM_CLAMP_MIN {
-            let inv_sqrt = 1.0 / prob_zero.sqrt();
-            let scale = Complex64::new(inv_sqrt, 0.0);
-            let t = &mut self.sites[qubit];
-            for alpha in 0..bl {
-                for beta in 0..br {
-                    let idx_0 = alpha * (2 * br) + beta;
-                    let idx_1 = alpha * (2 * br) + br + beta;
-                    t.data[idx_0] *= scale;
-                    t.data[idx_1] = ZERO;
-                }
-            }
-        } else {
-            self.apply_single_qubit_gate(qubit, &[[ZERO, ONE], [ONE, ZERO]]);
-        }
+        let prob = self.site_outcome_probabilities(qubit);
+        let outcome = usize::from(self.rng.random::<f64>() < prob[1].clamp(0.0, 1.0));
+        self.collapse_site_to_zero(qubit, outcome, prob[outcome].clamp(0.0, 1.0));
     }
 
     fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
@@ -1681,6 +1640,29 @@ impl MpsBackend {
             }
         }
         prob
+    }
+
+    /// Collapse a site onto `outcome` and return it to the zero state.
+    ///
+    /// Writing the surviving component straight into the zero slot folds in the
+    /// X that a trajectory reset would otherwise apply after projecting onto
+    /// outcome 1, and takes the Born probability from the caller so the site
+    /// environments are contracted once per reset rather than twice.
+    fn collapse_site_to_zero(&mut self, site: usize, outcome: usize, prob: f64) {
+        if prob <= NORM_CLAMP_MIN {
+            return;
+        }
+        let scale = Complex64::new(1.0 / prob.sqrt(), 0.0);
+        let t = &mut self.sites[site];
+        let br = t.bond_right;
+        for alpha in 0..t.bond_left {
+            let base = alpha * (2 * br);
+            for beta in 0..br {
+                let zero_idx = base + beta;
+                t.data[zero_idx] = t.data[base + outcome * br + beta] * scale;
+                t.data[zero_idx + br] = ZERO;
+            }
+        }
     }
 
     /// Project a logical qubit onto a requested computational-basis outcome.

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -276,10 +276,11 @@ impl SparseBackend {
 
     fn apply_reset(&mut self, qubit: usize) {
         let mask = 1usize << qubit;
-        let prob_zero = self.masked_prob(mask, false);
+        let prob_one = self.masked_prob(mask, true);
+        let outcome = self.rng.random::<f64>() < prob_one;
+        let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
 
-        if prob_zero > 0.0 {
-            let inv_norm = 1.0 / prob_zero.sqrt();
+        if !outcome {
             self.state.retain(|&idx, amp| {
                 if idx & mask == 0 {
                     *amp *= inv_norm;
@@ -288,10 +289,16 @@ impl SparseBackend {
                     false
                 }
             });
-        } else {
-            self.state.clear();
-            self.state.insert(0, Complex64::new(1.0, 0.0));
+            return;
         }
+
+        let folded: Vec<(usize, Complex64)> = self
+            .state
+            .drain()
+            .filter(|(idx, _)| idx & mask != 0)
+            .map(|(idx, amp)| (idx ^ mask, amp * inv_norm))
+            .collect();
+        self.state.extend(folded);
     }
 
     fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -2710,41 +2710,35 @@ impl StatevectorBackend {
     }
 
     #[inline(always)]
+    /// Reset `qubit` to `|0>` as one trajectory of the reset channel: sample
+    /// the measurement outcome, collapse onto it, then fold the `|1>` branch
+    /// down to `|0>`. See the [`Backend::reset`](crate::backend::Backend::reset)
+    /// contract for why a projection onto `|0>` is not equivalent.
     pub(super) fn apply_reset(&mut self, qubit: usize) {
+        let prob_one = self.qubit_probability_one(qubit);
+        let outcome = self.rng.random::<f64>() < prob_one;
+        let inv_norm = measurement_inv_norm(outcome, prob_one);
+
         #[cfg(feature = "parallel")]
         if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
-            self.apply_reset_par(qubit);
+            self.fold_reset_par(qubit, outcome);
+            self.pending_norm *= inv_norm;
             return;
         }
 
         let half = 1usize << qubit;
         let block_size = half << 1;
-        let norm_sq = self.pending_norm * self.pending_norm;
         let zero = Complex64::new(0.0, 0.0);
-
-        let mut prob_zero = 0.0f64;
-        for block in self.state.chunks(block_size) {
-            for amp in &block[..half] {
-                prob_zero += amp.norm_sqr();
+        for block in self.state.chunks_mut(block_size) {
+            let (lo, hi) = block.split_at_mut(half);
+            if outcome {
+                lo.copy_from_slice(hi);
             }
-        }
-        prob_zero *= norm_sq;
-
-        if prob_zero > 0.0 {
-            for block in self.state.chunks_mut(block_size) {
-                for amp in &mut block[half..] {
-                    *amp = zero;
-                }
-            }
-            let inv_norm = 1.0 / prob_zero.sqrt();
-            self.pending_norm *= inv_norm;
-        } else {
-            for amp in self.state.iter_mut() {
+            for amp in hi.iter_mut() {
                 *amp = zero;
             }
-            self.state[0] = Complex64::new(1.0, 0.0);
-            self.pending_norm = 1.0;
         }
+        self.pending_norm *= inv_norm;
     }
 
     /// Apply multiple single-qubit gates in a multi-tier tiled pass.
@@ -3123,36 +3117,19 @@ impl StatevectorBackend {
     }
 
     #[cfg(feature = "parallel")]
-    fn apply_reset_par(&mut self, qubit: usize) {
+    fn fold_reset_par(&mut self, qubit: usize, outcome: bool) {
         let half = 1usize << qubit;
         let block_size = half << 1;
-        let norm_sq = self.pending_norm * self.pending_norm;
-
-        let prob_zero: f64 = self
-            .state
-            .par_chunks(block_size)
+        self.state
+            .par_chunks_mut(block_size)
             .with_min_len(chunk_min_len(block_size))
-            .map(|chunk| simd::norm_sqr_sum(&chunk[..half]))
-            .sum::<f64>()
-            * norm_sq;
-
-        if prob_zero > 0.0 {
-            self.state
-                .par_chunks_mut(block_size)
-                .with_min_len(chunk_min_len(block_size))
-                .for_each(|chunk| {
-                    let (_, hi) = chunk.split_at_mut(half);
-                    simd::zero_slice(hi);
-                });
-            let inv_norm = 1.0 / prob_zero.sqrt();
-            self.pending_norm *= inv_norm;
-        } else {
-            self.state
-                .par_chunks_mut(crate::backend::MIN_PAR_ELEMS)
-                .for_each(simd::zero_slice);
-            self.state[0] = Complex64::new(1.0, 0.0);
-            self.pending_norm = 1.0;
-        }
+            .for_each(|chunk| {
+                let (lo, hi) = chunk.split_at_mut(half);
+                if outcome {
+                    lo.copy_from_slice(hi);
+                }
+                simd::zero_slice(hi);
+            });
     }
 
     pub(super) fn apply_diagonal_batch(&mut self, entries: &[DiagEntry]) {

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -385,6 +385,7 @@ impl StatevectorBackend {
     #[cfg(feature = "gpu")]
     fn apply_reset_gpu(&mut self, qubit: usize) -> Result<()> {
         use crate::gpu::kernels::dense as k;
+        use rand::RngExt;
 
         let gpu = self
             .gpu_state
@@ -392,20 +393,20 @@ impl StatevectorBackend {
             .expect("apply_reset_gpu called without gpu_state");
         let ctx = gpu.context().clone();
 
-        // Match CPU semantics (src/backend/statevector/kernels.rs::apply_reset):
-        // deterministic projection onto |0⟩ irrespective of the current amplitude on |1⟩.
         let prob_one = k::measure_prob_one(&ctx, gpu, qubit)?;
-        let prob_zero = (1.0 - prob_one).clamp(0.0, 1.0);
+        let u: f64 = self.rng.random();
+        let outcome = u < prob_one;
 
-        k::measure_collapse(&ctx, gpu, qubit, false)?;
+        let gpu = self
+            .gpu_state
+            .as_mut()
+            .expect("apply_reset_gpu called without gpu_state");
+        k::measure_collapse(&ctx, gpu, qubit, outcome)?;
+        let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
+        gpu.set_pending_norm(gpu.pending_norm() * inv_norm);
 
-        if prob_zero > crate::backend::NORM_CLAMP_MIN {
-            let inv_norm = 1.0 / prob_zero.sqrt();
-            gpu.set_pending_norm(gpu.pending_norm() * inv_norm);
-        } else {
-            // |0> half was empty, reinitialize to |0...0> (CPU does the same).
-            k::launch_set_initial_state(&ctx, gpu)?;
-            gpu.set_pending_norm(1.0);
+        if outcome {
+            self.dispatch_gate_gpu(&Gate::X, &[qubit])?;
         }
         Ok(())
     }

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -948,28 +948,25 @@ impl TensorNetworkBackend {
     }
 
     fn apply_reset(&mut self, qubit: usize) -> Result<()> {
-        let amplitudes = self.contract_to_statevector()?;
+        use rand::RngExt;
 
-        let mut collapsed = amplitudes;
-        let mut prob_zero = 0.0f64;
-        for (idx, amp) in collapsed.iter_mut().enumerate() {
-            let bit = (idx >> qubit) & 1 == 1;
-            if bit {
-                *amp = Complex64::new(0.0, 0.0);
-            } else {
-                prob_zero += amp.norm_sqr();
+        let amplitudes = self.contract_to_statevector()?;
+        let mask = 1usize << qubit;
+
+        let mut prob_one = 0.0f64;
+        for (idx, amp) in amplitudes.iter().enumerate() {
+            if idx & mask != 0 {
+                prob_one += amp.norm_sqr();
             }
         }
-        if prob_zero > NORM_CLAMP_MIN {
-            let norm = prob_zero.sqrt();
-            for amp in &mut collapsed {
-                *amp /= norm;
+        let outcome = self.rng.random::<f64>() < prob_one;
+        let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
+
+        let mut collapsed = vec![Complex64::new(0.0, 0.0); amplitudes.len()];
+        for (idx, amp) in amplitudes.iter().enumerate() {
+            if (idx & mask != 0) == outcome {
+                collapsed[idx & !mask] = amp * inv_norm;
             }
-        } else {
-            for amp in collapsed.iter_mut() {
-                *amp = Complex64::new(0.0, 0.0);
-            }
-            collapsed[0] = Complex64::new(1.0, 0.0);
         }
 
         self.replace_with_statevector(collapsed);

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -8,6 +8,7 @@ use crate::sim::compiled::{
     CompiledSampler, PackedShots, batch_propagate_backward, compile_measurements,
     rng::Xoshiro256PlusPlus, xor_words,
 };
+use crate::sim::noise::{NoiseChannel, NoiseEvent, NoiseModel};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -226,6 +227,90 @@ pub(super) fn compile_qec_noisy_sampler(program: &QecProgram) -> Result<QecCompi
 fn qec_noise_rng(seed: u64) -> Xoshiro256PlusPlus {
     let mut seed_rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(0x51A7_EC01));
     Xoshiro256PlusPlus::from_chacha(&mut seed_rng)
+}
+
+/// Lower a measurement-free QEC program into a circuit plus the matching
+/// density-matrix noise model.
+///
+/// Gates map one to one; a basis reset becomes `Reset` followed by the
+/// Z-to-basis rotation. Pauli-noise annotations become [`NoiseEvent`]s on the
+/// instruction they follow, which the density-matrix backend applies through
+/// its exact one-qubit Kraus and two-qubit depolarizing channels. Noise that
+/// precedes every instruction anchors on a barrier so each event has a host.
+///
+/// Measurements are rejected: they carry a per-shot record stream the mixed
+/// state does not hold. Callers route those programs to the reference runner.
+pub(super) fn lower_qec_program_to_density_matrix(
+    program: &QecProgram,
+) -> Result<(Circuit, NoiseModel)> {
+    let mut circuit = Circuit::new(program.num_qubits(), 0);
+    let mut after_gate: Vec<Vec<NoiseEvent>> = Vec::new();
+
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { gate, targets } => circuit.add_gate(gate.clone(), targets),
+            QecOp::Reset { basis, qubit } => {
+                circuit.add_reset(*qubit);
+                append_z_to_basis_rotation(&mut circuit, *basis, *qubit);
+            }
+            QecOp::Noise { channel, targets } if channel.probability() > 0.0 => {
+                if circuit.instructions.is_empty() {
+                    circuit.add_barrier(&[]);
+                }
+                let anchor = circuit.instructions.len() - 1;
+                after_gate.resize_with(circuit.instructions.len(), Vec::new);
+                push_density_matrix_noise_events(&mut after_gate[anchor], *channel, targets);
+            }
+            QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC density-matrix estimator".to_string(),
+                    reason: "the density matrix holds no measurement records; \
+                             `run_qec_program` routes measuring programs to the reference runner"
+                        .to_string(),
+                });
+            }
+            QecOp::Noise { .. }
+            | QecOp::ExpectationValue { .. }
+            | QecOp::Detector { .. }
+            | QecOp::ObservableInclude { .. }
+            | QecOp::Postselect { .. }
+            | QecOp::Tick => {}
+        }
+    }
+
+    after_gate.resize_with(circuit.instructions.len(), Vec::new);
+    let noise = NoiseModel {
+        after_gate,
+        readout: Vec::new(),
+    };
+    Ok((circuit, noise))
+}
+
+fn push_density_matrix_noise_events(
+    events: &mut Vec<NoiseEvent>,
+    channel: QecNoise,
+    targets: &[usize],
+) {
+    match channel {
+        QecNoise::XError(p) => {
+            events.extend(targets.iter().map(|&q| NoiseEvent::pauli(q, p, 0.0, 0.0)));
+        }
+        QecNoise::ZError(p) => {
+            events.extend(targets.iter().map(|&q| NoiseEvent::pauli(q, 0.0, 0.0, p)));
+        }
+        QecNoise::Depolarize1(p) => {
+            events.extend(targets.iter().map(|&q| NoiseEvent {
+                channel: NoiseChannel::Depolarizing { p },
+                qubits: SmallVec::from_slice(&[q]),
+            }));
+        }
+        QecNoise::Depolarize2(p) => {
+            events.extend(targets.chunks_exact(2).map(|pair| NoiseEvent {
+                channel: NoiseChannel::TwoQubitDepolarizing { p },
+                qubits: SmallVec::from_slice(pair),
+            }));
+        }
+    }
 }
 
 fn lower_qec_program_to_deferred_circuit(program: &QecProgram) -> Result<QecDeferredProgram> {

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -26,8 +26,12 @@ use rand_chacha::ChaCha8Rng;
 /// `DEPOLARIZE2`) are compiled into packed sensitivity rows that are XORed
 /// into the noiseless measurement records.
 ///
-/// Programs containing `EXP_VAL` ops are routed instead of packed-sampled:
-/// with active noise they run through [`run_qec_program_reference`].
+/// Programs containing `EXP_VAL` ops are routed instead of packed-sampled.
+/// With active noise, programs that produce no measurement records, carry no
+/// postselection predicate, and fit the density-matrix qubit cap are estimated
+/// exactly as `Tr(rho P)` on the density-matrix backend, reported with
+/// `variance` `0.0`; every other noisy program runs through
+/// [`run_qec_program_reference`].
 /// Noiseless programs with detectors split into a packed sampling run for
 /// the measurement, detector, and observable records plus an analytical
 /// estimator run, falling back to the reference runner when either half
@@ -52,7 +56,7 @@ pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
             .iter()
             .any(|op| matches!(op, QecOp::Noise { channel, .. } if channel.probability() > 0.0));
         if has_active_noise {
-            return run_qec_program_reference(program);
+            return run_qec_program_noisy_exp_val(program);
         }
         if program.num_detectors() > 0 {
             return run_qec_program_detectors_and_exp_val(program);
@@ -96,6 +100,73 @@ pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
         return qec_result_from_measurements(program, measurements);
     }
     qec_result_from_measurement_chunks(program, |chunk| sampler.sample_measurements_packed(chunk))
+}
+
+/// Execution for `EXP_VAL` programs carrying active noise.
+///
+/// Eligible programs are estimated exactly on the density-matrix backend:
+/// `rho` carries the whole noisy ensemble, so `Tr(rho P)` is the value the
+/// reference runner approximates by averaging per-shot statevector
+/// expectations, and it comes out with variance `0.0` instead of a sampling
+/// spread. Everything else keeps [`run_qec_program_reference`] unchanged.
+///
+/// A program is eligible when all of the following hold:
+///
+/// - It produces no measurement records. `M` and `MPP` collapse the state per
+///   shot and feed the measurement, detector, and observable rows of the
+///   result; the mixed state holds no record stream, so those programs need
+///   real sampling.
+/// - It has no postselection predicate. Postselection conditions the estimate
+///   on an accepted subensemble, and `Tr(rho P)` is unconditioned.
+/// - Its width is within the density-matrix cap. The backend stores `4^n`
+///   amplitudes (see `PRISM_MAX_DM_QUBITS`).
+///
+/// Resets are eligible. Both paths implement the reset channel
+/// `rho -> |0><0| (x) tr_q rho` per the [`Backend::reset`](crate::backend::Backend::reset)
+/// contract: the density matrix applies it directly, and the reference runner
+/// samples one trajectory of it per shot, so the shot mean still converges to
+/// `Tr(rho P)`.
+///
+/// Gates or channels the density-matrix path rejects surface as an error from
+/// the lowering or the oracle, which also falls back to the reference runner.
+fn run_qec_program_noisy_exp_val(program: &QecProgram) -> Result<QecSampleResult> {
+    qec_runner_chunk_size(program.options())?;
+    if program.num_measurements() > 0
+        || !program.postselection_rows()?.is_empty()
+        || program.num_qubits() > crate::backend::max_density_matrix_qubits()
+    {
+        return run_qec_program_reference(program);
+    }
+    let Ok((circuit, noise)) = super::noise::lower_qec_program_to_density_matrix(program) else {
+        return run_qec_program_reference(program);
+    };
+    let exp_val_ops = program.expectation_value_ops();
+    let observables: Vec<_> = exp_val_ops
+        .iter()
+        .map(|(terms, _)| super::qec_terms_to_pauli(terms))
+        .collect();
+    let Ok(values) = crate::sim::noise::density_matrix_expectation_values(
+        &circuit,
+        &observables,
+        Some(&noise),
+        program.options().seed,
+    ) else {
+        return run_qec_program_reference(program);
+    };
+
+    let shots = program.options().shots;
+    let measurements = PackedShots::from_shot_major(Vec::new(), shots, 0);
+    let result = qec_result_from_measurements(program, measurements)?;
+    let estimates = exp_val_ops
+        .iter()
+        .zip(&values)
+        .map(|(&(_, coefficient), value)| QecObservableEstimate {
+            mean: coefficient * value,
+            variance: 0.0,
+            num_shots: shots,
+        })
+        .collect();
+    Ok(result.with_expectation_values(estimates))
 }
 
 /// Split execution for noiseless `EXP_VAL` programs with detectors.

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -3435,6 +3435,19 @@ mod expectation_gpu_stub_tests {
         ]
     }
 
+    /// The two routes run the same CPU kernels but as separate invocations, so
+    /// a parallel reduction can pair its partial sums differently and land a
+    /// ulp apart. Agreement is what the test is about, not bit equality.
+    fn assert_expectations_close(left: &[f64], right: &[f64]) {
+        assert_eq!(left.len(), right.len());
+        for (slot, (a, b)) in left.iter().zip(right).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-12,
+                "observable {slot}: {a:.17} vs {b:.17}"
+            );
+        }
+    }
+
     #[test]
     fn auto_gpu_expectation_matches_auto_on_stub() {
         let circuit = dense_circuit(16);
@@ -3449,7 +3462,7 @@ mod expectation_gpu_stub_tests {
             42,
         )
         .unwrap();
-        assert_eq!(auto_vals, gpu_vals);
+        assert_expectations_close(&auto_vals, &gpu_vals);
     }
 
     /// Explicit `StatevectorGpu` expectation values resolve hard above the
@@ -3487,7 +3500,7 @@ mod expectation_gpu_stub_tests {
             42,
         )
         .unwrap();
-        assert_eq!(sv, gpu);
+        assert_expectations_close(&sv, &gpu);
     }
 }
 

--- a/tests/common/circuits.rs
+++ b/tests/common/circuits.rs
@@ -390,6 +390,20 @@ pub fn reset_from_one() -> Circuit {
     circuit
 }
 
+/// Reset a qubit holding |1> while another qubit is in superposition. The
+/// reset outcome is forced, so the case stays deterministic, but the spectator
+/// is what makes it discriminating: an implementation that reinitializes the
+/// whole register instead of the reset qubit collapses qubit 0 as well.
+/// One-qubit `reset_from_one` cannot see that.
+pub fn reset_from_one_with_spectator() -> Circuit {
+    let mut circuit = Circuit::new(2, 1);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_reset(1);
+    circuit.add_measure(1, 0);
+    circuit
+}
+
 pub fn superposition_measurement() -> Circuit {
     let mut circuit = Circuit::new(1, 1);
     circuit.add_gate(Gate::H, &[0]);
@@ -528,7 +542,7 @@ pub fn exact_small_cases() -> [CircuitCase; 18] {
     ]
 }
 
-pub fn measurement_cases() -> [CircuitCase; 3] {
+pub fn measurement_cases() -> [CircuitCase; 4] {
     [
         CircuitCase::new(
             "deterministic_measurement",
@@ -541,6 +555,15 @@ pub fn measurement_cases() -> [CircuitCase; 3] {
         CircuitCase::new(
             "reset_from_one",
             reset_from_one,
+            CircuitCapabilities::new()
+                .clifford_only()
+                .requires_measurement()
+                .requires_reset()
+                .product_separable(),
+        ),
+        CircuitCase::new(
+            "reset_from_one_with_spectator",
+            reset_from_one_with_spectator,
             CircuitCapabilities::new()
                 .clifford_only()
                 .requires_measurement()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,6 +25,16 @@ pub const FACTORED_EPS: f64 = 1e-10;
 
 pub const SEED: u64 = 42;
 
+/// Statevector probabilities used as the reference for the backend matrices.
+///
+/// The statevector is a participant, not an independent authority: a helper
+/// built on it can only report that two implementations disagree, and it will
+/// name the other backend as the failure. Anything this reference is expected
+/// to get right therefore needs a closed-form anchor in
+/// `tests/golden_small_circuits.rs` that names the statevector directly. The
+/// `reset` contract went unanchored there for a long time, and a
+/// projection-onto-|0> implementation survived a green matrix as a result:
+/// four correct backends were the ones reported as failing.
 pub fn sv_reference_probs(circuit: &Circuit) -> Vec<f64> {
     let mut backend = StatevectorBackend::new(SEED);
     sim::run_on(&mut backend, circuit).unwrap();

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -291,6 +291,70 @@ fn measure_collapsed_state_is_consistent() {
     }
 }
 
+// ---- Reset ----
+//
+// These anchor the statevector's own `reset` against hand-computed values.
+// The cross-backend matrices in `tests/measurement_matrix.rs` compare every
+// other backend against the statevector, so nothing there can tell which side
+// of a disagreement is wrong. `reset` went unanchored here for a long time,
+// and a projection-onto-|0> implementation survived as a result.
+
+#[test]
+fn reset_returns_qubit_to_zero() {
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::X, &[0]);
+    c.add_reset(0);
+    assert_probs(&run_and_probs(&c), &[1.0, 0.0]);
+}
+
+#[test]
+fn reset_from_one_preserves_a_spectator_superposition() {
+    // Resetting a qubit that holds |1> must clear that qubit and nothing else.
+    // q0 stays in |+>, so the two |q1 = 0> outcomes keep weight 1/2 each.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::X, &[1]);
+    c.add_gate(Gate::H, &[0]);
+    c.add_reset(1);
+    assert_probs(&run_and_probs(&c), &[0.5, 0.5, 0.0, 0.0]);
+}
+
+#[test]
+fn reset_of_an_entangled_partner_samples_both_branches() {
+    // Reset is the channel `rho -> |0><0| (x) tr_q rho`. A statevector carries
+    // one trajectory of it, so each run lands wholly on |00> or wholly on |01>
+    // (q0 set, q1 cleared), and over seeds both branches must occur. A
+    // projection onto |0> yields |00> every time, keeping the partner
+    // correlated with the |0> outcome. Sixty-four seeds make a one-sided
+    // result conclusive; `tests/reset_channel.rs` pins the 1/2 weights against
+    // the density-matrix oracle.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_reset(1);
+
+    let mut branches = [false; 2];
+    for seed in 0..64u64 {
+        let mut backend = StatevectorBackend::new(seed);
+        sim::run_on(&mut backend, &c).unwrap();
+        let probs = backend.probabilities().unwrap();
+        assert!(
+            probs[2].abs() < EPS && probs[3].abs() < EPS,
+            "seed {seed}: q1 must be cleared, got {probs:?}"
+        );
+        let branch = usize::from(probs[1] > 0.5);
+        assert!(
+            (probs[branch] - 1.0).abs() < EPS,
+            "seed {seed}: one trajectory is a single basis state, got {probs:?}"
+        );
+        branches[branch] = true;
+    }
+    assert!(
+        branches[0] && branches[1],
+        "reset must sample both branches of the partner, saw only {}",
+        if branches[0] { "|00>" } else { "|01>" }
+    );
+}
+
 // ---- Circuit depth ----
 
 #[test]

--- a/tests/measurement_matrix.rs
+++ b/tests/measurement_matrix.rs
@@ -19,6 +19,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_sparse_deterministic_matches_statevector => "deterministic_measurement",
         measurement_sparse_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_sparse_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_sparse_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }
@@ -41,6 +42,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_mps_deterministic_matches_statevector => "deterministic_measurement",
         measurement_mps_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_mps_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_mps_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }
@@ -63,6 +65,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_tensor_network_deterministic_matches_statevector => "deterministic_measurement",
         measurement_tensor_network_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_tensor_network_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_tensor_network_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }
@@ -85,6 +88,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_factored_deterministic_matches_statevector => "deterministic_measurement",
         measurement_factored_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_factored_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_factored_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }
@@ -107,6 +111,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_stabilizer_deterministic_matches_statevector => "deterministic_measurement",
         measurement_stabilizer_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_stabilizer_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_stabilizer_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }
@@ -129,6 +134,7 @@ backend_matrix_outcome_tests! {
     tests: {
         measurement_product_deterministic_matches_statevector => "deterministic_measurement",
         measurement_product_reset_from_one_matches_statevector => "reset_from_one",
+        measurement_product_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_product_reset_conditional_matches_statevector => "measurement_reset_conditional",
     }
 }

--- a/tests/qec_common/mod.rs
+++ b/tests/qec_common/mod.rs
@@ -2,7 +2,10 @@
 
 #![allow(dead_code)]
 
-use prism_q::{QecOptions, QecTStrategy};
+use prism_q::{
+    QecObservableEstimate, QecOptions, QecProgram, QecSampleResult, QecTStrategy, run_qec_program,
+    run_qec_program_reference,
+};
 
 pub const SEED: u64 = 0xDEAD_BEEF;
 
@@ -15,5 +18,104 @@ pub fn qec_options(shots: usize, chunk_size: usize, keep_measurements: bool) -> 
         seed: SEED,
         chunk_size: Some(chunk_size),
         keep_measurements,
+    }
+}
+
+/// The `EXP_VAL` estimates of a result, which every estimator path attaches.
+pub fn estimates(result: &QecSampleResult) -> &[QecObservableEstimate] {
+    result
+        .expectation_values
+        .as_deref()
+        .expect("EXP_VAL estimates")
+}
+
+pub fn means(result: &QecSampleResult) -> Vec<f64> {
+    estimates(result).iter().map(|e| e.mean).collect()
+}
+
+/// Variance at or below this carries no sampling information: SPD encodes
+/// truncation as squared discarded weight, and a reference run over identical
+/// shots leaves only float residue. A genuinely sampled estimate lands orders
+/// of magnitude above it.
+pub const EXACT_VARIANCE_EPS: f64 = 1e-12;
+
+/// Assert an exact estimator reproduces `expected` and reports no spread.
+///
+/// Exact paths (the analytical ladder, the density-matrix estimator, and a
+/// reference run whose shots are all identical) carry the closed-form value
+/// itself, so `tolerance` covers arithmetic only. Callers that require a
+/// literal `0.0` variance assert that separately.
+pub fn assert_exact_estimates(
+    estimates: &[QecObservableEstimate],
+    expected: &[f64],
+    tolerance: f64,
+    label: &str,
+) {
+    assert_eq!(
+        estimates.len(),
+        expected.len(),
+        "{label}: one estimate per EXP_VAL op in op order"
+    );
+    for (slot, (estimate, expected)) in estimates.iter().zip(expected).enumerate() {
+        assert!(
+            (estimate.mean - expected).abs() < tolerance,
+            "{label} slot {slot}: {:.14} vs closed form {expected:.14}",
+            estimate.mean
+        );
+        assert!(
+            estimate.variance <= EXACT_VARIANCE_EPS,
+            "{label} slot {slot}: exact estimate reports spread {:.3e}",
+            estimate.variance
+        );
+    }
+}
+
+/// Assert every estimate reports a literal zero variance, the property that
+/// separates an exact estimator from a sampled one.
+pub fn assert_zero_variance(estimates: &[QecObservableEstimate], label: &str) {
+    for (slot, estimate) in estimates.iter().enumerate() {
+        assert_eq!(
+            estimate.variance, 0.0,
+            "{label} slot {slot}: the estimate is exact, not statistical"
+        );
+    }
+}
+
+/// Assert `run_qec_program` reproduced the reference runner exactly, the
+/// signature of a program none of the faster routes could absorb. Returns the
+/// routed result so callers can check the records it carries.
+pub fn assert_matches_reference_runner(program: &QecProgram, label: &str) -> QecSampleResult {
+    let routed = run_qec_program(program).unwrap();
+    let reference = run_qec_program_reference(program).unwrap();
+    assert_eq!(
+        estimates(&routed),
+        estimates(&reference),
+        "{label}: must route to the reference runner"
+    );
+    routed
+}
+
+/// Assert sampled estimates agree with `reference` within their own sampling
+/// error, using a 5-sigma band widened by `slack` to absorb the closed form's
+/// own rounding and the variance estimate's noise at small shot counts.
+pub fn assert_within_sampling_error(
+    sampled: &[QecObservableEstimate],
+    reference: &[f64],
+    slack: f64,
+    label: &str,
+) {
+    assert_eq!(
+        sampled.len(),
+        reference.len(),
+        "{label}: one estimate per EXP_VAL op in op order"
+    );
+    for (slot, (estimate, reference)) in sampled.iter().zip(reference).enumerate() {
+        let sigma = (estimate.variance / estimate.num_shots.max(1) as f64).sqrt();
+        let tolerance = 5.0 * sigma + slack;
+        assert!(
+            (estimate.mean - reference).abs() < tolerance,
+            "{label} slot {slot}: sampled {:.6} vs reference {reference:.6} (tol {tolerance:.6})",
+            estimate.mean
+        );
     }
 }

--- a/tests/qec_e2e_d3.rs
+++ b/tests/qec_e2e_d3.rs
@@ -10,6 +10,10 @@
 //! `e2e-d3-s`: Clifford-only encoding under X noise with detectors,
 //! sampled through the compiled runner's reference route, compared against
 //! closed-form means within a 5-sigma band.
+//!
+//! `e2e-d3-d`: the same encoding plus transversal T under depolarizing noise
+//! and without syndrome measurement, routed to the exact density-matrix
+//! estimator and compared against closed-form means at 1e-10.
 
 mod qec_common;
 
@@ -71,44 +75,78 @@ fn e2e_d3_t() {
 
     for &strategy in &ANALYTICAL_STRATEGIES {
         let result = run_qec_program_with_strategy(&program, strategy).unwrap();
-        let estimates = result.expectation_values.expect("e2e-d3-t estimates");
-        assert_eq!(estimates.len(), 3, "e2e-d3-t: three EXP_VAL ops in order");
-        for (slot, (estimate, reference)) in estimates.iter().zip(expected.iter()).enumerate() {
-            assert!(
-                (estimate.mean - reference).abs() < 1e-6,
-                "e2e-d3-t strategy {strategy:?} slot {slot}: {:.8} vs closed form {reference:.8}",
-                estimate.mean
-            );
-        }
+        qec_common::assert_exact_estimates(
+            qec_common::estimates(&result),
+            &expected,
+            1e-6,
+            &format!("e2e-d3-t strategy {strategy:?}"),
+        );
     }
 
     let routed = run_qec_program(&program).unwrap();
     let auto = run_qec_program_with_strategy(&program, QecTStrategy::Auto).unwrap();
-    let routed_estimates = routed.expectation_values.expect("estimates");
-    let auto_estimates = auto.expectation_values.expect("estimates");
-    for (slot, (a, b)) in routed_estimates
-        .iter()
-        .zip(auto_estimates.iter())
-        .enumerate()
-    {
-        assert!(
-            (a.mean - b.mean).abs() < 1e-12,
-            "e2e-d3-t slot {slot}: compiled entry point must match the Auto ladder"
-        );
-    }
+    qec_common::assert_exact_estimates(
+        qec_common::estimates(&routed),
+        &qec_common::means(&auto),
+        1e-12,
+        "e2e-d3-t compiled entry point vs Auto ladder",
+    );
 
     // The syndrome round is deterministic on the logical |+> state, so the
     // sampled reference is exact shot for shot.
     let reference = run_qec_program_reference(&program).unwrap();
     assert_eq!(reference.accepted_shots, STAT_SHOTS);
-    let estimates = reference.expectation_values.expect("estimates");
-    for (slot, (estimate, expected)) in estimates.iter().zip(expected.iter()).enumerate() {
-        assert!(
-            (estimate.mean - expected).abs() < 1e-9,
-            "e2e-d3-t reference slot {slot}: {:.10} vs closed form {expected:.10}",
-            estimate.mean
-        );
-    }
+    qec_common::assert_exact_estimates(
+        qec_common::estimates(&reference),
+        &expected,
+        1e-9,
+        "e2e-d3-t reference",
+    );
+}
+
+#[test]
+fn e2e_d3_d() {
+    // Logical |+> plus transversal T, then DEPOLARIZE1(p) on every data
+    // qubit. No syndrome round, so the program carries no measurement
+    // records and routes to the density-matrix estimator. Depolarizing keeps
+    // (1-4p/3) of a term per data qubit it touches, so the weight-3 logical
+    // terms pick up the cube and Z0*Z1 the square.
+    let p = 0.06;
+    let mut program = QecProgram::with_options(3, qec_common::qec_options(STAT_SHOTS, 2048, false));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 2]).unwrap();
+    program.push_gate(Gate::T, &[0]).unwrap();
+    program.push_gate(Gate::T, &[1]).unwrap();
+    program.push_gate(Gate::T, &[2]).unwrap();
+    program.noise(QecNoise::Depolarize1(p), &[0, 1, 2]).unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::x(1), QecPauli::x(2)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::y(0), QecPauli::x(1), QecPauli::x(2)], -0.5)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], 1.0)
+        .unwrap();
+
+    let [x_l, y_l, zz] = e2e_d3_t_expected();
+    let decay = 1.0 - 4.0 * p / 3.0;
+    let expected = [x_l * decay.powi(3), y_l * decay.powi(3), zz * decay.powi(2)];
+
+    let result = run_qec_program(&program).unwrap();
+    let estimates = qec_common::estimates(&result);
+    qec_common::assert_exact_estimates(estimates, &expected, 1e-10, "e2e-d3-d");
+    qec_common::assert_zero_variance(estimates, "e2e-d3-d");
+    assert!(estimates.iter().all(|e| e.num_shots == STAT_SHOTS));
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    qec_common::assert_within_sampling_error(
+        qec_common::estimates(&reference),
+        &expected,
+        0.01,
+        "e2e-d3-d reference",
+    );
 }
 
 #[test]
@@ -130,20 +168,14 @@ fn e2e_d3_s() {
 
     let result = run_qec_program(&program).unwrap();
     assert_eq!(result.total_shots, STAT_SHOTS);
-    let estimates = result.expectation_values.expect("e2e-d3-s estimates");
-    assert_eq!(estimates.len(), 2, "e2e-d3-s: two EXP_VAL ops in order");
-    for (slot, (estimate, reference)) in estimates.iter().zip(expected.iter()).enumerate() {
+    let estimates = qec_common::estimates(&result);
+    qec_common::assert_within_sampling_error(estimates, &expected, 0.02, "e2e-d3-s");
+    for (slot, estimate) in estimates.iter().enumerate() {
         assert!(
             estimate.variance > 0.0,
-            "e2e-d3-s slot {slot}: sampled path must report nonzero variance"
+            "e2e-d3-s slot {slot}: measurement records keep this program on the sampled path"
         );
         assert_eq!(estimate.num_shots, STAT_SHOTS);
-        let tol = 5.0 * (estimate.variance / estimate.num_shots as f64).sqrt() + 0.02;
-        assert!(
-            (estimate.mean - reference).abs() < tol,
-            "e2e-d3-s slot {slot}: {:.4} vs closed form {reference:.4} (tol {tol:.4})",
-            estimate.mean
-        );
     }
 
     // Each detector fires when an odd number of its two data qubits flipped:

--- a/tests/qec_exp_val.rs
+++ b/tests/qec_exp_val.rs
@@ -82,6 +82,8 @@ fn exp_val_reference_rejects_programs_beyond_mask_width() {
 
 #[test]
 fn exp_val_coefficient_scales_mean_and_variance() {
+    // Sampled path, called directly: `run_qec_program` sends this program to
+    // the exact density-matrix estimator, which reports no spread to scale.
     let build = |coefficient: f64| {
         let mut program = program_with_shots(1, 512);
         program.noise(QecNoise::XError(0.3), &[0]).unwrap();
@@ -90,8 +92,8 @@ fn exp_val_coefficient_scales_mean_and_variance() {
             .unwrap();
         program
     };
-    let unit = run_qec_program(&build(1.0)).unwrap();
-    let scaled = run_qec_program(&build(-0.5)).unwrap();
+    let unit = run_qec_program_reference(&build(1.0)).unwrap();
+    let scaled = run_qec_program_reference(&build(-0.5)).unwrap();
     let unit = &unit.expectation_values.expect("estimates")[0];
     let scaled = &scaled.expectation_values.expect("estimates")[0];
     assert!((scaled.mean - (-0.5) * unit.mean).abs() < 1e-12);
@@ -122,20 +124,14 @@ fn exp_val_reference_matches_analytic_on_live_qubits_after_measurement() {
         .unwrap();
 
     let reference = run_qec_program_reference(&program).unwrap();
-    let ref_estimates = reference.expectation_values.expect("estimates");
     for &strategy in &ANALYTICAL_STRATEGIES {
         let result = run_qec_program_with_strategy(&program, strategy).unwrap();
-        let estimates = result.expectation_values.expect("estimates");
-        assert_eq!(estimates.len(), 3);
-        for (slot, (analytic, sampled)) in estimates.iter().zip(ref_estimates.iter()).enumerate() {
-            let tol = 5.0 * (sampled.variance / sampled.num_shots.max(1) as f64).sqrt() + 0.01;
-            assert!(
-                (analytic.mean - sampled.mean).abs() < tol,
-                "strategy {strategy:?} slot {slot}: analytic {:.4} vs reference {:.4} (tol {tol:.4})",
-                analytic.mean,
-                sampled.mean
-            );
-        }
+        qec_common::assert_within_sampling_error(
+            qec_common::estimates(&reference),
+            &qec_common::means(&result),
+            0.01,
+            &format!("strategy {strategy:?} vs reference"),
+        );
     }
 }
 
@@ -212,25 +208,68 @@ fn exp_val_routing_pinned() {
     noiseless.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
     let routed = run_qec_program(&noiseless).unwrap();
     let auto = run_qec_program_with_strategy(&noiseless, QecTStrategy::Auto).unwrap();
-    let routed_estimates = routed.expectation_values.expect("estimates");
-    let auto_estimates = auto.expectation_values.expect("estimates");
-    for (a, b) in routed_estimates.iter().zip(auto_estimates.iter()) {
-        assert!(
-            (a.mean - b.mean).abs() < 1e-12 && a.num_shots == b.num_shots,
-            "noiseless EXP_VAL programs must route to the analytical Auto ladder"
-        );
-    }
-
-    let mut noisy = base(1);
-    noisy.noise(QecNoise::XError(0.1), &[0]).unwrap();
-    noisy.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
-    let routed = run_qec_program(&noisy).unwrap();
-    let reference = run_qec_program_reference(&noisy).unwrap();
-    assert_eq!(
-        routed.expectation_values.expect("estimates"),
-        reference.expectation_values.expect("estimates"),
-        "noisy EXP_VAL programs must route to the reference runner"
+    qec_common::assert_exact_estimates(
+        qec_common::estimates(&routed),
+        &qec_common::means(&auto),
+        1e-12,
+        "noiseless EXP_VAL programs route to the analytical Auto ladder",
     );
+
+    // No measurement records and no postselection, so this is eligible for the
+    // exact route. DEPOLARIZE1 gives the sampled path genuine per-shot spread
+    // (the Y and Z branches flip the X observable), so a zero variance here
+    // can only come from the exact route. <X0> = cos(pi/4) * (1 - 4p/3).
+    let p = 0.3;
+    let mut noisy = base(1);
+    noisy.noise(QecNoise::Depolarize1(p), &[0]).unwrap();
+    noisy.expectation_value(&[QecPauli::x(0)], 1.0).unwrap();
+    let expected = [std::f64::consts::FRAC_1_SQRT_2 * (1.0 - 4.0 * p / 3.0)];
+    let routed = run_qec_program(&noisy).unwrap();
+    let estimates = qec_common::estimates(&routed);
+    qec_common::assert_exact_estimates(
+        estimates,
+        &expected,
+        1e-10,
+        "eligible noisy EXP_VAL programs route to the density-matrix estimator",
+    );
+    qec_common::assert_zero_variance(estimates, "density-matrix route");
+    let sampled = run_qec_program_reference(&noisy).unwrap();
+    assert!(
+        qec_common::estimates(&sampled)[0].variance > 0.0,
+        "fixture must separate the routes: the sampled path has to report spread"
+    );
+
+    // Measurement records force per-shot sampling: Z0 collapses to +1 or -1
+    // with the measured partner, so the reference runner keeps this program.
+    let mut noisy_measured = program_with_shots(2, 256);
+    noisy_measured.push_gate(Gate::H, &[0]).unwrap();
+    noisy_measured.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    noisy_measured.noise(QecNoise::XError(0.1), &[0]).unwrap();
+    noisy_measured.measure_z(1).unwrap();
+    noisy_measured
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    let routed =
+        qec_common::assert_matches_reference_runner(&noisy_measured, "measurement records");
+    assert!(
+        qec_common::estimates(&routed)[0].variance > 0.0,
+        "sampled path must report spread"
+    );
+    assert_eq!(routed.measurements.num_measurements(), 1);
+
+    // Postselection conditions the estimate on an accepted subensemble, which
+    // Tr(rho O) cannot express. The empty-record predicate never matches, so
+    // the reference runner reports an estimate over zero accepted shots.
+    let mut noisy_postselected = program_with_shots(1, 256);
+    noisy_postselected
+        .noise(QecNoise::XError(0.3), &[0])
+        .unwrap();
+    noisy_postselected.postselect(&[], true).unwrap();
+    noisy_postselected
+        .expectation_value(&[QecPauli::z(0)], 1.0)
+        .unwrap();
+    let routed = qec_common::assert_matches_reference_runner(&noisy_postselected, "postselection");
+    assert_eq!(routed.accepted_shots, 0);
 
     let mut with_detector = base(2);
     with_detector.push_gate(Gate::Cx, &[0, 1]).unwrap();
@@ -241,15 +280,98 @@ fn exp_val_routing_pinned() {
     with_detector
         .expectation_value(&[QecPauli::z(0)], 1.0)
         .unwrap();
-    let routed = run_qec_program(&with_detector).unwrap();
-    let reference = run_qec_program_reference(&with_detector).unwrap();
-    assert_eq!(
-        routed.expectation_values.expect("estimates"),
-        reference.expectation_values.expect("estimates"),
-        "non-Clifford EXP_VAL programs with detectors must fall back to the reference runner"
+    let routed = qec_common::assert_matches_reference_runner(
+        &with_detector,
+        "non-Clifford program with detectors",
     );
     assert_eq!(routed.detectors.num_measurements(), 1);
     assert_eq!(routed.detectors.num_shots(), 256);
+}
+
+#[test]
+fn exp_val_noisy_density_matrix_matches_closed_form() {
+    // Bell pair under all four QEC Pauli channels. Each channel rescales a
+    // Pauli expectation by a fixed factor: X_ERROR(a) and Z_ERROR(b) give
+    // (1-2a) and (1-2b) on terms that anticommute with them, DEPOLARIZE1(c)
+    // gives (1-4c/3) on a term touching its target (two of the three Paulis
+    // anticommute), and DEPOLARIZE2(d) gives (1-16d/15) on a two-qubit term
+    // (7 of the 15 non-identity two-qubit Paulis commute with it). On the
+    // Bell state <Z0*Z1> = <X0*X1> = 1 and <Y0*Y1> = -1.
+    let (a, b, c, d) = (0.1, 0.2, 0.15, 0.05);
+    let mut program = program_with_shots(2, STAT_SHOTS);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.noise(QecNoise::XError(a), &[0]).unwrap();
+    program.noise(QecNoise::ZError(b), &[1]).unwrap();
+    program.noise(QecNoise::Depolarize1(c), &[0]).unwrap();
+    program.noise(QecNoise::Depolarize2(d), &[0, 1]).unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], 1.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::x(0), QecPauli::x(1)], 2.0)
+        .unwrap();
+    program
+        .expectation_value(&[QecPauli::y(0), QecPauli::y(1)], -0.5)
+        .unwrap();
+
+    let shared = (1.0 - 4.0 * c / 3.0) * (1.0 - 16.0 * d / 15.0);
+    let expected = [
+        (1.0 - 2.0 * a) * shared,
+        2.0 * (1.0 - 2.0 * b) * shared,
+        0.5 * (1.0 - 2.0 * a) * (1.0 - 2.0 * b) * shared,
+    ];
+
+    let result = run_qec_program(&program).unwrap();
+    let estimates = qec_common::estimates(&result);
+    qec_common::assert_exact_estimates(estimates, &expected, 1e-10, "density-matrix estimate");
+    qec_common::assert_zero_variance(estimates, "density-matrix estimate");
+    assert!(estimates.iter().all(|e| e.num_shots == STAT_SHOTS));
+    assert_eq!(result.total_shots, STAT_SHOTS);
+    assert_eq!(result.accepted_shots, STAT_SHOTS);
+    assert_eq!(result.measurements.num_measurements(), 0);
+
+    // The per-shot reference runner estimates the same quantity by sampling,
+    // which cross-checks the channel lowering against the trajectory path.
+    let reference = run_qec_program_reference(&program).unwrap();
+    qec_common::assert_within_sampling_error(
+        qec_common::estimates(&reference),
+        &expected,
+        0.01,
+        "reference runner",
+    );
+}
+
+#[test]
+fn exp_val_noisy_density_matrix_absorbs_resets() {
+    // Both paths implement the reset channel, so resets stay on the exact
+    // route. Resetting qubit 1 of a Bell pair traces it out, leaving qubit 0
+    // maximally mixed (<Z0> = 0) and qubit 1 in |+>, whose <X1> decays to
+    // 1-2p under Z_ERROR(p). The reference runner samples one branch of the
+    // reset per shot, so its mean converges to the same values.
+    let p = 0.25;
+    let mut program = program_with_shots(2, STAT_SHOTS);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.reset(QecBasis::X, 1).unwrap();
+    program.noise(QecNoise::ZError(p), &[1]).unwrap();
+    program.expectation_value(&[QecPauli::x(1)], 1.0).unwrap();
+    program.expectation_value(&[QecPauli::z(0)], 1.0).unwrap();
+
+    let expected = [1.0 - 2.0 * p, 0.0];
+
+    let result = run_qec_program(&program).unwrap();
+    let estimates = qec_common::estimates(&result);
+    qec_common::assert_exact_estimates(estimates, &expected, 1e-10, "reset under noise");
+    qec_common::assert_zero_variance(estimates, "reset under noise");
+
+    let reference = run_qec_program_reference(&program).unwrap();
+    qec_common::assert_within_sampling_error(
+        qec_common::estimates(&reference),
+        &expected,
+        0.01,
+        "reset under noise reference",
+    );
 }
 
 #[test]

--- a/tests/qec_exp_val_oversize.rs
+++ b/tests/qec_exp_val_oversize.rs
@@ -1,0 +1,31 @@
+//! Oversize guard for the noisy `EXP_VAL` density-matrix route.
+//!
+//! Isolated in its own test binary: it overrides `PRISM_MAX_DM_QUBITS`, which
+//! `max_density_matrix_qubits()` caches per process, so it must not share a
+//! process with tests that expect the real memory-derived cap.
+
+mod qec_common;
+
+use prism_q::{Gate, QecNoise, QecPauli, QecProgram};
+
+#[test]
+fn noisy_exp_val_beyond_the_density_matrix_cap_keeps_the_reference_path() {
+    // SAFETY: single test in this binary; the variable is set before any cap
+    // query and no other thread is running.
+    unsafe { std::env::set_var("PRISM_MAX_DM_QUBITS", "1") };
+
+    let mut program = QecProgram::with_options(2, qec_common::qec_options(512, 2048, false));
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program.noise(QecNoise::XError(0.3), &[0]).unwrap();
+    program
+        .expectation_value(&[QecPauli::z(0), QecPauli::z(1)], 1.0)
+        .unwrap();
+
+    let routed =
+        qec_common::assert_matches_reference_runner(&program, "over the density-matrix cap");
+    assert!(
+        qec_common::estimates(&routed)[0].variance > 0.0,
+        "a program over the density-matrix cap must keep the sampled reference path"
+    );
+}

--- a/tests/reset_channel.rs
+++ b/tests/reset_channel.rs
@@ -1,0 +1,259 @@
+//! Cross-backend conformance for the `Backend::reset` contract.
+//!
+//! `reset` is the channel `rho -> |0><0| (x) tr_q rho`, not a projection onto
+//! `|0>`. The two agree whenever the reset qubit is unentangled, so a separable
+//! fixture cannot tell them apart. The cases below add an entangled partner,
+//! where projection leaks the `|0>`-outcome branch into the rest of the
+//! register, and a reset from `|1>`, where a projection has no branch to
+//! renormalize.
+//!
+//! The oracle is the density-matrix backend, which holds the mixture and
+//! applies the channel directly. It is deliberately not the statevector
+//! backend: the sv-reference matrix in `tests/backend_matrix.rs` cannot pin
+//! this contract, because the statevector is one of the implementations under
+//! test. Pure-state backends carry one trajectory per run, so a case whose
+//! branches differ is compared as an average over seeds.
+
+use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::backend::factored::FactoredBackend;
+use prism_q::backend::mps::MpsBackend;
+use prism_q::backend::product::ProductStateBackend;
+use prism_q::backend::sparse::SparseBackend;
+use prism_q::backend::stabilizer::StabilizerBackend;
+use prism_q::backend::statevector::StatevectorBackend;
+use prism_q::backend::tensornetwork::TensorNetworkBackend;
+use prism_q::circuit::Circuit;
+use prism_q::gates::Gate;
+use prism_q::sim;
+
+const SEED: u64 = 42;
+const TRIALS: usize = 2_000;
+/// Band on a seed-averaged probability at `TRIALS` samples. The tightest
+/// entry is a fair coin, whose standard error here is 0.011.
+const AVERAGED_EPS: f64 = 0.05;
+const EXACT_EPS: f64 = 1e-9;
+
+struct BackendEntry {
+    name: &'static str,
+    construct: fn(u64) -> Box<dyn Backend>,
+    /// Whether the representation can hold an entangled two-qubit state.
+    entangling: bool,
+}
+
+const BACKENDS: &[BackendEntry] = &[
+    BackendEntry {
+        name: "statevector",
+        construct: |s| Box::new(StatevectorBackend::new(s)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "sparse",
+        construct: |s| Box::new(SparseBackend::new(s)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "mps",
+        construct: |s| Box::new(MpsBackend::new(s, 64)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "factored",
+        construct: |s| Box::new(FactoredBackend::new(s)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "tensornetwork",
+        construct: |s| Box::new(TensorNetworkBackend::new(s)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "stabilizer",
+        construct: |s| Box::new(StabilizerBackend::new(s)),
+        entangling: true,
+    },
+    BackendEntry {
+        name: "product",
+        construct: |s| Box::new(ProductStateBackend::new(s)),
+        entangling: false,
+    },
+    BackendEntry {
+        name: "density_matrix",
+        construct: |s| Box::new(DensityMatrixBackend::new(s)),
+        entangling: true,
+    },
+];
+
+/// How a case's branches behave, which decides how it is compared.
+enum Branches {
+    /// Every branch lands on the same state, so one run is already exact.
+    Collapse,
+    /// The branches differ, so only the seed-averaged run is the channel. The
+    /// density-matrix backend still matches exactly, holding the mixture.
+    Differ,
+}
+
+struct ResetCase {
+    name: &'static str,
+    build: fn() -> Circuit,
+    expected: [f64; 4],
+    branches: Branches,
+    /// Whether the fixture entangles, which excludes product-state backends.
+    entangles: bool,
+}
+
+/// Bell pair, then reset the partner. The channel traces qubit 1 out and
+/// leaves qubit 0 maximally mixed; a projection onto |0> would also collapse
+/// qubit 0 and put all the weight on |00>.
+fn entangled_reset() -> Circuit {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_reset(1);
+    circuit
+}
+
+/// Reset a qubit holding |1>. A projection onto |0> has no surviving branch,
+/// and the fallback for that case used to reinitialize the whole register,
+/// destroying qubit 0's superposition.
+fn reset_from_one() -> Circuit {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_reset(1);
+    circuit
+}
+
+/// Reset an unentangled qubit in superposition. Both branches land on |0>
+/// without touching qubit 0, so projection and channel agree here.
+fn separable_superposition_reset() -> Circuit {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::H, &[1]);
+    circuit.add_reset(1);
+    circuit
+}
+
+const CASES: &[ResetCase] = &[
+    ResetCase {
+        name: "entangled_partner",
+        build: entangled_reset,
+        expected: [0.5, 0.5, 0.0, 0.0],
+        branches: Branches::Differ,
+        entangles: true,
+    },
+    ResetCase {
+        name: "from_one",
+        build: reset_from_one,
+        expected: [0.5, 0.5, 0.0, 0.0],
+        branches: Branches::Collapse,
+        entangles: false,
+    },
+    ResetCase {
+        name: "separable_superposition",
+        build: separable_superposition_reset,
+        expected: [0.5, 0.5, 0.0, 0.0],
+        branches: Branches::Collapse,
+        entangles: false,
+    },
+];
+
+fn probabilities(backend: &mut dyn Backend, circuit: &Circuit) -> Vec<f64> {
+    sim::run_on(backend, circuit).unwrap();
+    backend.probabilities().unwrap()
+}
+
+/// Mean probability vector over `TRIALS` independently seeded runs. Each run
+/// is one trajectory of the channel; the mean converges to the channel.
+fn averaged_probabilities(entry: &BackendEntry, circuit: &Circuit) -> Vec<f64> {
+    let mut totals = vec![0.0f64; 1 << circuit.num_qubits];
+    for trial in 0..TRIALS {
+        let mut backend = (entry.construct)(SEED + trial as u64);
+        for (slot, p) in probabilities(backend.as_mut(), circuit).iter().enumerate() {
+            totals[slot] += p;
+        }
+    }
+    totals.iter().map(|t| t / TRIALS as f64).collect()
+}
+
+fn assert_probs_close(actual: &[f64], expected: &[f64], eps: f64, label: &str) {
+    for (slot, (got, want)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (got - want).abs() < eps,
+            "{label} slot {slot}: {got:.6} vs channel {want:.6}"
+        );
+    }
+}
+
+fn find_case(name: &str) -> &'static ResetCase {
+    CASES
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("unknown reset case `{name}`"))
+}
+
+fn assert_reset_case(case: &ResetCase) {
+    let circuit = (case.build)();
+
+    // The oracle is exact on every case: it holds the mixture directly.
+    let mut oracle = DensityMatrixBackend::new(SEED);
+    assert_probs_close(
+        &probabilities(&mut oracle, &circuit),
+        &case.expected,
+        1e-12,
+        &format!("{}/density_matrix oracle", case.name),
+    );
+
+    for entry in BACKENDS {
+        if case.entangles && !entry.entangling {
+            continue;
+        }
+        let label = format!("{}/{}", case.name, entry.name);
+        match case.branches {
+            Branches::Collapse => {
+                // Forced or convergent branches, so each seed is exact.
+                for trial in 0..8u64 {
+                    let mut backend = (entry.construct)(SEED + trial);
+                    assert_probs_close(
+                        &probabilities(backend.as_mut(), &circuit),
+                        &case.expected,
+                        EXACT_EPS,
+                        &format!("{label} seed {trial}"),
+                    );
+                }
+            }
+            Branches::Differ if entry.name == "density_matrix" => {
+                let mut backend = (entry.construct)(SEED);
+                assert_probs_close(
+                    &probabilities(backend.as_mut(), &circuit),
+                    &case.expected,
+                    1e-12,
+                    &label,
+                );
+            }
+            Branches::Differ => {
+                assert_probs_close(
+                    &averaged_probabilities(entry, &circuit),
+                    &case.expected,
+                    AVERAGED_EPS,
+                    &format!("{label} seed-averaged"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn reset_of_an_entangled_partner_leaves_it_mixed() {
+    assert_reset_case(find_case("entangled_partner"));
+}
+
+#[test]
+fn reset_from_one_preserves_the_rest_of_the_register() {
+    assert_reset_case(find_case("from_one"));
+}
+
+#[test]
+fn reset_of_a_separable_superposition_is_deterministic() {
+    assert_reset_case(find_case("separable_superposition"));
+}


### PR DESCRIPTION
## Summary

Noisy `EXP_VAL` QEC programs were estimated by sampling the reference runner,
spending shots to approximate a quantity the density-matrix backend computes in
closed form. Eligible programs now lower to a circuit plus a `NoiseModel` and
route to `density_matrix_expectation_values`, giving an exact `Tr(rho O)` with
variance 0.0 and no shot noise. The reference runner stays as the fallback for
everything the mixed state cannot carry deterministically.

Scoping the eligibility rule surfaced a cross-backend semantic split in `reset`,
which is fixed here because the routing decision depends on the two paths
agreeing.

## Scope

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Measured with `--features parallel` on an otherwise idle host. Before is
`origin/main`, after is this branch, captured as a paired A/B against a saved
Criterion baseline.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| `mps/hotspots/measure_reset_32q_r3` | 487.15 us | 479.21 us | -4.5% (CI -9.98% to -0.03%, p = 0.12) | Yes |
| `stabilizer_rank/shots_mid_circuit/32q_chi4_64shots` | 89.460 ms | 77.012 ms | -13.9% | Unchanged code, see below |
| `stabilizer_rank/shots_mid_circuit/32q_chi8_64shots` | 270.879 ms | 269.390 ms | -0.5% | Unchanged code, see below |
| `stabilizer_rank/shots_mid_circuit/128q_chi2_64shots` | 121.868 ms | 226.225 ms | +85.6% | Unchanged code, see below |

Regression verdict: PASS

`measure_reset_32q_r3` is the only governed row that exercises changed code.
The channel reset needs both outcome probabilities in order to sample, where
the projection it replaces needed only `p(0)`, so a naive implementation read
+32% on this row. Folding the X into the collapse write and taking the Born
probability from the caller removes one environment contraction and one pass
over the site tensor, which returns the row to parity.

The `stabilizer_rank/shots_mid_circuit` group swung -13.9% to +85.6% across the
same A/B, but `git diff origin/main..HEAD -- src/backend/stabilizer*.rs` is
empty: both passes ran byte-identical code on that path. That spread is the
noise floor of the group at `sample_size(10)`, not an effect of this branch.
Do not gate on these rows without first establishing a same-code floor.

## Correctness

- [x] `cargo nextest run --features "parallel gpu"` passes locally (1879 passed, 0 failed)
- [x] `cargo test --doc --features "parallel gpu"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu" -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu"` passes with `-D warnings`
- [x] New public API has docstrings
- [x] Golden tests added against hand-computed values
- [x] `cargo test --features "parallel gpu" --test golden_gpu` passes (64 passed)

`distributed-mpi` does not build on this host, so the feature set above is
`parallel gpu` rather than `--all-features`. CI still covers the MPI path.

New coverage:

- `tests/qec_exp_val.rs`: routing pinned across all five estimator paths;
  closed-form exactness fixture over a Bell pair for all four noise channels at
  1e-10 with variance exactly 0.0; a reset-absorption case cross-checked against
  the reference runner inside a 5-sigma band.
- `tests/qec_exp_val_oversize.rs`: isolated binary that sets
  `PRISM_MAX_DM_QUBITS=1` before the cap is first queried and asserts oversize
  programs keep the reference path and its results.
- `tests/reset_channel.rs`: table-driven cases over every backend with the
  density-matrix backend as the oracle, covering entangled-partner mixing, reset
  from the one state, and the separable no-op.
- `tests/golden_small_circuits.rs`: three hand-computed reset anchors, including
  one over 64 seeds that asserts both branches of an entangled partner occur.
- `tests/measurement_matrix.rs`: `reset_from_one_with_spectator` wired across all
  six backends.

## Hotspot notes

`reset` is not in a gate-application inner loop, but the MPS path contracts the
site environments, which is the dominant cost on `measure_reset_32q_r3`.
Affected function: `MpsBackend::apply_reset`, now a single call to
`site_outcome_probabilities` followed by `collapse_site_to_zero`. Previously the
probability contraction ran twice, once directly and once inside
`project_site_outcome`, followed by a third pass for the X gate.

The QEC routing itself is cold. It runs once per program, not per shot.

## Architecture or design changes

- [x] `docs/architecture/qec-programs.md`: estimator flow diagram gains the
  density-matrix decision, plus the eligibility rule and an estimator-paths row.
- [x] `docs/architecture/backends.md`: new reset semantics section stating the
  channel contract and its trajectory implementation.

The eligibility rule is stated where the routing lives. A noisy `EXP_VAL`
program takes the density-matrix path when it has no measurement records, no
postselection predicate, and fits the density-matrix cap
(`max_density_matrix_qubits`, overridable with `PRISM_MAX_DM_QUBITS`). Anything
else, including any op the lowering rejects, falls back to the reference runner
unchanged.

## Breaking changes

`reset` now implements the channel `rho -> |0><0| (x) tr_q rho` in the six
backends that previously applied a renormalized projection onto the zero state
(statevector CPU and GPU, sparse, factored, MPS, tensor network, distributed).
Projection matches the channel only on an unentangled qubit, so resetting one
half of a Bell pair no longer collapses the partner. Two consequences for
callers:

- A reset consumes one RNG draw, so seeded streams shift for circuits that reset.
  This matches the stabilizer backend, which already had the channel.
- Results that depended on the old collapse change. `Z0` expectation after
  resetting a Bell partner reads 0.0 rather than 1.0.

Noisy `EXP_VAL` results also change shape in one respect: eligible programs now
report variance 0.0 rather than a sampling variance. Means agree with the
reference runner within sampling error, and the coefficient scaling, per-op
ordering, and postselection composition are unchanged.

## Risks and rollback

The QEC routing is guarded: every failure path in the density-matrix lowering
falls through to the reference runner, so an unsupported program degrades rather
than errors. Narrowing eligibility, or dropping the density-matrix branch
altogether, is a local edit to the routing function and needs no backend change.

The reset change carries the wider blast radius. It touches six backends and
shifts seeded RNG streams for any circuit that resets, so downstream fixtures
that pinned specific shot sequences will move. It is pinned by golden anchors
that name the statevector directly, so a regression reports against the backend
that actually broke rather than against the reference.

Routing and reset ship in one commit, so a revert takes both. Backing out only
the estimator path is an edit to the eligibility check rather than a revert.
Backing out only the reset change would reintroduce the semantic split that the
golden anchors now catch.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
