### PR TITLE
feat(backend): close the trait coverage holes, fix release and bench gating

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,13 +19,20 @@ diff. Link any related issue or discussion.
 
 ## Benchmarks (required for any change that touches a hot path)
 
-Run from a quiet machine with `--features parallel` and paste the numbers below. If this
-PR only changes documentation or non-performance code, write "N/A, no hot-path changes"
-and skip the table.
+Run `./scripts/bench_ab.sh --filter <rows> --ref <base>` and paste its table below. It
+builds both bench binaries first and runs them adjacent, which is the only method that
+reads correctly on a development host: separate `cargo bench` invocations minutes apart
+have moved a byte-identical control group by as much as +98%. See `benches/README.md`.
 
-| Benchmark | Before | After | Change | Within 5% threshold? |
-| --- | --- | --- | --- | --- |
-|  |  |  |  |  |
+If this PR only changes documentation or non-performance code, write "N/A, no hot-path
+changes" and skip the table.
+
+| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |
+
+Keep the control column. A change no larger than its row's same-code control spread is
+noise, not a result; say so rather than rounding it into a win.
 
 Regression verdict: PASS / FAIL / WAIVER
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,18 @@ jobs:
       - name: Doc tests
         run: cargo test --doc --no-default-features
 
+  # The release workflow publishes to crates.io with --no-confirm --execute and no
+  # manual gate, so the version arithmetic in front of it is verified here rather
+  # than at dispatch time. Seconds of runtime against a version number that can
+  # be yanked but never unpublished.
+  release-bump-level:
+    name: Release bump level
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify the conventional-commit mapping and the pre-1.0 clamp
+        run: bash scripts/release_bump_level_test.sh
+
   benchmark-regression:
     name: Benchmark Regression
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,39 +28,32 @@ jobs:
       - name: Install tools
         run: cargo install git-cliff cargo-release
 
