### PR TITLE
fix(backend): check the memory budget before a backend allocates its state

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -26,6 +26,44 @@ reset consumes one draw from the backend's RNG stream. The density-matrix backen
 the mixture and applies the channel directly, with no draw. `tests/reset_channel.rs`
 pins the contract across backends against the density-matrix oracle.
 
+## Memory budget
+
+A circuit that does not fit in memory is an error, not a fallback. No backend silently
+hands the work to a different one when its state would not fit: it returns
+`PrismError::IncompatibleBackend` naming itself, the qubit count, the cap, and the
+environment variable that overrides it. Choosing a different backend is the caller's
+decision, and `BackendKind::Auto` makes it from circuit structure before any backend is
+constructed.
+
+The check lives in `Backend::init`, which is the one point every execution path passes
+through before reserving its state. Putting it there means a caller that drives a backend
+directly, through `run_on` rather than `simulate`, gets the same guard as one that goes
+through dispatch.
+
+| Cap | Variable | Default |
+|-----|----------|---------|
+| Statevector state | `PRISM_MAX_SV_QUBITS` | Largest `2^n` `Complex64` state fitting half of detected physical memory |
+| Density-matrix state | `PRISM_MAX_DM_QUBITS` | `floor(cap_sv / 2)`, since a density matrix of `n` qubits is a `2n`-qubit statevector |
+| Dense probability output | `PRISM_MAX_PROB_QUBITS` | Same budget over `f64` |
+| Dense statevector export | `PRISM_MAX_EXPORT_QUBITS` | Same budget over `Complex64` |
+| Dense outcome sampling | `PRISM_MAX_DENSE_OUTCOME_BITS` | Same budget over two `f64` per outcome |
+
+The density-matrix backend applies the tighter of its own cap and half the statevector
+cap, so it reports the rejection itself rather than surfacing an error naming the
+statevector it allocates internally. When physical memory cannot be detected the caps are
+disabled and a warning is printed, because guessing a budget is worse than saying the
+budget is unknown.
+
+Parallel noisy trajectories are the one path holding more than one state at a time: each
+Rayon thread runs its own backend, so peak memory is `threads * state(n)`. That path is
+restricted to circuits below 14 qubits, where a statevector replica is 256 KiB and a full
+thread pool stays in the tens of megabytes. Above it trajectories run serially with one
+live backend, bounded by the ordinary state cap.
+
+Three growth paths are not yet bounded and can still exhaust memory on an adversarial
+input: MPS bond dimension when `max_bond_dim` is set very high, sparse-state entry count
+when a circuit densifies, and the transient peak inside a factored sub-state merge.
+
 ## Statevector
 
 Full-state simulation in a flat `Vec<Complex64>` of 2^n amplitudes. The primary backend for circuits up to ~28 qubits.

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -334,6 +334,17 @@ impl Backend for DensityMatrixBackend {
     }
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        // The state is a 2n-qubit statevector, so the statevector cap binds at
+        // half its value. Taking the tighter of the two here keeps this backend
+        // the one that reports the rejection, whatever the two caps are set to.
+        crate::backend::check_state_allocation(
+            "density_matrix",
+            num_qubits,
+            crate::backend::max_density_matrix_qubits()
+                .min(crate::backend::max_statevector_qubits() / 2),
+            "PRISM_MAX_DM_QUBITS",
+        )?;
+
         self.num_qubits = num_qubits;
         self.classical_bits = vec![false; num_classical_bits];
         self.sv.init(2 * num_qubits, 0)

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -116,6 +116,37 @@ fn max_dense_qubits_for_budget(budget_bytes: u64, bytes_per_basis_state: usize) 
     Some(max_qubits.min(usize::BITS as usize - 1))
 }
 
