### PR TITLE
perf(backend): cut redundant passes, hashing, and division from three backends

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -30,8 +30,80 @@ use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
-use crate::gates::Gate;
+use crate::gates::{Gate, McuData};
 use crate::sim::i_pow;
+
+/// Compile a one-qubit Kraus set into the 4x4 superoperator acting on the
+/// `(row-bit, col-bit)` block of `rho`, where block index `i = 2*a + b` orders
+/// `(row-bit a, col-bit b)`:
+/// `S[2a+b][2a'+b'] = sum_k K_k[a][a'] * conj(K_k[b][b'])`.
+///
+/// A single-element set `[U]` gives the unitary sandwich `U rho U^dagger`.
+fn block_superoperator(kraus: &[[[Complex64; 2]; 2]]) -> [[Complex64; 4]; 4] {
+    let mut s = [[Complex64::new(0.0, 0.0); 4]; 4];
+    for k in kraus {
+        for a in 0..2 {
+            for b in 0..2 {
+                for ap in 0..2 {
+                    for bp in 0..2 {
+                        s[2 * a + b][2 * ap + bp] += k[a][ap] * k[b][bp].conj();
+                    }
+                }
+            }
+        }
+    }
+    s
+}
+
+fn conjugate_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
+    [
+        [m[0][0].conj(), m[0][1].conj()],
+        [m[1][0].conj(), m[1][1].conj()],
+    ]
+}
+
+/// The gate's 2x2 matrix, or `None` for anything else. `Gate::num_qubits` is
+/// not a usable test here: it reports 1 for a `BatchPhase` with no phases, a
+/// single-qubit `DiagonalBatch`, and `QftBlock { num: 1 }`, none of which
+/// `matrix_2x2` accepts.
+fn matrix_1q(gate: &Gate) -> Option<[[Complex64; 2]; 2]> {
+    match gate {
+        Gate::Id
+        | Gate::X
+        | Gate::Y
+        | Gate::Z
+        | Gate::H
+        | Gate::S
+        | Gate::Sdg
+        | Gate::T
+        | Gate::Tdg
+        | Gate::SX
+        | Gate::SXdg
+        | Gate::Rx(_)
+        | Gate::Ry(_)
+        | Gate::Rz(_)
+        | Gate::P(_)
+        | Gate::Fused(_) => Some(gate.matrix_2x2()),
+        _ => None,
+    }
+}
+
+/// `conj(gate)` as a native gate variant, which is what the bra register of
+/// `rho -> U rho U^dagger` needs. `Cx`, `Cz`, and `Swap` are real, so they are
+/// their own conjugate. `None` means the variant has no native conjugate form
+/// and the caller falls back to conjugating the buffer around the gate.
+fn conjugate_gate(gate: &Gate) -> Option<Gate> {
+    match gate {
+        Gate::Cx | Gate::Cz | Gate::Swap => Some(gate.clone()),
+        Gate::Rzz(theta) => Some(Gate::Rzz(-*theta)),
+        Gate::Cu(mat) => Some(Gate::Cu(Box::new(conjugate_2x2(mat)))),
+        Gate::Mcu(data) => Some(Gate::Mcu(Box::new(McuData {
+            mat: conjugate_2x2(&data.mat),
+            num_controls: data.num_controls,
+        }))),
+        _ => None,
+    }
+}
 
 /// Exact density-matrix simulator. See the module docs for the state layout.
 pub struct DensityMatrixBackend {
@@ -79,22 +151,59 @@ impl DensityMatrixBackend {
         }
     }
 
+    /// Apply a compiled one-qubit block superoperator in a single buffer pass.
+    ///
+    /// The `(row-bit, col-bit)` block of `qubit` is the two-qubit subspace
+    /// `(qubit + n, qubit)` of the embedded `2n`-qubit statevector, so the
+    /// statevector two-qubit kernel applies `S` directly. That kernel indexes
+    /// its matrix as `2 * bit(q0) + bit(q1)`, matching the block index `2a + b`
+    /// once the row bit is passed as `q0`.
+    fn apply_block_superoperator(&mut self, qubit: usize, s: &[[Complex64; 4]; 4]) {
+        let n = self.num_qubits;
+        self.sv.apply_fused_2q(qubit + n, qubit, s);
+    }
+
     /// Evolve `rho -> U rho U^dagger` for the unitary `gate` on `targets`.
     ///
