### PR TITLE
feat(backend): sample shots and observables without a dense vector

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -656,6 +656,63 @@ fn bench_mps_hotspots(c: &mut Criterion) {
     group.finish();
 }
 
+// ---- Native shot sampling on the polynomial-state backends ----
+
+/// Terminal measurements on every qubit, the shape the native samplers serve.
+fn measure_all(circuit: &Circuit) -> Circuit {
+    let mut measured = Circuit::new(circuit.num_qubits, circuit.num_qubits);
+    measured.instructions = circuit.instructions.clone();
+    for q in 0..circuit.num_qubits {
+        measured.add_measure(q, q);
+    }
+    measured
+}
+
+/// Sizes past the dense probability cap, where the sampler is the only path to
+/// a bitstring. The 24q row stays inside the cap so the polynomial cost can be
+/// read against the dense route on the same circuit family.
+const SAMPLING_QUBITS: [usize; 4] = [24, 32, 48, 64];
+
+const SAMPLING_SHOTS: usize = 1_000;
+
+fn bench_mps_sampling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mps/sampling");
+    configure_group(&mut group);
+
+    for &n in &SAMPLING_QUBITS {
+        let circuit = measure_all(&dense_entanglement_circuit(n, 4));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    run_shots_with(
+                        BackendKind::Mps { max_bond_dim: 32 },
+                        circ,
+                        SAMPLING_SHOTS,
+                        SEED,
+                    )
+                    .unwrap(),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_sparse_sampling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse/sampling");
+    configure_group(&mut group);
+
+    for &n in &SAMPLING_QUBITS {
+        let circuit = measure_all(&sparse_entanglement_circuit(n, 2));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(run_shots_with(BackendKind::Sparse, circ, SAMPLING_SHOTS, SEED).unwrap())
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Product state backend ----
 
 fn bench_product_scaling(c: &mut Criterion) {
@@ -1687,10 +1744,12 @@ criterion_group!(
     // Sparse
     bench_sparse_scaling,
     bench_sparse_low_entanglement,
+    bench_sparse_sampling,
     // MPS
     bench_mps_scaling,
     bench_mps_linear_chain,
     bench_mps_hotspots,
+    bench_mps_sampling,
     // Product state
     bench_product_scaling,
     // Tensor network

--- a/docs/architecture/samplers.md
+++ b/docs/architecture/samplers.md
@@ -45,6 +45,45 @@ syndrome extraction avoids per-shot tableau replay. The sampler can return
 packed measurements, packed detectors, packed observables, detector counts, or
 feed packed detector chunks into any `ShotAccumulator`.
 
+## Native backend sampling (`Backend::sample_basis_states`)
+
+The compiled samplers above cover Clifford circuits. Everything else used to
+funnel through `Backend::probabilities()`, a dense `2^n` allocation, and sample
+from that, which put a hard qubit ceiling on shots for backends whose state is
+polynomial.
+
+Two `Backend` hooks lift it. `supports_native_sampling` declares that a backend
+draws outcomes from its own representation, and `sample_basis_states(num_shots,
+seed)` returns packed per-qubit outcomes as `BasisSamples`
+(`ceil(n / 64)` words per shot). Seeding is from the argument, not the backend's
+RNG, so a shot request replays exactly, and the call does not collapse the
+state. `supports_pauli_expectation` and `pauli_expectations(observables)` are
+the observable-side pair, normalization independent so a truncated MPS is
+divided by `⟨ψ|ψ⟩` rather than assumed unit.
+
+| Backend | Sampling cost | Method |
+|---------|---------------|--------|
+| Sparse | `O(k log k)` once, `O(log k)` per shot | CDF over the `k` stored amplitudes, ordered by basis index |
+| Factored | `O(Σ 2^kᵢ)` once, `O(B log)` per shot | One draw per sub-state, concatenated; `B` blocks |
+| MPS | `O(n·χ³)` once, `O(n·χ²)` per shot | Sequential conditional sampling against precomputed right environments |
+| Everything else | dense | Unchanged: `probabilities()` then CDF |
+
+`run_shots_with` picks the native path through `try_native_terminal_backend`,
+which requires the route to land on a single backend and probes the capability
+before `init`, so a backend without one costs an allocation and nothing else.
+`run_counts_with` needs no separate path: its tail is `run_shots_with(..).counts()`.
+
+MPS records each bit against the logical qubit currently hosted at a site rather
+than the site index, so a layout permuted by SWAP routing needs no
+canonicalization pass. `tests/native_sampling.rs` pins that case; the exact
+check that the conditional decomposition reproduces the dense vector to 1e-12
+lives in `mps_conditional_path_probabilities_match_the_dense_vector`
+(`src/backend/mps.rs`), and the corpus-wide comparison is the query matrix in
+`tests/conformance_matrix.rs`.
+
+The tensor network stays on the dense route by decision, not by omission; its
+module docstring records why.
+
 ## Noisy compiled sampler (`src/sim/noise.rs`)
 
 Backward Pauli propagation through circuit + noise sensitivity analysis. Each noise location gets an X-flip and Z-flip sensitivity row. During sampling, Bernoulli coin flips determine which noise channels fire, then XOR the sensitivity rows into the sample.

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -47,6 +47,33 @@ Notes:
   including gates, measurement, reset, and multi-shot sampling without gathering
   the dense state. Use `simulate(&circuit).distributed(context)`.
 
+## Shot and observable queries above the dense cap
+
+`simulate(...).shots(n)`, `.sample_counts(n)`, and `.expectation_values(...)`
+answer from a dense `2^n` vector unless the backend carries its own path. The
+dense route is capped by system memory (roughly 29 qubits on a 16 GiB host; see
+`PRISM_MAX_SV_QUBITS`). Backends marked `Native` below answer without it and are
+bounded only by their own representation.
+
+| Backend | Shots and counts | Expectation values |
+| --- | --- | --- |
+| Sparse | Native, CDF over the stored amplitudes | Native, `O(k)` over the amplitude map |
+| MPS | Native, sequential conditional sampling | Native, one chain contraction per observable |
+| Factored | Native, one draw per sub-state | Native, product over the blocks |
+| Statevector | Dense (streams from amplitudes, no probability vector) | Dense |
+| Stabilizer, Factored Stabilizer | Compiled Clifford sampler | Sparse Pauli Dynamics, exact |
+| Stochastic / Deterministic Pauli | Not applicable | Native Pauli propagation |
+| Tensor Network, Product State, Density Matrix | Dense | Rejected, naming the backend |
+
+Native sampling is deterministic from the seed alone: the same seed and shot
+count reproduce the same bitstrings. It is not shot-for-shot identical to the
+dense route, which consumes its randomness on a different schedule; the
+distributions agree.
+
+Backends without an observable path return `BackendUnsupported` naming
+themselves, so a rejected request says which engine could not serve it rather
+than blaming the route that selected it.
+
 ## Not yet supported
 
 | Target | Status | Notes |

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -16,10 +16,13 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::backend::simd;
 use crate::backend::statevector::insert_zero_bit;
-use crate::backend::{Backend, is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
+use crate::backend::{
+    Backend, BasisSamples, is_phase_one, measurement_inv_norm, sorted_mcu_qubits,
+};
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::{DiagEntry, Gate};
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 
 #[cfg(feature = "parallel")]
 use crate::backend::statevector::SendPtr;
@@ -510,6 +513,45 @@ impl FactoredBackend {
             }
         }
     }
+
+    /// Reduce a joint Pauli observable to per-sub-state masks in local qubit
+    /// coordinates. Rejects out-of-range qubits and duplicate factors.
+    fn substate_pauli_masks(&self, observable: &[PauliTerm]) -> Result<Vec<(usize, usize, u32)>> {
+        let mut masks = vec![(0usize, 0usize, 0u32); self.substates.len()];
+        let mut seen = vec![false; self.num_qubits];
+        for term in observable {
+            if term.qubit >= self.num_qubits {
+                return Err(crate::error::PrismError::InvalidQubit {
+                    index: term.qubit,
+                    register_size: self.num_qubits,
+                });
+            }
+            if seen[term.qubit] {
+                return Err(crate::error::PrismError::InvalidParameter {
+                    message: format!(
+                        "joint Pauli observable has duplicate factor on qubit {}",
+                        term.qubit
+                    ),
+                });
+            }
+            seen[term.qubit] = true;
+
+            let ss = self.qubit_to_substate[term.qubit];
+            let sub = self.substates[ss].as_ref().unwrap();
+            let bit = 1usize << Self::local_qubit(sub, term.qubit);
+            let entry = &mut masks[ss];
+            match term.axis {
+                PauliAxis::X => entry.0 |= bit,
+                PauliAxis::Z => entry.1 |= bit,
+                PauliAxis::Y => {
+                    entry.0 |= bit;
+                    entry.1 |= bit;
+                    entry.2 += 1;
+                }
+            }
+        }
+        Ok(masks)
+    }
 }
 
 impl Backend for FactoredBackend {
@@ -640,6 +682,72 @@ impl Backend for FactoredBackend {
 
     fn num_qubits(&self) -> usize {
         self.num_qubits
+    }
+
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Draws one local index per sub-state and concatenates them, so the cost
+    /// is the sum of the block dimensions rather than their product.
+    ///
+    /// Blocks are visited in slot order and each consumes one draw per shot,
+    /// which is the order and the count the dense factored sampler uses.
+    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let blocks: Vec<(Vec<f64>, &[usize])> = self
+            .substates
+            .iter()
+            .filter_map(|opt| opt.as_ref())
+            .map(|sub| {
+                let mut probs = vec![0.0_f64; sub.state.len()];
+                simd::norm_sqr_to_slice(&sub.state, &mut probs);
+                (crate::sim::shots::build_cdf(&probs), sub.qubits.as_slice())
+            })
+            .collect();
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut samples = BasisSamples::new(num_shots, self.num_qubits);
+        for shot in 0..num_shots {
+            for (cdf, qubits) in &blocks {
+                let r: f64 = rng.random();
+                let local = crate::sim::shots::sample_from_cdf(cdf, r);
+                for (bit, &qubit) in qubits.iter().enumerate() {
+                    if (local >> bit) & 1 == 1 {
+                        samples.set(shot, qubit);
+                    }
+                }
+            }
+        }
+        Ok(samples)
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// A joint Pauli factorizes across independent sub-states, so the value is
+    /// the product of the per-block expectations. Blocks the observable does
+    /// not touch contribute one and are skipped.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        observables
+            .iter()
+            .map(|observable| {
+                let masks = self.substate_pauli_masks(observable)?;
+                let mut product = 1.0f64;
+                for (ss, slot) in self.substates.iter().enumerate() {
+                    let Some(sub) = slot else { continue };
+                    let (xmask, zmask, num_y) = masks[ss];
+                    if xmask == 0 && zmask == 0 {
+                        continue;
+                    }
+                    let norm: f64 = sub.state.iter().map(|amp| amp.norm_sqr()).sum();
+                    product *= crate::sim::pauli_expectation_from_masks(
+                        &sub.state, xmask, zmask, num_y, norm,
+                    );
+                }
+                Ok(product)
+            })
+            .collect()
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -41,6 +41,7 @@ use num_complex::Complex64;
 
 use crate::circuit::Instruction;
 use crate::error::Result;
+use crate::sim::unified_pauli::PauliTerm;
 
 pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
 
@@ -130,6 +131,50 @@ pub(crate) fn sorted_mcu_qubits(controls: &[usize], target: usize, buf: &mut [us
     buf[controls.len()] = target;
     buf[..n].sort_unstable();
     n
+}
+
+/// Packed measurement outcomes produced by [`Backend::sample_basis_states`].
+///
+/// Holds `num_qubits.div_ceil(64)` words per shot; bit `q % 64` of word
+/// `q / 64` carries the outcome for qubit `q`. Packed rather than one index
+/// per shot because MPS and the factored backend run past 64 qubits, which is
+/// the regime the native samplers exist for.
+#[derive(Debug, Clone)]
+pub struct BasisSamples {
+    words: Vec<u64>,
+    words_per_shot: usize,
+}
+
+impl BasisSamples {
+    pub(crate) fn new(num_shots: usize, num_qubits: usize) -> Self {
+        let words_per_shot = num_qubits.div_ceil(64).max(1);
+        Self {
+            words: vec![0u64; num_shots * words_per_shot],
+            words_per_shot,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn set(&mut self, shot: usize, qubit: usize) {
+        self.words[shot * self.words_per_shot + qubit / 64] |= 1u64 << (qubit % 64);
+    }
+
+    /// Record a whole shot from a basis-state index, for backends that key
+    /// their state by one. A `usize` index never spans more than one word.
+    #[inline(always)]
+    pub(crate) fn set_index(&mut self, shot: usize, index: usize) {
+        self.words[shot * self.words_per_shot] = index as u64;
+    }
+
+    pub fn num_shots(&self) -> usize {
+        self.words.len() / self.words_per_shot
+    }
+
+    #[inline(always)]
+    pub fn bit(&self, shot: usize, qubit: usize) -> bool {
+        let word = self.words[shot * self.words_per_shot + qubit / 64];
+        (word >> (qubit % 64)) & 1 == 1
+    }
 }
 
 /// Trait that all simulation backends must implement.
@@ -256,6 +301,48 @@ pub trait Backend {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
             operation: "reset".to_string(),
+        })
+    }
+
+    /// Whether [`Backend::sample_basis_states`] draws from this backend's own
+    /// representation.
+    ///
+    /// `false` routes shot and count queries through the dense probability
+    /// vector, which caps them at the machine's dense-output budget. Backends
+    /// holding a polynomial-size representation override both this and
+    /// [`Backend::sample_basis_states`].
+    fn supports_native_sampling(&self) -> bool {
+        false
+    }
+
+    /// Draw `num_shots` computational-basis outcomes from the current state.
+    ///
+    /// Seeded from `seed` alone rather than from the backend's own RNG, so a
+    /// shot request replays exactly. Does not collapse the state. The default
+    /// reports that the backend has no native sampler.
+    fn sample_basis_states(&self, _num_shots: usize, _seed: u64) -> Result<BasisSamples> {
+        Err(crate::error::PrismError::BackendUnsupported {
+            backend: self.name().to_string(),
+            operation: "native basis-state sampling".to_string(),
+        })
+    }
+
+    /// Whether [`Backend::pauli_expectations`] evaluates observables on this
+    /// backend's own representation.
+    fn supports_pauli_expectation(&self) -> bool {
+        false
+    }
+
+    /// Exact `⟨ψ|P_k|ψ⟩` for each joint Pauli observable `P_k`.
+    ///
+    /// Each observable lists one factor per non-identity qubit; omitted qubits
+    /// carry identity. Normalization independent, so implementors divide by
+    /// `⟨ψ|ψ⟩` rather than assuming a unit-norm state. Duplicate factors on one
+    /// qubit are rejected.
+    fn pauli_expectations(&self, _observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        Err(crate::error::PrismError::BackendUnsupported {
+            backend: self.name().to_string(),
+            operation: "Pauli expectation values".to_string(),
         })
     }
 

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -35,12 +35,13 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
 use crate::backend::{
-    Backend, NORM_CLAMP_MIN, dense_probability_len, dense_statevector_len, reserve_dense_output,
-    simd,
+    Backend, BasisSamples, NORM_CLAMP_MIN, dense_probability_len, dense_statevector_len,
+    reserve_dense_output, simd,
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::Gate;
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -1476,6 +1477,66 @@ impl MpsBackend {
         env
     }
 
+    /// Absorb one site into a right environment, in the two passes
+    /// [`Self::inner_product`] uses: `O(χ³)` instead of the four-index sum's
+    /// `O(χ⁴)`. `tmp` carries the intermediate across a sweep so the inner
+    /// buffer is allocated once rather than per site.
+    ///
+    /// [`Self::compute_right_env`] deliberately keeps the four-index form
+    /// instead of calling this. Its callers are measurement and reset, where
+    /// projection has just zeroed half of each site tensor and the environments
+    /// are mostly zero; the `env_val == ZERO` skip there beats dense `O(χ³)`
+    /// arithmetic by 14% on `mps/hotspots/measure_reset_32q_r3` (496 µs against
+    /// 574 µs). The sweep below runs on unprojected chains where the
+    /// environments are dense and the asymptotics decide instead. Measure both
+    /// before unifying them.
+    fn contract_right_env(
+        &self,
+        site: usize,
+        env: &[Complex64],
+        tmp: &mut Vec<Complex64>,
+    ) -> Vec<Complex64> {
+        let t = &self.sites[site];
+        let bl = t.bond_left;
+        let br = t.bond_right;
+
+        // tmp[α, i, β'] = Σ_β A[α, i, β] · env[β, β']
+        tmp.clear();
+        tmp.resize(bl * 2 * br, ZERO);
+        for alpha in 0..bl {
+            for i in 0..2 {
+                for beta in 0..br {
+                    let a = t.data[t.idx(alpha, i, beta)];
+                    if a == ZERO {
+                        continue;
+                    }
+                    let dst = (alpha * 2 + i) * br;
+                    let src = beta * br;
+                    for beta_p in 0..br {
+                        tmp[dst + beta_p] += a * env[src + beta_p];
+                    }
+                }
+            }
+        }
+
+        // new_env[α, α'] = Σ_{i, β'} tmp[α, i, β'] · conj(A[α', i, β'])
+        let mut new_env = vec![ZERO; bl * bl];
+        for alpha_p in 0..bl {
+            for i in 0..2 {
+                for beta_p in 0..br {
+                    let a = t.data[t.idx(alpha_p, i, beta_p)].conj();
+                    if a == ZERO {
+                        continue;
+                    }
+                    for alpha in 0..bl {
+                        new_env[alpha * bl + alpha_p] += tmp[(alpha * 2 + i) * br + beta_p] * a;
+                    }
+                }
+            }
+        }
+        new_env
+    }
+
     fn compute_right_env(&self, site: usize) -> Vec<Complex64> {
         let mut env = vec![ONE];
         let mut env_dim = 1usize;
@@ -1537,6 +1598,24 @@ impl MpsBackend {
             env_dim = bl;
         }
         env
+    }
+
+    /// Right environment of every site, in one backward sweep.
+    ///
+    /// `envs[s]` is what [`Self::compute_right_env`] returns for `s`, but the
+    /// sweep shares each partial contraction with the site to its left, so all
+    /// `n` cost one pass instead of `n`.
+    fn right_environments(&self) -> Vec<Vec<Complex64>> {
+        let n = self.num_qubits;
+        let mut envs: Vec<Vec<Complex64>> = Vec::with_capacity(n);
+        let mut tmp = Vec::new();
+        envs.push(vec![ONE]);
+        for site in (1..n).rev() {
+            let next = self.contract_right_env(site, envs.last().unwrap(), &mut tmp);
+            envs.push(next);
+        }
+        envs.reverse();
+        envs
     }
 
     fn apply_reset(&mut self, qubit: usize) {
@@ -1710,6 +1789,54 @@ impl MpsBackend {
         }
 
         rho
+    }
+
+    /// Conditional outcome weights at `site`, given the boundary vector `left`
+    /// that carries the bits already fixed to its left.
+    ///
+    /// Writes `w[i * bond_right + β] = Σ_α left[α] · A[α, i, β]` into `w` and
+    /// returns the unnormalized weight of each outcome. The conditioned left
+    /// environment is the rank-one `left[α]·conj(left[α'])`, which collapses
+    /// the four-index contraction of [`Self::site_outcome_probabilities`] to
+    /// `O(χ²)`.
+    fn site_conditional_weights(
+        &self,
+        site: usize,
+        left: &[Complex64],
+        right: &[Complex64],
+        w: &mut [Complex64],
+    ) -> [f64; 2] {
+        let t = &self.sites[site];
+        let bl = t.bond_left;
+        let br = t.bond_right;
+
+        let w = &mut w[..2 * br];
+        w.fill(ZERO);
+        for (alpha, &l) in left[..bl].iter().enumerate() {
+            if l == ZERO {
+                continue;
+            }
+            let row = &t.data[alpha * (2 * br)..(alpha + 1) * (2 * br)];
+            for (dst, &src) in w.iter_mut().zip(row) {
+                *dst += l * src;
+            }
+        }
+
+        let mut prob = [0.0f64; 2];
+        for (i, prob_out) in prob.iter_mut().enumerate() {
+            let wi = &w[i * br..(i + 1) * br];
+            let mut acc = ZERO;
+            for (beta, &w_beta) in wi.iter().enumerate() {
+                if w_beta == ZERO {
+                    continue;
+                }
+                let row = &right[beta * br..(beta + 1) * br];
+                let inner: Complex64 = row.iter().zip(wi).map(|(&r, &v)| r * v.conj()).sum();
+                acc += w_beta * inner;
+            }
+            *prob_out = acc.re;
+        }
+        prob
     }
 
     fn chain_amplitude(&self, basis: usize) -> Complex64 {
@@ -1897,6 +2024,92 @@ impl Backend for MpsBackend {
         self.num_qubits
     }
 
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Sequential conditional sampling over the chain: `O(n·χ²)` per shot after
+    /// one `O(n·χ³)` sweep for the right environments.
+    ///
+    /// Sites are visited left to right and each bit is recorded against the
+    /// logical qubit currently hosted there, so a layout permuted by SWAP
+    /// routing needs no canonicalization pass.
+    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let n = self.num_qubits;
+        let mut samples = BasisSamples::new(num_shots, n);
+        if n == 0 {
+            return Ok(samples);
+        }
+
+        let right = self.right_environments();
+        let max_bond = self
+            .sites
+            .iter()
+            .map(|site| site.bond_left.max(site.bond_right))
+            .max()
+            .unwrap_or(1);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut left = vec![ZERO; max_bond];
+        let mut w = vec![ZERO; 2 * max_bond];
+
+        for shot in 0..num_shots {
+            left[0] = ONE;
+            left[1..].fill(ZERO);
+            for (site, right_env) in right.iter().enumerate() {
+                let br = self.sites[site].bond_right;
+                let prob = self.site_conditional_weights(site, &left, right_env, &mut w);
+
+                let total = prob[0] + prob[1];
+                let prob_one = if total > 0.0 {
+                    (prob[1] / total).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
+                let outcome = usize::from(rng.random::<f64>() < prob_one);
+                if outcome == 1 {
+                    samples.set(shot, self.logical_for_site(site));
+                }
+
+                let scale = 1.0 / prob[outcome].max(NORM_CLAMP_MIN).sqrt();
+                left[..br].copy_from_slice(&w[outcome * br..(outcome + 1) * br]);
+                for value in &mut left[..br] {
+                    *value *= scale;
+                }
+            }
+        }
+        Ok(samples)
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// Routes each observable through [`MpsBackend::pauli_expectation`], which
+    /// contracts the chain once per observable. Divided by `⟨ψ|ψ⟩` because a
+    /// truncated chain is not exactly normalized.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let norm = self.pauli_expectation(&[])?.re;
+        observables
+            .iter()
+            .map(|observable| {
+                let factors: Vec<(usize, MpsPauliAxis)> = observable
+                    .iter()
+                    .map(|term| {
+                        let axis = match term.axis {
+                            PauliAxis::X => MpsPauliAxis::X,
+                            PauliAxis::Y => MpsPauliAxis::Y,
+                            PauliAxis::Z => MpsPauliAxis::Z,
+                        };
+                        (term.qubit, axis)
+                    })
+                    .collect();
+                let value = self.pauli_expectation(&factors)?;
+                Ok(if norm == 0.0 { 0.0 } else { value.re / norm })
+            })
+            .collect()
+    }
+
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         let dim = dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
         let mut state = Vec::new();
@@ -1990,6 +2203,63 @@ mod tests {
             sum += amps[x].conj() * (Complex64::new(sign, 0.0) * i_factor) * amps[y];
         }
         sum
+    }
+
+    /// The sampler picks each site from `site_conditional_weights`, so the
+    /// product of the conditionals along a path is the probability it draws
+    /// that path with. Comparing it to the dense vector pins the sampled
+    /// distribution exactly rather than statistically, and covers the
+    /// site-to-logical mapping the SWAP-routed layout leaves behind.
+    #[test]
+    fn mps_conditional_path_probabilities_match_the_dense_vector() {
+        let mut c = Circuit::new(5, 0);
+        for q in 0..5 {
+            c.add_gate(Gate::Ry(0.4 + 0.2 * q as f64), &[q]);
+        }
+        c.add_gate(Gate::Cx, &[0, 3]);
+        c.add_gate(Gate::Cx, &[4, 1]);
+        c.add_gate(Gate::T, &[2]);
+        c.add_gate(Gate::Cx, &[2, 0]);
+        let b = run_mps(&c);
+
+        let dense = b.probabilities().unwrap();
+        let right = b.right_environments();
+        let max_bond = b
+            .sites
+            .iter()
+            .map(|site| site.bond_left.max(site.bond_right))
+            .max()
+            .unwrap();
+
+        for (basis, &expected) in dense.iter().enumerate() {
+            assert!(
+                expected > 1e-6,
+                "basis {basis} carries probability {expected:.3e}; the case is meant to have \
+                 full support so every conditional is exercised"
+            );
+
+            let mut left = vec![ZERO; max_bond];
+            let mut w = vec![ZERO; 2 * max_bond];
+            left[0] = ONE;
+            let mut joint = 1.0f64;
+            for (site, right_env) in right.iter().enumerate() {
+                let br = b.sites[site].bond_right;
+                let prob = b.site_conditional_weights(site, &left, right_env, &mut w);
+                let bit = (basis >> b.logical_for_site(site)) & 1;
+                joint *= prob[bit] / (prob[0] + prob[1]);
+
+                let scale = 1.0 / prob[bit].sqrt();
+                left[..br].copy_from_slice(&w[bit * br..(bit + 1) * br]);
+                for value in &mut left[..br] {
+                    *value *= scale;
+                }
+                left[br..].fill(ZERO);
+            }
+            assert!(
+                (joint - expected).abs() < 1e-12,
+                "basis {basis}: conditional path gives {joint}, dense vector gives {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -30,12 +30,14 @@ use rayon::prelude::*;
 const MIN_STATES_FOR_PAR: usize = 4096;
 
 use crate::backend::{
-    Backend, dense_probability_len, dense_statevector_len, is_phase_one, reserve_dense_output,
+    Backend, BasisSamples, dense_probability_len, dense_statevector_len, is_phase_one,
+    reserve_dense_output,
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
 use crate::gates::{DiagEntry, Gate};
 use crate::hash::FxHashMap;
+use crate::sim::unified_pauli::PauliTerm;
 
 const DEFAULT_EPSILON: f64 = 1e-16;
 
@@ -503,6 +505,63 @@ impl Backend for SparseBackend {
 
     fn num_qubits(&self) -> usize {
         self.num_qubits
+    }
+
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Samples from a CDF over the `k` stored amplitudes instead of `2^n`.
+    ///
+    /// Entries are ordered by basis index, which is the order the dense route
+    /// accumulates its CDF in, so the same seed draws the same basis states
+    /// the dense path would have drawn.
+    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let mut indices: Vec<usize> = self.state.keys().copied().collect();
+        indices.sort_unstable();
+        let probs: Vec<f64> = indices
+            .iter()
+            .map(|idx| self.state[idx].norm_sqr())
+            .collect();
+        let cdf = crate::sim::shots::build_cdf(&probs);
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut samples = BasisSamples::new(num_shots, self.num_qubits);
+        for shot in 0..num_shots {
+            let r: f64 = rng.random();
+            samples.set_index(shot, indices[crate::sim::shots::sample_from_cdf(&cdf, r)]);
+        }
+        Ok(samples)
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let norm: f64 = self.state.values().map(|amp| amp.norm_sqr()).sum();
+        observables
+            .iter()
+            .map(|observable| {
+                let (xmask, zmask, num_y) = crate::sim::pauli_masks(observable, self.num_qubits)?;
+                if norm == 0.0 {
+                    return Ok(0.0);
+                }
+                let mut acc = Complex64::new(0.0, 0.0);
+                for (&idx, &amp) in &self.state {
+                    let Some(&partner) = self.state.get(&(idx ^ xmask)) else {
+                        continue;
+                    };
+                    let sign = if (idx & zmask).count_ones() & 1 == 1 {
+                        -1.0
+                    } else {
+                        1.0
+                    };
+                    acc += partner.conj() * amp * sign;
+                }
+                Ok((acc * crate::sim::i_pow(num_y)).re / norm)
+            })
+            .collect()
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -14,6 +14,29 @@
 //!
 //! Greedy min-size heuristic: repeatedly contract the pair of tensors whose
 //! result has the smallest total element count. O(T²) where T = tensor count.
+//!
+//! # Shot and observable queries stay on the dense route
+//!
+//! Unlike the sparse, MPS, and factored backends, this one does not override
+//! `Backend::sample_basis_states` or `Backend::pauli_expectations`. Both report
+//! `BackendUnsupported` naming this backend, and shots continue to route through
+//! `probabilities()`.
+//!
+//! Sampling one bitstring from a deferred network means contracting it once per
+//! qubit to get each conditional, so a shot costs `n` contractions against the
+//! single contraction the dense route pays for the whole distribution. That is
+//! strictly worse whenever the statevector fits, and when it does not fit the
+//! per-qubit contractions do not fit either: the cost is set by treewidth, which
+//! conditioning does not reduce.
+//!
+//! An exact scalar observable path does exist here, `expectation_zero_state`,
+//! which contracts `⟨0|U†PU|0⟩` without a statevector. It takes a circuit rather
+//! than an evolved backend, and this backend swaps its network for a dense
+//! statevector after any measurement, so reaching it from the trait hook would
+//! need a second contraction path carrying its own bra-side leg bookkeeping.
+//! Auto never selects this backend above the statevector cap (it picks sparse or
+//! MPS), so that path would serve explicit `BackendKind::TensorNetwork` requests
+//! only. Revisit if Auto starts routing wide low-treewidth circuits here.
 
 use std::borrow::Cow;
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -41,7 +41,7 @@ use crate::backend::statevector::StatevectorBackend;
 use crate::backend::{Backend, max_statevector_qubits};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
-use shots::{packed_shots_to_classical_bits, sample_shots};
+use shots::{packed_shots_to_classical_bits, sample_shots, shots_from_basis_samples};
 use terminal_sampling::{
     sample_counts_from_probs, sample_counts_from_state, sample_shots_from_probs,
     sample_shots_from_state,
@@ -240,7 +240,10 @@ impl<'c> Simulate<'c, Seeded> {
     ///
     /// Each observable is a product of single-qubit Paulis (identity factors
     /// omitted). The circuit must be unitary. Clifford circuits propagate each
-    /// observable exactly; non-Clifford circuits use the state vector.
+    /// observable exactly. Non-Clifford circuits use the state vector while they
+    /// fit it; above that cap the selected backend evaluates the observable on
+    /// its own representation, and a backend without one reports
+    /// `BackendUnsupported` naming itself.
     #[inline]
     pub fn expectation_values(self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
         let seed = self.seed_value();
@@ -667,6 +670,38 @@ fn try_terminal_statevector_backend(
     Ok(Some((backend, meas_map)))
 }
 
+/// Build and run the backend for a terminal-measurement circuit when routing
+/// lands on a single backend that samples from its own representation.
+///
+/// Returns `None` when the route is not a direct single backend, or when that
+/// backend has no native sampler, leaving the dense probability path untouched.
+/// The capability is probed before `init`, so a backend without one costs an
+/// allocation and nothing else.
+fn try_native_terminal_backend(
+    kind: &BackendKind,
+    stripped: &Circuit,
+    seed: u64,
+) -> Result<Option<Box<dyn Backend>>> {
+    if !kind.is_auto() {
+        validate_explicit_backend(kind, stripped)?;
+    }
+    let ProbabilityRoute::Direct {
+        has_partial_independence,
+    } = plan_probability_route(kind, stripped)
+    else {
+        return Ok(None);
+    };
+    let ExecutionPlan::Backend(plan) = resolve(kind, stripped, has_partial_independence) else {
+        return Ok(None);
+    };
+    let mut backend = plan.build(seed);
+    if !backend.supports_native_sampling() {
+        return Ok(None);
+    }
+    execute(&mut *backend, stripped, &SimOptions::classical_only())?;
+    Ok(Some(backend))
+}
+
 /// Execute a circuit multiple times with automatic backend selection and return counts.
 ///
 /// Use this when only a frequency histogram is needed. Optimized paths can
@@ -903,14 +938,7 @@ fn run_expectation_values_with(
                     .collect()
             } else if kind.is_auto() {
                 if circuit.num_qubits > max_statevector_qubits() {
-                    return Err(PrismError::IncompatibleBackend {
-                        backend: format!("{kind:?}"),
-                        reason: format!(
-                            "expectation values for a {}-qubit non-Clifford circuit exceed the statevector cap ({} qubits); no exact accelerated path exists for arbitrary Pauli observables here",
-                            circuit.num_qubits,
-                            max_statevector_qubits()
-                        ),
-                    });
+                    return expectation_values_native(&kind, circuit, observables, seed);
                 }
                 expectation_values_statevector(&kind, circuit, observables, seed)
             } else {
@@ -927,17 +955,50 @@ fn run_expectation_values_with(
         BackendKind::StatevectorGpu { .. } => {
             expectation_values_statevector(&kind, circuit, observables, seed)
         }
-        other => {
-            #[cfg(feature = "gpu")]
-            let supported = "expectation values support Auto, AutoGpu, Statevector, StatevectorGpu, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli";
-            #[cfg(not(feature = "gpu"))]
-            let supported = "expectation values support Auto, Statevector, Stabilizer, FactoredStabilizer, StochasticPauli, and DeterministicPauli";
-            Err(PrismError::IncompatibleBackend {
-                backend: format!("{other:?}"),
-                reason: supported.into(),
-            })
-        }
+        other => expectation_values_native(other, circuit, observables, seed),
     }
+}
+
+/// Evaluate `observables` on the backend `kind` resolves to, using that
+/// backend's own representation.
+///
+/// Backends without a native Pauli path report `BackendUnsupported` naming
+/// themselves, so a request that cannot be served says which engine could not
+/// serve it rather than blaming the route that picked it.
+fn expectation_values_native(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    observables: &[Vec<PauliTerm>],
+    seed: u64,
+) -> Result<Vec<f64>> {
+    if !kind.is_auto() {
+        validate_explicit_backend(kind, circuit)?;
+    }
+    // Before the run, matching the statevector path, so a typo in an observable
+    // does not cost a 40-qubit simulation first.
+    for observable in observables {
+        validate_observable(observable, circuit.num_qubits)?;
+    }
+
+    let (_, has_partial_independence) = analyze_independence(circuit);
+    let ExecutionPlan::Backend(plan) = resolve(kind, circuit, has_partial_independence) else {
+        return Err(PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "expectation values need a backend that holds a state; the stabilizer-rank \
+                     route returns probabilities only"
+                .into(),
+        });
+    };
+
+    let mut backend = plan.build(seed);
+    if !backend.supports_pauli_expectation() {
+        return Err(PrismError::BackendUnsupported {
+            backend: backend.name().to_string(),
+            operation: "Pauli expectation values".to_string(),
+        });
+    }
+    execute(&mut *backend, circuit, &SimOptions::classical_only())?;
+    backend.pauli_expectations(observables)
 }
 
 fn expectation_values_statevector(
@@ -977,6 +1038,33 @@ fn expectation_values_statevector(
             pauli_expectation_from_masks(state, xmask, zmask, num_y, norm)
         })
         .collect())
+}
+
+/// Reject out-of-range qubits and duplicate factors in a joint Pauli
+/// observable.
+///
+/// Same checks [`pauli_masks`] makes, without its `1 << qubit` mask width, so
+/// it also covers the backends that run past 64 qubits.
+pub(crate) fn validate_observable(observable: &[PauliTerm], num_qubits: usize) -> Result<()> {
+    let mut seen = vec![false; num_qubits];
+    for term in observable {
+        if term.qubit >= num_qubits {
+            return Err(PrismError::InvalidQubit {
+                index: term.qubit,
+                register_size: num_qubits,
+            });
+        }
+        if seen[term.qubit] {
+            return Err(PrismError::InvalidParameter {
+                message: format!(
+                    "joint Pauli observable has duplicate factor on qubit {}",
+                    term.qubit
+                ),
+            });
+        }
+        seen[term.qubit] = true;
+    }
+    Ok(())
 }
 
 /// Validate a joint Pauli observable and reduce it to `(Xmask, Zmask, #Y)`,
@@ -1231,6 +1319,14 @@ pub(crate) fn run_shots_with(
 
     if circuit.has_terminal_measurements_only() {
         let stripped = circuit.without_measurements();
+        if let Some(backend) = try_native_terminal_backend(&kind, &stripped, seed)? {
+            let samples = backend.sample_basis_states(num_shots, seed)?;
+            let meas_map = circuit.measurement_map();
+            return Ok(ShotsResult::from_shots(
+                shots_from_basis_samples(&samples, &meas_map, circuit.num_classical_bits),
+                circuit.num_classical_bits,
+            ));
+        }
         let result = run_with_internal(kind.clone(), &stripped, seed, SimOptions::default())?;
         if let Some(probs) = result.probabilities {
             let meas_map = circuit.measurement_map();

--- a/src/sim/shots.rs
+++ b/src/sim/shots.rs
@@ -97,7 +97,7 @@ pub fn bitstring(key: &[u64], num_bits: usize) -> String {
     s
 }
 
-pub(super) fn build_cdf(probs: &[f64]) -> Vec<f64> {
+pub(crate) fn build_cdf(probs: &[f64]) -> Vec<f64> {
     let mut cdf = Vec::with_capacity(probs.len());
     let mut acc = 0.0;
     for &p in probs {
@@ -168,6 +168,23 @@ pub(crate) fn sample_shots(
         }
     }
 
+    shots
+}
+
+/// Project packed per-qubit outcomes from a native backend sampler onto
+/// classical bits. Later measurements of the same classical bit win, matching
+/// [`sample_shots`].
+pub(crate) fn shots_from_basis_samples(
+    samples: &crate::backend::BasisSamples,
+    meas_map: &[(usize, usize)],
+    num_classical_bits: usize,
+) -> Vec<Vec<bool>> {
+    let mut shots = vec![vec![false; num_classical_bits]; samples.num_shots()];
+    for (index, shot) in shots.iter_mut().enumerate() {
+        for &(qubit, cbit) in meas_map {
+            shot[cbit] = samples.bit(index, qubit);
+        }
+    }
     shots
 }
 

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -70,6 +70,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use num_complex::Complex64;
+use prism_q::PauliTerm;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
 use prism_q::backend::factored::FactoredBackend;
@@ -885,10 +886,19 @@ pub enum SkipReason {
     FactoredBlocksHaveNoJointState,
     /// Amplitudes are only defined once the trajectory is fixed.
     BranchingTrajectory,
+    /// Outside the query matrices. They cover the backends that gained a path
+    /// from their own state to shots and observables (sparse, MPS, factored)
+    /// plus the statevector they have to agree with. Every other participant is
+    /// a route, or an engine whose query path is unchanged.
+    OutsideQueryMatrix,
+    /// The query matrices append terminal measurements and call the
+    /// unitary-only expectation API, neither of which a circuit that already
+    /// measures, resets, or conditions can carry.
+    QueryNeedsUnitaryCircuit,
 }
 
 impl SkipReason {
-    pub const ALL: [SkipReason; 15] = [
+    pub const ALL: [SkipReason; 17] = [
         SkipReason::NonClifford,
         SkipReason::EntanglingGates,
         SkipReason::StabilizerRankNoTGates,
@@ -904,6 +914,8 @@ impl SkipReason {
         SkipReason::NoAmplitudeExport,
         SkipReason::FactoredBlocksHaveNoJointState,
         SkipReason::BranchingTrajectory,
+        SkipReason::OutsideQueryMatrix,
+        SkipReason::QueryNeedsUnitaryCircuit,
     ];
 
     pub const fn name(self) -> &'static str {
@@ -923,6 +935,8 @@ impl SkipReason {
             SkipReason::NoAmplitudeExport => "no_amplitude_export",
             SkipReason::FactoredBlocksHaveNoJointState => "factored_blocks_have_no_joint_state",
             SkipReason::BranchingTrajectory => "branching_trajectory",
+            SkipReason::OutsideQueryMatrix => "outside_query_matrix",
+            SkipReason::QueryNeedsUnitaryCircuit => "query_needs_unitary_circuit",
         }
     }
 }
@@ -955,12 +969,31 @@ pub struct Participant {
     exec: Executor,
     rules: fn(&CaseProfile) -> Eligibility,
     export_rules: fn(&CaseProfile) -> Eligibility,
+    /// Backend kind the shot and observable queries are driven through, for the
+    /// participants the query matrices cover. `None` keeps the participant out
+    /// of them.
+    query_kind: Option<BackendKind>,
     pub anchor: Option<Anchor>,
 }
 
 impl Participant {
     pub fn eligibility(&self, profile: &CaseProfile) -> Eligibility {
         (self.rules)(profile)
+    }
+
+    /// Query comparison narrows the probability rule: the participant has to be
+    /// in the matrix and the circuit has to be unitary.
+    pub fn query_eligibility(&self, profile: &CaseProfile) -> Eligibility {
+        match self.eligibility(profile) {
+            Eligibility::Skip(reason) => Eligibility::Skip(reason),
+            Eligibility::Compare if self.query_kind.is_none() => {
+                Eligibility::Skip(SkipReason::OutsideQueryMatrix)
+            }
+            Eligibility::Compare if !profile.unitary() => {
+                Eligibility::Skip(SkipReason::QueryNeedsUnitaryCircuit)
+            }
+            Eligibility::Compare => Eligibility::Compare,
+        }
     }
 
     /// Amplitude comparison narrows the probability rule: the trajectory has to
@@ -1080,6 +1113,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(StatevectorBackend::new(s))),
             rules: always,
             export_rules: always,
+            query_kind: Some(BackendKind::Statevector),
             anchor: None,
         },
         Participant {
@@ -1087,6 +1121,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(SparseBackend::new(s))),
             rules: always,
             export_rules: always,
+            query_kind: Some(BackendKind::Sparse),
             anchor: None,
         },
         Participant {
@@ -1094,6 +1129,9 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Mps,
             rules: mps_rules,
             export_rules: always,
+            query_kind: Some(BackendKind::Mps {
+                max_bond_dim: MPS_MAX_BOND,
+            }),
             anchor: None,
         },
         Participant {
@@ -1101,6 +1139,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(TensorNetworkBackend::new(s))),
             rules: tensor_network_rules,
             export_rules: always,
+            query_kind: None,
             anchor: None,
         },
         Participant {
@@ -1108,6 +1147,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(FactoredBackend::new(s))),
             rules: always,
             export_rules: no_state_export,
+            query_kind: Some(BackendKind::Factored),
             anchor: None,
         },
         Participant {
@@ -1115,6 +1155,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(StabilizerBackend::new(s))),
             rules: stabilizer_rules,
             export_rules: always,
+            query_kind: None,
             anchor: Some(Anchor::Tableau),
         },
         Participant {
@@ -1122,6 +1163,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(FactoredStabilizerBackend::new(s))),
             rules: stabilizer_rules,
             export_rules: factored_stabilizer_export,
+            query_kind: None,
             anchor: Some(Anchor::Tableau),
         },
         Participant {
@@ -1129,6 +1171,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(ProductStateBackend::new(s))),
             rules: product_rules,
             export_rules: always,
+            query_kind: None,
             anchor: None,
         },
         Participant {
@@ -1136,6 +1179,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(DensityMatrixBackend::new(s))),
             rules: density_matrix_rules,
             export_rules: no_state_export,
+            query_kind: None,
             anchor: Some(Anchor::Channel),
         },
         Participant {
@@ -1143,6 +1187,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Route(run_auto),
             rules: always,
             export_rules: no_state_export,
+            query_kind: None,
             anchor: None,
         },
         Participant {
@@ -1150,6 +1195,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Route(run_decomposition),
             rules: decomposition_rules,
             export_rules: no_state_export,
+            query_kind: None,
             anchor: None,
         },
         Participant {
@@ -1157,23 +1203,27 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Route(run_stabilizer_rank),
             rules: stabilizer_rank_rules,
             export_rules: no_state_export,
+            query_kind: None,
             anchor: None,
         },
     ]
 }
 
-/// Which skip rules the corpus fires, over both the probability matrix and the
-/// amplitude matrix, with counts.
+/// Which skip rules the corpus fires, over the probability, amplitude, and
+/// query matrices, with counts.
 pub fn skip_ledger() -> BTreeMap<SkipReason, usize> {
     let mut ledger: BTreeMap<SkipReason, usize> = BTreeMap::new();
     let participants = participants();
     for case in generated_cases() {
         for participant in &participants {
-            if let Eligibility::Skip(reason) = participant.eligibility(&case.profile) {
-                *ledger.entry(reason).or_default() += 1;
-            }
-            if let Eligibility::Skip(reason) = participant.amplitude_eligibility(&case.profile) {
-                *ledger.entry(reason).or_default() += 1;
+            for eligibility in [
+                participant.eligibility(&case.profile),
+                participant.amplitude_eligibility(&case.profile),
+                participant.query_eligibility(&case.profile),
+            ] {
+                if let Eligibility::Skip(reason) = eligibility {
+                    *ledger.entry(reason).or_default() += 1;
+                }
             }
         }
     }
@@ -1196,9 +1246,13 @@ pub fn matrix_report() -> String {
                 Eligibility::Compare => "compare".to_string(),
                 Eligibility::Skip(reason) => format!("skip:{}", reason.name()),
             };
+            let query = match participant.query_eligibility(&case.profile) {
+                Eligibility::Compare => "compare".to_string(),
+                Eligibility::Skip(reason) => format!("skip:{}", reason.name()),
+            };
             writeln!(
                 out,
-                "  {:<20} probs {:<34} amps {amps}",
+                "  {:<20} probs {:<34} amps {amps:<34} query {query}",
                 participant.name, probs
             )
             .unwrap();
@@ -1555,6 +1609,171 @@ pub fn assert_amplitudes(case: &GeneratedCase, participants: &[Participant]) {
                         "{}amplitude[{i}]: `{}` gave {got}, `{name}` gave {want} \
                          (diff {diff:.2e}, eps {AMP_EPS:.0e})",
                         case.context(),
+                        participant.name
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ---- Query matrices ----
+
+/// Shots drawn per participant in the sampling matrix.
+pub const QUERY_SHOTS: usize = 8_000;
+
+/// Reference probability below which an outcome must never be sampled. Far
+/// above the amplitude noise floor of every participant and far below the
+/// smallest weight any generated case puts on a reachable outcome.
+pub const SAMPLING_SUPPORT_FLOOR: f64 = 1e-12;
+
+/// Band on a sampled frequency: four binomial standard errors at
+/// [`QUERY_SHOTS`] draws, plus a floor so a near-deterministic outcome does not
+/// demand an exact hit.
+fn sampling_band(p: f64) -> f64 {
+    4.0 * (p * (1.0 - p) / QUERY_SHOTS as f64).sqrt() + 0.004
+}
+
+/// Observables the expectation matrix compares, fixed by qubit count so every
+/// participant on a case is asked the same questions. Mixes all three axes and
+/// includes the identity and a full-width string.
+pub fn query_observables(num_qubits: usize) -> Vec<Vec<PauliTerm>> {
+    let mut observables = vec![vec![], vec![PauliTerm::z(0)]];
+    if num_qubits >= 2 {
+        observables.push(vec![PauliTerm::x(0), PauliTerm::z(num_qubits - 1)]);
+        observables.push(vec![PauliTerm::y(0), PauliTerm::y(num_qubits - 1)]);
+    }
+    observables.push(
+        (0..num_qubits)
+            .map(|q| match q % 3 {
+                0 => PauliTerm::x(q),
+                1 => PauliTerm::y(q),
+                _ => PauliTerm::z(q),
+            })
+            .collect(),
+    );
+    observables
+}
+
+fn with_terminal_measurements(circuit: &Circuit) -> Circuit {
+    let mut measured = Circuit::new(circuit.num_qubits, circuit.num_qubits);
+    measured.instructions = circuit.instructions.clone();
+    for q in 0..circuit.num_qubits {
+        measured.add_measure(q, q);
+    }
+    measured
+}
+
+/// Shots from every participant in the query matrix, checked against that
+/// participant's own probability vector.
+///
+/// Support is exact: an outcome the state cannot produce is a failure however
+/// rare. The frequency comparison is the one statistical check in the harness,
+/// and its band is stated rather than tuned until green.
+pub fn assert_native_sampling(case: &GeneratedCase, participants: &[Participant]) {
+    for participant in participants {
+        if !participant.query_eligibility(&case.profile).is_compared() {
+            continue;
+        }
+        let kind = participant.query_kind.clone().unwrap();
+        let reference = run_or_fail(participant, case, CONFORMANCE_SEED, false).probs;
+        let measured = with_terminal_measurements(&case.circuit);
+
+        let result = sim::simulate(&measured)
+            .backend(kind.clone())
+            .seed(CONFORMANCE_SEED)
+            .shots(QUERY_SHOTS)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{}participant `{}` is in the query matrix but shot sampling failed: {err}",
+                    case.context(),
+                    participant.name
+                )
+            });
+
+        let mut counts = vec![0usize; reference.len()];
+        for shot in &result.shots {
+            let index: usize = shot
+                .iter()
+                .enumerate()
+                .filter(|&(_, &bit)| bit)
+                .map(|(q, _)| 1usize << q)
+                .sum();
+            counts[index] += 1;
+        }
+
+        for (index, &count) in counts.iter().enumerate() {
+            if count == 0 {
+                continue;
+            }
+            assert!(
+                reference[index] > SAMPLING_SUPPORT_FLOOR,
+                "{}`{}` sampled basis state {index} {count} times, but its own probability \
+                 vector puts {:.3e} there",
+                case.context(),
+                participant.name,
+                reference[index]
+            );
+            let frequency = count as f64 / QUERY_SHOTS as f64;
+            let band = sampling_band(reference[index]);
+            assert!(
+                (frequency - reference[index]).abs() < band,
+                "{}`{}` sampled basis state {index} at {frequency:.6} against its own \
+                 probability {:.6} (band {band:.6} at {QUERY_SHOTS} shots)",
+                case.context(),
+                participant.name,
+                reference[index]
+            );
+        }
+
+        let replay = sim::simulate(&measured)
+            .backend(kind)
+            .seed(CONFORMANCE_SEED)
+            .shots(QUERY_SHOTS)
+            .unwrap();
+        assert_eq!(
+            result.shots,
+            replay.shots,
+            "{}`{}` produced different shots from the same seed",
+            case.context(),
+            participant.name
+        );
+    }
+}
+
+/// Expectation values from every participant in the query matrix, compared
+/// against each other at [`PROB_EPS`].
+pub fn assert_expectation_values(case: &GeneratedCase, participants: &[Participant]) {
+    let observables = query_observables(case.circuit.num_qubits);
+    let mut reference: Option<(&'static str, Vec<f64>)> = None;
+
+    for participant in participants {
+        if !participant.query_eligibility(&case.profile).is_compared() {
+            continue;
+        }
+        let values = sim::simulate(&case.circuit)
+            .backend(participant.query_kind.clone().unwrap())
+            .seed(CONFORMANCE_SEED)
+            .expectation_values(&observables)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{}participant `{}` is in the query matrix but expectation values failed: \
+                     {err}",
+                    case.context(),
+                    participant.name
+                )
+            });
+
+        match &reference {
+            None => reference = Some((participant.name, values)),
+            Some((name, expected)) => {
+                for (i, (got, want)) in values.iter().zip(expected).enumerate() {
+                    assert!(
+                        (got - want).abs() < PROB_EPS,
+                        "{}observable {i} {:?}: `{}` gave {got}, `{name}` gave {want} \
+                         (eps {PROB_EPS:.0e})",
+                        case.context(),
+                        observables[i],
                         participant.name
                     );
                 }

--- a/tests/conformance_matrix.rs
+++ b/tests/conformance_matrix.rs
@@ -12,7 +12,8 @@ use std::collections::BTreeMap;
 use common::conformance::{
     self, Anchor, AnchorPolicy, CONFORMANCE_SEED, Family, MIN_CONSENSUS_PARTICIPANTS, Regime,
     SkipReason, assert_amplitudes, assert_deterministic_case, assert_exact_mixture_case,
-    assert_sampled_mixture_case, cases_in, generated_cases, participants,
+    assert_expectation_values, assert_native_sampling, assert_sampled_mixture_case, cases_in,
+    generated_cases, participants,
 };
 
 /// Skip rules the corpus is expected to fire. A rule that starts or stops
@@ -29,6 +30,8 @@ const EXPECTED_FIRING: &[SkipReason] = &[
     SkipReason::NoAmplitudeExport,
     SkipReason::FactoredBlocksHaveNoJointState,
     SkipReason::BranchingTrajectory,
+    SkipReason::OutsideQueryMatrix,
+    SkipReason::QueryNeedsUnitaryCircuit,
 ];
 
 /// Rules the corpus does not reach, each with why. Encoded so the matrix still
@@ -143,6 +146,56 @@ fn conformance_classical_conditioning_branches_agree_across_backends() {
             case.context()
         );
         assert_sampled_mixture_case(&case, &participants);
+    }
+}
+
+/// Shot sampling on the backends that draw from their own representation, over
+/// the whole unitary corpus. Each participant is checked against its own
+/// probability vector, so a disagreement names the sampler rather than the
+/// evolution.
+#[test]
+fn conformance_native_sampling_matches_each_backend_distribution() {
+    let participants = participants();
+    for case in generated_cases() {
+        assert_native_sampling(&case, &participants);
+    }
+}
+
+/// The query matrices are differential, so a unitary case that reaches fewer
+/// than two participants compares nothing while still reporting pass.
+#[test]
+fn conformance_query_matrix_compares_every_unitary_case() {
+    let participants = participants();
+    let mut unitary_cases = 0;
+    for case in generated_cases() {
+        if !case.profile.unitary() {
+            continue;
+        }
+        unitary_cases += 1;
+        let compared: Vec<&str> = participants
+            .iter()
+            .filter(|participant| participant.query_eligibility(&case.profile).is_compared())
+            .map(|participant| participant.name)
+            .collect();
+        assert!(
+            compared.len() >= 2,
+            "{}only {:?} reached the query matrix; shots and observables need at least two \
+             participants to compare",
+            case.context(),
+            compared
+        );
+    }
+    assert!(
+        unitary_cases > 0,
+        "the corpus produced no unitary case, so the query matrices ran empty"
+    );
+}
+
+#[test]
+fn conformance_expectation_values_agree_where_the_matrix_exposes_them() {
+    let participants = participants();
+    for case in generated_cases() {
+        assert_expectation_values(&case, &participants);
     }
 }
 

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -180,3 +180,167 @@ fn non_unitary_circuit_is_rejected() {
         }
     }
 }
+
+// ===== backends that hold a polynomial-size state =====
+
+/// Observables that mix all three axes over a non-Clifford, entangled state.
+/// Wide enough that a backend confusing qubit order or dropping a factor
+/// cannot land on the statevector value by accident.
+fn mixed_axis_observables() -> [Vec<PauliTerm>; 5] {
+    [
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::x(1), PauliTerm::y(3)],
+        vec![PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)],
+        vec![
+            PauliTerm::y(0),
+            PauliTerm::x(2),
+            PauliTerm::z(4),
+            PauliTerm::y(5),
+        ],
+        vec![],
+    ]
+}
+
+fn entangled_non_clifford(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.3 + 0.15 * q as f64), &[q]);
+    }
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c.add_gate(Gate::T, &[1]);
+    c.add_gate(Gate::Cx, &[0, n - 1]);
+    c
+}
+
+fn assert_matches_statevector(label: &str, backend: BackendKind, circuit: &Circuit) {
+    let observables = mixed_axis_observables();
+    let sv = simulate(circuit)
+        .backend(BackendKind::Statevector)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    let got = simulate(circuit)
+        .backend(backend)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    common::assert_probs_close(&got, &sv, 1e-9, label);
+}
+
+#[test]
+fn mps_expectation_values_match_statevector() {
+    assert_matches_statevector(
+        "mps expectation",
+        BackendKind::Mps {
+            max_bond_dim: 1 << 8,
+        },
+        &entangled_non_clifford(6),
+    );
+}
+
+/// SWAP routing permutes the site layout, so the observable's logical qubits
+/// no longer index the sites they started on.
+#[test]
+fn mps_expectation_values_survive_swap_routing() {
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Ry(0.25 * (q + 1) as f64), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, 5]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cx, &[1, 4]);
+    assert_matches_statevector(
+        "mps expectation swap routed",
+        BackendKind::Mps {
+            max_bond_dim: 1 << 8,
+        },
+        &c,
+    );
+}
+
+#[test]
+fn sparse_expectation_values_match_statevector() {
+    assert_matches_statevector(
+        "sparse expectation",
+        BackendKind::Sparse,
+        &entangled_non_clifford(6),
+    );
+}
+
+#[test]
+fn factored_expectation_values_match_statevector() {
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Ry(0.4 + 0.1 * q as f64), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+    c.add_gate(Gate::Cx, &[4, 5]);
+    assert_matches_statevector("factored expectation blocks", BackendKind::Factored, &c);
+}
+
+#[test]
+fn factored_expectation_values_match_statevector_when_fully_merged() {
+    assert_matches_statevector(
+        "factored expectation merged",
+        BackendKind::Factored,
+        &entangled_non_clifford(6),
+    );
+}
+
+/// The tensor network contracts to a dense statevector by construction, so it
+/// has no native observable path. The rejection has to name the backend that
+/// cannot serve the request, not the route that selected it.
+#[test]
+fn backends_without_a_native_path_name_themselves() {
+    let c = entangled_non_clifford(5);
+    let observables = [vec![PauliTerm::z(0)]];
+    for (backend, name) in [
+        (BackendKind::TensorNetwork, "tensornetwork"),
+        (BackendKind::DensityMatrix, "density_matrix"),
+    ] {
+        let err = simulate(&c)
+            .backend(backend.clone())
+            .seed(42)
+            .expectation_values(&observables)
+            .unwrap_err();
+        match err {
+            prism_q::PrismError::BackendUnsupported {
+                backend: reported, ..
+            } => assert_eq!(reported, name, "{backend:?} reported the wrong backend"),
+            other => {
+                panic!("{backend:?}: expected a BackendUnsupported naming {name}, got {other:?}")
+            }
+        }
+    }
+}
+
+/// The native path validates observables before it runs, so a bad qubit index
+/// costs nothing on a circuit the statevector could not hold.
+#[test]
+fn invalid_observable_is_rejected_on_the_native_path() {
+    use prism_q::PrismError::{InvalidParameter, InvalidQubit};
+    let c = entangled_non_clifford(5);
+    let mps = BackendKind::Mps {
+        max_bond_dim: 1 << 8,
+    };
+    assert!(matches!(
+        simulate(&c)
+            .backend(mps.clone())
+            .seed(42)
+            .expectation_values(&[vec![PauliTerm::z(9)]])
+            .unwrap_err(),
+        InvalidQubit { .. }
+    ));
+    assert!(matches!(
+        simulate(&c)
+            .backend(mps)
+            .seed(42)
+            .expectation_values(&[vec![PauliTerm::z(0), PauliTerm::x(0)]])
+            .unwrap_err(),
+        InvalidParameter { .. }
+    ));
+}