+/// Reject a dense state that would exceed `cap` before the backend reserves it.
+///
+/// Backends call this at the top of `init`, the one point every execution path
+/// passes through before allocating, so a caller that drives a backend directly
+/// through [`run_on`](crate::run_on) cannot bypass the dispatch-level caps and
+/// reach an allocation the machine cannot satisfy. Exceeding a cap is an error,
+/// never a silent fallback to another backend.
+pub(crate) fn check_state_allocation(
+    backend: &str,
+    num_qubits: usize,
+    cap: usize,
+    env_var: &str,
+) -> Result<()> {
+    if num_qubits >= usize::BITS as usize {
+        return Err(PrismError::IncompatibleBackend {
+            backend: backend.to_string(),
+            reason: format!("circuit has {num_qubits} qubits, exceeding addressable memory"),
+        });
+    }
+    if num_qubits > cap {
+        return Err(PrismError::IncompatibleBackend {
+            backend: backend.to_string(),
+            reason: format!(
+                "circuit has {num_qubits} qubits, exceeding the cap of {cap} on this machine \
+                 (set {env_var} to override)"
+            ),
+        });
+    }
+    Ok(())
+}
+
 pub(crate) fn dense_probability_len(backend: &str, num_qubits: usize) -> Result<usize> {
     dense_output_len(
         backend,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -77,7 +77,7 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) use memory::{
-    dense_probability_len, dense_statevector_len, max_dense_outcome_bits,
+    check_state_allocation, dense_probability_len, dense_statevector_len, max_dense_outcome_bits,
     max_density_matrix_qubits, max_statevector_qubits, reserve_dense_output,
     tensor_probability_len,
 };

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -601,6 +601,13 @@ impl Backend for StatevectorBackend {
     }
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        crate::backend::check_state_allocation(
+            "statevector",
+            num_qubits,
+            crate::backend::max_statevector_qubits(),
+            "PRISM_MAX_SV_QUBITS",
+        )?;
+
         #[cfg(feature = "parallel")]
         crate::backend::init_thread_pool();
 

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -357,6 +357,12 @@ pub(crate) fn run_trajectory_shot(
 /// saturate the pool, and nesting shot tasks inside kernel joins piles stolen
 /// shot frames onto one worker stack until it overflows. Same guard as
 /// `MAX_BLOCK_QUBITS_FOR_PAR` in the decomposed path.
+/// Replica cap for parallel trajectories. Each Rayon thread holds its own
+/// backend, so peak memory is `threads * state(num_qubits)` rather than one
+/// state. Bounding the qubit count bounds the replica set: at 14 qubits a
+/// statevector replica is 256 KiB, so even a large thread pool stays in the
+/// tens of megabytes. Above this the trajectories run serially, one live
+/// backend at a time, and the backend's own `init` cap is the only limit.
 #[cfg(feature = "parallel")]
 const MAX_QUBITS_FOR_PAR_SHOTS: usize = 14;
 
@@ -418,6 +424,27 @@ fn run_trajectories_par(
 mod tests {
     use super::*;
     use crate::circuits;
+
+    /// The replica cap is only a memory bound if it stays at or below the cap
+    /// governing a single state. Raising `MAX_QUBITS_FOR_PAR_SHOTS` past the
+    /// statevector cap would let the parallel path allocate one oversize state
+    /// per thread, which is the failure `run_trajectories` avoids by falling
+    /// back to serial execution.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn parallel_trajectory_replicas_stay_within_a_single_state_cap() {
+        let cap = crate::backend::max_statevector_qubits();
+        assert!(
+            MAX_QUBITS_FOR_PAR_SHOTS <= cap,
+            "parallel replica cap {MAX_QUBITS_FOR_PAR_SHOTS} exceeds the statevector cap {cap}"
+        );
+        let replica_bytes = (1usize << MAX_QUBITS_FOR_PAR_SHOTS) * size_of::<Complex64>();
+        assert_eq!(
+            replica_bytes,
+            256 * 1024,
+            "replica size documented as 256 KiB"
+        );
+    }
 
     #[test]
     fn trajectory_pauli_matches_brute_force() {

--- a/tests/memory_budget_oversize.rs
+++ b/tests/memory_budget_oversize.rs
@@ -1,0 +1,116 @@
+//! Oversize guards for the backend memory-budget contract.
+//!
+//! Isolated in its own test binary: it overrides `PRISM_MAX_SV_QUBITS` and
+//! `PRISM_MAX_DM_QUBITS`, which the cap helpers cache per process, so it must
+//! not share a process with tests that expect the real memory-derived caps.
+//!
+//! The caps are what make these cases cheap. Every rejection here is decided
+//! before the backend reserves anything, so no test allocates an oversize state.
+
+use std::sync::Once;
+
+use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::gates::Gate;
+use prism_q::{Circuit, PrismError, StatevectorBackend, run_on};
+
+/// Caps keep the default relationship, where a density matrix of `n` qubits is
+/// a `2n`-qubit statevector, so neither backend's guard depends on the other
+/// being set inconsistently.
+const SV_CAP: usize = 8;
+const DM_CAP: usize = SV_CAP / 2;
+
+fn small_caps() {
+    static SET: Once = Once::new();
+    SET.call_once(|| {
+        // SAFETY: set exactly once, and every reader in this binary is gated
+        // behind this `Once`, so no thread queries a cap while it is written.
+        unsafe {
+            std::env::set_var("PRISM_MAX_SV_QUBITS", "8");
+            std::env::set_var("PRISM_MAX_DM_QUBITS", "4");
+        }
+    });
+}
+
+fn entangling_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::H, &[0]);
+    for q in 1..n {
+        c.add_gate(Gate::Cx, &[q - 1, q]);
+    }
+    c
+}
+
+fn assert_cap_error(err: PrismError, backend: &str) {
+    match err {
+        PrismError::IncompatibleBackend {
+            backend: named,
+            reason,
+        } => {
+            assert_eq!(named, backend, "wrong backend named: {reason}");
+            assert!(
+                reason.contains("exceeding the cap"),
+                "expected a cap rejection, got {reason}"
+            );
+        }
+        other => panic!("expected a clean cap error, got {other:?}"),
+    }
+}
+
+/// The path a caller reaches by driving a backend directly instead of through
+/// dispatch, which is what the Python `state_vector()` terminal does. Before
+/// the cap moved into `init` this allocated unchecked and aborted the process.
+#[test]
+fn statevector_init_over_cap_returns_clean_error() {
+    small_caps();
+    let mut backend = StatevectorBackend::new(42);
+    let err = run_on(&mut backend, &entangling_circuit(SV_CAP + 2)).unwrap_err();
+    assert_cap_error(err, "statevector");
+}
+
+#[test]
+fn density_matrix_init_over_cap_returns_clean_error() {
+    small_caps();
+    let mut backend = DensityMatrixBackend::new(42);
+    let err = backend.init(DM_CAP + 2, 0).unwrap_err();
+    assert_cap_error(err, "density_matrix");
+}
+
+#[test]
+fn statevector_init_at_the_cap_still_runs() {
+    small_caps();
+    let mut backend = StatevectorBackend::new(42);
+    run_on(&mut backend, &entangling_circuit(SV_CAP)).expect("a circuit at the cap must still run");
+    let probs = backend.probabilities().unwrap();
+    assert_eq!(probs.len(), 1 << SV_CAP);
+    assert!(
+        (probs[0] - 0.5).abs() < 1e-12 && (probs[(1 << SV_CAP) - 1] - 0.5).abs() < 1e-12,
+        "GHZ at the cap should stay correct: {probs:?}"
+    );
+}
+
+#[test]
+fn density_matrix_init_at_the_cap_still_runs() {
+    small_caps();
+    let mut backend = DensityMatrixBackend::new(42);
+    backend
+        .init(DM_CAP, 0)
+        .expect("a circuit at the cap must still run");
+    assert_eq!(backend.num_qubits(), DM_CAP);
+}
+
+#[test]
+fn unaddressable_qubit_count_is_rejected_before_the_shift() {
+    small_caps();
+    let mut backend = StatevectorBackend::new(42);
+    let err = backend.init(usize::BITS as usize, 0).unwrap_err();
+    match err {
+        PrismError::IncompatibleBackend { reason, .. } => {
+            assert!(
+                reason.contains("addressable memory"),
+                "expected an addressability rejection, got {reason}"
+            );
+        }
+        other => panic!("expected a clean addressability error, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Qubit caps were enforced only in dispatch, so any caller that drove a backend directly bypassed them. `StatevectorBackend::init` computed `1 << num_qubits` and allocated without a check, and the Python `state_vector()` terminal reaches exactly that path through `run_on`. An oversize circuit there asked the allocator for a state larger than the machine, and allocation failure aborts the process rather than unwinding, so the caller got no error to handle.

The check now lives in `Backend::init`, the single point every execution path passes through before reserving its state. Exceeding a cap returns `IncompatibleBackend` naming the backend, the qubit count, the cap, and the variable that overrides it. Exceeding a cap is never a silent fallback to a different backend: choosing one is the caller's decision, and automatic dispatch makes it from circuit structure before any backend is constructed.

The density-matrix backend applies the tighter of its own cap and half the statevector cap, because its state is a `2n`-qubit statevector. Without that it would pass its own check and then fail inside the statevector it allocates internally, reporting the wrong backend and a qubit count the caller never asked for.

Parallel noisy trajectories are the one path holding several states at once, one per Rayon thread. The existing 14-qubit threshold is what bounds that replica set, which was load-bearing but undocumented; it is now stated on the constant and pinned by a test asserting it stays within a single-state cap.

MPS bond growth, sparse entry count, and the factored merge peak remain unbounded. They sit near hot loops, so a ceiling on them needs before/after rows, and the contract section says so rather than implying full coverage.