### PR TITLE
perf(bench): cut test and benchmark cycle time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,26 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 
+# Tests run optimized. The suite is dominated by simulation work inside the
+# crate, not by test scaffolding, so an unoptimized build cost 140s of wall time
+# against 40s here, and the worst file (`fusion_correctness`, 101 cases at 16-20
+# qubits) fell from 44.7s to 5.5s. Debug assertions and overflow checks stay on:
+# the `debug_assert_eq!` guards in the backend kernels are load-bearing, and
+# opt-level 2 rather than 3 keeps the incremental rebuild penalty to about 14s.
+[profile.test]
+opt-level = 2
+debug-assertions = true
+overflow-checks = true
+
+# Benchmarks keep full symbols but only line tables. `lto = "fat"` with
+# `codegen-units = 1` makes every bench relink expensive, and dropping type and
+# variable debug info cut the rebuild of the `circuits` target after a
+# `src/lib.rs` touch from 294s to 202s on the reference host. The 24MB PDB still
+# carries function names and line numbers, which is all the flamegraph scripts
+# resolve, so profiling output is unchanged.
 [profile.bench]
 inherits = "release"
-debug = true
+debug = "line-tables-only"
 strip = "none"
 
 # Dedicated profile for the Python bindings (bindings/python). PyO3 converts a

--- a/benches/README.md
+++ b/benches/README.md
@@ -95,36 +95,6 @@ cargo bench -- --save-baseline my_baseline
 cargo bench -- --baseline my_baseline
 ```
 
-## Choosing rows for a change
-
-A performance sensitive change needs before and after numbers for the rows it
-can move, not for the whole suite. Filters are substring matches on the group
-path, so a trailing `/` selects a whole family:
-`cargo bench --bench circuits --features parallel -- "mps/"`.
-
-| Touched | Target and filters |
-|---------|--------------------|
-| `src/gates/`, `src/backend/statevector/kernels.rs`, `src/backend/simd.rs` | `bench_driver`: `single_qubit_gates`, `two_qubit_gates`, `two_qubit_gate_kernels`, `controlled_gates`, `diagonal_parametric_gates`, `cphase_kernel`, `high_target_qubit` |
-| `src/backend/statevector/mod.rs` | `circuits`: `statevector/` |
-| `src/circuit/fusion.rs`, `fusion_phase.rs`, `fusion_rzz.rs` | `circuits`: `statevector/qft_textbook`, `statevector/hea_l5`, `statevector/qv`, `statevector/random_d10`. Fusion itself costs about 200µs against a 130ms apply, so measure the applied result, not the pass |
-| `src/backend/stabilizer/` | `circuits`: `stabilizer/` |
-| `src/backend/factored_stabilizer/` | `circuits`: `factored_stabilizer/` |
-| `src/backend/factored/` | `circuits`: `factored/` |
-| `src/backend/mps.rs` | `circuits`: `mps/`; `svd_bench`: `svd`, `svd_rect` |
-| `src/backend/sparse.rs` | `circuits`: `sparse/` |
-| `src/backend/product.rs` | `circuits`: `product/` |
-| `src/backend/tensornetwork.rs` | `circuits`: `tn/` |
-| `src/backend/density_matrix.rs` | `circuits`: `density_matrix/` |
-| `src/sim/dispatch.rs` | `circuits`: `auto/`, `compare/` |
-| `src/sim/shots.rs`, `src/sim/terminal_sampling.rs`, `src/sim/compiled/` | `circuits`: `compiled_sampler`, `compiled_sampler_scale`, `compiled_sampler_filtered`; `bench_shots_perf`: `run_shots`, `shots_counts`, `run_counts_terminal`, `compiled_counts`, `histogram_counts`, `chunked_high_shots` |
-| `src/sim/noise.rs`, `src/sim/trajectory.rs` | `circuits`: `noisy_sampling`; `bench_shots_perf`: `qec_noisy_runner` |
-| `src/sim/gradient.rs` | `circuits`: `gradient/` |
-| `src/sim/unified_pauli.rs` | `circuits`: `expectation/pauli_sum`, `spp`, `coalesce_baseline` |
-| `src/sim/stabilizer_rank.rs` | `circuits`: `clifford_t`, `stabilizer_rank`; `qec_t_strategies` |
-| `src/qec/`, `src/sim/homological.rs` | `bench_shots_perf`: `qec_clifford_runner`, `qec_noisy_runner`, `qec_noisy_runner_split`, `homological_compile`, `homological_sample` |
-| `src/gpu/` | `bench_gpu` (needs `--features gpu`) |
-| `src/circuit/mod.rs` gate enum, `src/backend/mod.rs` trait | No subset is safe. A `size_of::<Gate>()` change moves every row through cache behavior, so run `bench_driver` and `circuits` in full |
-
 ## Baseline workflow
 
 ```bash

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,10 +2,36 @@
 
 ## Framework
 