--- a/tests/expectation_values_oversize.rs
+++ b/tests/expectation_values_oversize.rs
@@ -1,27 +1,52 @@
-//! Oversize guard for the Auto non-Clifford expectation-value route.
+//! Auto non-Clifford expectation values above the statevector cap.
 //!
 //! Isolated in its own test binary: it overrides `PRISM_MAX_SV_QUBITS`, which
 //! `max_statevector_qubits()` caches per process, so it must not share a process
 //! with tests that expect the real memory-derived cap.
+//!
+//! Above the cap the route no longer rejects the request. It lands on a backend
+//! that evaluates the observable on its own representation, so the reference
+//! here is closed form: an explicit statevector run is unavailable under the
+//! same cap and cannot serve as one.
 
 use prism_q::gates::Gate;
 use prism_q::{Circuit, PauliTerm, run_expectation_values};
 
+const TOL: f64 = 1e-9;
+
 #[test]
-fn auto_non_clifford_oversize_returns_clean_error() {
+fn auto_non_clifford_oversize_evaluates_on_the_selected_backend() {
     // SAFETY: single test in this binary; the variable is set before any cap
     // query and no other thread is running.
     unsafe { std::env::set_var("PRISM_MAX_SV_QUBITS", "4") };
 
+    let theta = 0.3_f64;
     let mut c = Circuit::new(6, 0);
     for q in 0..6 {
-        c.add_gate(Gate::Rx(0.3), &[q]);
+        c.add_gate(Gate::Rx(theta), &[q]);
     }
     c.add_gate(Gate::Cx, &[0, 1]);
 
-    let err = run_expectation_values(&c, &[vec![PauliTerm::z(0)]], 42).unwrap_err();
-    assert!(
-        matches!(err, prism_q::PrismError::IncompatibleBackend { .. }),
-        "expected a clean statevector-cap error, got {err:?}"
-    );
+    // Rx(theta) on every qubit, then CX(0->1). Z0 commutes through the control,
+    // so <Z0> = cos(theta). Z5 is untouched by the CX, so <Z5> = cos(theta) too.
+    // Z0*Z1 is the CX-conjugated Z0*Z0*Z1 = Z1, giving <Z0 Z1> = cos(theta).
+    let vals = run_expectation_values(
+        &c,
+        &[
+            vec![PauliTerm::z(0)],
+            vec![PauliTerm::z(5)],
+            vec![PauliTerm::z(0), PauliTerm::z(1)],
+            vec![],
+        ],
+        42,
+    )
+    .unwrap();
+
+    let want = [theta.cos(), theta.cos(), theta.cos(), 1.0];
+    for (i, (&got, &expected)) in vals.iter().zip(&want).enumerate() {
+        assert!(
+            (got - expected).abs() < TOL,
+            "observable {i}: got {got}, want {expected}"
+        );
+    }
 }

--- a/tests/native_sampling.rs
+++ b/tests/native_sampling.rs
@@ -1,0 +1,413 @@
+//! Native shot sampling on the backends that hold a polynomial-size state.
+//!
+//! Sparse, Factored, and MPS draw measurement outcomes from their own
+//! representation instead of a dense `2^n` probability vector.
+//!
+//! Most cases run below the dense cap, where the statevector distribution is
+//! available as the reference. The oversize section at the bottom runs at 40
+//! qubits, where it is not: those cases use GHZ and Bell-pair states, whose
+//! support is known in closed form, and they open by pinning that the dense
+//! route rejects the same circuit. No environment override is involved; a `2^40`
+//! amplitude vector is eight terabytes.
+//!
+//! Three properties are checked per backend, and only the second is
+//! statistical:
+//!
+//! 1. Support. Every sampled bitstring has non-zero reference probability. A
+//!    sampler that walks the wrong conditional, or reads the wrong site for a
+//!    permuted MPS layout, emits impossible outcomes and fails here exactly.
+//! 2. Frequency. Per-outcome frequencies sit inside a four-sigma binomial band.
+//! 3. Determinism. One seed replays bit for bit, across separate runs.
+
+mod common;
+
+use std::collections::HashMap;
+
+use common::{SEED, sv_reference_probs};
+use prism_q::circuit::Circuit;
+use prism_q::gates::Gate;
+use prism_q::sim::{BackendKind, ShotsResult, simulate};
+
+/// Shots per sampling case. Sets the width of the frequency band below.
+const SHOTS: usize = 20_000;
+
+/// Reference probability under which an outcome counts as unreachable. Well
+/// above the amplitude noise floor of every backend here and far below the
+/// smallest weight any of these circuits puts on a reachable outcome.
+const SUPPORT_FLOOR: f64 = 1e-12;
+
+/// Frequency band: four standard errors of a binomial at [`SHOTS`] draws, plus
+/// a floor that keeps near-deterministic outcomes from demanding an exact hit.
+fn frequency_band(p: f64) -> f64 {
+    4.0 * (p * (1.0 - p) / SHOTS as f64).sqrt() + 0.002
+}
+
+fn measure_all(circuit: &Circuit) -> Circuit {
+    let mut measured = Circuit::new(circuit.num_qubits, circuit.num_qubits);
+    measured.instructions = circuit.instructions.clone();
+    for q in 0..circuit.num_qubits {
+        measured.add_measure(q, q);
+    }
+    measured
+}
+
+/// Basis-state index of one shot, reading classical bit `q` as qubit `q`.
+fn shot_index(shot: &[bool]) -> usize {
+    shot.iter()
+        .enumerate()
+        .filter(|&(_, &b)| b)
+        .map(|(i, _)| 1usize << i)
+        .sum()
+}
+
+fn outcome_frequencies(result: &ShotsResult) -> HashMap<usize, f64> {
+    let mut counts: HashMap<usize, usize> = HashMap::new();
+    for shot in &result.shots {
+        *counts.entry(shot_index(shot)).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .map(|(index, count)| (index, count as f64 / result.shots.len() as f64))
+        .collect()
+}
+
+/// Run `circuit` with terminal measurements on `kind` and check the sampled
+/// distribution against the statevector reference.
+fn check_sampling(label: &str, kind: BackendKind, circuit: &Circuit) {
+    let reference = sv_reference_probs(circuit);
+    let measured = measure_all(circuit);
+
+    let result = simulate(&measured)
+        .backend(kind.clone())
+        .seed(SEED)
+        .shots(SHOTS)
+        .unwrap();
+    assert_eq!(result.shots.len(), SHOTS, "{label}: wrong shot count");
+
+    let observed = outcome_frequencies(&result);
+    for (&index, &frequency) in &observed {
+        assert!(
+            reference[index] > SUPPORT_FLOOR,
+            "{label}: sampled basis state {index} has reference probability {:.3e}, \
+             so the sampler drew an outcome the state cannot produce",
+            reference[index]
+        );
+        let band = frequency_band(reference[index]);
+        assert!(
+            (frequency - reference[index]).abs() < band,
+            "{label}: outcome {index} frequency {frequency:.6} vs reference {:.6} \
+             (band {band:.6} at {SHOTS} shots)",
+            reference[index]
+        );
+    }
+
+    for (index, &p) in reference.iter().enumerate() {
+        if p > 4.0 * frequency_band(p) {
+            assert!(
+                observed.contains_key(&index),
+                "{label}: outcome {index} carries probability {p:.6} and was never sampled"
+            );
+        }
+    }
+
+    let replay = simulate(&measured)
+        .backend(kind)
+        .seed(SEED)
+        .shots(SHOTS)
+        .unwrap();
+    assert_eq!(
+        result.shots, replay.shots,
+        "{label}: same seed produced different shots"
+    );
+}
+
+/// Counts must agree with the shot histogram drawn from the same seed. The
+/// counts entry point has no shortcut for these backends, so it routes through
+/// the same native sampler.
+fn check_counts_match_shots(label: &str, kind: BackendKind, circuit: &Circuit) {
+    let measured = measure_all(circuit);
+    let shots = simulate(&measured)
+        .backend(kind.clone())
+        .seed(SEED)
+        .shots(SHOTS)
+        .unwrap();
+    let counts = simulate(&measured)
+        .backend(kind)
+        .seed(SEED)
+        .sample_counts(SHOTS)
+        .unwrap();
+    assert_eq!(
+        shots.counts(),
+        counts.into_counts(),
+        "{label}: counts disagree with the shot histogram at the same seed"
+    );
+}
+
+fn ghz(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::H, &[0]);
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c
+}
+
+/// Sparse-friendly: a permutation layer over a small superposition keeps the
+/// amplitude map far below `2^n` entries.
+fn sparse_friendly(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::T, &[0]);
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c.add_gate(Gate::X, &[n - 1]);
+    c
+}
+
+// ===== sparse =====
+
+#[test]
+fn sparse_samples_ghz_distribution() {
+    check_sampling("sparse ghz 10q", BackendKind::Sparse, &ghz(10));
+}
+
+#[test]
+fn sparse_samples_sparse_friendly_distribution() {
+    check_sampling(
+        "sparse mixed 10q",
+        BackendKind::Sparse,
+        &sparse_friendly(10),
+    );
+}
+
+#[test]
+fn sparse_counts_match_shots() {
+    check_counts_match_shots("sparse ghz 10q", BackendKind::Sparse, &ghz(10));
+}
+
+// ===== factored =====
+
+#[test]
+fn factored_samples_independent_blocks() {
+    check_sampling(
+        "factored blocks 10q",
+        BackendKind::Factored,
+        &prism_q::circuits::independent_bell_pairs(5),
+    );
+}
+
+#[test]
+fn factored_samples_single_merged_block() {
+    check_sampling("factored ghz 10q", BackendKind::Factored, &ghz(10));
+}
+
+#[test]
+fn factored_counts_match_shots() {
+    check_counts_match_shots(
+        "factored blocks 10q",
+        BackendKind::Factored,
+        &prism_q::circuits::independent_bell_pairs(5),
+    );
+}
+
+// ===== mps =====
+
+const MPS: BackendKind = BackendKind::Mps {
+    max_bond_dim: 1 << 8,
+};
+
+#[test]
+fn mps_samples_ghz_distribution() {
+    check_sampling("mps ghz 10q", MPS, &ghz(10));
+}
+
+#[test]
+fn mps_samples_rotation_chain_distribution() {
+    let mut c = Circuit::new(8, 0);
+    for q in 0..8 {
+        c.add_gate(Gate::Ry(0.5 + 0.1 * q as f64), &[q]);
+    }
+    for q in 0..7 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    check_sampling("mps rotation chain 8q", MPS, &c);
+}
+
+/// Long-range gates route through SWAP chains, so the site holding a logical
+/// qubit is no longer its index. A sampler that reads the site index straight
+/// through returns permuted bitstrings, which the support check rejects.
+#[test]
+fn mps_samples_swap_routed_layout() {
+    let mut c = Circuit::new(8, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 7]);
+    c.add_gate(Gate::Ry(0.7), &[3]);
+    c.add_gate(Gate::Cx, &[3, 6]);
+    c.add_gate(Gate::T, &[5]);
+    c.add_gate(Gate::Cx, &[1, 5]);
+    check_sampling("mps swap routed 8q", MPS, &c);
+}
+
+#[test]
+fn mps_counts_match_shots() {
+    check_counts_match_shots("mps ghz 10q", MPS, &ghz(10));
+}
+
+// ===== above the dense cap =====
+
+/// Qubit count for the oversize cases. A `2^40` amplitude vector is eight
+/// terabytes, so no machine's memory-derived cap admits it and the dense route
+/// is unreachable by construction rather than by an environment override.
+const OVERSIZE_QUBITS: usize = 40;
+
+fn oversize_ghz() -> Circuit {
+    measure_all(&ghz(OVERSIZE_QUBITS))
+}
+
+/// Pins the premise the oversize cases rest on: the dense route cannot serve
+/// this circuit, so anything that does is not going through it.
+#[test]
+fn oversize_dense_route_is_unavailable() {
+    let err = simulate(&oversize_ghz())
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .shots(8)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            prism_q::PrismError::IncompatibleBackend { .. }
+                | prism_q::PrismError::BackendUnsupported { .. }
+        ),
+        "expected the statevector route to reject {OVERSIZE_QUBITS} qubits, got {err:?}"
+    );
+}
+
+/// GHZ has exactly two outcomes, all zeros and all ones, so an oversize sample
+/// is checkable without any reference vector.
+fn assert_oversize_ghz_shots(label: &str, kind: BackendKind) {
+    let circuit = oversize_ghz();
+    let shots = 512;
+
+    let result = simulate(&circuit)
+        .backend(kind.clone())
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    assert_eq!(result.shots.len(), shots, "{label}: wrong shot count");
+
+    let mut ones = 0usize;
+    for shot in &result.shots {
+        let set = shot.iter().filter(|&&b| b).count();
+        assert!(
+            set == 0 || set == OVERSIZE_QUBITS,
+            "{label}: GHZ shot has {set} of {OVERSIZE_QUBITS} bits set, so the chain broke"
+        );
+        if set == OVERSIZE_QUBITS {
+            ones += 1;
+        }
+    }
+    let fraction = ones as f64 / shots as f64;
+    assert!(
+        (fraction - 0.5).abs() < frequency_band(0.5) * (SHOTS as f64 / shots as f64).sqrt(),
+        "{label}: all-ones fraction {fraction:.4} is not a fair coin"
+    );
+
+    let counts = simulate(&circuit)
+        .backend(kind.clone())
+        .seed(SEED)
+        .sample_counts(shots)
+        .unwrap();
+    assert_eq!(
+        counts.into_counts().len(),
+        2,
+        "{label}: GHZ counts must have exactly two outcomes"
+    );
+
+    let replay = simulate(&circuit)
+        .backend(kind)
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    assert_eq!(
+        result.shots, replay.shots,
+        "{label}: same seed produced different shots"
+    );
+}
+
+#[test]
+fn mps_samples_above_the_dense_cap() {
+    assert_oversize_ghz_shots(
+        "mps 40q",
+        BackendKind::Mps {
+            max_bond_dim: 1 << 4,
+        },
+    );
+}
+
+#[test]
+fn sparse_samples_above_the_dense_cap() {
+    assert_oversize_ghz_shots("sparse 40q", BackendKind::Sparse);
+}
+
+#[test]
+fn factored_samples_above_the_dense_cap() {
+    let mut c = Circuit::new(OVERSIZE_QUBITS, OVERSIZE_QUBITS);
+    for pair in 0..OVERSIZE_QUBITS / 2 {
+        c.add_gate(Gate::H, &[2 * pair]);
+        c.add_gate(Gate::Cx, &[2 * pair, 2 * pair + 1]);
+    }
+    for q in 0..OVERSIZE_QUBITS {
+        c.add_measure(q, q);
+    }
+
+    let shots = 256;
+    let result = simulate(&c)
+        .backend(BackendKind::Factored)
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    assert_eq!(result.shots.len(), shots);
+    for shot in &result.shots {
+        for pair in 0..OVERSIZE_QUBITS / 2 {
+            assert_eq!(
+                shot[2 * pair],
+                shot[2 * pair + 1],
+                "factored 40q: bell pair {pair} came back uncorrelated"
+            );
+        }
+    }
+}
+
+/// The headline of the expectation-value half: exact observables on a state the
+/// dense route cannot hold. GHZ gives `<Z_0 Z_k> = 1` for every `k` and
+/// `<Z_0> = 0`.
+#[test]
+fn mps_expectation_values_above_the_dense_cap() {
+    let unitary = ghz(OVERSIZE_QUBITS);
+    let values = simulate(&unitary)
+        .backend(BackendKind::Mps {
+            max_bond_dim: 1 << 4,
+        })
+        .seed(SEED)
+        .expectation_values(&[
+            vec![
+                prism_q::PauliTerm::z(0),
+                prism_q::PauliTerm::z(OVERSIZE_QUBITS - 1),
+            ],
+            vec![prism_q::PauliTerm::z(0)],
+            vec![prism_q::PauliTerm::x(0)],
+            vec![],
+        ])
+        .unwrap();
+
+    let want = [1.0, 0.0, 0.0, 1.0];
+    for (i, (&got, &expected)) in values.iter().zip(&want).enumerate() {
+        assert!(
+            (got - expected).abs() < 1e-9,
+            "observable {i}: got {got}, want {expected}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Sparse, MPS, and Factored each hold a state representation that answers shot
sampling and Pauli observables in polynomial time, but every public path forced
them through a dense `2^n` array and they hit the memory cap. A 40-qubit circuit
on any of the three could evolve a state it could not report on. This adds two
`Backend` hooks behind capability probes whose defaults leave the dense route
unchanged, then overrides them per backend and teaches dispatch to prefer the
native path when it exists.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Host: i7-6700K class, Windows, `--features parallel`, Criterion `sample_size: 10`,
one bench process at a time.

New rows, 1000 shots. No "before" exists: at 32 qubits and above the dense route
cannot allocate the probability vector at all.

| Benchmark | Before | After | Change | Within 5% threshold? |
| --- | --- | --- | --- | --- |
| `mps/sampling/24` | n/a, new row | 1.19 ms | n/a | n/a |
| `mps/sampling/32` | n/a, new row | 1.56 ms | n/a | n/a |
| `mps/sampling/48` | n/a, new row | 2.32 ms | n/a | n/a |
| `mps/sampling/64` | n/a, new row | 3.20 ms | n/a | n/a |
| `sparse/sampling/24` | n/a, new row | 446 us | n/a | n/a |
| `sparse/sampling/32` | n/a, new row | 489 us | n/a | n/a |
| `sparse/sampling/48` | n/a, new row | 631 us | n/a | n/a |
| `sparse/sampling/64` | n/a, new row | 749 us | n/a | n/a |
| `mps/hotspots/measure_reset_32q_r3` | 496 us | 492 us | -0.8% | Yes |

Both new rows scale linearly in qubit count, which is the property they exist to
gate.

Regression verdict: PASS on every row this host can resolve, with one gap stated
below rather than claimed.

The gate microbenchmark comparison (`bench_driver`) is **not measured**. An A/B
against the pre-change library moved 58 of 75 rows past 5% in both directions
with tight confidence intervals: `single_qubit_gates/rx_gate/12` read -45.8%
while `two_qubit_gates/fused2q_high/16` read +20.8%, and both groups exercise
only statevector kernels this branch never opens. One diff cannot produce that
split, so the run measures the host, not the change. At `sample_size: 10` this
machine cannot resolve a 5% gate. A defensible number needs a quiet host at a
higher sample size, which is what the pending baseline refresh exists to provide.

The structural argument in the meantime, offered with its limit: every
`bench_driver` row calls `run_with` or `run_qasm` on `BackendKind::Statevector`,
entering `run_with_internal`, which is unmodified. The only edit to an existing
execution path is one probe inside `run_shots_with` that no row reaches, and
which the statevector kind returns from earlier anyway. Every hunk in `mps.rs`,
`sparse.rs`, and `factored/mod.rs` is a pure insertion. The one effect that is
not provably zero is that four new default trait methods grow the `dyn Backend`
vtable by four slots; existing calls use fixed offsets, so this should be
unmeasurable, but it was not demonstrated on this host.

## Correctness

- [x] Tests pass locally. `--all-features` is unavailable on this host because
      `distributed-mpi` needs libclang for `mpi-sys` bindgen, so the run was
      `cargo nextest run --features "parallel gpu distributed"`: 1980 passed,
      0 skipped. Doctests pass under the same feature set.
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with no warnings
- [x] New public API has docstrings
- [x] New backend paths have tests against the statevector backend
- [x] GPU suite runs clean (`golden_gpu` is included in the run above; no GPU
      code is touched)

Test coverage added:

- `tests/native_sampling.rs`: support, frequency, and determinism per backend.
  Support is exact, so a sampler that walks the wrong conditional or reads the
  wrong site for a permuted MPS layout fails on an impossible outcome rather
  than on a statistic. The oversize section runs at 40 qubits and opens by
  pinning that the dense route rejects the same circuit.
- `mps_conditional_path_probabilities_match_the_dense_vector` in
  `src/backend/mps.rs`: the product of the sampler's conditionals along every
  basis path equals the dense probability vector to 1e-12. This pins the sampled
  distribution exactly rather than statistically.
- `tests/conformance_matrix.rs`: two query matrices over the generated corpus,
  with two new skip rules added to the pinned ledger and a guard test that every
  unitary case reaches at least two participants, so neither matrix can pass
  while comparing nothing.
- `tests/expectation_values.rs`: agreement with the statevector at 1e-9 for
  Sparse, MPS (including a SWAP-routed layout), and Factored in both the
  blocked and fully merged shapes.
- `tests/expectation_values_oversize.rs`: re-pinned. Above the cap the route no
  longer rejects the request, so the case now asserts closed-form values. An
  explicit statevector reference cannot run under the same cap, so the expected
  side is hand algebra.

## Hotspot notes

No gate-application kernel is modified. `compute_right_env`, on the MPS
measurement path, is byte-identical to `main`.

Worth recording for the next reader: this branch initially unified
`compute_right_env` onto the new two-pass `O(chi^3)` contraction, which looked
like a strict win on paper. A back-to-back A/B showed the original four-index
form is 14.3% faster on `mps/hotspots/measure_reset_32q_r3` (496 us against
574 us). After projection the environments are mostly zero, and the
`env_val == ZERO` skip beats dense `O(chi^3)` arithmetic. The unification was
reverted. Both forms now coexist: the four-index form for measurement, the
two-pass form for the sampler's all-sites sweep where the environments are
dense. `contract_right_env` carries the measured numbers and a note to measure
both before unifying them again.

## Architecture or design changes

- [x] `docs/architecture/samplers.md` gains a native backend sampling section
      with the per-backend cost table and the dispatch entry point
- [x] `docs/guides/capabilities.md` gains a query-path matrix covering which
      backends answer shots and observables natively and which stay dense
- [x] The tensor network decision is recorded in its module docstring with the
      reasoning and a revisit trigger

The tensor network stays on the dense route deliberately. Sampling a deferred
network costs one full contraction per qubit per shot against the single
contraction the dense route pays for the whole distribution, and that is worse
whenever the statevector fits and no better when it does not, since treewidth
sets the cost and conditioning does not reduce it. An exact scalar observable
contraction does already exist in that module, but it takes a circuit rather
than an evolved backend, and the backend swaps its network for a dense
statevector after any measurement, so reaching it from the trait hook would need
a second contraction path with its own bra-side leg bookkeeping. Auto never
selects the tensor network above the statevector cap, so that path would serve
explicit requests only.

## Breaking changes

Two behavioral differences, neither of them an API break.

1. Seeded shot values change for Sparse, MPS, and Factored. These backends now
   sample from their own representation and consume randomness on a different
   schedule than the dense CDF did. The distributions are unchanged; a caller
   pinning exact bitstrings from a fixed seed on these three backends will see
   different bitstrings. Statevector and stabilizer are unaffected.
2. `expectation_values` above the statevector cap now returns values where it
   previously returned `IncompatibleBackend`. Backends with no observable path
   return `BackendUnsupported` naming themselves instead of a routing error
   naming the request.

`Backend` gains four methods, all with defaults, so out-of-tree implementors
keep compiling.

## Risks and rollback

Blast radius is bounded by the two capability probes. Every backend that does
not override them takes the identical dense route, so the risk is confined to
Sparse, MPS, and Factored on the shot, count, and expectation terminals.

Rollback without reverting the commit: make `supports_native_sampling` and
`supports_pauli_expectation` return `false` in the three overriding backends.
Dispatch then falls through to the dense path everywhere and behavior matches
`main`, at the cost of the qubit ceiling this change lifts.

The sampler does not mutate state (`&self`) and is seeded from its argument
rather than the backend RNG, so it cannot perturb an in-progress simulation or
make a run irreproducible.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