+      - name: Verify the bump level mapping
+        run: bash scripts/release_bump_level_test.sh
+
       - name: Determine bump level from conventional commits
         id: bump
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            RANGE="HEAD"
-          else
-            RANGE="${LAST_TAG}..HEAD"
+          # Outside the worktree: cargo-release refuses to run on a dirty tree.
+          bash scripts/release_bump_level.sh > "$RUNNER_TEMP/bump.env"
+          cat "$RUNNER_TEMP/bump.env"
+          cat "$RUNNER_TEMP/bump.env" >> "$GITHUB_OUTPUT"
+
+      - name: Report bump level
+        env:
+          LEVEL: ${{ steps.bump.outputs.level }}
+          RAW_LEVEL: ${{ steps.bump.outputs.raw_level }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          echo "### Bump level: \`$LEVEL\` (from \`$VERSION\`)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$LEVEL" != "$RAW_LEVEL" ]; then
+            {
+              echo ""
+              echo "Conventional commits asked for \`$RAW_LEVEL\`, clamped to \`$LEVEL\`:"
+              echo "the crate is pre-1.0, where the minor is the compatibility boundary."
+              echo "Cut 1.0.0 deliberately rather than letting a breaking commit spend it."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
-
-          COMMITS=$(git log --format="%s" $RANGE 2>/dev/null || true)
-          if [ -z "$COMMITS" ]; then
-            echo "level=none" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          LEVEL="none"
-
-          # Check for breaking changes
-          if echo "$COMMITS" | grep -qiE '^[a-z]+(\(.+\))?!:'; then
-            LEVEL="major"
-          elif git log --format="%b" $RANGE 2>/dev/null | grep -q "^BREAKING CHANGE:"; then
-            LEVEL="major"
-          # Check for features
-          elif echo "$COMMITS" | grep -qE '^feat(\(.+\))?:'; then
-            LEVEL="minor"
-          # Check for fixes or perf
-          elif echo "$COMMITS" | grep -qE '^(fix|perf)(\(.+\))?:'; then
-            LEVEL="patch"
-          fi
-
-          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
-          echo "### Bump level: \`$LEVEL\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Skip if no release needed
         if: steps.bump.outputs.level == 'none'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,22 +79,35 @@ multiple `cargo bench` processes at once. Rayon contention causes noisy results.
 
 ### Regression checks
 
+Before/after numbers that have to hold to the 5% gate go through the
+adjacent-binary A/B. It builds both bench binaries first, verifies the working tree
+did not move between the two builds, then runs them adjacent with no rebuild in
+between, and reports every row against its own same-code control:
+
+```bash
+./scripts/bench_ab.sh --filter '^factored/noise_kraus/' --ref main
+```
+
+Separate `cargo bench` invocations minutes apart are not a valid A/B on a
+development host: the rebuild lands between them and a byte-identical control group
+has read as much as +98%. Do not report a change without its control column, and
+say so plainly when a delta lands inside the noise floor. `benches/README.md` has
+the method and the list of rows this cannot resolve.
+
+Stored baselines remain useful for tracking a number over weeks and for the CI
+gate, where both sides run in one job:
+
 ```bash
 cargo bench --features parallel
 ./scripts/bench_check.sh save --name "before"
-.\scripts\bench_check.ps1 save -Name "before"
 
 cargo bench --features parallel
-
 ./scripts/bench_check.sh compare --baseline "before"
-.\scripts\bench_check.ps1 compare -Baseline "before"
-
 ./scripts/bench_check.sh table --baseline "before"
-.\scripts\bench_check.ps1 table -Baseline "before"
 ```
 
 `compare` exits non zero on regression. `table` emits a markdown summary for the PR
-description.
+description. Both need `jq` and `bc`; `bench_ab.sh` needs neither.
 
 ## PR guidelines
 
@@ -104,11 +117,45 @@ description.
 - The pull request template at `.github/PULL_REQUEST_TEMPLATE.md` captures the required
   checklist.
 
+## Releases
+
+`.github/workflows/release.yml` runs on manual dispatch. It reads the conventional
+commits since the last tag, resolves a bump level, and hands that level to
+`cargo release --no-confirm --execute`, which publishes to crates.io.
+
+The level comes from `scripts/release_bump_level.sh` in two stages:
+
+| Commits since the last tag | Conventional level | Level used while the crate is 0.x |
+| --- | --- | --- |
+| `type!:` subject, or a `BREAKING CHANGE:` body | major | **minor** |
+| `feat:` | minor | minor |
+| `fix:` or `perf:` | patch | patch |
+| anything else | none | none |
+
+The second column is the specification. The third is what actually ships below
+1.0, and the difference is deliberate. Cargo reads `0.27.0` as `^0.27.0`, so under
+0.x the minor position is the compatibility boundary: `0.27` to `0.28` already
+signals a break to every downstream caret requirement. `cargo release major` on a
+0.x version resolves to 1.0.0 instead, which crates.io permits yanking but never
+unpublishing, and which claims an API stability the crate has not reached.
+
+The clamp is gated on the major version read from `Cargo.toml`, not hardcoded, so
+a deliberate 1.0.0 restores the major path with no edit to the script.
+
+`scripts/release_bump_level_test.sh` drives the mapping against synthetic commit
+lists, asserting both the level and the version it produces (a `feat!:` commit on
+0.27.0 resolves to `minor` and publishes 0.28.0). The `release-bump-level` CI job
+runs it on every pull request, and the release workflow runs it again before
+reading the commit range.
+
+To cut 1.0.0, set the version in `Cargo.toml` by hand and release from there. The
+workflow will not reach it on its own.
+
 ## CI
 
-PRs run formatting, clippy, nextest, doctests, doc build, coverage, aarch64
-cross-compile, macOS ARM64 tests, and `cargo-deny` (security advisories plus license
-audit).
+PRs run formatting, clippy, nextest, doctests, doc build, coverage, the release
+bump-level check, aarch64 cross-compile, macOS ARM64 tests, and `cargo-deny`
+(security advisories plus license audit).
 
 ## Hot-path rules
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -16,9 +16,10 @@ Criterion.rs. Two benchmark binaries:
 
 Sample count controls the precision of one run's mean. It does not remove
 drift between runs: on the reference host, back-to-back runs of identical code
-at 100 samples still moved -9.5% to +7.9%. A comparison that has to hold to the
-5% gate needs a quiet host, and preferably both variants benchmarked as rows in
-the same run so drift cancels.
+at 100 samples still moved -9.5% to +7.9%. Any comparison that has to hold to
+the 5% gate goes through the adjacent-binary A/B below, which removes the build
+and the source edit from between the two measurements and reports each row
+against its own same-code control.
 
 ### Build cost
 
@@ -95,7 +96,71 @@ cargo bench -- --save-baseline my_baseline
 cargo bench -- --baseline my_baseline
 ```
 
-## Baseline workflow
+## Gating comparisons: adjacent-binary A/B
+
+**This is the required method for any before/after claim that has to hold to the
+5% gate.** It supersedes save-a-baseline-then-compare-later for that purpose.
+
+```bash
+./scripts/bench_ab.sh --filter '^factored/noise_kraus/'
+./scripts/bench_ab.sh -f '^density_matrix/' -r main -b circuits
+./scripts/bench_ab.sh -f '^sparse/' --ref-dir /tmp/prism-q-ref   # cache the reference build
+```
+
+The script builds the bench binary from the working tree, builds the same target
+from a reference git ref in a separate worktree, verifies the working tree did
+not change between the two builds, then runs the two executables adjacent with no
+build and no source edit in between. One discarded warmup pass per binary, then
+four measured passes in the order ref, new, new, ref: both means are centred on
+the same point in time so linear drift cancels, and each binary is measured twice
+so every row reports a same-code control alongside its change.
+
+The warmup passes are load bearing. Without them the first measured pass absorbs
+the cold start after two builds, and whichever binary owns it looks slow: three
+rows read -15% to -18% on identical code, all against the binary in pass 1.
+
+```text
+| Benchmark                      | Ref      | New      | Change | Control (ref) | Control (new) | Verdict |
+| single_qubit_gates/h_gate/12   | 29.11 us | 27.64 us | -5.0%  | +11.5%        | -0.4%         | noise   |
+```
+
+That row is from a run where both binaries carried identical code. The -5.0%
+"improvement" is drift, and the +11.5% control is what says so. **Do not report a
+change without its control column.** A change no larger than the row's control
+spread is noise, not a result, and rows whose control spread exceeds the threshold
+are listed separately as unresolvable on this host.
+
+### Why separate invocations do not work
+
+Baseline and after runs minutes apart drift 8-20% on microsecond rows and up to
++98% on a byte-identical control group, because the rebuild and the editor's
+re-index land between them. Every measured optimization in the archive was taken
+with the adjacent-binary method instead: density matrix -29% to -72%, sparse -15%
+to -66%, tensor network -15% to -22%.
+
+The method removes the drift the rebuild causes. It does not make a busy host
+quiet. `density_matrix/neutrality/22` has read a control spread of -15.9% to
++37.0% under this method with the editor consuming about half the CPU, so read the
+control column on every run rather than assuming any row is stable. When the
+controls are wide, the answer is "not measurable right now", not a number.
+
+The two binaries are never byte identical even from identical sources, because
+`[profile.bench] debug = "line-tables-only"` records the package path and the two
+worktrees differ. The script decides "same code" from git, not from `cmp`.
+
+Reference-build cost: the first `--ref-dir` build is a cold build of the crate in
+a second package path (about 2m30s here); later runs against the same ref reuse
+it. Dependencies are shared, since the worktree builds into the same target
+directory.
+
+`bench_ab.sh` needs only git, awk, and cargo. It deliberately avoids `jq` and
+`bc`, neither of which is present on the reference host.
+
+## Stored baselines
+
+Point-in-time snapshots for tracking a number across weeks, and the mechanism the
+CI gate uses (where both sides run in one job on one runner, so the drift the
+method above defends against does not apply). Not a substitute for it locally.
 
 ```bash
 # Save (Unix)
@@ -113,6 +178,10 @@ cargo bench -- --baseline my_baseline
 # Custom threshold
 REGRESSION_THRESHOLD=10 ./scripts/bench_compare.sh
 ```
+
+`scripts/bench_check.sh` (`save`, `compare`, `table`, `list`) reads
+`target/criterion/` and writes to `bench_results/baselines/`. It requires `jq`
+and `bc`, so it runs in CI but not on the Windows reference host.
 
 ## CI regression gate
 
@@ -164,19 +233,46 @@ CI_BENCH_FEATURES=parallel,bench-fast ./scripts/bench_ci.sh
 
 Default threshold: **5%** per benchmark (configurable via `REGRESSION_THRESHOLD`).
 
-`bench_check.*` reads Criterion JSON from `target/criterion/`, compares matching
-benchmark means, and exits with code 1 when any benchmark exceeds the threshold.
-The older `bench_compare.*` wrappers still parse Criterion console output for
-quick baseline checks.
+`bench_ab.sh` applies the threshold per row and only calls a row a regression when
+it exceeds both the threshold and that row's own control spread. `bench_check.*`
+reads Criterion JSON from `target/criterion/`, compares matching benchmark means,
+and exits with code 1 when any benchmark exceeds the threshold. The older
+`bench_compare.*` wrappers still parse Criterion console output for quick baseline
+checks.
+
+### Rows this host cannot resolve
+
+Some rows carry a same-code control spread above the 5% gate. Do not gate a change
+on them; `bench_ab.sh` lists them under the table on every run.
+
+| Row family | Same-code spread observed |
+| --- | --- |
+| `sparse/low_entanglement/{8,12,16,20}` | -4.4% to +15.5%, no consistent sign |
+| `stabilizer/scaling/10`, `factored_stabilizer/scaling/10` | +9% to +13% (L1 resident) |
+| `stabilizer_rank/shots_mid_circuit` | -17.8% to +88% |
+| `gpu_stab_direct/clifford_d10/{2000,5000}` | +118% to +124% (bimodal clock state) |
+| `qec_t_strategies` | about 50% at 10 samples |
+| `factored/independent/*` | -45.5% to +49.7% (tens of microseconds) |
+| `factored/noise_kraus/*` | 12% to 16%, dominated by per-shot backend construction |
+| `noisy_sampling/*` | +9.8% to +48.3% |
+
+Those last three were measured on a host at roughly 50% background load, so treat
+them as an upper bound rather than an intrinsic property of the row.
+
+Gate sparse work on `sparse/random_d10` and `compare/*/sparse/*`, and the
+stabilizer families on their 50q+ rows, which reproduced consistent signs across
+independent pairs.
 
 ## Reproducibility checklist
 
 - [ ] Fixed RNG seed (`0xDEAD_BEEF` for circuit generation, `42` for simulation)
 - [ ] Criterion defaults: 5s warm-up, 5s measurement, 100 samples
-- [ ] Document CPU model, OS, Rust version, RUSTFLAGS
+- [ ] Gating comparisons run through `scripts/bench_ab.sh`, with the control column reported
+- [ ] Document CPU model, OS, Rust version, RUSTFLAGS (`bench_ab.sh` records these in its table)
 - [ ] Disable CPU frequency scaling if possible (`performance` governor on Linux)
 - [ ] Close background applications
 - [ ] Consider CPU pinning (`taskset` on Linux) for reduced variance
+- [ ] One `cargo bench` process at a time. Rayon pools contend and swing the numbers
 
 ## Output
 

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -213,6 +213,28 @@ fn with_terminal_measurements(mut circuit: Circuit) -> Circuit {
     circuit
 }
 
+/// Thermal relaxation on every gate target. `t2 < 2 * t1` keeps the dephasing
+/// branch live, so the event costs a reset draw plus a possible Z.
+fn thermal_noise_model(circuit: &Circuit) -> prism_q::NoiseModel {
+    let mut model = prism_q::NoiseModel::uniform_depolarizing(circuit, 0.0);
+    for (index, instruction) in circuit.instructions.iter().enumerate() {
+        if let prism_q::Instruction::Gate { targets, .. } = instruction {
+            model.after_gate[index] = targets
+                .iter()
+                .map(|&q| prism_q::NoiseEvent {
+                    channel: prism_q::NoiseChannel::ThermalRelaxation {
+                        t1: 100.0,
+                        t2: 80.0,
+                        gate_time: 1.0,
+                    },
+                    qubits: prism_q::circuit::SmallVec::from_slice(&[q]),
+                })
+                .collect();
+        }
+    }
+    model
+}
+
 fn non_clifford_noise_circuit(n_qubits: usize, depth: usize) -> Circuit {
     let mut circuit = Circuit::new(n_qubits, 0);
     for layer in 0..depth {
@@ -1256,6 +1278,52 @@ fn bench_factored_dynamic(c: &mut Criterion) {
     group.finish();
 }
 
+/// Non-Pauli trajectory noise on the factored backend, the only path that reaches
+/// `Backend::apply_1q_matrix`. Pauli noise routes to gate application instead, so
+/// `noisy_sampling` does not cover this at all.
+///
+/// Four-qubit blocks keep each sub-state at 16 amplitudes, so per-call cost in
+/// that method is a visible fraction of the kernel. Deep and shot-light because a
+/// shot allocates a fresh backend per block: at depth 5 with 256 shots that
+/// construction read a 36% spread on identical code.
+///
+/// The thermal rows are the control. Thermal relaxation samples a reset branch and
+/// a `Z` branch, never a Kraus matrix, so it shares the shape and the allocator
+/// behavior without touching the method under test.
+fn bench_factored_noise_kraus(c: &mut Criterion) {
+    let mut group = c.benchmark_group("factored/noise_kraus");
+    configure_group(&mut group);
+
+    for &total_q in &[16, 24] {
+        let circuit = with_terminal_measurements(circuits::independent_random_blocks(
+            total_q / 4,
+            4,
+            60,
+            SEED,
+        ));
+
+        let damping = prism_q::NoiseModel::with_amplitude_damping(&circuit, 0.01);
+        group.bench_with_input(
+            BenchmarkId::new("amplitude_damping", total_q),
+            &circuit,
+            |b, circ| {
+                b.iter(|| {
+                    run_shots_with_noise(BackendKind::Factored, circ, &damping, 32, SEED).unwrap();
+                });
+            },
+        );
+
+        let thermal = thermal_noise_model(&circuit);
+        group.bench_with_input(BenchmarkId::new("thermal", total_q), &circuit, |b, circ| {
+            b.iter(|| {
+                run_shots_with_noise(BackendKind::Factored, circ, &thermal, 32, SEED).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_factored_dense(c: &mut Criterion) {
     let mut group = c.benchmark_group("factored/dense");
     configure_group(&mut group);
@@ -1783,6 +1851,7 @@ criterion_group! {
     bench_factored_sim_only,
     bench_factored_dynamic,
     bench_factored_dense,
+    bench_factored_noise_kraus,
     // Clifford+T (SPD/SPP)
     bench_clifford_t,
     // Stabilizer rank

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# Adjacent-binary A/B benchmark comparison.
+#
+# The gating method for any before/after claim on a development host. Separate
+# `cargo bench` invocations minutes apart are not a valid A/B: the rebuild and
+# whatever else the machine does between them drift the measurement by more than
+# the 5% regression gate, and a byte-identical control group has read as much as
+# +98% under that pattern. This script removes the build and the source edit from
+# between the two measurements.
+#
+#   1. Build the bench binary from the working tree and copy it aside.
+#   2. Build the same bench binary from a reference git ref in a separate
+#      worktree and copy it aside.
+#   3. Verify the working tree did not change between the two builds.
+#   4. Run the two binaries adjacent, no build in between: one discarded warmup
+#      pass each, then four measured passes.
+#   5. Emit a markdown table with a same-code control column per row.
+#
+# The measured pass order is ref, new, new, ref. Both means are centred on the
+# same point in time, so linear drift cancels, and each binary is measured twice
+# so every row carries its own noise floor. A change smaller than that floor is
+# reported as noise, not as a win.
+#
+# Usage:
+#   scripts/bench_ab.sh --filter '^factored/noise_kraus/'
+#   scripts/bench_ab.sh -f '^density_matrix/' -r main -b circuits
+#   scripts/bench_ab.sh -f '^sparse/' --ref-dir /tmp/prism-q-ref   # reuse the build
+#
+# Options:
+#   --filter,   -f  Criterion filter regex, applied to every pass (required)
+#   --ref,      -r  git ref for the reference build (default: HEAD)
+#   --bench,    -b  bench target (default: circuits)
+#   --features      cargo feature list (default: parallel)
+#   --ref-dir       reference worktree path. Persists between runs, so the
+#                   reference build is cached. Default: a temporary directory
+#                   removed on exit.
+#   --out           markdown output path (default: bench_results/ab-<stamp>.md)
+#
+# Environment:
+#   REGRESSION_THRESHOLD   regression gate in percent (default: 5.0)
+#   PRISM_BENCH_SAMPLES    samples per row, recorded in the report
+#   PRISM_BENCH_PLOTS      set to render Criterion HTML (about 58s per row)
+#   PRISM_BENCH_HIGH_QUBITS  set to admit the 28q/30q statevector rows
+#
+# Requires git, awk, and cargo. Deliberately not jq or bc: neither is present on
+# the reference host, which is why the stored-baseline tooling never ran there.
+#
+# Batch every row you need into one invocation. Touching `src/lib.rs` rebuilds
+# the `circuits` target in about 202s because `[profile.bench]` inherits
+# `lto = "fat"` with `codegen-units = 1`, and filtering does not avoid the relink.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+FILTER=""
+REF="HEAD"
+BENCH="circuits"
+FEATURES="parallel"
+REF_DIR=""
+OUT=""
+THRESHOLD="${REGRESSION_THRESHOLD:-5.0}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --filter|-f)   FILTER="$2"; shift 2 ;;
+        --ref|-r)      REF="$2"; shift 2 ;;
+        --bench|-b)    BENCH="$2"; shift 2 ;;
+        --features)    FEATURES="$2"; shift 2 ;;
+        --ref-dir)     REF_DIR="$2"; shift 2 ;;
+        --out)         OUT="$2"; shift 2 ;;
+        --threshold|-t) THRESHOLD="$2"; shift 2 ;;
+        -h|--help)     awk 'NR > 1 && !/^#/ { exit } NR > 1' "${BASH_SOURCE[0]}"; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$FILTER" ]]; then
+    echo "Error: --filter is required. Name the rows to compare." >&2
+    exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+for cmd in git awk cargo; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' not found." >&2; exit 1; }
+done
+
+WORKDIR="$(mktemp -d)"
+KEEP_REF_DIR=true
+if [[ -z "$REF_DIR" ]]; then
+    REF_DIR="$WORKDIR/ref"
+    KEEP_REF_DIR=false
+fi
+
+cleanup() {
+    if [[ "$KEEP_REF_DIR" == "false" && -d "$REF_DIR" ]]; then
+        git worktree remove --force "$REF_DIR" 2>/dev/null || true
+    fi
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Windows-native path for variables read by cargo and by the bench binary. MSYS
+# converts arguments but not arbitrary environment variables, so a POSIX path in
+# CARGO_TARGET_DIR or CRITERION_HOME reaches the native binary unusable.
+native_path() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -w "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
+TARGET_DIR_NATIVE="$(native_path "$PROJECT_DIR/target")"
+
+# Content hash of the working tree: HEAD, every tracked modification against it,
+# and every untracked file that is not ignored. Recomputed after the reference
+# build so a save from the editor between the two builds is caught rather than
+# silently pairing two binaries that no longer differ by the change under test.
+tree_fingerprint() {
+    {
+        git rev-parse HEAD
+        git diff HEAD --binary
+        git ls-files -o --exclude-standard -z | while IFS= read -r -d '' f; do
+            printf '%s ' "$f"
+            git hash-object "$f"
+        done
+    } | git hash-object --stdin
+}
+
+# Build the bench target in `dir` and copy the resulting executable to `out`.
+# The path comes from cargo's own artifact message, not from an mtime scan of
+# the deps directory, so a build that relinks nothing still resolves correctly.
+build_bench_exe() {
+    local dir="$1" out="$2" label="$3"
+    local log="$WORKDIR/build-$label.json"
+
+    echo ">>> building $label: cargo bench --bench $BENCH --features \"$FEATURES\" --no-run"
+    (
+        cd "$dir"
+        CARGO_TARGET_DIR="$TARGET_DIR_NATIVE" \
+            cargo bench --bench "$BENCH" --features "$FEATURES" --no-run --message-format=json
+    ) > "$log"
+
+    local exe
+    exe="$(awk -v want="$BENCH" '
+        /"reason":"compiler-artifact"/ && index($0, "\"executable\":\"") > 0 {
+            name = ""
+            if (match($0, /"name":"[^"]*"/)) {
+                name = substr($0, RSTART + 8, RLENGTH - 9)
+            }
+            if (name != want) next
+            if (match($0, /"executable":"[^"]*"/)) {
+                print substr($0, RSTART + 14, RLENGTH - 15)
+            }
+        }' "$log" | tail -1)"
+
+    if [[ -z "$exe" ]]; then
+        echo "Error: cargo reported no executable for bench target '$BENCH'." >&2
+        echo "  artifact log: $log" >&2
+        exit 1
+    fi
+
+    # Cargo emits an escaped Windows path in JSON; unescape before touching it.
+    exe="${exe//\\\\//}"
+    if [[ ! -f "$exe" ]] && command -v cygpath >/dev/null 2>&1; then
+        exe="$(cygpath -u "$exe")"
+    fi
+    if [[ ! -f "$exe" ]]; then
+        echo "Error: bench executable '$exe' does not exist." >&2
+        exit 1
+    fi
+
+    cp "$exe" "$out"
+    echo "    $out"
+}
+
+# Extract `full_id<TAB>mean_ns` for every row a pass measured. The mean is the
+# first point estimate in the JSON object, which serde writes before the median.
+snapshot() {
+    local home="$1" out="$2"
+
+    find "$home" -path "*/new/estimates.json" -print 2>/dev/null | while IFS= read -r est; do
+        local bm="${est%estimates.json}benchmark.json"
+        [[ -f "$bm" ]] || continue
+
+        local id mean
+        id="$(awk 'match($0, /"full_id":"[^"]*"/) {
+                print substr($0, RSTART + 11, RLENGTH - 12); exit
+            }' "$bm")"
+        mean="$(awk '{
+                seg = $0
+                cut = index(seg, "\"median\"")
+                if (cut > 0) seg = substr(seg, 1, cut - 1)
+                if (match(seg, /"point_estimate":[-0-9.eE+]+/)) {
+                    print substr(seg, RSTART + 17, RLENGTH - 17)
+                }
+                exit
+            }' "$est")"
+
+        [[ -n "$id" && -n "$mean" ]] && printf '%s\t%s\n' "$id" "$mean"
+    done | sort > "$out"
+}
+
+run_pass() {
+    local idx="$1" label="$2" exe="$3"
+    local home="$WORKDIR/crit-$idx"
+    mkdir -p "$home"
+
+    echo ">>> pass $idx ($label)"
+    CRITERION_HOME="$(native_path "$home")" "$exe" --bench "$FILTER"
+
+    snapshot "$home" "$WORKDIR/pass-$idx.tsv"
+    local rows
+    rows="$(wc -l < "$WORKDIR/pass-$idx.tsv" | tr -d '[:space:]')"
+    if (( rows == 0 )); then
+        echo "Error: pass $idx produced no Criterion estimates under $home." >&2
+        echo "  Either --filter '$FILTER' matched nothing, or CRITERION_HOME was ignored." >&2
+        exit 1
+    fi
+    echo "    pass $idx measured $rows rows"
+    echo ""
+}
+
+# One discarded pass per binary before anything is recorded.
+#
+# Without them the first measured pass absorbs the whole cold start (page faults
+# on the freshly linked executable, cache and turbo state after two builds) and
+# whichever binary owns it looks slow. On the reference host the first ordering
+# tried put the reference binary in pass 1 and its same-code control read -17.1%,
+# -15.2%, and -18.4% on three rows while the second binary's control read within
+# 1%: a systematic penalty against the earlier binary, not host noise. Both
+# binaries now enter the measured passes with the same warm history.
+warm_up() {
+    local idx="$1" exe="$2"
+    local home="$WORKDIR/warm-$idx"
+    mkdir -p "$home"
+    echo ">>> warmup $idx (discarded)"
+    CRITERION_HOME="$(native_path "$home")" "$exe" --bench "$FILTER" > /dev/null
+    echo ""
+}
+
+host_cpu() {
+    if [[ -r /proc/cpuinfo ]]; then
+        awk -F': ' '/model name/ { print $2; exit }' /proc/cpuinfo
+    elif command -v sysctl >/dev/null 2>&1 && sysctl -n machdep.cpu.brand_string >/dev/null 2>&1; then
+        sysctl -n machdep.cpu.brand_string
+    else
+        printf '%s' "${PROCESSOR_IDENTIFIER:-unknown}"
+    fi
+}
+
+# --- Build both binaries ---
+
+REF_SHA="$(git rev-parse --short "$REF")"
+FINGERPRINT_BEFORE="$(tree_fingerprint)"
+
+echo "=== PRISM-Q adjacent-binary A/B ==="
+echo "  bench:     $BENCH"
+echo "  filter:    $FILTER"
+echo "  features:  $FEATURES"
+echo "  reference: $REF ($REF_SHA)"
+echo "  threshold: ${THRESHOLD}%"
+echo ""
+
+build_bench_exe "$PROJECT_DIR" "$WORKDIR/new" "new"
+
+if [[ -d "$REF_DIR/.git" || -f "$REF_DIR/.git" ]]; then
+    echo ">>> reusing reference worktree $REF_DIR"
+    git -C "$REF_DIR" checkout --detach --force "$REF_SHA" >/dev/null 2>&1
+    git -C "$REF_DIR" clean -fdq
+else
+    echo ">>> adding reference worktree $REF_DIR at $REF_SHA"
+    git worktree add --detach --force "$REF_DIR" "$REF_SHA" >/dev/null
+fi
+
+build_bench_exe "$REF_DIR" "$WORKDIR/ref" "ref"
+
+FINGERPRINT_AFTER="$(tree_fingerprint)"
+if [[ "$FINGERPRINT_BEFORE" != "$FINGERPRINT_AFTER" ]]; then
+    echo "Error: the working tree changed between the two builds." >&2
+    echo "  The two binaries no longer differ by the change under test, so the" >&2
+    echo "  comparison would be meaningless. Re-run with the tree settled." >&2
+    exit 1
+fi
+
+# The two binaries are never byte identical even from identical sources, because
+# `debug = "line-tables-only"` records the package path and the worktrees differ.
+# Same code is decided from git instead.
+if [[ -z "$(git status --porcelain)" && "$(git rev-parse HEAD)" == "$(git rev-parse "$REF_SHA")" ]]; then
+    echo "Note: the working tree matches $REF exactly, so both binaries carry the"
+    echo "      same code and every row is a control row. This is the same-code"
+    echo "      noise floor of the host, with no change under test."
+    echo ""
+fi
+
+# --- Measure ---
+
+echo "=== two discarded warmup passes, then four adjacent passes ==="
+echo ""
+warm_up 1 "$WORKDIR/ref"
+warm_up 2 "$WORKDIR/new"
+run_pass 1 "ref" "$WORKDIR/ref"
+run_pass 2 "new" "$WORKDIR/new"
+run_pass 3 "new" "$WORKDIR/new"
+run_pass 4 "ref" "$WORKDIR/ref"
+
+# --- Report ---
+
+MERGED="$WORKDIR/merged.tsv"
+: > "$MERGED"
+for idx in 1 2 3 4; do
+    awk -v p="$idx" 'BEGIN { OFS = "\t" } { print p, $1, $2 }' "$WORKDIR/pass-$idx.tsv" >> "$MERGED"
+done
+
+if [[ -z "$OUT" ]]; then
+    mkdir -p "$PROJECT_DIR/bench_results"
+    OUT="$PROJECT_DIR/bench_results/ab-$(date +%Y-%m-%d_%H%M%S).md"
+fi
+
+HIGH_QUBITS_STATE="off"
+if [[ -n "${PRISM_BENCH_HIGH_QUBITS:-}" ]]; then
+    HIGH_QUBITS_STATE="enabled"
+fi
+
+set +e
+{
+    echo "## Adjacent-binary A/B: \`$BENCH\`"
+    echo ""
+    echo "| Setting | Value |"
+    echo "| --- | --- |"
+    echo "| Filter | \`$FILTER\` |"
+    echo "| Reference | \`$REF\` ($REF_SHA) |"
+    echo "| Features | \`$FEATURES\` |"
+    echo "| Pass order | ref, new discarded, then ref, new, new, ref (adjacent, no rebuild) |"
+    echo "| Samples | ${PRISM_BENCH_SAMPLES:-100} |"
+    echo "| High-qubit rows | $HIGH_QUBITS_STATE |"
+    echo "| CPU | $(host_cpu) |"
+    echo "| OS | $(uname -srm) |"
+    echo "| Toolchain | $(rustc --version) |"
+    echo "| Bench profile | \`lto = \"fat\"\`, \`codegen-units = 1\`, \`debug = \"line-tables-only\"\` |"
+    echo "| Threshold | ${THRESHOLD}% |"
+    echo ""
+
+    awk -v threshold="$THRESHOLD" '
+        BEGIN { FS = "\t"; SEP = "\x1f" }
+
+        {
+            mean[$1 SEP $2] = $3
+            if ($1 == 1) { order[++n] = $2 }
+        }
+
+        function fmt(ns) {
+            if (ns >= 1000000000) { return sprintf("%.3f s", ns / 1000000000) }
+            if (ns >= 1000000)    { return sprintf("%.2f ms", ns / 1000000) }
+            if (ns >= 1000)       { return sprintf("%.2f us", ns / 1000) }
+            return sprintf("%.1f ns", ns)
+        }
+
+        function pct(v) { return sprintf("%+.1f%%", v) }
+        function abs(v) { return v < 0 ? -v : v }
+
+        END {
+            print "| Benchmark | Ref | New | Change | Control (ref) | Control (new) | Verdict |"
+            print "| --- | ---: | ---: | ---: | ---: | ---: | --- |"
+
+            compared = 0
+            regressions = 0
+            unresolvable = 0
+            worst_floor = 0
+
+            for (i = 1; i <= n; i++) {
+                id = order[i]
+                a1 = mean[1 SEP id]; b1 = mean[2 SEP id]
+                b2 = mean[3 SEP id]; a2 = mean[4 SEP id]
+                if (a1 == "" || b1 == "" || b2 == "" || a2 == "") { continue }
+
+                ref = (a1 + a2) / 2
+                new = (b1 + b2) / 2
+                change = (new - ref) * 100 / ref
+                ctl_ref = (a2 - a1) * 100 / a1
+                ctl_new = (b2 - b1) * 100 / b1
+                floor = abs(ctl_ref) > abs(ctl_new) ? abs(ctl_ref) : abs(ctl_new)
+                if (floor > worst_floor) { worst_floor = floor }
+
+                if (abs(change) <= floor) {
+                    verdict = "noise"
+                } else if (change < 0) {
+                    verdict = "faster"
+                } else {
+                    verdict = "slower"
+                }
+
+                if (change > threshold && change > floor) { regressions++ }
+                if (floor > threshold) { unresolvable++; unresolved[unresolvable] = id }
+
+                printf "| `%s` | %s | %s | %s | %s | %s | %s |\n",
+                    id, fmt(ref), fmt(new), pct(change), pct(ctl_ref), pct(ctl_new), verdict
+                compared++
+            }
+
+            print ""
+            printf "%d rows compared. Worst same-code control spread: %.1f%%.\n", compared, worst_floor
+            print ""
+
+            if (compared == 0) {
+                print "**Regression verdict**: NO DATA. No row appeared in all four passes."
+                exit 1
+            }
+
+            status = 0
+            if (regressions > 0) {
+                status = 1
+                printf "**Regression verdict**: FAIL. %d row(s) regressed beyond %s%% and beyond their own control spread.\n",
+                    regressions, threshold
+            } else {
+                printf "**Regression verdict**: PASS at %s%%.\n", threshold
+            }
+
+            if (unresolvable > 0) {
+                print ""
+                printf "%d row(s) have a same-code control spread above the %s%% gate, so this host cannot resolve the gate on them:\n",
+                    unresolvable, threshold
+                print ""
+                for (i = 1; i <= unresolvable; i++) { printf "- `%s`\n", unresolved[i] }
+                print ""
+                print "Treat their Change column as unmeasured, not as a result."
+            }
+
+            exit status
+        }
+    ' "$MERGED"
+} > "$OUT"
+REPORT_STATUS=$?
+set -e
+
+cat "$OUT"
+echo ""
+echo "Markdown written to $OUT"
+exit "$REPORT_STATUS"

