### PR TITLE
fix: drop the serialization feature that never had an implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   # Features exercised on runners without CUDA. The `gpu` feature links against CUDA via
   # cudarc's dynamic-linking mode and can't build on hosts that don't have the NVIDIA
   # toolkit installed, so CI enumerates features instead of using --all-features.
-  CI_FEATURES: parallel,serialization
+  CI_FEATURES: parallel
   CI_BENCH_FEATURES: parallel,bench-fast
   REGRESSION_THRESHOLD: ${{ vars.REGRESSION_THRESHOLD || '5.0' }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,8 +1131,6 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "serde",
- "serde_json",
  "smallvec",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ smallvec = "1"
 thiserror = "2"
 rayon = { version = "1.12", optional = true }
 num_cpus = { version = "1", optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
 faer = { version = "0.24", optional = true, default-features = false, features = ["std", "rayon", "linalg"] }
 cudarc = { version = "0.19", optional = true, default-features = false, features = ["cuda-12040", "dynamic-linking", "driver", "nvrtc", "std"] }
 mpi = { version = "0.8", optional = true }
@@ -38,7 +36,6 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [features]
 default = ["parallel"]
 parallel = ["rayon", "num_cpus", "faer"]
-serialization = ["serde", "serde_json"]
 gpu = ["dep:cudarc"]
 distributed = []
 distributed-mpi = ["distributed", "dep:mpi"]

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -23,7 +23,6 @@ version by hand instead, take it from
 | Feature | Default | Enables |
 |---------|---------|---------|
 | `parallel` | yes | Rayon parallel kernels (≥14 qubits) and the faer SVD path for MPS |
-| `serialization` | no | `serde` derives for circuits and results |
 | `gpu` | no | Optional CUDA backend (see the [GPU guide](../guides/gpu.md)) |
 | `distributed` | no | Statevector partitioning across ranks (see [Capabilities](../guides/capabilities.md)) |
 | `distributed-mpi` | no | `distributed` plus the MPI transport |


### PR DESCRIPTION
Cargo.toml declared `serialization = ["serde", "serde_json"]`, but `serde` appeared zero times in src/. No derive, no cfg_attr, no gated module. Enabling the feature compiled two extra crates and changed no behaviour, so the crate advertised a capability it did not have.

CI compounded this by running the whole suite under `CI_FEATURES: parallel,serialization`, which read as coverage of a flag with no effect. That variable is now `parallel`.

Implementing serde instead was rejected. Eight of the twenty-two Gate variants are fusion artifacts rather than gates anyone writes: Fused, BatchPhase, BatchRzz, DiagonalBatch, MultiFused, Fused2q, Multi2q, and QftBlock. Deriving Serialize across the enum would publish those internals as a wire format and put a compatibility constraint on the 16-byte enum whose payload layout is reshaped for cache reasons. Circuit export belongs in an OpenQASM writer, where the format is an existing standard.

Removing a cargo feature breaks any dependent that named it. Drop `features = ["serialization"]` from the dependency entry; nothing else is required, since the feature gated no code.