-    /// `U` on the ket register (targets offset by `n`) is the left product
-    /// `U rho`; the same `U` on the bra register (original targets) sandwiched
-    /// between two whole-buffer conjugations applies `conj(U)`, giving the right
-    /// product `rho U^dagger`.
+    /// `U` applies to the ket register (targets offset by `n`) for the left
+    /// product `U rho`, and `conj(U)` to the bra register (original targets) for
+    /// the right product `rho U^dagger`. Variants with no native conjugate form
+    /// fall back to conjugating the whole buffer around the gate, which costs
+    /// two extra passes.
+    ///
+    /// A one-qubit gate can instead compile to a block superoperator and sweep
+    /// the buffer once, which wins once the buffer stops fitting in cache. Below
+    /// that the superoperator's dense 4x4 block loses to two cheap passes, so
+    /// the crossover is the point where the embedded `2n`-qubit statevector
+    /// reaches the kernels' own parallel threshold.
     fn apply_unitary(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         let n = self.num_qubits;
+
+        if let Some(mat) = matrix_1q(gate) {
+            if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+                let s = block_superoperator(&[mat]);
+                self.apply_block_superoperator(targets[0], &s);
+                return Ok(());
+            }
+            self.sv.apply_1q_matrix(targets[0] + n, &mat)?;
+            return self.sv.apply_1q_matrix(targets[0], &conjugate_2x2(&mat));
+        }
+
         let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
         self.sv.apply(&Instruction::Gate {
             gate: gate.clone(),
             targets: ket_targets,
         })?;
 
-        self.conjugate_buffer();
         let bra_targets: SmallVec<[usize; 4]> = targets.iter().copied().collect();