--- a/scripts/release_bump_level.sh
+++ b/scripts/release_bump_level.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Resolve the cargo-release bump level for a commit range.
+#
+# Two stages. The first maps conventional commits to a level exactly as the
+# specification describes. The second clamps that level against the crate's
+# current major version, because below 1.0 a "major" bump is not available:
+# Cargo reads `0.27.0` as `^0.27.0`, so under 0.x the minor is the compatibility
+# boundary and a breaking change belongs there. `cargo release major` on a 0.x
+# version would publish 1.0.0, which crates.io lets you yank but never
+# unpublish, and which declares an API stability the crate has not reached.
+#
+# Once the crate ships a deliberate 1.0.0 the clamp stops firing and breaking
+# commits resolve to major again, with no change to this script.
+#
+# Usage:
+#   scripts/release_bump_level.sh [RANGE]
+#
+# Emits `key=value` lines on stdout, suitable for appending straight to
+# `$GITHUB_OUTPUT`:
+#
+#   level=minor        the level to hand cargo-release
+#   raw_level=major    the level before the pre-1.0 clamp
+#   version=0.27.0     the version read from the manifest
+#
+# RANGE defaults to `<last tag>..HEAD`, or `HEAD` when the repository has no
+# tags. Override the manifest with the MANIFEST environment variable.
+#
+# scripts/release_bump_level_test.sh sources this file and drives the pure
+# functions below against synthetic commit lists.
+
+set -euo pipefail
+
+# Bump level implied by conventional-commit subjects and bodies, ignoring the
+# current version. Echoes one of: major, minor, patch, none.
+conventional_bump_level() {
+    local subjects="$1"
+    local bodies="$2"
+
+    if [[ -z "${subjects//[[:space:]]/}" ]]; then
+        echo "none"
+        return
+    fi
+
+    if printf '%s\n' "$subjects" | grep -qiE '^[a-z]+(\(.+\))?!:'; then
+        echo "major"
+    elif printf '%s\n' "$bodies" | grep -q '^BREAKING CHANGE:'; then
+        echo "major"
+    elif printf '%s\n' "$subjects" | grep -qE '^feat(\(.+\))?:'; then
+        echo "minor"
+    elif printf '%s\n' "$subjects" | grep -qE '^(fix|perf)(\(.+\))?:'; then
+        echo "patch"
+    else
+        echo "none"
+    fi
+}
+
+# Clamp a conventional-commit level against the crate's current major version.
+# Below 1.0 a major bump becomes a minor bump; every other level passes through.
+clamp_bump_level() {
+    local level="$1"
+    local major="$2"
+
+    if [[ "$level" == "major" && "$major" == "0" ]]; then
+        echo "minor"
+    else
+        echo "$level"
+    fi
+}
+
+# Version string from the `[package]` table of a Cargo manifest. Stops at the
+# first version key inside that table, so `[workspace]` and dependency tables
+# below it cannot shadow it.
+crate_version() {
+    local manifest="${1:-Cargo.toml}"
+
+    awk -F'"' '
+        /^\[/ { in_package = ($0 == "[package]"); next }
+        in_package && /^version[[:space:]]*=/ { print $2; exit }
+    ' "$manifest"
+}
+
+main() {
+    local range="${1:-}"
+    if [[ -z "$range" ]]; then
+        local last_tag
+        last_tag="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+        if [[ -z "$last_tag" ]]; then
+            range="HEAD"
+        else
+            range="${last_tag}..HEAD"
+        fi
+    fi
+
+    local subjects bodies version raw_level level
+    subjects="$(git log --format="%s" "$range" 2>/dev/null || true)"
+    bodies="$(git log --format="%b" "$range" 2>/dev/null || true)"
+    version="$(crate_version "${MANIFEST:-Cargo.toml}")"
+
+    if [[ -z "$version" ]]; then
+        echo "Error: no [package] version in ${MANIFEST:-Cargo.toml}" >&2
+        exit 1
+    fi
+
+    raw_level="$(conventional_bump_level "$subjects" "$bodies")"
+    level="$(clamp_bump_level "$raw_level" "${version%%.*}")"
+
+    echo "level=$level"
+    echo "raw_level=$raw_level"
+    echo "version=$version"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/release_bump_level_test.sh
+++ b/scripts/release_bump_level_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Verify scripts/release_bump_level.sh against synthetic commit lists.
+#
+# The release workflow has no test harness of its own, so the bump logic lives
+# in sourceable functions and this script drives them directly. Each case states
+# the commit subjects, the commit bodies, the manifest version, and the version
+# the resolved level produces, so the pre-1.0 clamp is asserted rather than
+# eyeballed.
+#
+# Usage: scripts/release_bump_level_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release_bump_level.sh
+source "$SCRIPT_DIR/release_bump_level.sh"
+
+PASS=0
+FAIL=0
+
+# Version cargo-release produces by applying `level` to `version`. Mirrors
+# cargo-release's own arithmetic so a case can state the published number.
+next_version() {
+    local level="$1" version="$2"
+    local major="${version%%.*}"
+    local rest="${version#*.}"
+    local minor="${rest%%.*}"
+    local patch="${rest#*.}"
+
+    case "$level" in
+        major) echo "$((major + 1)).0.0" ;;
+        minor) echo "${major}.$((minor + 1)).0" ;;
+        patch) echo "${major}.${minor}.$((patch + 1))" ;;
+        none)  echo "$version" ;;
+        *)     echo "unknown-level" ;;
+    esac
+}
+
+check() {
+    local label="$1" subjects="$2" bodies="$3" version="$4"
+    local want_level="$5" want_version="$6"
+
+    local raw got_level got_version
+    raw="$(conventional_bump_level "$subjects" "$bodies")"
+    got_level="$(clamp_bump_level "$raw" "${version%%.*}")"
+    got_version="$(next_version "$got_level" "$version")"
+
+    if [[ "$got_level" == "$want_level" && "$got_version" == "$want_version" ]]; then
+        PASS=$((PASS + 1))
+        printf 'ok    %-46s %s -> %s (%s)\n' "$label" "$version" "$got_version" "$got_level"
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL  %-46s want %s/%s, got %s/%s (raw %s)\n' \
+            "$label" "$want_level" "$want_version" "$got_level" "$got_version" "$raw"
+    fi
+}
+
+echo "=== release bump level ==="
+
+# The bug this harness exists for: a breaking commit on 0.x must not cut a 1.0.
+check "breaking subject on 0.x" \
+    "feat!: drop the inert serialization feature" "" "0.27.0" minor "0.28.0"
+check "scoped breaking subject on 0.x" \
+    "feat(backend)!: change the trait signature" "" "0.27.0" minor "0.28.0"
+check "breaking body on 0.x" \
+    "refactor: rework the noise API" $'BREAKING CHANGE: NoiseModel is now per qubit.' \
+    "0.27.0" minor "0.28.0"
+check "breaking subject wins over feat on 0.x" \
+    $'chore: bump deps\nfeat!: remove the old builder' "" "0.27.0" minor "0.28.0"
+
+# The clamp is version gated, so a deliberate 1.0 keeps the major path working.
+check "breaking subject on 1.x" \
+    "feat!: drop the old API" "" "1.4.2" major "2.0.0"
+check "breaking body on 1.x" \
+    "refactor: rework the noise API" $'BREAKING CHANGE: NoiseModel is now per qubit.' \
+    "1.4.2" major "2.0.0"
+
+# Non-breaking mappings are unchanged by the clamp.
+check "feat maps to minor" "feat: add a factored trajectory row" "" "0.27.0" minor "0.28.0"
+check "scoped feat maps to minor" "feat(bench): add a noise row" "" "0.27.0" minor "0.28.0"
+check "fix maps to patch" "fix: correct the reset channel" "" "0.27.0" patch "0.27.1"
+check "perf maps to patch" "perf(backend): drop a buffer pass" "" "0.27.0" patch "0.27.1"
+check "feat outranks fix" $'fix: correct the reset channel\nfeat: add a row' "" \
+    "0.27.0" minor "0.28.0"
+check "docs and perf map to patch" $'docs: describe the A/B method\nperf: drop a pass' "" \
+    "0.27.0" patch "0.27.1"
+
+# Nothing release worthy.
+check "chore only maps to none" "chore: tidy the tracker" "" "0.27.0" none "0.27.0"
+check "empty range maps to none" "" "" "0.27.0" none "0.27.0"
+check "whitespace range maps to none" $'\n  \n' "" "0.27.0" none "0.27.0"
+
+# Guards against widening the breaking match.
+check "mid line breaking text is not breaking" \
+    "docs: link the changelog" "See BREAKING CHANGE: notes in the guide." \
+    "0.27.0" none "0.27.0"
+check "bang without colon is not breaking" \
+    "feat! add a row" "" "0.27.0" none "0.27.0"
+
+echo ""
+echo "=== manifest version ==="
+
+MANIFEST_FIXTURE="$(mktemp)"
+trap 'rm -f "$MANIFEST_FIXTURE"' EXIT
+cat > "$MANIFEST_FIXTURE" <<'EOF'
+[package]
+name = "prism-q"
+version = "0.27.0"
+edition = "2024"
+
+[workspace]
+members = [".", "bindings/python"]
+
+[dependencies]
+num-complex = { version = "9.9.9" }
+EOF
+
+fixture_version="$(crate_version "$MANIFEST_FIXTURE")"
+if [[ "$fixture_version" == "0.27.0" ]]; then
+    PASS=$((PASS + 1))
+    echo "ok    package version read past workspace and dependency tables"
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL  package version: want 0.27.0, got '$fixture_version'"
+fi
+
+repo_version="$(crate_version "$SCRIPT_DIR/../Cargo.toml")"
+if [[ "$repo_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    PASS=$((PASS + 1))
+    echo "ok    repository manifest version parses ($repo_version)"
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL  repository manifest version did not parse: '$repo_version'"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+if (( FAIL > 0 )); then
+    exit 1
+fi

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -495,4 +495,20 @@ impl Backend for DensityMatrixBackend {
         }
         Ok([[r00, r01], [r10, r11]])
     }
+
+    /// Evolve `rho -> K rho K^dagger` for an arbitrary `K`, on the same kernel
+    /// selection as the one-qubit branch of `apply_unitary`. Trajectories never
+    /// route here, since `supports_noisy_per_shot` excludes the density matrix in
+    /// favour of `apply_1q_kraus` on the mixture; this keeps the trait method
+    /// allocation-free on every backend that holds a state.
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        let n = self.num_qubits;
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            let s = block_superoperator(&[*matrix]);
+            self.apply_block_superoperator(qubit, &s);
+            return Ok(());
+        }
+        self.sv.apply_1q_matrix(qubit + n, matrix)?;
+        self.sv.apply_1q_matrix(qubit, &conjugate_2x2(matrix))
+    }
 }

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1459,4 +1459,37 @@ impl Backend for DistributedStatevectorBackend {
     fn reset(&mut self, qubit: usize) -> Result<()> {
         self.reset_dist(qubit)
     }
+
+    /// Apply a 2x2 matrix to one circuit qubit across the rank split, on the same
+    /// route `apply_gate` takes for a one-qubit gate: relabel a non-diagonal
+    /// target into a local position when a victim exists, apply locally when the
+    /// physical position is local, otherwise exchange with the partner rank.
+    ///
+    /// Collective when the target is global, so every rank must call it with the
+    /// same qubit.
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        if self.global_qubits == 0 {
+            return self.inner.apply_1q_matrix(qubit, matrix);
+        }
+
+        let diagonal = is_diagonal_2x2(matrix);
+        if self.relabel {
+            self.tick += 1;
+            self.last_used[qubit] = self.tick;
+            if !diagonal {
+                self.make_local(&[qubit]);
+            }
+        }
+
+        let target = self.physical_qubit(qubit);
+        if target < self.local_qubits() {
+            return self.inner.apply_1q_matrix(target, matrix);
+        }
+        if diagonal {
+            self.apply_global_diagonal_1q(target, matrix[0][0], matrix[1][1]);
+        } else {
+            self.apply_global_1q(target, *matrix);
+        }
+        Ok(())
+    }
 }

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -1308,3 +1308,78 @@ fn shots_without_measurements_still_validate_configuration() {
         );
     }
 }