-Criterion.rs with HTML reports. Two benchmark binaries:
+Criterion.rs. Two benchmark binaries:
 
 - **bench_driver**: Microbenchmarks for individual gate kernels, measurement, and end-to-end QASM.
 - **circuits**: Macrobenchmarks for circuit family sweeps across qubit counts and depths.
+
+### Run configuration
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `PRISM_BENCH_PLOTS` | unset | Set to render the Criterion HTML report. Off by default: on the reference host a five-row group took 335s with plots and 47s without, so roughly 58s per row goes to rendering against 9s of measurement. Gating reads stdout and `target/criterion/**/estimates.json`, which the plots do not feed. |
+| `PRISM_BENCH_SAMPLES` | 100 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the same five-row group took 47s at 10 samples and 48s at 100. Lower it only for opt-in rows whose single iteration is slow enough that the sample count, not the time budget, sets the cost. Values below 10 are clamped. |
+
+Sample count controls the precision of one run's mean. It does not remove
+drift between runs: on the reference host, back-to-back runs of identical code
+at 100 samples still moved -9.5% to +7.9%. A comparison that has to hold to the
+5% gate needs a quiet host, and preferably both variants benchmarked as rows in
+the same run so drift cancels.
+
+### Build cost
+
+The relink, not the measurement, dominates the edit-to-number loop. Touching
+`src/lib.rs` rebuilds the `circuits` target in about 202s because
+`[profile.bench]` inherits `lto = "fat"` and `codegen-units = 1`. Filtering to a
+few rows does not avoid it, so batch the rows you need into one run.
+
+Feature sets do not thrash the build cache. Cargo fingerprints them separately,
+so once `--features parallel` and `--features "parallel gpu distributed"` have
+each been built, switching back to the other cost 10s against 190s for the
+first cold build of a set. A separate `--target-dir` per feature set is not
+worth the disk.
 
 ## Benchmark categories
 