+        if let Some(conjugate) = conjugate_gate(gate) {
+            return self.sv.apply(&Instruction::Gate {
+                gate: conjugate,
+                targets: bra_targets,
+            });
+        }
+
+        self.conjugate_buffer();
         self.sv.apply(&Instruction::Gate {
             gate: gate.clone(),
             targets: bra_targets,
@@ -185,45 +294,9 @@ impl DensityMatrixBackend {
     /// on `qubit`. The Kraus set is compiled once into a 4x4 block
     /// superoperator acting on each `(row-bit, col-bit)` block of `rho`, so the
     /// buffer is swept once with no per-element allocation.
-    ///
-    /// Block index `i = 2*a + b` orders `(row-bit a, col-bit b)`; the
-    /// superoperator is `S[2a+b][2a'+b'] = sum_k K_k[a][a'] * conj(K_k[b][b'])`.
     pub fn apply_1q_kraus(&mut self, qubit: usize, kraus: &[[[Complex64; 2]; 2]]) {
-        let n = self.num_qubits;
-        let d = self.dim();
-        let rmask = 1usize << (qubit + n);
-        let cmask = 1usize << qubit;
-
-        let mut s = [[Complex64::new(0.0, 0.0); 4]; 4];
-        for k in kraus {
-            for a in 0..2 {
-                for b in 0..2 {
-                    for ap in 0..2 {
-                        for bp in 0..2 {
-                            s[2 * a + b][2 * ap + bp] += k[a][ap] * k[b][bp].conj();
-                        }
-                    }
-                }
-            }
-        }
-
-        for m in 0..((d * d) >> 2) {
-            let base = insert_zero_bit(insert_zero_bit(m, qubit), qubit + n);
-            let idx = [base, base | cmask, base | rmask, base | rmask | cmask];
-            let v = [
-                self.sv.state[idx[0]],
-                self.sv.state[idx[1]],
-                self.sv.state[idx[2]],
-                self.sv.state[idx[3]],
-            ];
-            for i in 0..4 {
-                let mut acc = Complex64::new(0.0, 0.0);
-                for j in 0..4 {
-                    acc += s[i][j] * v[j];
-                }
-                self.sv.state[idx[i]] = acc;
-            }
-        }
+        let s = block_superoperator(kraus);
+        self.apply_block_superoperator(qubit, &s);
     }
 
     /// Apply symmetric two-qubit depolarizing on `(q0, q1)`:

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -42,7 +42,6 @@ use num_complex::Complex64;
 use crate::circuit::Instruction;
 use crate::error::Result;
 
-#[cfg(feature = "parallel")]
 pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
 
 #[cfg(feature = "parallel")]

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -1,8 +1,11 @@
 //! Sparse state-vector simulation backend.
 //!
-//! Stores only non-zero amplitudes in a `HashMap<usize, Complex64>`, giving O(k) memory
-//! where k is the number of non-zero basis states. Amplitudes below a configurable
-//! epsilon are pruned after each gate to maintain sparsity.
+//! Stores only non-zero amplitudes in a map keyed by basis-state index, giving
+//! O(k) memory where k is the number of non-zero basis states. Amplitudes below
+//! a configurable epsilon are pruned after each gate to maintain sparsity.
+//!
+//! Every gate walks the map, so the map hashes basis-state indices with the
+//! crate's multiply-xor hasher rather than the stdlib default.
 //!
 //! # When to prefer this backend
 //!
@@ -14,8 +17,6 @@
 //!
 //! - After a layer of Hadamard gates (state becomes maximally dense).
 //! - Small qubit counts where dense statevector is faster due to HashMap overhead.
-
-use std::collections::HashMap;
 
 use num_complex::Complex64;
 use rand::RngExt;
@@ -34,14 +35,15 @@ use crate::backend::{
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::{DiagEntry, Gate};
+use crate::hash::FxHashMap;
 
 const DEFAULT_EPSILON: f64 = 1e-16;
 
 /// Sparse state-vector backend, O(k) where k is the number of non-zero amplitudes.
 pub struct SparseBackend {
     num_qubits: usize,
-    state: HashMap<usize, Complex64>,
-    swap_buf: HashMap<usize, Complex64>,
+    state: FxHashMap<usize, Complex64>,
+    swap_buf: FxHashMap<usize, Complex64>,
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
     epsilon: f64,
@@ -52,8 +54,8 @@ impl SparseBackend {
     pub fn new(seed: u64) -> Self {
         Self {
             num_qubits: 0,
-            state: HashMap::new(),
-            swap_buf: HashMap::new(),
+            state: FxHashMap::default(),
+            swap_buf: FxHashMap::default(),
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
             epsilon: DEFAULT_EPSILON,

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -2222,7 +2222,7 @@ impl StatevectorBackend {
     }
 
     #[inline(always)]
-    pub(super) fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+    pub(crate) fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
         if q0.max(q1) - q0.min(q1) == 1 {
             #[cfg(feature = "parallel")]
             if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -15,6 +15,8 @@
 //! Greedy min-size heuristic: repeatedly contract the pair of tensors whose
 //! result has the smallest total element count. O(T²) where T = tensor count.
 
+use std::borrow::Cow;
+
 use num_complex::Complex64;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -54,6 +56,50 @@ impl Tensor {
     }
 }
 
+/// Fill `out` with transposed elements, `out[0]` being output index `start`.
+///
+/// The output index is walked as an odometer over the permuted axes, so the
+/// source offset advances by addition. Only the initial `start` decomposition
+/// divides, which is once per call rather than once per axis per element. The
+/// odometer carries a fixed setup cost, so this is worth calling only for
+/// chunks large enough to amortize it, which is what the parallel path does.
+///
+/// `steps[a]` is the source stride of the axis that output axis `a` came from.
+#[cfg(feature = "parallel")]
+fn transpose_range(
+    out: &mut [Complex64],
+    src: &[Complex64],
+    start: usize,
+    new_shape: &[usize],
+    new_strides: &[usize],
+    steps: &[usize],
+) {
+    let rank = new_shape.len();
+    let mut counter: SmallVec<[usize; 6]> = SmallVec::from_elem(0usize, rank);
+    let mut src_idx = 0usize;
+    if start != 0 {
+        let mut rem = start;
+        for a in 0..rank {
+            counter[a] = rem / new_strides[a];
+            rem %= new_strides[a];
+            src_idx += counter[a] * steps[a];
+        }
+    }
+
+    for slot in out.iter_mut() {
+        *slot = src[src_idx];
+        for a in (0..rank).rev() {
+            counter[a] += 1;
+            src_idx += steps[a];
+            if counter[a] < new_shape[a] {
+                break;
+            }
+            counter[a] = 0;
+            src_idx -= steps[a] * new_shape[a];
+        }
+    }
+}
+
 /// Transpose a tensor by permuting its axes.
 ///
 /// `perm[new_axis] = old_axis`. The output tensor has shape
@@ -88,7 +134,32 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
-    // Permuted strides: for each old axis, what stride does it contribute in the new layout?
+    let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
+
+    #[cfg(feature = "parallel")]
+    if total >= MIN_PAR_ELEMS {
+        let src = &t.data;
+        new_data
+            .par_chunks_mut(MIN_PAR_ELEMS)
+            .enumerate()
+            .for_each(|(chunk_idx, out)| {
+                transpose_range(
+                    out,
+                    src,
+                    chunk_idx * MIN_PAR_ELEMS,
+                    &new_shape,
+                    &new_strides,
+                    &steps,
+                );
+            });
+
+        return Tensor {
+            data: new_data,
+            shape: new_shape,
+            legs: new_legs,
+        };
+    }
+
     let perm_strides: SmallVec<[usize; 6]> = (0..rank)
         .map(|old_ax| {
             let new_ax = perm.iter().position(|&p| p == old_ax).unwrap();
@@ -96,41 +167,7 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         })
         .collect();
 
-    #[cfg(feature = "parallel")]
-    if total >= MIN_PAR_ELEMS {
-        let old_strides_ref = &old_strides;
-        let perm_strides_ref = &perm_strides;
-        let src = &t.data;
-        new_data
-            .par_iter_mut()
-            .enumerate()
-            .for_each(|(new_linear, out)| {
-                let mut old_linear = 0usize;
-                let mut rem = new_linear;
-                for a in 0..rank {
-                    let idx = rem / new_strides[a];
-                    rem %= new_strides[a];
-                    let old_ax = perm[a];
-                    old_linear += idx * old_strides_ref[old_ax];
-                }
-                let _ = perm_strides_ref;
-                *out = src[old_linear];
-            });
-    } else {
-        for old_linear in 0..total {
-            let mut new_linear = 0usize;
-            let mut rem = old_linear;
-            for i in 0..rank {
-                let idx = rem / old_strides[i];
-                rem %= old_strides[i];
-                new_linear += idx * perm_strides[i];
-            }
-            new_data[new_linear] = t.data[old_linear];
-        }
-    }
-
-    #[cfg(not(feature = "parallel"))]
-    for old_linear in 0..total {
+    for (old_linear, &amp) in t.data.iter().enumerate() {
         let mut new_linear = 0usize;
         let mut rem = old_linear;
         for i in 0..rank {
@@ -138,7 +175,7 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
             rem %= old_strides[i];
             new_linear += idx * perm_strides[i];
         }
-        new_data[new_linear] = t.data[old_linear];
+        new_data[new_linear] = amp;
     }
 
     Tensor {
@@ -176,15 +213,15 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     b_perm.extend_from_slice(&b_free);
 
     let a_t = if a_perm.iter().enumerate().all(|(i, &p)| i == p) {
-        a.clone()
+        Cow::Borrowed(a)
     } else {
-        transpose(a, &a_perm)
+        Cow::Owned(transpose(a, &a_perm))
     };
 
     let b_t = if b_perm.iter().enumerate().all(|(i, &p)| i == p) {
-        b.clone()
+        Cow::Borrowed(b)
     } else {
-        transpose(b, &b_perm)
+        Cow::Owned(transpose(b, &b_perm))
     };
 
     let m: usize = a_free.iter().map(|&i| a.shape[i]).product::<usize>().max(1);

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -134,6 +134,7 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
+    #[cfg(feature = "parallel")]
     let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
 
     #[cfg(feature = "parallel")]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,87 @@
+//! Integer-keyed hashing for hot maps.
+//!
+//! The stdlib default hasher is SipHash-1-3, which is collision-resistant
+//! against adversarial keys. Nothing in this crate hashes untrusted input: keys
+//! are basis-state indices and packed measurement words. The multiply-xor hash
+//! below costs a rotate, an xor, and a multiply per word, which is what the
+//! sparse state map and the shot histogram want on their inner loops.
+
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hasher};
+
+pub(crate) struct FxHasher {
+    hash: u64,
+}
+
+impl FxHasher {
+    const SEED: u64 = 0x517cc1b727220a95;
+}
+
+impl Hasher for FxHasher {
+    /// The multiply-xor step drives entropy toward the high bits while the
+    /// table takes its bucket index from the low ones, so structured keys
+    /// cluster. Basis-state indices from a low-entanglement circuit are exactly
+    /// that, and the clustering grows with the key count: without this
+    /// finalizer `sparse/low_entanglement` regresses 11.8% at 20 qubits while
+    /// the high-entropy `sparse/random_d10` rows are unaffected.
+    #[inline]
+    fn finish(&self) -> u64 {
+        let mut h = self.hash;
+        h ^= h >> 33;
+        h = h.wrapping_mul(0xff51_afd7_ed55_8ccd);
+        h ^= h >> 33;
+        h
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for chunk in bytes.chunks(8) {
+            let mut buf = [0u8; 8];
+            buf[..chunk.len()].copy_from_slice(chunk);
+            let word = u64::from_ne_bytes(buf);
+            self.hash = (self.hash.rotate_left(5) ^ word).wrapping_mul(Self::SEED);
+        }
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.hash = (self.hash.rotate_left(5) ^ i).wrapping_mul(Self::SEED);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        self.hash = (self.hash.rotate_left(5) ^ i as u64).wrapping_mul(Self::SEED);
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct FxBuildHasher;
+
+impl BuildHasher for FxBuildHasher {
+    type Hasher = FxHasher;
+
+    fn build_hasher(&self) -> FxHasher {
+        FxHasher { hash: 0 }
+    }
+}
+
+pub(crate) type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fx_hasher_finish_changes_with_writes() {
+        let mut h1 = FxBuildHasher.build_hasher();
+        h1.write(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let v1 = h1.finish();
+        let mut h2 = FxBuildHasher.build_hasher();
+        h2.write_u64(42);
+        h2.write_usize(7);
+        let v2 = h2.finish();
+        assert_ne!(v1, 0);
+        assert_ne!(v2, 0);
+        assert_ne!(v1, v2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod error;
 pub mod gates;
 #[cfg(feature = "gpu")]
 pub mod gpu;
+mod hash;
 pub mod qec;
 pub mod sim;
 

--- a/src/sim/compiled/accumulator.rs
+++ b/src/sim/compiled/accumulator.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::hash::{BuildHasher, Hasher};
+
+use crate::hash::FxHashMap;
 
 use super::{
     PackedShots, ShotLayout, count_vec_key, count_vec_key_masked, shot_major_padding_bits_set,
@@ -52,53 +53,6 @@ pub(crate) fn marginals_from_chunks(
     sample_chunked(&mut acc);
     acc.marginals()
 }
-
-struct FxHasher {
-    hash: u64,
-}
-
-impl FxHasher {
-    const SEED: u64 = 0x517cc1b727220a95;
-}
-
-impl Hasher for FxHasher {
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.hash
-    }
-
-    #[inline]
-    fn write(&mut self, bytes: &[u8]) {
-        for chunk in bytes.chunks(8) {
-            let mut buf = [0u8; 8];
-            buf[..chunk.len()].copy_from_slice(chunk);
-            let word = u64::from_ne_bytes(buf);
-            self.hash = (self.hash.rotate_left(5) ^ word).wrapping_mul(Self::SEED);
-        }
-    }
-
-    #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.hash = (self.hash.rotate_left(5) ^ i).wrapping_mul(Self::SEED);
-    }
-
-    #[inline]
-    fn write_usize(&mut self, i: usize) {
-        self.hash = (self.hash.rotate_left(5) ^ i as u64).wrapping_mul(Self::SEED);
-    }
-}
-
-#[derive(Clone, Default)]
-struct FxBuildHasher;
-
-impl BuildHasher for FxBuildHasher {
-    type Hasher = FxHasher;
-    fn build_hasher(&self) -> FxHasher {
-        FxHasher { hash: 0 }
-    }
-}
-
-type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 
 #[cfg(feature = "parallel")]
 const MIN_SHOTS_FOR_PAR_HISTOGRAM: usize = 65536;
@@ -1233,20 +1187,5 @@ mod tests {
         transpose_64x64(&mut matrix);
         transpose_64x64(&mut matrix);
         assert_eq!(matrix, original);
-    }
-
-    #[test]
-    fn fx_hasher_finish_changes_with_writes() {
-        use std::hash::Hasher as _;
-        let mut h1 = FxBuildHasher.build_hasher();
-        h1.write(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        let v1 = h1.finish();
-        let mut h2 = FxBuildHasher.build_hasher();
-        h2.write_u64(42);
-        h2.write_usize(7);
-        let v2 = h2.finish();
-        assert_ne!(v1, 0);
-        assert_ne!(v2, 0);
-        assert_ne!(v1, v2);
     }
 }


### PR DESCRIPTION
# perf(backend): cut redundant passes, hashing, and division from three backends

## Summary

Three constant-factor removals found by a source review of the hot paths, one
per backend.

The density-matrix backend applied every unitary in four passes over its `4^n`
buffer: `U` on the ket register, conjugate the whole buffer, `U` on the bra
register, conjugate again. One-qubit gates now compile to a 4x4 block
superoperator and sweep the buffer once; two-qubit gates with a native
conjugate skip both conjugation passes. `apply_1q_kraus` shares the compiled
path and loses its hand-rolled serial loop.

The sparse backend keyed its amplitude map with SipHash on a path that hashes
twice per non-zero amplitude per gate. The multiply-xor hasher already present
in the shot histogram moves to a shared private module and both use it.

The tensor-network transpose divided once per axis per element on an otherwise
bandwidth-bound copy. The parallel path walks the output index as an odometer
instead, and `contract` stops cloning a whole tensor on the identity
permutation.

The three touch disjoint files and disjoint benchmark groups.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Measured on the dev box (i7-6700K, `--features parallel`, full Criterion).

Separate `cargo bench` invocations are not a valid A/B on this host. Baseline
and after runs taken minutes apart drift 8-20% on microsecond rows, and a
byte-identical control group read as high as +98%, because the rebuild and the
editor re-index land between the two measurements. Every number below comes
from building both bench binaries first, then running them back to back with no
source edits in between. `density_matrix/neutrality/22` is the control: an
untouched statevector row carried under a touched group name.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| density_matrix/unitary_layers/4 | 24.51 µs | 17.11 µs | -29.5% | yes |
| density_matrix/unitary_layers/8 | 14.18 ms | 6.771 ms | -54.5% | yes |
| density_matrix/unitary_layers/10 | 682.4 ms | 189.4 ms | -72.2% | yes |
| density_matrix/unitary_layers/12 | 13.37 s | 3.776 s | -71.8% | yes |
| density_matrix/neutrality/22 (control) | 188.1 ms | 184.5 ms | -1.9%, no change | yes |
| sparse/random_d10/4 | 5.434 µs | 3.836 µs | -35.3% | yes |
| sparse/random_d10/8 | 224.5 µs | 90.29 µs | -58.0% | yes |
| sparse/random_d10/12 | 105.6 µs | 90.66 µs | -14.9% | yes |
| sparse/random_d10/16 | 8.212 ms | 5.788 ms | -26.9% | yes |
| compare/clifford_d10/sparse/8 | | | -54.6% | yes |
| compare/general_d10/sparse/8 | | | -52.7% | yes |
| tn/random_d10/12 | 497.9 µs | 424.7 µs | -15.4% | yes |
| tn/linear_chain/8 | 2.283 ms | 1.728 ms | -16.8% | yes |
| tn/linear_chain/12 | 2.918 ms | 2.199 ms | -21.6% | yes |
| tn/linear_chain/4 | 151.2 µs | 150.6 µs | -0.5%, no change | yes |
| compiled_sampler_filtered/compile/bell_pairs_500q | 2.648 ms | 2.340 ms | -13.6% | yes |
| compiled_sampler/packed/packed_1000q_10k | | | -6.0% | yes |
| compiled_sampler_filtered/compile/bell_pairs_1000q | | | +3.8% | yes |

Regression verdict: PASS

Three regressions appeared during the work and are fixed in this change. Each
fix is load-bearing, so they are recorded rather than dropped:

- `density_matrix/unitary_layers/4` read +49.1%. The one-qubit block
  superoperator is a dense 4x4 and loses to two cheap passes while the buffer
  is L1-resident. The one-qubit path selects on the statevector kernels'
  existing parallel threshold rather than a new constant.
- `sparse/low_entanglement/20` read +11.8%. The integer hasher drives entropy
  into the high bits while the table indexes on the low bits, so structured
  basis-state keys cluster. A finalizer folding the high half down fixed it,
  and produced most of the `compiled_sampler*` gains above.
- `tn/linear_chain/4` read +7.0%. The odometer's fixed setup does not amortize
  over small tensors, so the sequential path keeps direct index computation and
  only the parallel path uses the odometer.

`sparse/low_entanglement/{8,12,16,20}` cannot be gated on this host. Three
independent A/B pairs on this branch read `/16` at -4.3%, -0.6%, +14.7% and
`/20` at -4.4%, -0.2%, +15.5%, with no consistent sign; they are
tens-of-microsecond rows. Sparse work is gated here on `sparse/random_d10` and
`compare/*/sparse/*`, which reproduced -15% to -66% across all three pairs.

## Correctness

- [x] Test suite passes locally: 1907 tests, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps` passes
- [x] New public API has docstrings (none added; every new item is crate-private)
- [x] Backend change has golden tests against the statevector backend
- [x] GPU golden suite runs green

Feature scope: run as `--features "parallel gpu"`, not `--all-features`. The
MPI feature does not build on this host, which lacks libclang for the bindgen
step. Nothing in this change sits behind an MPI feature gate.

Existing coverage carries the change rather than new tests. The density-matrix
path is pinned by `dm_random_layers_match_statevector`,
`dm_two_qubit_gates_match_statevector`, `dm_qft_matches_statevector`, the Kraus
and two-qubit depolarizing analytic cases, and the noisy expectation-value
closed-form checks, all of which compare against the statevector backend or an
analytic result. The generated cross-backend matrix covers sparse and tensor
network against the same oracle.

One hazard was found in review and closed before the change settled. The
one-qubit fast path first selected on `Gate::num_qubits() == 1`, which is not
the same set as "has a 2x2 matrix": `num_qubits` reports 1 for a `BatchPhase`
with no phases, a single-qubit `DiagonalBatch`, and `QftBlock { num: 1 }`, and
`matrix_2x2` panics on all three. Selection is now an explicit variant list
matching the statevector dispatch, and anything outside it falls through to the
general path.

## Hotspot notes

Functions changed, all on per-amplitude or per-element paths:

- `DensityMatrixBackend::apply_unitary` and `apply_1q_kraus`. One pass for
  one-qubit gates above the parallel threshold, via a 4x4 block superoperator
  fed to the existing two-qubit statevector kernel. Two passes otherwise, using
  the gate's native conjugate. The buffer is well past cache at 10 and 12
  qubits, which is why removing passes tracks the measured gain so closely.
- `SparseBackend` state and scratch maps. The hash sat on the inner loop of
  every gate; the one-qubit path takes two hashed lookups per non-zero
  amplitude.
- `tensornetwork::transpose`. Up to six integer divisions per element became
  one decomposition per parallel chunk plus pointer arithmetic. `contract` also
  stopped cloning a whole tensor, data buffer included, on the identity
  permutation.

No profiler output attached. The changes were located by reading the paths, and
each is a counted reduction in passes, divisions, or hash operations rather
than a redistribution of time, so the benchmark deltas are the evidence.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

Not structural. The density-matrix module docs are updated in place, since
describing gate application as a conjugate sandwich no longer matches the code.
No backend gained or lost a capability, and dispatch is untouched.

## Breaking changes

None. No public item changed signature or visibility. `apply_fused_2q` widened
from `pub(super)` to `pub(crate)`, and the integer hasher moved to a new private
`crate::hash` module shared by the sparse backend and the shot histogram. Both
are crate-internal.

One behavioral note that is not a breakage: changing the hasher changes
iteration order of the sparse amplitude map, so floating-point summation order
in `masked_prob` changes with it. That sum was already order-nondeterministic
under the parallel feature, and the seeded golden and equivalence tests hold.

## Risks and rollback

Blast radius is three backends, two of them explicit-dispatch only. The sparse
backend is reachable from automatic dispatch on the oversize sparse-friendly
route, and the shared hasher reaches the shot histogram, which is the
widest-reaching piece here and the reason the compiled sampler groups are
measured above.

There is no feature flag or dispatch guard, and the three changes are now a
single commit, so rollback is a revert of the whole change. They touch disjoint
files, so a partial revert by file is available if only one proves at fault.

The residual risk worth naming is the one-qubit density-matrix crossover. It is
tied to the statevector parallel threshold, which brackets the measured rows at
4 and 8 qubits but is not itself calibrated for this backend. Circuits sitting
between those points are correct either way and take at worst the two-pass
path, which is still half the previous cost.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale (none added; the existing integer
      hasher was reused rather than pulling in a crate)
- [ ] CI is green