+
+/// The override has to reproduce the route `apply_gate` takes for a one-qubit gate
+/// at every position of the local/global split, including the diagonal shortcut.
+/// The third matrix is a non-unitary jump branch, which is what the trajectory
+/// engine actually hands this method.
+#[test]
+fn loopback_apply_1q_matrix_all_qubit_splits() {
+    relax_min_local_qubits();
+    let n = 4;
+
+    let dense = [
+        [Complex64::new(0.6, 0.0), Complex64::new(0.8, 0.0)],
+        [Complex64::new(0.8, 0.0), Complex64::new(-0.6, 0.0)],
+    ];
+    let diagonal = [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::from_polar(1.0, 0.7)],
+    ];
+    let jump = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.3, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+
+    let mut b = CircuitBuilder::new(n);
+    b.rx(0.3, 0).ry(0.8, 1).rx(1.2, 2).t(3).h(3).cx(0, 2);
+    let prep = b.build();
+
+    for (label, matrix) in [("dense", dense), ("diagonal", diagonal), ("jump", jump)] {
+        for target in 0..n {
+            let mut sv = StatevectorBackend::new(SEED);
+            sv.init(n, 0).unwrap();
+            sv.apply_instructions(&prep.instructions).unwrap();
+            sv.apply_1q_matrix(target, &matrix).unwrap();
+            let expected = sv.export_statevector().unwrap();
+
+            for &relabel in &[true, false] {
+                for &size in &[1usize, 2, 4] {
+                    let shared = LoopbackShared::new(size);
+                    let handles: Vec<_> = (0..size)
+                        .map(|rank| {
+                            let comm = LoopbackComm {
+                                shared: shared.clone(),
+                                rank,
+                            };
+                            let prep = prep.clone();
+                            std::thread::Builder::new()
+                                .stack_size(64 * 1024 * 1024)
+                                .spawn(move || {
+                                    let ctx = DistributedContext::from_comm(Arc::new(comm));
+                                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                                    backend.set_relabel(relabel);
+                                    backend.init(n, 0).unwrap();
+                                    backend.apply_instructions(&prep.instructions).unwrap();
+                                    backend.apply_1q_matrix(target, &matrix).unwrap();
+                                    backend.export_statevector().unwrap()
+                                })
+                                .expect("spawn rank thread")
+                        })
+                        .collect();
+
+                    for actual in handles.into_iter().map(|h| h.join().unwrap()) {
+                        assert_eq!(expected.len(), actual.len());
+                        for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+                            assert!(
+                                (e - a).norm() < TOL,
+                                "{label} on q{target}, size {size}, relabel {relabel}: \
+                                 amp[{i}] expected {e}, got {a}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -14,6 +14,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use smallvec::{SmallVec, smallvec};
 
+use crate::backend::memory::dense_statevector_len;
 use crate::backend::simd;
 use crate::backend::statevector::insert_zero_bit;
 use crate::backend::{
@@ -21,7 +22,7 @@ use crate::backend::{
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
-use crate::gates::{DiagEntry, Gate};
+use crate::gates::{DiagEntry, Gate, is_diagonal_2x2};
 use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 
 #[cfg(feature = "parallel")]
@@ -638,6 +639,80 @@ impl Backend for FactoredBackend {
             [Complex64::new(p0, 0.0), r.conj()],
             [r, Complex64::new(p1, 0.0)],
         ])
+    }
+
+    /// Apply a Kraus branch to one qubit without boxing a `Gate::Fused`.
+    ///
+    /// The default routes through `apply`, which allocates per call, and this is
+    /// the one override a live path depends on: a non-Pauli channel on a factored
+    /// run reaches here once per damping event. A single target never merges
+    /// sub-states, so kernel selection matches the `Gate::Fused` arm of
+    /// `dispatch_gate` exactly.
+    fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        let ss_idx = self.qubit_to_substate[qubit];
+        let sub = self.substates[ss_idx].as_mut().unwrap();
+        let local = Self::local_qubit(sub, qubit);
+
+        #[cfg(feature = "parallel")]
+        let par = sub.qubits.len() >= PARALLEL_THRESHOLD_QUBITS;
+
+        if is_diagonal_2x2(matrix) {
+            let skip_lo = is_phase_one(matrix[0][0]);
+            #[cfg(feature = "parallel")]
+            if par {
+                par_apply_diagonal(&mut sub.state, local, matrix[0][0], matrix[1][1], skip_lo);
+                return Ok(());
+            }
+            simd::apply_diagonal_sequential(
+                &mut sub.state,
+                local,
+                matrix[0][0],
+                matrix[1][1],
+                skip_lo,
+            );
+        } else {
+            #[cfg(feature = "parallel")]
+            if par {
+                par_apply_1q(&mut sub.state, local, matrix);
+                return Ok(());
+            }
+            simd::PreparedGate1q::new(matrix).apply_full_sequential(&mut sub.state, local);
+        }
+        Ok(())
+    }
+
+    /// Tensor the live sub-states back into a joint amplitude vector.
+    ///
+    /// The state is a product over blocks, so the joint amplitude at a global
+    /// index is the product of each block's amplitude at the index restricted to
+    /// that block's qubits. Sub-states stay normalized through measurement, so no
+    /// pending norm is carried.
+    fn export_statevector(&self) -> Result<Vec<Complex64>> {
+        let dim = dense_statevector_len(self.name(), "statevector export", self.num_qubits)?;
+
+        let active: SmallVec<[&SubState; 16]> = self
+            .substates
+            .iter()
+            .filter_map(|opt| opt.as_ref())
+            .collect();
+
+        if active.len() == 1 && active[0].qubits.len() == self.num_qubits {
+            return Ok(active[0].state.clone());
+        }
+
+        let mut joint = vec![Complex64::new(0.0, 0.0); dim];
+        for (index, amp) in joint.iter_mut().enumerate() {
+            let mut product = Complex64::new(1.0, 0.0);
+            for sub in &active {
+                let mut local = 0usize;
+                for (bit, &q) in sub.qubits.iter().enumerate() {
+                    local |= ((index >> q) & 1) << bit;
+                }
+                product *= sub.state[local];
+            }
+            *amp = product;
+        }
+        Ok(joint)
     }
 
     fn classical_results(&self) -> &[bool] {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,6 +17,25 @@
 //! - Use `#[inline]` and `#[inline(always)]` on gate kernels.
 //! - Document all `unsafe` blocks with safety invariants.
 //!
+//! # Optional methods and what declines them
+//!
+//! Several trait methods carry a default that reports the operation unsupported.
+//! Which representations decline, and why they cannot answer:
+//!
+//! | Method | Declined by | Reason |
+//! | --- | --- | --- |
+//! | `apply_1q_matrix` | Stabilizer, FactoredStabilizer | A tableau stores a state by its stabilizer group, closed under Clifford conjugation. A general 2x2 has no image in that group, and a Kraus branch is not even unitary. |
+//! | `reduced_density_matrix_1q` | Stabilizer, FactoredStabilizer | Derivable from a tableau, but the operator it feeds cannot be applied (row above), so the branch would be sampled and never used. |
+//! | `reduced_density_matrix_1q` | TensorNetwork | A local reduced state needs the network contracted with two indices left open, which the contraction planner does not express. Its only route is the full dense contraction behind `export_statevector`. |
+//! | `reduced_density_matrix_1q` | DistributedStatevector | Trajectories run shots on Rayon workers whose order differs per rank, so per-shot noise would issue rank collectives out of lockstep. `run_shots_with_noise` rejects the backend for that reason, which closes the only path here. |
+//! | `export_statevector` | DensityMatrix | A mixture of pure states has no statevector. Read `DensityMatrixBackend::purity` or reduce the state instead. |
+//! | `export_statevector` | FactoredStabilizer | Exports while one tableau covers every qubit; past that there is no joint tableau to expand. |
+//!
+//! [`Backend::reduced_density_matrix_1q`] and [`Backend::apply_1q_matrix`] are
+//! two halves of one capability, sampling a non-Pauli branch and applying the
+//! operator it selects, so their coverage is one set by construction. That set is
+//! `BackendKind::supports_general_noise`.
+//!
 //! # Adding a new backend
 //!
 //! Implement the [`Backend`] trait below, following the contract and
@@ -243,8 +262,9 @@ pub trait Backend {
     /// vector. Enables backend transitions (e.g., Stabilizer → Statevector
     /// for temporal Clifford decomposition).
     ///
-    /// Not all backends support this efficiently. The default implementation
-    /// returns `Err(BackendUnsupported)`.
+    /// Implemented by every backend that holds a pure state, including the
+    /// factored one, whose blocks tensor back into a joint vector. See the module
+    /// docs for what declines it.
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
@@ -266,10 +286,9 @@ pub trait Backend {
     ///
     /// Returned as `[[p0, r*], [r, p1]]`, where `r = <1|rho|0>`.
     /// Used by the trajectory engine for dense custom Kraus channels whose
-    /// branch probabilities depend on coherence, not just populations. The
-    /// default returns `BackendUnsupported`; backends override when their
-    /// representation can expose this quantity efficiently enough for noise
-    /// sampling.
+    /// branch probabilities depend on coherence, not just populations. Backends
+    /// override when their representation can expose this efficiently enough for
+    /// noise sampling; see the module docs for what declines it and why.
     fn reduced_density_matrix_1q(&self, _qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
@@ -349,10 +368,14 @@ pub trait Backend {
     /// Apply a 2×2 matrix to a single qubit without allocating.
     ///
     /// Used by the trajectory engine to apply Kraus operators (amplitude
-    /// damping, phase damping, thermal relaxation) without boxing into a
-    /// `Gate::Fused` on every call. The default falls back to building a
-    /// `Gate::Fused` and dispatching via `apply`; backends may override for a
-    /// zero-allocation fast path.
+    /// damping, phase damping, thermal relaxation, generic normalized Kraus).
+    /// The matrix need not be unitary: a jump branch is a projector scaled by
+    /// `1/sqrt(p_jump)`, and the no-jump branch renormalizes.
+    ///
+    /// The default builds a `Gate::Fused` and dispatches via `apply`, which
+    /// heap-allocates once per call inside a gate-application path, so every
+    /// backend that can reach this method overrides it. See the module docs for
+    /// what declines it.
     fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
         use crate::circuit::smallvec;
         self.apply(&crate::circuit::Instruction::Gate {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -2401,12 +2401,26 @@ mod tests {
         }
     }
 
+    /// `make_general_circuit` entangles `{0, 1}` and leaves qubit 2 alone, so the
+    /// export runs with two live sub-states rather than one.
     #[test]
-    fn test_export_factored_unsupported() {
+    fn test_export_factored_tensors_multiple_blocks() {
         let circuit = make_general_circuit();
         let mut backend = crate::backend::factored::FactoredBackend::new(42);
         run_on(&mut backend, &circuit).unwrap();
-        assert!(backend.export_statevector().is_err());
+        let state = backend.export_statevector().unwrap();
+        assert_unit_norm(&state, "factored multi-block export");
+
+        let mut sv = StatevectorBackend::new(42);
+        run_on(&mut sv, &circuit).unwrap();
+        let expected = sv.export_statevector().unwrap();
+        assert_eq!(state.len(), expected.len());
+        for (i, (a, e)) in state.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).norm() < 1e-12,
+                "factored export[{i}]: expected {e}, got {a}"
+            );
+        }
     }
 
     #[test]

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -2287,7 +2287,7 @@ pub(crate) fn run_shots_noisy_brute_with(
 
     for i in 0..num_shots {
         let shot_seed = seed.wrapping_add(i as u64);
-        let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
+        let mut rng = crate::sim::trajectory::noise_rng(shot_seed);
         let mut backend = backend_factory(shot_seed);
         backend.init(circuit.num_qubits, circuit.num_classical_bits)?;
 

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -13,6 +13,19 @@ use crate::sim::noise::{NoiseChannel, NoiseEvent, NoiseModel};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+/// Noise sampler for one shot, on a ChaCha stream of its own.
+///
+/// The backend is seeded from the same shot seed and is also `ChaCha8Rng`, so on
+/// the default stream the two emit the same sequence and a branch draw lands on
+/// the same value as the measurement draw after it. Amplitude damping at
+/// `gamma = 0.15` on `H|0>` read `P(1) = 0.384` over 200k shots against an exact
+/// 0.425. A second stream keeps one seed reproducible and the draws independent.
+pub(crate) fn noise_rng(shot_seed: u64) -> ChaCha8Rng {
+    let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
+    rng.set_stream(1);
+    rng
+}
+
 fn apply_pauli(
     backend: &mut dyn Backend,
     qubit: usize,
@@ -390,7 +403,7 @@ pub(crate) fn run_trajectories(
     let mut shots = Vec::with_capacity(num_shots);
     for i in 0..num_shots {
         let shot_seed = seed.wrapping_add(i as u64);
-        let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
+        let mut rng = noise_rng(shot_seed);
         let mut backend = backend_factory(shot_seed);
         let result = run_trajectory_shot(backend.as_mut(), circuit, noise, &mut rng)?;
         shots.push(result);
@@ -411,7 +424,7 @@ fn run_trajectories_par(
         .into_par_iter()
         .map(|i| {
             let shot_seed = seed.wrapping_add(i as u64);
-            let mut rng = ChaCha8Rng::seed_from_u64(shot_seed);
+            let mut rng = noise_rng(shot_seed);
             let mut backend = backend_factory(shot_seed);
             run_trajectory_shot(backend.as_mut(), circuit, noise, &mut rng)
         })

--- a/tests/backend_equivalence.rs
+++ b/tests/backend_equivalence.rs
@@ -910,6 +910,89 @@ fn product_export_statevector_matches() {
     }
 }
 
+/// One entangled block spanning every qubit, which the factored backend holds as
+/// a single dense sub-state, so the export is the identity case.
+#[test]
+fn factored_export_statevector_single_block_matches() {
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+
+    let sv_ref = run_and_state(&c);
+
+    let mut fac = prism_q::backend::factored::FactoredBackend::new(SEED);
+    sim::run_on(&mut fac, &c).unwrap();
+    let sv = fac.export_statevector().unwrap();
+    for (i, (a, e)) in sv.iter().zip(sv_ref.iter()).enumerate() {
+        assert!(
+            (a - e).norm() < EPS,
+            "factored export[{i}]: expected {e}, got {a}"
+        );
+    }
+}
+
+/// Three live sub-states, one of them interleaved with another in global qubit
+/// order (`{0, 3}` and `{1, 2}`), so the export cannot assume a block owns a
+/// contiguous bit range. Amplitudes, not probabilities: a tensor product of
+/// blocks carries each block's phase, and only the amplitude check sees them.
+#[test]
+fn factored_export_statevector_interleaved_blocks_matches() {
+    let mut c = Circuit::new(5, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::Cx, &[0, 3]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::S, &[2]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::Ry(0.9), &[4]);
+
+    let sv_ref = run_and_state(&c);
+
+    let mut fac = prism_q::backend::factored::FactoredBackend::new(SEED);
+    sim::run_on(&mut fac, &c).unwrap();
+    let sv = fac.export_statevector().unwrap();
+    assert_eq!(sv.len(), sv_ref.len());
+    for (i, (a, e)) in sv.iter().zip(sv_ref.iter()).enumerate() {
+        assert!(
+            (a - e).norm() < EPS,
+            "factored export[{i}]: expected {e}, got {a}"
+        );
+    }
+}
+
+/// After a measurement collapses one block, the surviving amplitudes must still
+/// come out normalized, since the export carries no pending norm of its own.
+#[test]
+fn factored_export_statevector_after_measurement_is_normalized() {
+    let mut c = Circuit::new(4, 1);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::H, &[2]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+    c.add_measure(0, 0);
+
+    let mut fac = prism_q::backend::factored::FactoredBackend::new(SEED);
+    sim::run_on(&mut fac, &c).unwrap();
+    let sv = fac.export_statevector().unwrap();
+
+    let norm: f64 = sv.iter().map(|a| a.norm_sqr()).sum();
+    assert!(
+        (norm - 1.0).abs() < EPS,
+        "export norm after measure: {norm}"
+    );
+
+    let probs = fac.probabilities().unwrap();
+    for (i, (amp, p)) in sv.iter().zip(probs.iter()).enumerate() {
+        assert!(
+            (amp.norm_sqr() - p).abs() < EPS,
+            "factored export[{i}] disagrees with probabilities: {} vs {p}",
+            amp.norm_sqr()
+        );
+    }
+}
+
 // ---- MCU cross-backend tests ----
 
 #[test]

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -1146,7 +1146,9 @@ pub fn participants() -> Vec<Participant> {
             name: "factored",
             exec: Executor::Direct(|s| Box::new(FactoredBackend::new(s))),
             rules: always,
-            export_rules: no_state_export,
+            // Blocks tensor back into a joint vector, so the export is exact at
+            // any block count.
+            export_rules: always,
             query_kind: Some(BackendKind::Factored),
             anchor: None,
         },

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -453,3 +453,55 @@ fn dm_reduced_density_matrix_matches_statevector() {
         }
     }
 }
+
+/// The override against the boxed `Gate::Fused` route it replaces, at both sides
+/// of the crossover the one-qubit path selects on: below the parallel threshold
+/// the embedded `2n`-qubit statevector takes two passes, at or above it one block
+/// superoperator pass. The second matrix is a non-unitary jump branch, so this is
+/// not restricted to `rho -> U rho U^dagger`.
+#[test]
+fn dm_apply_1q_matrix_matches_fused_gate_route() {
+    let dense = [[c(0.6, 0.0), c(0.8, 0.0)], [c(0.8, 0.0), c(-0.6, 0.0)]];
+    let jump = [[c(0.0, 0.0), c(1.3, 0.0)], [c(0.0, 0.0), c(0.0, 0.0)]];
+
+    // 4 qubits embeds an 8-qubit statevector (two-pass path); 7 embeds a
+    // 14-qubit one, which is the block-superoperator path.
+    for n in [4usize, 7] {
+        for (label, matrix) in [("dense", dense), ("jump", jump)] {
+            for target in [0usize, n - 1] {
+                let circuit = circuits::random_circuit(n, 6, SEED);
+
+                let mut direct = dm_backend(&circuit, SEED);
+                direct.apply_1q_matrix(target, &matrix).unwrap();
+
+                let mut boxed = dm_backend(&circuit, SEED);
+                boxed
+                    .apply(&prism_q::circuit::Instruction::Gate {
+                        gate: prism_q::gates::Gate::Fused(Box::new(matrix)),
+                        targets: [target].into_iter().collect(),
+                    })
+                    .unwrap();
+
+                let a = direct.probabilities().unwrap();
+                let b = boxed.probabilities().unwrap();
+                assert_probs_close(&a, &b, 1e-12, &format!("{label} on q{target} of {n}"));
+
+                for q in 0..n {
+                    let ra = direct.reduced_density_matrix_1q(q).unwrap();
+                    let rb = boxed.reduced_density_matrix_1q(q).unwrap();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(
+                                (ra[i][j] - rb[i][j]).norm() < 1e-12,
+                                "{label} on q{target} of {n}: rdm[{q}][{i}][{j}] \
+                                 direct={} boxed={}",
+                                ra[i][j],
+                                rb[i][j]
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/trajectory_correctness.rs
+++ b/tests/trajectory_correctness.rs
@@ -427,6 +427,199 @@ fn custom_kraus_dense_channel_uses_coherence() {
     }
 }
 
+/// `H|0>` damped at `gamma` has exact `P(1) = (1 - gamma) / 2`. With the noise
+/// sampler and the backend sharing a ChaCha stream, the jump fired on exactly the
+/// shots that would have measured `|0>` anyway and this read 0.384 against 0.425,
+/// 37 standard errors out. The tight bound is what holds the two streams apart.
+#[test]
+fn noise_and_measurement_draws_are_independent() {
+    let gamma = 0.15;
+    let num_shots = 100_000;
+    let exact = (1.0 - gamma) / 2.0;
+
+    let mut circuit = Circuit::new(1, 1);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    let noise = NoiseModel::with_amplitude_damping(&circuit, gamma);
+
+    for kind in [BackendKind::Statevector, BackendKind::Factored] {
+        let result = run_shots_with_noise(kind.clone(), &circuit, &noise, num_shots, 42).unwrap();
+        let ones = result.shots.iter().filter(|shot| shot[0]).count();
+        let p_one = ones as f64 / num_shots as f64;
+        let sigma = (exact * (1.0 - exact) / num_shots as f64).sqrt();
+
+        assert!(
+            (p_one - exact).abs() <= 5.0 * sigma,
+            "{kind:?}: P(1) = {p_one}, exact = {exact}, off by {} standard errors",
+            (p_one - exact).abs() / sigma
+        );
+    }
+}
+
+/// Two independent two-qubit blocks with no gate bridging them, so the factored
+/// backend holds a product of sub-states rather than one dense block.
+fn damped_two_block_circuit(num_classical: usize) -> Circuit {
+    let mut circuit = Circuit::new(4, num_classical);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::H, &[2]);
+    circuit.add_gate(Gate::Cx, &[2, 3]);
+    circuit.add_gate(Gate::T, &[1]);
+    circuit.add_gate(Gate::Ry(0.7), &[3]);
+    circuit
+}
+
+/// The non-Pauli trajectory path on the factored backend: the engine reads
+/// `qubit_probability`, samples a branch, and applies that branch's Kraus operator
+/// through `Backend::apply_1q_matrix`. The density matrix evolves the same channel
+/// exactly with no sampling, so it is the reference here, not a second opinion.
+#[test]
+fn factored_amplitude_damping_matches_density_matrix() {
+    let gamma = 0.15;
+    let num_shots = 8000;
+
+    let unitary = damped_two_block_circuit(0);
+    let mut measured = damped_two_block_circuit(4);
+    for q in 0..4 {
+        measured.add_measure(q, q);
+    }
+
+    // `with_amplitude_damping` attaches events only after gate instructions, so
+    // the two models agree on every index the gates occupy.
+    let reference_noise = NoiseModel::with_amplitude_damping(&unitary, gamma);
+    let observables: Vec<Vec<PauliTerm>> = (0..4).map(|q| vec![PauliTerm::z(q)]).collect();
+    let exact =
+        density_matrix_expectation_values(&unitary, &observables, Some(&reference_noise), 42)
+            .unwrap();
+
+    let noise = NoiseModel::with_amplitude_damping(&measured, gamma);
+    let result =
+        run_shots_with_noise(BackendKind::Factored, &measured, &noise, num_shots, 42).unwrap();
+
+    for q in 0..4 {
+        let ones = result.shots.iter().filter(|shot| shot[q]).count();
+        let p_one = ones as f64 / num_shots as f64;
+        let measured_z = 1.0 - 2.0 * p_one;
+
+        let p_exact = (1.0 - exact[q]) / 2.0;
+        // Standard error of <Z> from `num_shots` Bernoulli draws, floored so a
+        // near-deterministic qubit still admits the last few bits of rounding.
+        let sigma = (2.0 * (p_exact * (1.0 - p_exact) / num_shots as f64).sqrt()).max(1e-9);
+
+        assert!(
+            (measured_z - exact[q]).abs() <= 5.0 * sigma,
+            "factored trajectory <Z_{q}> = {measured_z}, density matrix = {}, \
+             difference {} exceeds 5 sigma ({})",
+            exact[q],
+            (measured_z - exact[q]).abs(),
+            5.0 * sigma
+        );
+    }
+}
+
+/// The same channel through the density matrix and the statevector, so a
+/// disagreement above names the factored backend rather than the reference.
+#[test]
+fn statevector_amplitude_damping_matches_density_matrix() {
+    let gamma = 0.15;
+    let num_shots = 8000;
+
+    let unitary = damped_two_block_circuit(0);
+    let mut measured = damped_two_block_circuit(4);
+    for q in 0..4 {
+        measured.add_measure(q, q);
+    }
+
+    let reference_noise = NoiseModel::with_amplitude_damping(&unitary, gamma);
+    let observables: Vec<Vec<PauliTerm>> = (0..4).map(|q| vec![PauliTerm::z(q)]).collect();
+    let exact =
+        density_matrix_expectation_values(&unitary, &observables, Some(&reference_noise), 42)
+            .unwrap();
+
+    let noise = NoiseModel::with_amplitude_damping(&measured, gamma);
+    let result =
+        run_shots_with_noise(BackendKind::Statevector, &measured, &noise, num_shots, 42).unwrap();
+
+    for q in 0..4 {
+        let ones = result.shots.iter().filter(|shot| shot[q]).count();
+        let measured_z = 1.0 - 2.0 * (ones as f64 / num_shots as f64);
+        let p_exact = (1.0 - exact[q]) / 2.0;
+        let sigma = (2.0 * (p_exact * (1.0 - p_exact) / num_shots as f64).sqrt()).max(1e-9);
+
+        assert!(
+            (measured_z - exact[q]).abs() <= 5.0 * sigma,
+            "statevector trajectory <Z_{q}> = {measured_z}, density matrix = {}",
+            exact[q]
+        );
+    }
+}
+
+/// Thermal relaxation on the factored backend routes through `reset` and the
+/// dephasing branch rather than a Kraus matrix, so it exercises the other half
+/// of the non-Pauli path on the same two-block state.
+#[test]
+fn factored_thermal_relaxation_matches_density_matrix() {
+    let num_shots = 8000;
+    let channel = NoiseChannel::ThermalRelaxation {
+        t1: 100.0,
+        t2: 80.0,
+        gate_time: 20.0,
+    };
+
+    let unitary = damped_two_block_circuit(0);
+    let mut measured = damped_two_block_circuit(4);
+    for q in 0..4 {
+        measured.add_measure(q, q);
+    }
+
+    let thermal_model = |circuit: &Circuit| {
+        let mut model = NoiseModel::uniform_depolarizing(circuit, 0.0);
+        for (index, instruction) in circuit.instructions.iter().enumerate() {
+            if let Instruction::Gate { targets, .. } = instruction {
+                model.after_gate[index] = targets
+                    .iter()
+                    .map(|&q| NoiseEvent {
+                        channel: channel.clone(),
+                        qubits: SmallVec::from_slice(&[q]),
+                    })
+                    .collect();
+            }
+        }
+        model
+    };
+
+    let observables: Vec<Vec<PauliTerm>> = (0..4).map(|q| vec![PauliTerm::z(q)]).collect();
+    let exact = density_matrix_expectation_values(
+        &unitary,
+        &observables,
+        Some(&thermal_model(&unitary)),
+        42,
+    )
+    .unwrap();
+
+    let result = run_shots_with_noise(
+        BackendKind::Factored,
+        &measured,
+        &thermal_model(&measured),
+        num_shots,
+        42,
+    )
+    .unwrap();
+
+    for q in 0..4 {
+        let ones = result.shots.iter().filter(|shot| shot[q]).count();
+        let measured_z = 1.0 - 2.0 * (ones as f64 / num_shots as f64);
+        let p_exact = (1.0 - exact[q]) / 2.0;
+        let sigma = (2.0 * (p_exact * (1.0 - p_exact) / num_shots as f64).sqrt()).max(1e-9);
+
+        assert!(
+            (measured_z - exact[q]).abs() <= 5.0 * sigma,
+            "factored thermal <Z_{q}> = {measured_z}, density matrix = {}",
+            exact[q]
+        );
+    }
+}
+
 #[test]
 fn noise_model_validate_catches_invalid_custom_channel() {
     use num_complex::Complex64;


### PR DESCRIPTION
## Summary

Three slices of engineering hygiene plus a correctness bug the third turned up. They
share a theme: each is a claim the repository made about itself that was not true.

The release workflow would have published **1.0.0** on its next dispatch, because a
breaking commit mapped to `cargo release major` on a 0.x version. Benchmark gating named
a stored baseline file that never existed on the development host and could not, since
the tooling that writes it needs `jq` and `bc`. And the backend trait had unimplemented
cells with no stated reason, one of which put a heap allocation inside a
gate-application path.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

`factored/noise_kraus` is a new group. `noisy_sampling` runs `uniform_depolarizing`,
which is Pauli and routes to gate application, so no existing row reached
`Backend::apply_1q_matrix` at all. Two independent `scripts/bench_ab.sh` runs against
the row's introducing state:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `factored/noise_kraus/amplitude_damping/16` (run 1) | 6.28 ms | 5.95 ms | -5.3% | -0.5%, -0.0% | yes |
| `factored/noise_kraus/amplitude_damping/16` (run 2) | 6.12 ms | 5.98 ms | -2.2% | -1.8%, -5.2% | yes |
| `factored/noise_kraus/amplitude_damping/24` (run 1) | 9.98 ms | 9.26 ms | -7.3% | -12.1%, -3.3% | unresolved |
| `factored/noise_kraus/amplitude_damping/24` (run 2) | 9.22 ms | 9.77 ms | +6.0% | -3.1%, +5.2% | unresolved |
| `factored/noise_kraus/thermal/16` (run 1) | 4.23 ms | 4.13 ms | -2.5% | -6.0%, +5.1% | yes |
| `factored/noise_kraus/thermal/16` (run 2) | 4.29 ms | 4.32 ms | +0.6% | +1.9%, -7.3% | yes |
| `factored/noise_kraus/thermal/24` (run 1) | 6.32 ms | 6.54 ms | +3.4% | +4.6%, -6.6% | yes |
| `factored/noise_kraus/thermal/24` (run 2) | 6.12 ms | 6.45 ms | +5.4% | -1.8%, -15.8% | yes |

Regression verdict: **PASS**, with the effect unresolved.

Stated plainly: this is not a measured win and is not claimed as one. The two runs
disagree in sign on `amplitude_damping/24`, and the second run puts `/16` inside its own
control spread. The `thermal/*` rows are the in-group control, since thermal relaxation
samples a reset branch and a `Z` branch and never builds a Kraus matrix, and they read
flat both times, which is the one thing that behaved as designed. The change stands on
the hot-path allocation invariant, which does not depend on a percentage.

Reshaping the row from depth 5 with 256 shots to depth 60 with 32 shots cut the worst
same-code spread from 36% to 12-16%, so per-shot backend construction was most of the
variance, but the residue still exceeds the effect. Recorded as unresolvable in
`benches/README.md` so nobody gates factored trajectory work on it.

**Neutrality against `main` could not be measured.** Two attempts returned a control
spread above the gate on every row, up to +48.3%, including `density_matrix/neutrality/22`
at -15.9% to +37.0%, with the editor holding roughly half the CPU. Reporting those deltas
would break the rule this PR adds, so they are not reported. The structural argument
carries it instead: the only edit to an existing library code path is one
`rng.set_stream(1)` per shot, and the entire backend diff deletes exactly one line, an
import replaced by a wider one. Everything else is new trait methods with no existing
caller, tests, docs, and a new bench group.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes: 1989 tests, 0 failures
- [x] `cargo nextest run --no-default-features` passes: 1791 tests, 0 failures
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps` passes with `RUSTDOCFLAGS=-D warnings`
- [x] New public API has docstrings
- [x] New backend capability has golden tests against the statevector backend
- [x] GPU-affecting paths run `cargo test --features "parallel gpu" --test golden_gpu`

`--all-features` is substituted with `--features "parallel gpu distributed"` throughout:
`distributed-mpi` needs libclang for `mpi-sys` bindgen, which is absent on this host.

## Hotspot notes

`Backend::apply_1q_matrix`, reached once per non-Pauli noise event. The Factored backend
previously routed through the trait default, which allocated a
`Box<[[Complex64; 2]; 2]>` per call, re-derived the matrix through `Gate::matrix_2x2`,
and re-entered `dispatch_gate`. The override selects the same diagonal or dense kernel
directly, so the gate arithmetic is unchanged and only the allocation and the dispatch
disappear. A single-target instruction never merges sub-states, so no merge behavior
changes.

Factored is the only backend that paid this on a live path. It is in
`BackendKind::supports_general_noise`; DensityMatrix is excluded from
`supports_noisy_per_shot` and evolves the mixture directly through `apply_1q_kraus`, and
the distributed backend is rejected for noisy shots outright, so those two overrides are
about the trait contract rather than a measured path.

`size_of::<Gate>()` is unchanged at 16 bytes; no gate variants were added, and the guard
in `src/gates/mod.rs` passes.

## Architecture or design changes

- [x] Trait contract documentation updated in `src/backend/mod.rs`
- [ ] `docs/architecture/` updated (not needed: no page claimed coverage for the cells that moved)

The per-representation reasons for a method being absent live in one table in the
`src/backend/mod.rs` module docs, with each method keeping its contract plus a pointer.
No dispatch, layout, or memory change.

## Breaking changes

**Noisy trajectory shot values for a given seed change**, because the noise sampler moved
to a different ChaCha stream. Reproducibility from a seed is preserved. The previous
values sampled a biased distribution, so this is a fix rather than a behavioral choice,
and it is why the release-level clamp in this same change matters: the work is
conventionally a `feat`, not a break, and under 0.x it resolves to a minor bump.

`FactoredBackend::export_statevector` returns `Ok` where it previously returned
`BackendUnsupported`. Callers matching on that error for the factored backend will stop
seeing it.

## Risks and rollback

- The release change only narrows what the workflow will publish. Its failure mode is a
  release that bumps minor when a maintainer wanted major, which is visible in the step
  summary and recoverable by setting the version by hand. Cutting 1.0.0 is now a
  deliberate act.
- `scripts/bench_ab.sh` is new tooling and touches no library code. It creates a git
  worktree outside the repository and removes it on exit unless `--ref-dir` is given.
- The RNG stream change has the largest blast radius: every noisy trajectory result
  moves. It is covered by the three density-matrix comparison tests plus the independence
  test, and reverting it is a one-line change to `noise_rng`.
- The trait overrides are additive, each with a test comparing it against the route it
  replaces, so reverting any one restores the default without touching a caller.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