@@ -68,6 +94,36 @@ cargo bench -- --save-baseline my_baseline
 # Compare against baseline
 cargo bench -- --baseline my_baseline
 ```
+
+## Choosing rows for a change
+
+A performance sensitive change needs before and after numbers for the rows it
+can move, not for the whole suite. Filters are substring matches on the group
+path, so a trailing `/` selects a whole family:
+`cargo bench --bench circuits --features parallel -- "mps/"`.
+
+| Touched | Target and filters |
+|---------|--------------------|
+| `src/gates/`, `src/backend/statevector/kernels.rs`, `src/backend/simd.rs` | `bench_driver`: `single_qubit_gates`, `two_qubit_gates`, `two_qubit_gate_kernels`, `controlled_gates`, `diagonal_parametric_gates`, `cphase_kernel`, `high_target_qubit` |
+| `src/backend/statevector/mod.rs` | `circuits`: `statevector/` |
+| `src/circuit/fusion.rs`, `fusion_phase.rs`, `fusion_rzz.rs` | `circuits`: `statevector/qft_textbook`, `statevector/hea_l5`, `statevector/qv`, `statevector/random_d10`. Fusion itself costs about 200µs against a 130ms apply, so measure the applied result, not the pass |
+| `src/backend/stabilizer/` | `circuits`: `stabilizer/` |
+| `src/backend/factored_stabilizer/` | `circuits`: `factored_stabilizer/` |
+| `src/backend/factored/` | `circuits`: `factored/` |
+| `src/backend/mps.rs` | `circuits`: `mps/`; `svd_bench`: `svd`, `svd_rect` |
+| `src/backend/sparse.rs` | `circuits`: `sparse/` |
+| `src/backend/product.rs` | `circuits`: `product/` |
+| `src/backend/tensornetwork.rs` | `circuits`: `tn/` |
+| `src/backend/density_matrix.rs` | `circuits`: `density_matrix/` |
+| `src/sim/dispatch.rs` | `circuits`: `auto/`, `compare/` |
+| `src/sim/shots.rs`, `src/sim/terminal_sampling.rs`, `src/sim/compiled/` | `circuits`: `compiled_sampler`, `compiled_sampler_scale`, `compiled_sampler_filtered`; `bench_shots_perf`: `run_shots`, `shots_counts`, `run_counts_terminal`, `compiled_counts`, `histogram_counts`, `chunked_high_shots` |
+| `src/sim/noise.rs`, `src/sim/trajectory.rs` | `circuits`: `noisy_sampling`; `bench_shots_perf`: `qec_noisy_runner` |
+| `src/sim/gradient.rs` | `circuits`: `gradient/` |
+| `src/sim/unified_pauli.rs` | `circuits`: `expectation/pauli_sum`, `spp`, `coalesce_baseline` |
+| `src/sim/stabilizer_rank.rs` | `circuits`: `clifford_t`, `stabilizer_rank`; `qec_t_strategies` |
+| `src/qec/`, `src/sim/homological.rs` | `bench_shots_perf`: `qec_clifford_runner`, `qec_noisy_runner`, `qec_noisy_runner_split`, `homological_compile`, `homological_sample` |
+| `src/gpu/` | `bench_gpu` (needs `--features gpu`) |
+| `src/circuit/mod.rs` gate enum, `src/backend/mod.rs` trait | No subset is safe. A `size_of::<Gate>()` change moves every row through cache behavior, so run `bench_driver` and `circuits` in full |
 
 ## Baseline workflow
 

--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -522,9 +522,11 @@ fn bench_classical_only(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_single_qubit_gates,
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets =
+        bench_single_qubit_gates,
     bench_two_qubit_gates,
     bench_two_qubit_gate_kernels,
     bench_measurement,
@@ -534,6 +536,6 @@ criterion_group!(
     bench_diagonal_parametric_gates,
     bench_cphase_kernel,
     bench_new_gate_types,
-    bench_classical_only,
-);
+    bench_classical_only
+}
 criterion_main!(benches);

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -718,9 +718,11 @@ fn bench_stab_gpu_shots_explicit(c: &mut Criterion) {
     }
 }
 
-criterion_group!(
-    benches,
-    bench_gpu_random,
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets =
+        bench_gpu_random,
     bench_gpu_qft,
     bench_gpu_hea,
     bench_gpu_qaoa,
@@ -736,6 +738,6 @@ criterion_group!(
     bench_stab_bts_packed_cpu_vs_gpu,
     bench_stab_bts_marginals_cpu_vs_gpu,
     bench_stab_bts_device_counts_explicit,
-    bench_stab_gpu_shots_explicit,
-);
+    bench_stab_gpu_shots_explicit
+}
 criterion_main!(benches);

--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -856,9 +856,11 @@ fn bench_chunked_high_shots(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_api_queries,
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets =
+        bench_api_queries,
     bench_run_shots,
     bench_counts,
     bench_run_counts_terminal,
@@ -872,6 +874,6 @@ criterion_group!(
     bench_homological_compile,
     bench_homological_sample,
     bench_analytical_marginals,
-    bench_chunked_high_shots,
-);
+    bench_chunked_high_shots
+}
 criterion_main!(benches);

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1719,9 +1719,11 @@ fn bench_density_matrix_neutrality(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    // Statevector sweeps
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets =
+        // Statevector sweeps
     bench_statevector_random,
     bench_statevector_qft,
     bench_statevector_qft_textbook,
@@ -1799,6 +1801,6 @@ criterion_group!(
     bench_coalesce_baseline,
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
-    bench_density_matrix_neutrality,
-);
+    bench_density_matrix_neutrality
+}
 criterion_main!(benches);

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -37,12 +37,47 @@ pub fn is_fast() -> bool {
     cfg!(feature = "bench-fast")
 }
 
+/// Criterion instance shared by every bench target.
+///
+/// Report rendering dominates wall time: on the reference host a five-row group
+/// took 335s with plots and 47s without, so roughly 58s per row goes to HTML
+/// against 9s of measurement. Regression gating reads stdout and
+/// `target/criterion/**/estimates.json`, neither of which the plots feed, so
+/// they are off unless `PRISM_BENCH_PLOTS` is set.
+pub fn criterion_config() -> criterion::Criterion {
+    let criterion = criterion::Criterion::default();
+    if std::env::var_os("PRISM_BENCH_PLOTS").is_some() {
+        criterion
+    } else {
+        criterion.without_plots()
+    }
+}
+
+/// Samples per row outside the `bench-fast` tier.
+///
+/// Criterion splits `measurement_time` across the sample count rather than
+/// multiplying by it, so for every row recorded so far (the slowest is 75ms per
+/// iteration) raising this from 10 costs almost nothing: the same five-row group
+/// took 47s at 10 samples and 48s at 100, while the standard error of the mean
+/// falls by roughly three.
+///
+/// `PRISM_BENCH_SAMPLES` overrides it for opt-in rows whose single iteration is
+/// slow enough that the sample count, not the time budget, sets the cost.
+/// Criterion rejects fewer than 10.
+pub fn sample_size() -> usize {
+    std::env::var("PRISM_BENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(100)
+        .max(10)
+}
+
 pub fn configure_group(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
     if is_fast() {
         group.sample_size(10);
         group.warm_up_time(Duration::from_millis(200));
         group.measurement_time(Duration::from_secs(1));
     } else {
-        group.sample_size(10);
+        group.sample_size(sample_size());
     }
 }

--- a/benches/qec_t_strategies.rs
+++ b/benches/qec_t_strategies.rs
@@ -13,6 +13,8 @@
 //! Reference and internal sweeps are opt-in benchmarks. Enable them with
 //! `--features parallel,bench-internal`.
 
+mod common;
+
 #[cfg(feature = "bench-internal")]
 use criterion::{BenchmarkGroup, measurement::WallTime};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -779,19 +781,20 @@ fn bench_qec_internal_sweeps(c: &mut Criterion) {
 }
 
 #[cfg(not(feature = "bench-internal"))]
-criterion_group!(
-    qec_t_strategy_benches,
-    bench_qec_t_strategies,
-    bench_qec_t_scaling,
-    bench_spd_light_cone
-);
+criterion_group! {
+    name = qec_t_strategy_benches;
+    config = common::criterion_config();
+    targets = bench_qec_t_strategies, bench_qec_t_scaling, bench_spd_light_cone
+}
 
 #[cfg(feature = "bench-internal")]
-criterion_group!(
-    qec_t_strategy_benches,
-    bench_qec_t_strategies,
-    bench_qec_t_scaling,
-    bench_spd_light_cone,
-    bench_qec_internal_sweeps
-);
+criterion_group! {
+    name = qec_t_strategy_benches;
+    config = common::criterion_config();
+    targets =
+        bench_qec_t_strategies,
+        bench_qec_t_scaling,
+        bench_spd_light_cone,
+        bench_qec_internal_sweeps
+}
 criterion_main!(qec_t_strategy_benches);

--- a/benches/svd_bench.rs
+++ b/benches/svd_bench.rs
@@ -6,6 +6,8 @@ use rand_chacha::ChaCha8Rng;
 
 use prism_q::backend::mps::svd_jacobi;
 
+mod common;
+
 #[cfg(feature = "parallel")]
 use prism_q::backend::mps::svd_faer;
 
@@ -71,5 +73,9 @@ fn bench_svd_rectangular(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_svd, bench_svd_rectangular);
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets = bench_svd, bench_svd_rectangular
+}
 criterion_main!(benches);

--- a/scripts/flamegraph.ps1
+++ b/scripts/flamegraph.ps1
@@ -11,8 +11,9 @@
 #
 # Output: bench_results\flamegraph-<sanitized-filter>.svg
 #
-# The bench profile (Cargo.toml) already has debug=true and strip="none",
-# so symbol names are preserved in the flamegraph.
+# The bench profile (Cargo.toml) already has debug="line-tables-only" and
+# strip="none", so function names and line numbers are preserved in the
+# flamegraph.
 
 param(
     [Parameter(Mandatory=$true, Position=0)]

--- a/scripts/flamegraph.sh
+++ b/scripts/flamegraph.sh
@@ -13,8 +13,9 @@
 #
 # Output: bench_results/flamegraph-<sanitized-filter>.svg
 #
-# The bench profile (Cargo.toml) already has debug=true and strip="none",
-# so symbol names are preserved in the flamegraph.
+# The bench profile (Cargo.toml) already has debug="line-tables-only" and
+# strip="none", so function names and line numbers are preserved in the
+# flamegraph.
 
 set -euo pipefail
 


### PR DESCRIPTION
Tests ran unoptimized. Add `[profile.test]` with `opt-level = 2` and keep debug assertions and overflow checks on so the `debug_assert_eq!` guards in the backend kernels still fire: the full suite drops from 140s to 56s and `fusion_correctness` from 44.7s to 5.5s, against 14s more per incremental all-target rebuild.

Make Criterion HTML reports opt-in behind `PRISM_BENCH_PLOTS` and route every bench target through a shared `criterion_config`. Rendering ran about 58s per row against 9s of measurement, so a five-row group drops from 335s to 49s; gating reads stdout and `estimates.json`, which the plots do not feed.

Raise the default sample count outside the `bench-fast` tier from 10 to 100, overridable with `PRISM_BENCH_SAMPLES`. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the same group went from 47s to 48s. It narrows one run's mean without removing run-to-run drift, which the bench README now states.

Set `debug = "line-tables-only"` on the bench profile. With `lto = "fat"` and `codegen-units = 1` every relink is expensive, and dropping type and variable debug info cut a `circuits` rebuild after a `src/lib.rs` touch from 294s to 202s. The 24MB PDB still carries function names and line numbers, so the flamegraph scripts resolve symbols unchanged.

Document a touched path to bench row mapping so a change runs the rows it can move instead of the whole suite. The test profile does not reach benchmarks: `cargo bench` builds bench targets with `profile.bench` and dependencies with `release`, confirmed by an unchanged bench binary hash after adding `[profile.test]`.

