### PR TITLE
feat(backend): answer shots and observables from the product state

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -752,6 +752,28 @@ fn bench_product_scaling(c: &mut Criterion) {
     group.finish();
 }
 
+/// Product sampling is `O(shots·n)` with no `2^n` term anywhere, so the widths
+/// go past where the other samplers stop. The row exists to show the cost is
+/// linear in `n`: each step doubles the width and should double the time.
+const PRODUCT_SAMPLING_QUBITS: [usize; 4] = [64, 128, 256, 512];
+
+fn bench_product_sampling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("product/sampling");
+    configure_group(&mut group);
+
+    for &n in &PRODUCT_SAMPLING_QUBITS {
+        let circuit = measure_all(&random_single_qubit_circuit(n, 10, SEED));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    run_shots_with(BackendKind::ProductState, circ, SAMPLING_SHOTS, SEED).unwrap(),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Tensor Network backend ----
 
 fn bench_tn_scaling(c: &mut Criterion) {
@@ -1822,6 +1844,7 @@ criterion_group! {
     bench_mps_sampling,
     // Product state
     bench_product_scaling,
+    bench_product_sampling,
     // Tensor network
     bench_tn_scaling,
     bench_tn_linear_chain,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -103,6 +103,8 @@ Hybrid SVD dispatch: faer (bidiag+D&C) for matrices with m×n ≥ 256, hand-roll
 
 Per-qubit `[Complex64; 2]` storage. O(n) memory, O(1) per single-qubit gate. Rejects entangling gates. Selected automatically for circuits with no 2q gates.
 
+Shots and Pauli expectations answer from the per-qubit states rather than the `2^n` probability vector, so both stay O(n) and the backend runs queries at widths no dense route reaches. See [Sampling Architecture](./samplers.md).
+
 ## Tensor Network
 
 Deferred contraction with a greedy min-size heuristic. Gates append tensors; contraction happens lazily at measurement or probability extraction. `MAX_PROB_QUBITS = 25` guards against exponential blowup.

--- a/docs/architecture/samplers.md
+++ b/docs/architecture/samplers.md
@@ -66,12 +66,21 @@ divided by `⟨ψ|ψ⟩` rather than assumed unit.
 | Sparse | `O(k log k)` once, `O(log k)` per shot | CDF over the `k` stored amplitudes, ordered by basis index |
 | Factored | `O(Σ 2^kᵢ)` once, `O(B log)` per shot | One draw per sub-state, concatenated; `B` blocks |
 | MPS | `O(n·χ³)` once, `O(n·χ²)` per shot | Sequential conditional sampling against precomputed right environments |
+| Product State | `O(n)` once, `O(n)` per shot | One Bernoulli draw per qubit against that qubit's own weight on `1` |
 | Everything else | dense | Unchanged: `probabilities()` then CDF |
 
 `run_shots_with` picks the native path through `try_native_terminal_backend`,
 which requires the route to land on a single backend and probes the capability
 before `init`, so a backend without one costs an allocation and nothing else.
 `run_counts_with` needs no separate path: its tail is `run_shots_with(..).counts()`.
+
+The product state is the one backend taken past subsystem decomposition. It
+already stores one factor per qubit, so splitting a non-entangling circuit into
+independent blocks pays a backend, a partition, and a merge per block to rebuild
+what one native draw reads off the state, and past 64 qubits the merged block
+distribution has no representation at all. Every other backend keeps the block
+split it had before, which `only_the_product_state_takes_the_native_sampler_past_decomposition`
+(`src/sim/mod.rs`) pins from both sides.
 
 MPS records each bit against the logical qubit currently hosted at a site rather
 than the site index, so a layout permuted by SWAP routing needs no

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -60,10 +60,11 @@ bounded only by their own representation.
 | Sparse | Native, CDF over the stored amplitudes | Native, `O(k)` over the amplitude map |
 | MPS | Native, sequential conditional sampling | Native, one chain contraction per observable |
 | Factored | Native, one draw per sub-state | Native, product over the blocks |
+| Product State | Native, one Bernoulli draw per qubit | Native, one closed-form factor per qubit |
 | Statevector | Dense (streams from amplitudes, no probability vector) | Dense |
 | Stabilizer, Factored Stabilizer | Compiled Clifford sampler | Sparse Pauli Dynamics, exact |
 | Stochastic / Deterministic Pauli | Not applicable | Native Pauli propagation |
-| Tensor Network, Product State, Density Matrix | Dense | Rejected, naming the backend |
+| Tensor Network, Density Matrix | Dense | Rejected, naming the backend |
 
 Native sampling is deterministic from the seed alone: the same seed and shot
 count reproduce the same bitstrings. It is not shot-for-shot identical to the

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -113,8 +113,6 @@ native_path() {
     fi
 }
 
-TARGET_DIR_NATIVE="$(native_path "$PROJECT_DIR/target")"
-
 # Content hash of the working tree: HEAD, every tracked modification against it,
 # and every untracked file that is not ignored. Recomputed after the reference
 # build so a save from the editor between the two builds is caught rather than
@@ -133,6 +131,15 @@ tree_fingerprint() {
 # Build the bench target in `dir` and copy the resulting executable to `out`.
 # The path comes from cargo's own artifact message, not from an mtime scan of
 # the deps directory, so a build that relinks nothing still resolves correctly.
+#
+# Each worktree builds into its own target directory. Sharing one directory
+# looks like a free dependency cache and is not: cargo derives the same unit
+# metadata for both worktrees, so the second build overwrites the first's
+# artifact and fingerprint, and every later build reports "Finished" in under a
+# second while handing back whichever binary was linked last. The report then
+# reads as a pure noise floor, because both binaries really are the same one.
+# The reference worktree keeps its cache between runs whenever --ref-dir names
+# a path that persists.
 build_bench_exe() {
     local dir="$1" out="$2" label="$3"
     local log="$WORKDIR/build-$label.json"
@@ -140,7 +147,7 @@ build_bench_exe() {
     echo ">>> building $label: cargo bench --bench $BENCH --features \"$FEATURES\" --no-run"
     (
         cd "$dir"
-        CARGO_TARGET_DIR="$TARGET_DIR_NATIVE" \
+        CARGO_TARGET_DIR="$(native_path "$dir/target")" \
             cargo bench --bench "$BENCH" --features "$FEATURES" --no-run --message-format=json
     ) > "$log"
 
@@ -265,7 +272,7 @@ echo "  reference: $REF ($REF_SHA)"
 echo "  threshold: ${THRESHOLD}%"
 echo ""
 
-build_bench_exe "$PROJECT_DIR" "$WORKDIR/new" "new"
+build_bench_exe "$PROJECT_DIR" "$WORKDIR/exe-new" "new"
 
 if [[ -d "$REF_DIR/.git" || -f "$REF_DIR/.git" ]]; then
     echo ">>> reusing reference worktree $REF_DIR"
@@ -276,7 +283,7 @@ else
     git worktree add --detach --force "$REF_DIR" "$REF_SHA" >/dev/null
 fi
 
-build_bench_exe "$REF_DIR" "$WORKDIR/ref" "ref"
+build_bench_exe "$REF_DIR" "$WORKDIR/exe-ref" "ref"
 
 FINGERPRINT_AFTER="$(tree_fingerprint)"
 if [[ "$FINGERPRINT_BEFORE" != "$FINGERPRINT_AFTER" ]]; then
@@ -300,12 +307,12 @@ fi
 
 echo "=== two discarded warmup passes, then four adjacent passes ==="
 echo ""
-warm_up 1 "$WORKDIR/ref"
-warm_up 2 "$WORKDIR/new"
-run_pass 1 "ref" "$WORKDIR/ref"
-run_pass 2 "new" "$WORKDIR/new"
-run_pass 3 "new" "$WORKDIR/new"
-run_pass 4 "ref" "$WORKDIR/ref"
+warm_up 1 "$WORKDIR/exe-ref"
+warm_up 2 "$WORKDIR/exe-new"
+run_pass 1 "ref" "$WORKDIR/exe-ref"
+run_pass 2 "new" "$WORKDIR/exe-new"
+run_pass 3 "new" "$WORKDIR/exe-new"
+run_pass 4 "ref" "$WORKDIR/exe-ref"
 
 # --- Report ---
 

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -15,6 +15,12 @@
 //! entries apply the same way per target. Entangling gates return
 //! `BackendUnsupported` since product states cannot represent entanglement.
 //!
+//! # Queries
+//!
+//! Shots and Pauli expectations answer from the per-qubit states: a shot is one
+//! Bernoulli draw per qubit and an observable is one factor per qubit it names,
+//! so neither builds the `2^n` vector [`Backend::probabilities`] returns.
+//!
 //! # When to prefer this backend
 //!
 //! - Circuits with zero entangling gates (e.g., single-qubit randomized benchmarking).
@@ -32,11 +38,13 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
 use crate::backend::{
-    Backend, NORM_CLAMP_MIN, dense_probability_len, dense_statevector_len, reserve_dense_output,
+    Backend, BasisSamples, NORM_CLAMP_MIN, dense_probability_len, dense_statevector_len,
+    reserve_dense_output,
 };
 use crate::circuit::Instruction;
 use crate::error::{PrismError, Result};
 use crate::gates::{DiagEntry, Gate};
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 
 /// Per-qubit O(n) backend for non-entangling circuits.
 pub struct ProductStateBackend {
@@ -238,6 +246,76 @@ impl Backend for ProductStateBackend {
 
     fn num_qubits(&self) -> usize {
         self.num_qubits
+    }
+
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Qubits are independent, so a shot is `n` Bernoulli draws on the
+    /// per-qubit `|β|²` rather than one draw from a `2^n` CDF: `O(shots·n)`
+    /// with the probabilities computed once up front.
+    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let prob_one: Vec<f64> = self
+            .qubits
+            .iter()
+            .map(|[alpha, beta]| {
+                let weight_one = beta.norm_sqr();
+                let norm = alpha.norm_sqr() + weight_one;
+                if norm > 0.0 {
+                    (weight_one / norm).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut samples = BasisSamples::new(num_shots, self.num_qubits);
+        for shot in 0..num_shots {
+            for (qubit, &p1) in prob_one.iter().enumerate() {
+                if rng.random::<f64>() < p1 {
+                    samples.set(shot, qubit);
+                }
+            }
+        }
+        Ok(samples)
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// A product state factorizes a joint Pauli into one single-qubit
+    /// expectation per factor, so a term costs `O(1)` per qubit it names and
+    /// identity qubits contribute nothing.
+    ///
+    /// Each factor divides by its own qubit's `⟨φ|φ⟩`, which is how the whole
+    /// value ends up divided by `⟨ψ|ψ⟩`: the untouched qubits cancel between
+    /// numerator and denominator.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        observables
+            .iter()
+            .map(|observable| {
+                crate::sim::validate_observable(observable, self.num_qubits)?;
+                let mut product = 1.0f64;
+                for term in observable {
+                    let [alpha, beta] = self.qubits[term.qubit];
+                    let norm = alpha.norm_sqr() + beta.norm_sqr();
+                    if norm == 0.0 {
+                        return Ok(0.0);
+                    }
+                    let off_diagonal = alpha.conj() * beta;
+                    let factor = match term.axis {
+                        PauliAxis::X => 2.0 * off_diagonal.re,
+                        PauliAxis::Y => 2.0 * off_diagonal.im,
+                        PauliAxis::Z => alpha.norm_sqr() - beta.norm_sqr(),
+                    };
+                    product *= factor / norm;
+                }
+                Ok(product)
+            })
+            .collect()
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
@@ -480,6 +558,97 @@ mod tests {
                 assert!(p.abs() < EPS, "prob[{i}] should be 0, got {p}");
             }
         }
+    }
+
+    #[test]
+    fn test_sample_basis_states_matches_the_dense_distribution() {
+        let mut b = init_backend(6);
+        for q in 0..6 {
+            b.apply(&Instruction::Gate {
+                gate: Gate::Ry(0.3 + 0.2 * q as f64),
+                targets: smallvec![q],
+            })
+            .unwrap();
+        }
+
+        let probs = b.probabilities().unwrap();
+        let shots = 40_000;
+        let samples = b.sample_basis_states(shots, 42).unwrap();
+
+        let mut counts = vec![0usize; probs.len()];
+        for shot in 0..shots {
+            let index = (0..6)
+                .filter(|&q| samples.bit(shot, q))
+                .fold(0, |acc, q| acc | 1 << q);
+            counts[index] += 1;
+        }
+        for (index, &p) in probs.iter().enumerate() {
+            let frequency = counts[index] as f64 / shots as f64;
+            let band = 4.0 * (p * (1.0 - p) / shots as f64).sqrt() + 0.002;
+            assert!(
+                (frequency - p).abs() < band,
+                "basis state {index}: sampled {frequency:.6} against {p:.6}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sample_basis_states_repeats_from_the_seed() {
+        let mut b = init_backend(3);
+        b.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: smallvec![1],
+        })
+        .unwrap();
+        let first = b.sample_basis_states(64, 42).unwrap();
+        let second = b.sample_basis_states(64, 42).unwrap();
+        let other_seed = b.sample_basis_states(64, 43).unwrap();
+
+        let bits = |s: &BasisSamples| -> Vec<bool> {
+            (0..64)
+                .flat_map(|shot| (0..3).map(move |q| (shot, q)))
+                .map(|(shot, q)| s.bit(shot, q))
+                .collect()
+        };
+        assert_eq!(bits(&first), bits(&second));
+        assert_ne!(bits(&first), bits(&other_seed));
+    }
+
+    #[test]
+    fn test_pauli_expectations_are_normalization_independent() {
+        let mut b = init_backend(2);
+        b.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: smallvec![0],
+        })
+        .unwrap();
+        let scaled = b.qubits[1].map(|amp| amp * 3.0);
+        b.qubits[1] = scaled;
+
+        let values = b
+            .pauli_expectations(&[
+                vec![PauliTerm::x(0)],
+                vec![PauliTerm::z(1)],
+                vec![PauliTerm::x(0), PauliTerm::z(1)],
+                vec![],
+            ])
+            .unwrap();
+        for (got, want) in values.iter().zip(&[1.0, 1.0, 1.0, 1.0]) {
+            assert!((got - want).abs() < EPS, "got {got}, want {want}");
+        }
+    }
+
+    #[test]
+    fn test_pauli_expectations_reject_bad_observables() {
+        let b = init_backend(2);
+        assert!(matches!(
+            b.pauli_expectations(&[vec![PauliTerm::z(2)]]),
+            Err(PrismError::InvalidQubit { .. })
+        ));
+        assert!(matches!(
+            b.pauli_expectations(&[vec![PauliTerm::z(0), PauliTerm::x(0)]]),
+            Err(PrismError::InvalidParameter { .. })
+        ));
     }
 
     #[test]

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -712,6 +712,13 @@ fn try_terminal_statevector_backend(
 /// backend has no native sampler, leaving the dense probability path untouched.
 /// The capability is probed before `init`, so a backend without one costs an
 /// allocation and nothing else.
+///
+/// The product state is the one route taken past subsystem decomposition: it
+/// already stores one factor per qubit, so splitting the circuit into
+/// independent blocks pays a backend, a partition, and a merge per block to
+/// rebuild what one native draw reads straight off the state, and above 64
+/// qubits the merged block distribution does not exist at all. Every other
+/// backend keeps the block split.
 fn try_native_terminal_backend(
     kind: &BackendKind,
     stripped: &Circuit,
@@ -720,15 +727,19 @@ fn try_native_terminal_backend(
     if !kind.is_auto() {
         validate_explicit_backend(kind, stripped)?;
     }
-    let ProbabilityRoute::Direct {
-        has_partial_independence,
-    } = plan_probability_route(kind, stripped)
-    else {
-        return Ok(None);
+    let (decomposed, has_partial_independence) = match plan_probability_route(kind, stripped) {
+        ProbabilityRoute::Direct {
+            has_partial_independence,
+        } => (false, has_partial_independence),
+        ProbabilityRoute::Decomposed(_) => (true, false),
+        _ => return Ok(None),
     };
     let ExecutionPlan::Backend(plan) = resolve(kind, stripped, has_partial_independence) else {
         return Ok(None);
     };
+    if decomposed && !matches!(plan, BackendPlan::ProductState) {
+        return Ok(None);
+    }
     let mut backend = plan.build(seed);
     if !backend.supports_native_sampling() {
         return Ok(None);
@@ -1673,6 +1684,52 @@ mod tests {
             if auto_terminal_statevector_candidate(circuit) {
                 assert!(candidate_is_direct(circuit));
             }
+        }
+    }
+
+    // The decomposition bypass in `try_native_terminal_backend` is scoped to
+    // the product state. Pin both halves: a product circuit reaches the native
+    // sampler even though its route is decomposed, and a decomposable circuit
+    // on any other backend keeps the block split it had before.
+    #[test]
+    fn only_the_product_state_takes_the_native_sampler_past_decomposition() {
+        let mut product = Circuit::new(12, 0);
+        for q in 0..12 {
+            product.add_gate(Gate::Ry(0.3 + 0.1 * q as f64), &[q]);
+        }
+        assert!(matches!(
+            plan_probability_route(&BackendKind::Auto, &product),
+            ProbabilityRoute::Decomposed(_)
+        ));
+        for kind in [BackendKind::Auto, BackendKind::ProductState] {
+            let backend = try_native_terminal_backend(&kind, &product, 42).unwrap();
+            assert_eq!(
+                backend.map(|b| b.name()),
+                Some("productstate"),
+                "{kind:?} did not reach the product sampler"
+            );
+        }
+
+        let mut blocks = Circuit::new(10, 0);
+        for pair in 0..5 {
+            blocks.add_gate(Gate::Ry(0.2 + 0.1 * pair as f64), &[2 * pair]);
+            blocks.add_gate(Gate::Cx, &[2 * pair, 2 * pair + 1]);
+        }
+        assert!(matches!(
+            plan_probability_route(&BackendKind::Sparse, &blocks),
+            ProbabilityRoute::Decomposed(_)
+        ));
+        for kind in [
+            BackendKind::Sparse,
+            BackendKind::Factored,
+            BackendKind::Mps { max_bond_dim: 32 },
+        ] {
+            assert!(
+                try_native_terminal_backend(&kind, &blocks, 42)
+                    .unwrap()
+                    .is_none(),
+                "{kind:?} left the decomposed route"
+            );
         }
     }
 

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -886,8 +886,8 @@ pub enum SkipReason {
     FactoredBlocksHaveNoJointState,
     /// Amplitudes are only defined once the trajectory is fixed.
     BranchingTrajectory,
-    /// Outside the query matrices. They cover the backends that gained a path
-    /// from their own state to shots and observables (sparse, MPS, factored)
+    /// Outside the query matrices. They cover the backends that answer shots
+    /// and observables from their own state (sparse, MPS, factored, product)
     /// plus the statevector they have to agree with. Every other participant is
     /// a route, or an engine whose query path is unchanged.
     OutsideQueryMatrix,
@@ -1173,7 +1173,7 @@ pub fn participants() -> Vec<Participant> {
             exec: Executor::Direct(|s| Box::new(ProductStateBackend::new(s))),
             rules: product_rules,
             export_rules: always,
-            query_kind: None,
+            query_kind: Some(BackendKind::ProductState),
             anchor: None,
         },
         Participant {

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -290,6 +290,58 @@ fn factored_expectation_values_match_statevector_when_fully_merged() {
     );
 }
 
+// The product state factorizes an observable into one closed-form factor per
+// qubit. The statevector is the reference for the signs, which is the half of
+// those closed forms hand algebra gets wrong.
+#[test]
+fn product_expectation_values_match_statevector() {
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Ry(0.35 + 0.2 * q as f64), &[q]);
+        c.add_gate(Gate::Rz(0.15 + 0.25 * q as f64), &[q]);
+    }
+    c.add_gate(Gate::T, &[3]);
+    assert_matches_statevector("product expectation", BackendKind::ProductState, &c);
+}
+
+// Every single-qubit axis on every axis eigenstate, so a swapped sign or a
+// swapped real and imaginary part in one closed form cannot hide behind the
+// others averaging out.
+#[test]
+fn product_expectation_values_cover_each_axis_eigenstate() {
+    let mut c = Circuit::new(6, 0);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::X, &[2]);
+    c.add_gate(Gate::H, &[3]);
+    c.add_gate(Gate::Z, &[3]);
+    c.add_gate(Gate::H, &[4]);
+    c.add_gate(Gate::S, &[4]);
+    c.add_gate(Gate::H, &[5]);
+    c.add_gate(Gate::Sdg, &[5]);
+
+    let axes = [PauliAxis::X, PauliAxis::Y, PauliAxis::Z];
+    let observables: Vec<Vec<PauliTerm>> = (0..6)
+        .flat_map(|q| axes.iter().map(move |&axis| vec![PauliTerm::new(q, axis)]))
+        .collect();
+
+    // q0 |0>, q1 |+>, q2 |1>, q3 |->, q4 |+i>, q5 |-i>.
+    #[rustfmt::skip]
+    let want = [
+        0.0, 0.0, 1.0,
+        1.0, 0.0, 0.0,
+        0.0, 0.0, -1.0,
+        -1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+        0.0, -1.0, 0.0,
+    ];
+    let got = simulate(&c)
+        .backend(BackendKind::ProductState)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    assert_close(&got, &want, TOL);
+}
+
 // The tensor network contracts to a dense statevector by construction, so it
 // has no native observable path. The rejection has to name the backend that
 // cannot serve the request, not the route that selected it.

--- a/tests/native_sampling.rs
+++ b/tests/native_sampling.rs
@@ -1,9 +1,10 @@
-//! Native shot sampling on Sparse, Factored, and MPS, which draw outcomes
-//! from their own representation instead of a dense `2^n` probability vector.
-//! Below the dense cap the statevector distribution is the reference; the
-//! 40-qubit oversize cases use GHZ and Bell-pair states, whose support is
+//! Native shot sampling on Sparse, Factored, MPS, and ProductState, which draw
+//! outcomes from their own representation instead of a dense `2^n` probability
+//! vector. Below the dense cap the statevector distribution is the reference;
+//! the 40-qubit oversize cases use GHZ and Bell-pair states, whose support is
 //! known in closed form, and open by pinning that the dense route rejects the
-//! same circuit.
+//! same circuit. The product cases run past 1000 qubits, where no dense vector
+//! and no merged block distribution exist at all.
 
 mod common;
 
@@ -240,6 +241,45 @@ fn mps_counts_match_shots() {
     check_counts_match_shots("mps ghz 10q", MPS, &ghz(10));
 }
 
+// ===== product state =====
+
+/// Single-qubit rotations only, so every qubit stays independent. The `Rz`
+/// layer detunes the per-qubit weights away from a fair coin, so a sampler
+/// that ignored the amplitudes would still fail the frequency band.
+fn product_layers(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.3 + 0.17 * q as f64), &[q]);
+        c.add_gate(Gate::Rz(0.2 * q as f64), &[q]);
+    }
+    c
+}
+
+#[test]
+fn product_samples_rotation_layers_distribution() {
+    check_sampling(
+        "product 10q",
+        BackendKind::ProductState,
+        &product_layers(10),
+    );
+}
+
+// Auto routes a circuit with no entangling gates to the product state, so the
+// same sampler has to serve it without the caller naming the backend.
+#[test]
+fn product_auto_route_samples_the_same_distribution() {
+    check_sampling("product auto 10q", BackendKind::Auto, &product_layers(10));
+}
+
+#[test]
+fn product_counts_match_shots() {
+    check_counts_match_shots(
+        "product 10q",
+        BackendKind::ProductState,
+        &product_layers(10),
+    );
+}
+
 // ===== above the dense cap =====
 
 /// Qubit count for the oversize cases. A `2^40` amplitude vector is eight
@@ -363,6 +403,153 @@ fn factored_samples_above_the_dense_cap() {
                 "factored 40q: bell pair {pair} came back uncorrelated"
             );
         }
+    }
+}
+
+// ===== wide product circuits =====
+
+/// Width for the product cases. Well past 64 qubits, where the merged block
+/// distribution the decomposed route builds stops existing, and past any dense
+/// vector by a margin no memory cap changes.
+const WIDE_QUBITS: usize = 1024;
+
+/// Qubit `q` ends in `|1>`, `|+>`, or `|0>` by `q % 3`, so every bit is either
+/// pinned or a fair coin and the shots are checkable without a reference
+/// vector. `Rz(0.4)` keeps the circuit non-Clifford, which is what stops the
+/// compiled Clifford sampler from answering instead.
+fn wide_product_circuit() -> Circuit {
+    let mut c = Circuit::new(WIDE_QUBITS, 0);
+    for q in 0..WIDE_QUBITS {
+        match q % 3 {
+            0 => c.add_gate(Gate::X, &[q]),
+            1 => c.add_gate(Gate::H, &[q]),
+            _ => c.add_gate(Gate::Rz(0.4), &[q]),
+        }
+    }
+    c
+}
+
+fn assert_wide_product_shots(label: &str, kind: BackendKind) {
+    let circuit = measure_all(&wide_product_circuit());
+    let shots = 512;
+
+    let result = simulate(&circuit)
+        .backend(kind.clone())
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    assert_eq!(result.shots.len(), shots, "{label}: wrong shot count");
+
+    let fair: Vec<usize> = (0..WIDE_QUBITS).filter(|q| q % 3 == 1).collect();
+    let mut ones = vec![0usize; WIDE_QUBITS];
+    for shot in &result.shots {
+        for (q, &bit) in shot.iter().enumerate() {
+            match q % 3 {
+                0 => assert!(bit, "{label}: qubit {q} is |1> and came back 0"),
+                2 => assert!(!bit, "{label}: qubit {q} is |0> and came back 1"),
+                _ => ones[q] += usize::from(bit),
+            }
+        }
+        assert!(
+            fair.iter().any(|&q| shot[q] != shot[fair[0]]),
+            "{label}: every fair qubit agreed in one shot, so they share a draw"
+        );
+    }
+
+    let band = frequency_band(0.5) * (SHOTS as f64 / shots as f64).sqrt();
+    for &q in &fair {
+        let fraction = ones[q] as f64 / shots as f64;
+        assert!(
+            (fraction - 0.5).abs() < band,
+            "{label}: qubit {q} is |+> and came back at {fraction:.4}"
+        );
+    }
+
+    let counts = simulate(&circuit)
+        .backend(kind.clone())
+        .seed(SEED)
+        .sample_counts(shots)
+        .unwrap();
+    assert_eq!(
+        result.counts(),
+        counts.into_counts(),
+        "{label}: counts disagree with the shot histogram at the same seed"
+    );
+
+    let replay = simulate(&circuit)
+        .backend(kind)
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    assert_eq!(
+        result.shots, replay.shots,
+        "{label}: same seed produced different shots"
+    );
+}
+
+// Pins the premise: nothing else can serve this width, so the shots above came
+// from the per-qubit sampler.
+#[test]
+fn wide_product_dense_route_is_unavailable() {
+    let err = simulate(&measure_all(&wide_product_circuit()))
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .shots(8)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            prism_q::PrismError::IncompatibleBackend { .. }
+                | prism_q::PrismError::BackendUnsupported { .. }
+        ),
+        "expected the statevector route to reject {WIDE_QUBITS} qubits, got {err:?}"
+    );
+}
+
+#[test]
+fn product_samples_a_thousand_qubits() {
+    assert_wide_product_shots("product 1024q", BackendKind::ProductState);
+}
+
+#[test]
+fn product_auto_route_samples_a_thousand_qubits() {
+    assert_wide_product_shots("product auto 1024q", BackendKind::Auto);
+}
+
+// Closed-form observables on a product state no dense route can hold: `|1>`
+// gives `<Z> = -1` and `<X> = 0`, `|+>` gives `<X> = 1` and `<Z> = 0`, and
+// `Rz(0.4)|0>` is `|0>` up to a phase, so `<Z> = 1` and `<X> = 0`. A joint
+// string is the product of its factors.
+#[test]
+fn product_expectation_values_above_the_dense_cap() {
+    let circuit = wide_product_circuit();
+    let last_one = WIDE_QUBITS - 1 - (WIDE_QUBITS - 1) % 3;
+    let values = simulate(&circuit)
+        .backend(BackendKind::ProductState)
+        .seed(SEED)
+        .expectation_values(&[
+            vec![prism_q::PauliTerm::z(0)],
+            vec![prism_q::PauliTerm::x(0)],
+            vec![prism_q::PauliTerm::x(1)],
+            vec![prism_q::PauliTerm::z(1)],
+            vec![prism_q::PauliTerm::z(2)],
+            vec![prism_q::PauliTerm::z(0), prism_q::PauliTerm::z(last_one)],
+            vec![
+                prism_q::PauliTerm::z(0),
+                prism_q::PauliTerm::x(1),
+                prism_q::PauliTerm::z(2),
+            ],
+            vec![prism_q::PauliTerm::y(1)],
+            vec![],
+        ])
+        .unwrap();
+
+    let want = [-1.0, 0.0, 1.0, 0.0, 1.0, 1.0, -1.0, 0.0, 1.0];
+    for (i, (&got, &expected)) in values.iter().zip(&want).enumerate() {
+        assert!(
+            (got - expected).abs() < 1e-12,
+            "observable {i}: got {got}, want {expected}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

The product state stores one amplitude pair per qubit but routed every shot, count, and
expectation through a dense `2^n` vector, so the cheapest backend paid the most expensive
query cost and a wide product circuit could not be sampled at all. It now answers both
from its own representation, behind the same capability probes the other polynomial-state
backends use.

Also fixes two defects in `scripts/bench_ab.sh` that made it compare one binary against
itself and report the result as a clean noise floor.

## Scope

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## What changed

A shot is one Bernoulli draw per qubit on `|beta|^2` over that qubit's norm, precomputed
before the loop, so it costs `O(n)` and allocates nothing inside it. An observable
factorizes into `2Re(a*b)`, `2Im(a*b)`, and `|a|^2-|b|^2` per named qubit, each over its
own norm, so identity qubits cancel and the value is normalization independent without
ever forming `<psi|psi>`.

Neither hook was reachable before. A circuit with no entangling gates decomposes into one
block per qubit at eight qubits and up, so the route was `Decomposed` and
`try_native_terminal_backend` returned before probing; above 64 qubits that route has no
merged block distribution at all and shots resimulated the circuit once per shot. The
bypass is scoped to the product plan, which already stores the factorization the block
split would rebuild. Every other backend keeps its block route.

Results are deterministic from the seed alone and are not shot-for-shot identical to the
dense route, whose randomness runs on a different schedule. The distributions agree.
Marginals stay on the dense route for every backend.

## Benchmarks

New row, 1000 shots, `--features parallel`. Linear in qubit count, which is what the row
exists to gate. The "before" column is the same bench source linked against the base
library, where widths above 64 qubits fall back to per-shot resimulation.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `product/sampling/64` | 771 us | 771 us | 0.0% | n/a, new row | Yes |
| `product/sampling/128` | 88.5 ms | 1.56 ms | -98.2% | n/a, new row | Yes |
| `product/sampling/256` | 269 ms | 3.58 ms | -98.7% | n/a, new row | Yes |
| `product/sampling/512` | 343 ms | 6.71 ms | -98.0% | n/a, new row | Yes |

Adjacent-binary A/B against the base on the rows that share the modified routing function:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `mps/sampling/24` | 1.35 ms | 1.34 ms | -0.2% | +4.9% / -10.0% | Unresolved |
| `mps/sampling/32` | 1.71 ms | 1.62 ms | -5.3% | -0.7% / +8.0% | Unresolved |
| `mps/sampling/48` | 2.47 ms | 2.56 ms | +3.4% | -4.5% / -2.2% | Yes |
| `mps/sampling/64` | 3.25 ms | 3.14 ms | -3.2% | -5.9% / +2.9% | Unresolved |
| `sparse/sampling/24` | 463.17 us | 415.58 us | -10.3% | +7.2% / -6.2% | Unresolved |
| `sparse/sampling/32` | 509.71 us | 479.27 us | -6.0% | -7.9% / -10.1% | Unresolved |
| `sparse/sampling/48` | 752.33 us | 713.88 us | -5.1% | +10.9% / -25.6% | Unresolved |
| `sparse/sampling/64` | 863.16 us | 827.49 us | -4.1% | -8.4% / -12.6% | Unresolved |
| `product/scaling_d10/4` | 1.46 us | 1.54 us | +5.2% | -4.6% / -7.7% | Unresolved |
| `product/scaling_d10/8` | 36.66 us | 38.24 us | +4.3% | -2.0% / -13.9% | Unresolved |
| `product/scaling_d10/16` | 59.99 us | 62.30 us | +3.8% | -15.7% / +17.5% | Unresolved |
| `product/scaling_d10/32` | 111.78 us | 117.69 us | +5.3% | -9.1% / -6.1% | Unresolved |
| `product/scaling_d10/64` | 184.61 us | 190.54 us | +3.2% | -0.9% / -9.3% | Unresolved |
| `product/scaling_d10/128` | 255.39 us | 270.68 us | +6.0% | -1.9% / -18.3% | Unresolved |
| `product/scaling_d10/256` | 437.75 us | 425.15 us | -2.9% | -3.2% / -9.1% | Unresolved |

Every change is no larger than its row's own same-code control spread, so these are noise,
not results. The host ran an editor and a game engine throughout; the worst control spread
was 18.3%. `sparse/sampling/64` first read +13.9% against a 6.9% control floor and was
re-run alone: -4.1%, opposite sign, not reproduced. The only change on that path is one
`resolve()` call returning an already-computed `BackendPlan`, which cannot cost the 116 us
the first reading implied.

Regression verdict: PASS, with the qualification that 14 of 15 comparison rows are
unresolved on this host rather than measured clean.

## Correctness

- [x] `cargo nextest run --all-features` passes locally (2014 tests)
- [x] `cargo test --doc --all-features` passes (11 doctests)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add information the name and signature do
      not carry, and stay concise; none restate the signature
- [x] Closed forms are pinned against the statevector, not hand algebra
- [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
      (N/A, no GPU path touched)

Tests added:

- `tests/native_sampling.rs`: distribution against the statevector at 10 qubits under both
  the explicit backend and auto routing; counts against the shot histogram; 1024-qubit
  shots, counts, and expectations, opened by pinning that the dense route rejects that
  width, so a shot that comes back at all came from the per-qubit sampler.
- `tests/expectation_values.rs`: statevector goldens, plus all six single-qubit axis
  eigenstates, where a swapped sign or a swapped real and imaginary part cannot hide
  behind the others averaging out.
- `tests/conformance_matrix.rs`: the product state joins the shot and observable query
  matrices over the generated corpus.
- `src/sim/mod.rs`: `only_the_product_state_takes_the_native_sampler_past_decomposition`
  pins the routing bypass from both sides, so no other backend can drift onto it.
- `src/backend/product.rs`: sampled distribution against the dense vector, seed replay,
  normalization independence on a deliberately unnormalized state, and observable
  rejection.

## Hotspot notes

The gate-application inner loops are untouched. The added work on non-product backends is
one `resolve()` call per `shots()` invocation on circuits that decompose, which returns an
already-computed enum; it is outside any per-shot or per-gate loop.

## Architecture or design changes

- [x] `docs/architecture/samplers.md` gains the product row and the reason the product
      state is the one route taken past subsystem decomposition
- [x] `docs/architecture/backends.md` and `docs/guides/capabilities.md` updated

## Breaking changes

None to the API. One behavioral difference: for a circuit with no entangling gates and
terminal measurements, `shots()` and `sample_counts()` now return different bitstrings for
a given seed, because the native sampler consumes randomness on a different schedule than
the dense route. The distributions are unchanged.

## Risks and rollback

Blast radius is the shots path for circuits with no entangling gates. The routing bypass
is one `matches!` on `BackendPlan::ProductState`; reverting that line restores the previous
route without touching the backend. The two `Backend` methods are additive and inert
unless their probes return true.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
