### PR TITLE
perf(backend): fold diagonal gate runs into one pass, sync backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,16 +171,22 @@ let result = simulate(&c).seed(42).run().unwrap();
 | --- | --- | --- | --- |
 | **Statevector** | General circuits | O(2ⁿ) | Full SIMD, tiled L2/L3 kernels, optional CUDA path |
 | **Stabilizer** | Clifford only | O(n²) | SIMD optimized, scales to thousands of qubits |
+| **Factored Stabilizer** | Clifford with independent blocks | O(n²) per cluster | Per-cluster tableaux, dynamic merge and split |
 | **Sparse** | Few live amplitudes | O(k) | HashMap with parallel measurement |
 | **MPS** | Low entanglement or 1D | O(nχ²) | Hybrid faer / Jacobi SVD |
 | **Product State** | No entanglement | O(n) | Per qubit, instant |
 | **Tensor Network** | Low treewidth | Depends on contraction order | Greedy min size heuristic |
 | **Factored** | Partial entanglement | Dynamic | Tracks independent sub-states |
+| **Density Matrix** | Exact noisy evolution | O(4ⁿ) | Explicit dispatch only, reuses statevector kernels |
+| **Distributed Statevector** | Beyond single-host memory | O(2ⁿ) over MPI ranks | `distributed` feature, exact results |
 
 `BackendKind::Auto` selects at dispatch time. Non-entangling circuits go to Product
-State, all-Clifford circuits go to Stabilizer, large circuits fall through to MPS with
-bond dimension 256 once they exceed the statevector memory budget, and everything else
-runs on Statevector. The memory budget is dynamic, derived from available RAM at
+State; all-Clifford circuits go to Stabilizer, or Factored Stabilizer when a large
+circuit splits into independent blocks; circuits past the statevector memory budget go
+to Sparse when sparse-friendly and otherwise to MPS with bond dimension 256; partially
+independent circuits go to Factored; everything else runs on Statevector. Clifford+T
+circuits with few T gates route through the stabilizer rank and Pauli propagation
+engines before this tree. The memory budget is dynamic, derived from available RAM at
 dispatch time, and can be overridden with `PRISM_MAX_SV_QUBITS`.
 
 ## Gates and OpenQASM support
@@ -241,7 +247,9 @@ sampling. Crossover thresholds are conservative by default and can be tuned thro
 `PRISM_GPU_MIN_QUBITS`, `PRISM_STABILIZER_GPU_MIN_QUBITS`, and
 `PRISM_GPU_BTS_MIN_SHOTS`.
 
-`BackendKind::Auto` does not yet route to GPU. See
+`simulate(&circuit).gpu_auto(ctx)` runs automatic backend selection with the device
+opted in: statevector and stabilizer workloads that clear the qubit crossover and fit
+in VRAM run on the device, and everything else takes the identical CPU path. See
 [`docs/guides/gpu.md`](docs/guides/gpu.md) for kernel design, crossover analysis,
 and the full set of tuning knobs.
 
@@ -284,13 +292,13 @@ SVGs land in `bench_results/` (gitignored).
 
 ## Roadmap
 
-- Density matrix backend: mixed state simulation for noise and decoherence modeling.
-- GPU auto dispatch: thread a GPU context into `BackendKind::Auto` so large circuits
-  route to GPU without an explicit `BackendKind::StatevectorGpu`. Crossover and
-  decomposition already work through the explicit variant.
 - Expanded classical control: mid circuit branching beyond the current `if` form, and
   parameterized circuit reuse for variational workloads.
-- Distributed statevector: multi node sharding for circuits beyond single host memory.
+- Multi GPU and distributed GPU execution: a GPU context currently binds a single
+  device, and the distributed backend is CPU only.
+- ROCm (AMD GPU) ports of the CUDA statevector and stabilizer kernels.
+- Distributed noisy shots: noise models are rejected on the distributed backend
+  because trajectory execution is not lockstep across ranks.
 
 ## Architecture
 

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -380,6 +380,24 @@ fn bench_statevector_qaoa(c: &mut Criterion) {
     group.finish();
 }
 
+// Gates on the parallel `DiagonalBatch` sweep: the fused stream carrying a
+// `DiagonalBatch` is pinned by `fusion_diag_mixed_batches_and_matches_unfused`.
+fn bench_statevector_diag_mixed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statevector/diag_mixed_l6");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let circuit = circuits::diagonal_mixed_circuit(n, 6, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_statevector_qv(c: &mut Criterion) {
     let mut group = c.benchmark_group("statevector/qv");
     configure_group(&mut group);
@@ -1820,6 +1838,7 @@ criterion_group! {
     bench_statevector_qpe,
     bench_statevector_hea,
     bench_statevector_qaoa,
+    bench_statevector_diag_mixed,
     bench_statevector_qv,
     bench_statevector_w_state,
     bench_statevector_clifford,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -1,10 +1,11 @@
 # Backends
 
-PRISM-Q ships eight CPU backends plus an optional CUDA path, and an explicit-only
-density-matrix backend for exact mixed-state evolution. The
-[simulation engine](./engine.md) picks one of the eight automatically, or you can select
-explicitly. For a task-oriented version of this material, see the
-[Backends Deep Dive guide](../guides/backends.md).
+PRISM-Q ships nine CPU backends, an optional CUDA path attached to the statevector and
+stabilizer backends, and a feature-gated distributed statevector backend that shards the
+dense state across MPI ranks. The [simulation engine](./engine.md) picks a backend
+automatically (the density matrix, tensor network, and distributed backends are
+explicit-dispatch only), or you can select explicitly. For a task-oriented version of
+this material, see the [Backends Deep Dive guide](../guides/backends.md).
 
 The diagrams below are rendered directly from PRISM-Q's own SVG circuit renderer.
 
@@ -127,4 +128,6 @@ Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host a
 32 GiB (`PRISM_MAX_DM_QUBITS` overrides). This backend is CPU-only and explicit-dispatch
 only; `Auto` never selects it.
 
-The [GPU backend](../guides/gpu.md) is documented as a user guide.
+The [GPU backend](../guides/gpu.md) is documented as a user guide. The distributed
+statevector backend is covered in the
+[Capability and Support Matrix](../guides/capabilities.md).

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -1,6 +1,6 @@
 # Backends Deep Dive
 
-PRISM-Q does not have one simulation algorithm. It has eight, each optimal for a
+PRISM-Q does not have one simulation algorithm. It has nine, each optimal for a
 different class of circuit. This guide is the task-oriented companion to the
 [architecture reference](../architecture/backends.md): it focuses on scaling and when to
 reach for each one. To select a backend in code, see
@@ -20,6 +20,11 @@ GPU architectures each backend supports, see the
 | Product | $O(n)$ | No entanglement | Unbounded |
 | Tensor Network | order-dependent | Shallow / structured | $\le 25$ prob qubits |
 | Factored | $O(2^n)$ worst case | Partially independent | Block-bound |
+| Density Matrix | $O(4^n)$ | Exact noisy evolution | ~14 qubits (RAM-bound) |
+
+The distributed statevector backend (behind the `distributed` feature) shards the dense
+state across MPI ranks; see the
+[Capability and Support Matrix](./capabilities.md) for its status.
 
 ## Statevector
 
@@ -39,7 +44,7 @@ backend no longer applies. For a small number of such gates, see
 [Clifford+T Simulation](./clifford-t.md).
 ```
 
-## Sparse, MPS, Product, Tensor Network, Factored
+## Sparse, MPS, Product, Tensor Network, Factored, Density Matrix
 
 - **Sparse** wins when the state stays concentrated in a handful of computational-basis
   states (amplitude pruning keeps the map small).
@@ -50,6 +55,8 @@ backend no longer applies. For a small number of such gates, see
   structured circuits.
 - **Factored** detects partial independence and simulates sub-registers separately,
   merging lazily via a Kronecker product computed on demand.
+- **Density Matrix** evolves the full mixed state exactly, for noise studies below the
+  $4^n$ memory ceiling. Explicit dispatch only; `Auto` never selects it.
 
 For the internal kernels behind each of these, read the
 [architecture reference](../architecture/backends.md). For raw speed mechanics, see

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -18,19 +18,34 @@ scalar path is used.
 
 ## Backend support by architecture
 
+The nine CPU backends implement the `Backend` trait; the distributed statevector
+backend is a tenth, feature-gated implementation covered by the Distributed
+column. `Planned` marks only work the roadmap carries: a ROCm port of the
+existing CUDA kernels. Backends without a CUDA kernel have nothing to port, so
+their ROCm cell is `No`, and the roadmap carries no distributed execution for
+any backend other than the statevector.
+
 | Backend | x86-64 | AVX2/FMA/BMI2 | ARM64 | NEON | CUDA (NVIDIA) | ROCm (AMD) | Distributed |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Statevector | Yes | SIMD | Yes | SIMD | Yes | Planned | Yes |
-| Stabilizer | Yes | SIMD | Yes | SIMD | Yes | Planned | Planned |
-| Factored Stabilizer | Yes | SIMD | Yes | SIMD | No | Planned | Planned |
-| Sparse | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
-| MPS | Yes | SIMD | Yes | SIMD | No | Planned | Planned |
-| Product State | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
-| Tensor Network | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
-| Factored | Yes | SIMD | Yes | SIMD | No | Planned | Planned |
-| Stabilizer Rank | Yes | SIMD | Yes | SIMD | No | Planned | Planned |
-| Stochastic Pauli | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
-| Deterministic Pauli | Yes | Scalar | Yes | Scalar | No | Planned | Planned |
+| Stabilizer | Yes | SIMD | Yes | SIMD | Yes | Planned | No |
+| Factored Stabilizer | Yes | SIMD | Yes | SIMD | No | No | No |
+| Sparse | Yes | Scalar | Yes | Scalar | No | No | No |
+| MPS | Yes | SIMD | Yes | SIMD | No | No | No |
+| Product State | Yes | Scalar | Yes | Scalar | No | No | No |
+| Tensor Network | Yes | Scalar | Yes | Scalar | No | No | No |
+| Factored | Yes | SIMD | Yes | SIMD | No | No | No |
+| Density Matrix | Yes | SIMD | Yes | SIMD | No | No | No |
+
+The Clifford+T engines below are not `Backend` implementations; they serve
+probability, shot, and observable queries through their own routes (see
+[Clifford+T Simulation](./clifford-t.md)).
+
+| Engine | x86-64 | AVX2/FMA/BMI2 | ARM64 | NEON | CUDA (NVIDIA) | ROCm (AMD) | Distributed |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Stabilizer Rank | Yes | SIMD | Yes | SIMD | No | No | No |
+| Stochastic Pauli | Yes | Scalar | Yes | Scalar | No | No | No |
+| Deterministic Pauli | Yes | Scalar | Yes | Scalar | No | No | No |
 
 Notes:
 

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -11,16 +11,23 @@ cargo test --features "parallel gpu" --test golden_gpu
 ```
 
 CUDA acceleration covers statevector execution, stabilizer execution, and compiled
-BTS sampling. Five entry points are available:
+BTS sampling. Six entry points are available:
 
+- **`BackendKind::AutoGpu { context }`** (`simulate(circuit).gpu_auto(ctx)`).
+  Automatic backend selection with the device opted in. The shape-based decision
+  tree runs unchanged; a selected statevector or stabilizer workload that clears the
+  family's qubit crossover and fits in VRAM runs on the device. Everything else,
+  including a device allocation that fails at `init`, takes the identical CPU path
+  (the soft VRAM fallback).
 - **`BackendKind::StatevectorGpu { context }`**. Public dispatch path for statevector
   GPU execution. It routes through `simulate(circuit).backend(kind).seed(seed).run()`,
   keeps fusion and subsystem
   decomposition, and uses `crate::gpu::min_qubits()` (default 14,
   `PRISM_GPU_MIN_QUBITS` override) to keep small sub-circuits on CPU.
 - **`BackendKind::StabilizerGpu { context }`**. Public dispatch path for stabilizer
-  GPU execution. Gate application uses a device tableau and one batched Clifford
-  kernel (`stab_apply_batch`). Measurement and reset keep pivot search, row cascade,
+  GPU execution. Gate application uses a device tableau and one word-grouped batched
+  Clifford kernel (`stab_apply_word_grouped`). Measurement and reset keep pivot
+  search, row cascade,
   phase fixup, and deterministic outcomes on the device. The default crossover stays
   conservative (`STABILIZER_MIN_QUBITS_DEFAULT = 100_000`,
   `PRISM_STABILIZER_GPU_MIN_QUBITS` override) until benchmarks justify lowering it.
@@ -55,9 +62,10 @@ of a host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
 | `mod.rs` | `GpuContext`, `GpuState` public entry points |
 | `device.rs` | `GpuDevice`: cudarc wrapper, compiles PTX at device construction |
 | `memory.rs` | `GpuBuffer`: device `Complex64` storage |
-| `kernels/mod.rs` | `KERNEL_NAMES`, composed `kernel_source()` concatenating dense + stabilizer |
+| `kernels/mod.rs` | `KERNEL_NAMES`, `LauncherScratch`, composed `kernel_source()` concatenating dense + stabilizer + BTS |
 | `kernels/dense.rs` | PTX source and Rust launcher for every `Gate` variant |
 | `kernels/stabilizer.rs` | PTX source and launchers for tableau init, 11 Clifford gates, `rowmul_words` |
+| `kernels/bts.rs` | PTX source and launchers for compiled BTS shot sampling |
 
 ## Kernel coverage
 
@@ -82,14 +90,12 @@ the `BackendKind::StatevectorGpu` public dispatch path at the crossover boundary
 
 ## Current limits
 
-- `BackendKind::Auto` does not yet dispatch to GPU. The `StatevectorGpu` variant is the
-  explicit opt-in until `Auto` can receive a default GPU context.
-- Several fused launchers (`launch_apply_fused_2q`, `launch_apply_mcu`,
-  `launch_apply_mcu_phase`, `launch_apply_batch_phase`, `launch_apply_batch_rzz`,
-  `launch_apply_diagonal_batch`, `launch_apply_multi_fused_nondiag`) upload small
-  metadata tables per dispatch via `clone_htod`. This is the next launch overhead
-  target.
-- `measure_prob_one` allocates a device partials buffer and reduces on the host every
-  call. Matters for measurement-heavy circuits.
+- Device placement is silent. Circuits below the crossover run on the host, and the
+  `AutoGpu` soft VRAM fallback degrades to host execution without a report; nothing
+  user-visible says whether a run executed on the device.
+- Stabilizer `probabilities()`, `export_tableau()`, and `export_statevector()` read
+  back to the CPU.
+- A `Custom` Kraus noise event reads the full state back to the host, and every
+  trajectory shot rebuilds the backend, reallocating the device buffer.
 - Kernel design and crossover analysis live in the module docstrings on
   `src/gpu/kernels/dense.rs`.

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -2907,7 +2907,7 @@ mod tests {
             ("src/backend/simd.rs", 29),
             ("src/backend/word_ops.rs", 2),
             ("src/backend/stabilizer/kernels/simd.rs", 3),
-            ("src/backend/statevector/kernels.rs", 10),
+            ("src/backend/statevector/kernels.rs", 11),
         ];
         for (file, want) in expected {
             let path = format!("{root}/{file}");

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -48,7 +48,7 @@ use crate::backend::{
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
-use crate::gates::{DiagEntry, Gate};
+use crate::gates::{Gate, diag_entries_phase, is_diagonal_2x2};
 use crate::hash::FxHashMap;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -85,6 +85,11 @@ impl SparseBackend {
 
     #[inline(always)]
     fn apply_single_qubit(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
+        if is_diagonal_2x2(&mat) {
+            self.apply_diagonal_1q(target, mat[0][0], mat[1][1]);
+            return;
+        }
+
         let mask = 1usize << target;
         let zero = Complex64::new(0.0, 0.0);
         self.swap_buf.clear();
@@ -100,6 +105,19 @@ impl SparseBackend {
 
         std::mem::swap(&mut self.state, &mut self.swap_buf);
         self.prune();
+    }
+
+    /// A diagonal 2x2 scales amplitudes in place: no partner entries, no map rebuild.
+    /// A sub-unit diagonal (a Kraus operator) can shrink amplitudes below epsilon,
+    /// so only that case pays the prune pass.
+    #[inline(always)]
+    fn apply_diagonal_1q(&mut self, target: usize, d0: Complex64, d1: Complex64) {
+        for (idx, amp) in self.state.iter_mut() {
+            *amp *= if (*idx >> target) & 1 == 1 { d1 } else { d0 };
+        }
+        if d0.norm_sqr() < 1.0 - 1e-12 || d1.norm_sqr() < 1.0 - 1e-12 {
+            self.prune();
+        }
     }
 
     /// CX is a deterministic 1:1 index mapping. No near-zero amplitudes are created.
@@ -223,6 +241,27 @@ impl SparseBackend {
         for (idx, amp) in self.state.iter_mut() {
             let parity = ((*idx >> q0) ^ (*idx >> q1)) & 1;
             *amp *= if parity == 0 { phase_same } else { phase_diff };
+        }
+    }
+
+    /// One walk over the map with the per-edge phase pair precomputed, instead of
+    /// one walk (and two `from_polar`) per edge.
+    fn apply_batch_rzz(&mut self, edges: &[(usize, usize, f64)]) {
+        let phases: Vec<(usize, usize, [Complex64; 2])> = edges
+            .iter()
+            .map(|&(q0, q1, theta)| {
+                let same = Complex64::from_polar(1.0, -theta / 2.0);
+                let diff = Complex64::from_polar(1.0, theta / 2.0);
+                (q0, q1, [same, diff])
+            })
+            .collect();
+
+        for (idx, amp) in self.state.iter_mut() {
+            let mut combined = Complex64::new(1.0, 0.0);
+            for &(q0, q1, pair) in &phases {
+                combined *= pair[((*idx >> q0) ^ (*idx >> q1)) & 1];
+            }
+            *amp *= combined;
         }
     }
 
@@ -369,38 +408,11 @@ impl SparseBackend {
                 self.apply_batch_phase(targets[0], &data.phases);
             }
             Gate::BatchRzz(data) => {
-                for &(q0, q1, theta) in &data.edges {
-                    self.apply_rzz(q0, q1, theta);
-                }
+                self.apply_batch_rzz(&data.edges);
             }
             Gate::DiagonalBatch(data) => {
-                for entry in &data.entries {
-                    match entry {
-                        DiagEntry::Phase1q { qubit, d0, d1 } => {
-                            let mask = 1usize << qubit;
-                            for (idx, amp) in self.state.iter_mut() {
-                                if (*idx & mask) != 0 {
-                                    *amp *= d1;
-                                } else {
-                                    *amp *= d0;
-                                }
-                            }
-                        }
-                        DiagEntry::Phase2q { q0, q1, phase } => {
-                            let mask = (1usize << q0) | (1usize << q1);
-                            for (idx, amp) in self.state.iter_mut() {
-                                if (*idx & mask) == mask {
-                                    *amp *= phase;
-                                }
-                            }
-                        }
-                        DiagEntry::Parity2q { q0, q1, same, diff } => {
-                            for (idx, amp) in self.state.iter_mut() {
-                                let parity = ((*idx >> q0) ^ (*idx >> q1)) & 1;
-                                *amp *= if parity == 0 { *same } else { *diff };
-                            }
-                        }
-                    }
+                for (idx, amp) in self.state.iter_mut() {
+                    *amp *= diag_entries_phase(*idx, &data.entries);
                 }
             }
             Gate::MultiFused(data) => {
@@ -833,6 +845,103 @@ mod tests {
         c2.add_gate(Gate::Cz, &[0, 1]);
 
         let b1 = run_sparse(&c1);
+        let b2 = run_sparse(&c2);
+
+        for (&idx, &amp1) in &b1.state {
+            let amp2 = b2
+                .state
+                .get(&idx)
+                .copied()
+                .unwrap_or(Complex64::new(0.0, 0.0));
+            assert!((amp1 - amp2).norm() < EPS, "mismatch at idx {idx}");
+        }
+    }
+
+    #[test]
+    fn test_diagonal_1q_in_place() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::P(1.234), &[0]);
+        let b = run_sparse(&c);
+        assert_eq!(b.state.len(), 2);
+        let h = 1.0 / 2.0_f64.sqrt();
+        assert!((b.state[&0].re - h).abs() < EPS);
+        assert!((b.state[&1] - Complex64::from_polar(h, 1.234)).norm() < EPS);
+    }
+
+    #[test]
+    fn test_batch_rzz_matches_individual() {
+        use crate::gates::BatchRzzData;
+
+        let edges = vec![(0usize, 1usize, 0.7f64), (1, 2, 1.3)];
+
+        let mut c1 = Circuit::new(3, 0);
+        for q in 0..3 {
+            c1.add_gate(Gate::H, &[q]);
+        }
+        for &(q0, q1, theta) in &edges {
+            c1.add_gate(Gate::Rzz(theta), &[q0, q1]);
+        }
+        let b1 = run_sparse(&c1);
+
+        let mut c2 = Circuit::new(3, 0);
+        for q in 0..3 {
+            c2.add_gate(Gate::H, &[q]);
+        }
+        c2.add_gate(Gate::BatchRzz(Box::new(BatchRzzData { edges })), &[0, 1, 2]);
+        let b2 = run_sparse(&c2);
+
+        for (&idx, &amp1) in &b1.state {
+            let amp2 = b2
+                .state
+                .get(&idx)
+                .copied()
+                .unwrap_or(Complex64::new(0.0, 0.0));
+            assert!((amp1 - amp2).norm() < EPS, "mismatch at idx {idx}");
+        }
+    }
+
+    #[test]
+    fn test_diagonal_batch_matches_individual() {
+        use crate::gates::{DiagEntry, DiagonalBatchData};
+
+        let mut c1 = Circuit::new(3, 0);
+        for q in 0..3 {
+            c1.add_gate(Gate::H, &[q]);
+        }
+        c1.add_gate(Gate::S, &[0]);
+        c1.add_gate(Gate::Cz, &[0, 1]);
+        c1.add_gate(Gate::Rzz(0.9), &[1, 2]);
+        let b1 = run_sparse(&c1);
+
+        let s_mat = Gate::S.matrix_2x2();
+        let mut c2 = Circuit::new(3, 0);
+        for q in 0..3 {
+            c2.add_gate(Gate::H, &[q]);
+        }
+        c2.add_gate(
+            Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+                entries: vec![
+                    DiagEntry::Phase1q {
+                        qubit: 0,
+                        d0: s_mat[0][0],
+                        d1: s_mat[1][1],
+                    },
+                    DiagEntry::Phase2q {
+                        q0: 0,
+                        q1: 1,
+                        phase: Complex64::new(-1.0, 0.0),
+                    },
+                    DiagEntry::Parity2q {
+                        q0: 1,
+                        q1: 2,
+                        same: Complex64::from_polar(1.0, -0.45),
+                        diff: Complex64::from_polar(1.0, 0.45),
+                    },
+                ],
+            })),
+            &[0, 1, 2],
+        );
         let b2 = run_sparse(&c2);
 
         for (&idx, &amp1) in &b1.state {

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -16,7 +16,7 @@ use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS, SendPtr};
 use crate::backend::simd;
 use crate::backend::{is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
 use crate::circuit::{QftTextbookStep, qft_textbook_steps};
-use crate::gates::{DiagEntry, Gate};
+use crate::gates::{DiagEntry, Gate, diag_entries_phase};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -3133,6 +3133,12 @@ impl StatevectorBackend {
     }
 
     pub(super) fn apply_diagonal_batch(&mut self, entries: &[DiagEntry]) {
+        #[cfg(feature = "parallel")]
+        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            self.apply_diagonal_batch_par(entries);
+            return;
+        }
+
         let Some(built) = build_diagonal_batch_tables(entries) else {
             self.apply_diagonal_batch_fallback(entries);
             return;
@@ -3164,31 +3170,64 @@ impl StatevectorBackend {
         );
     }
 
+    #[cfg(feature = "parallel")]
+    fn apply_diagonal_batch_par(&mut self, entries: &[DiagEntry]) {
+        let Some(built) = build_diagonal_batch_tables(entries) else {
+            self.state
+                .par_chunks_mut(MIN_PAR_ELEMS)
+                .enumerate()
+                .for_each(|(chunk_idx, chunk)| {
+                    let base = chunk_idx * MIN_PAR_ELEMS;
+                    for (j, amp) in chunk.iter_mut().enumerate() {
+                        *amp *= diag_entries_phase(base + j, entries);
+                    }
+                });
+            return;
+        };
+        if built.num_groups == 0 {
+            return;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if simd::has_bmi2() && simd::has_fma() {
+            self.state
+                .par_chunks_mut(MIN_PAR_ELEMS)
+                .enumerate()
+                .for_each(|(chunk_idx, chunk)| {
+                    let base = chunk_idx * MIN_PAR_ELEMS;
+                    // SAFETY: has_bmi2() + has_fma() confirmed above
+                    unsafe {
+                        diagonal_batch_tile_bmi2(
+                            chunk,
+                            base,
+                            &built.tables,
+                            &built.group_pext_masks,
+                            built.num_groups,
+                        );
+                    }
+                });
+            return;
+        }
+
+        let group_shifts = diag_batch_group_shifts(&built.unique_qubits);
+        self.state
+            .par_chunks_mut(MIN_PAR_ELEMS)
+            .enumerate()
+            .for_each(|(chunk_idx, chunk)| {
+                diagonal_batch_tile_scalar(
+                    chunk,
+                    chunk_idx * MIN_PAR_ELEMS,
+                    &built.tables,
+                    &group_shifts,
+                    &built.group_sizes,
+                    built.num_groups,
+                );
+            });
+    }
+
     fn apply_diagonal_batch_fallback(&mut self, entries: &[DiagEntry]) {
-        let one = Complex64::new(1.0, 0.0);
         for (i, amp) in self.state.iter_mut().enumerate() {
-            let mut phase = one;
-            for e in entries {
-                match e {
-                    DiagEntry::Phase1q { qubit, d0, d1 } => {
-                        if (i >> qubit) & 1 == 1 {
-                            phase *= d1;
-                        } else {
-                            phase *= d0;
-                        }
-                    }
-                    DiagEntry::Phase2q { q0, q1, phase: p } => {
-                        if ((i >> q0) & 1 == 1) && ((i >> q1) & 1 == 1) {
-                            phase *= p;
-                        }
-                    }
-                    DiagEntry::Parity2q { q0, q1, same, diff } => {
-                        let parity = ((i >> q0) ^ (i >> q1)) & 1;
-                        phase *= if parity == 0 { *same } else { *diff };
-                    }
-                }
-            }
-            *amp *= phase;
+            *amp *= diag_entries_phase(i, entries);
         }
     }
 }
@@ -3213,6 +3252,63 @@ unsafe fn apply_diagonal_batch_bmi2(
     }
 }
 
+#[cfg(all(target_arch = "x86_64", feature = "parallel"))]
+#[target_feature(enable = "bmi2,fma")]
+unsafe fn diagonal_batch_tile_bmi2(
+    tile: &mut [Complex64],
+    base_idx: usize,
+    tables: &[[Complex64; DIAG_BATCH_TABLE_SIZE]; MAX_DIAG_BATCH_GROUPS],
+    pext_masks: &[u64; MAX_DIAG_BATCH_GROUPS],
+    num_groups: usize,
+) {
+    use std::arch::x86_64::_pext_u64;
+    let one = Complex64::new(1.0, 0.0);
+    for (j, amp) in tile.iter_mut().enumerate() {
+        let i = base_idx + j;
+        let mut combined = one;
+        for g in 0..num_groups {
+            let bits = _pext_u64(i as u64, pext_masks[g]) as usize;
+            combined *= tables[g][bits];
+        }
+        *amp *= combined;
+    }
+}
+
+/// Per-group qubit positions, the non-x86_64 stand-in for the PEXT masks.
+fn diag_batch_group_shifts(
+    unique_qubits: &SmallVec<[usize; 32]>,
+) -> [[usize; DIAG_BATCH_MAX_QUBITS_PER_GROUP]; MAX_DIAG_BATCH_GROUPS] {
+    let mut group_shifts = [[0usize; DIAG_BATCH_MAX_QUBITS_PER_GROUP]; MAX_DIAG_BATCH_GROUPS];
+    for (idx, &q) in unique_qubits.iter().enumerate() {
+        group_shifts[idx / DIAG_BATCH_MAX_QUBITS_PER_GROUP]
+            [idx % DIAG_BATCH_MAX_QUBITS_PER_GROUP] = q;
+    }
+    group_shifts
+}
+
+fn diagonal_batch_tile_scalar(
+    tile: &mut [Complex64],
+    base_idx: usize,
+    tables: &[[Complex64; DIAG_BATCH_TABLE_SIZE]; MAX_DIAG_BATCH_GROUPS],
+    group_shifts: &[[usize; DIAG_BATCH_MAX_QUBITS_PER_GROUP]; MAX_DIAG_BATCH_GROUPS],
+    group_sizes: &[usize; MAX_DIAG_BATCH_GROUPS],
+    num_groups: usize,
+) {
+    let one = Complex64::new(1.0, 0.0);
+    for (j, amp) in tile.iter_mut().enumerate() {
+        let i = base_idx + j;
+        let mut combined = one;
+        for (g, shifts) in group_shifts.iter().enumerate().take(num_groups) {
+            let mut bits = 0usize;
+            for (p, &shift) in shifts[..group_sizes[g]].iter().enumerate() {
+                bits |= ((i >> shift) & 1) << p;
+            }
+            combined *= tables[g][bits];
+        }
+        *amp *= combined;
+    }
+}
+
 fn apply_diagonal_batch_scalar(
     state: &mut [Complex64],
     tables: &[[Complex64; DIAG_BATCH_TABLE_SIZE]; MAX_DIAG_BATCH_GROUPS],
@@ -3220,23 +3316,6 @@ fn apply_diagonal_batch_scalar(
     group_sizes: &[usize; MAX_DIAG_BATCH_GROUPS],
     num_groups: usize,
 ) {
-    let one = Complex64::new(1.0, 0.0);
-    let mut group_shifts = [[0usize; DIAG_BATCH_MAX_QUBITS_PER_GROUP]; MAX_DIAG_BATCH_GROUPS];
-    for (idx, &q) in unique_qubits.iter().enumerate() {
-        group_shifts[idx / DIAG_BATCH_MAX_QUBITS_PER_GROUP]
-            [idx % DIAG_BATCH_MAX_QUBITS_PER_GROUP] = q;
-    }
-
-    for (i, amp) in state.iter_mut().enumerate() {
-        let mut combined = one;
-        for g in 0..num_groups {
-            let k = group_sizes[g];
-            let mut bits = 0usize;
-            for (p, &shift) in group_shifts[g][..k].iter().enumerate() {
-                bits |= ((i >> shift) & 1) << p;
-            }
-            combined *= tables[g][bits];
-        }
-        *amp *= combined;
-    }
+    let group_shifts = diag_batch_group_shifts(unique_qubits);
+    diagonal_batch_tile_scalar(state, 0, tables, &group_shifts, group_sizes, num_groups);
 }

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1403,6 +1403,80 @@ fn batch_phase_matches_independent_reference() {
     assert_state_close(&got, &expected, 1e-12);
 }
 
+// `apply_diagonal_batch` vs an independent reference at the parallel threshold, so a
+// BMI2+FMA host exercises `diagonal_batch_tile_bmi2` and others
+// `diagonal_batch_tile_scalar`. All three entry kinds appear, and the qubits are spread
+// past `DIAG_BATCH_MAX_QUBITS_PER_GROUP` so more than one group is built.
+#[test]
+fn diagonal_batch_par_matches_independent_reference() {
+    use crate::circuit::{Instruction, SmallVec, smallvec};
+    use crate::gates::{DiagEntry, DiagonalBatchData, Gate};
+
+    let n = 14usize;
+    let entries = vec![
+        DiagEntry::Phase1q {
+            qubit: 0,
+            d0: Complex64::from_polar(1.0, 0.21),
+            d1: Complex64::from_polar(1.0, -0.64),
+        },
+        DiagEntry::Phase2q {
+            q0: 3,
+            q1: 11,
+            phase: Complex64::from_polar(1.0, 1.07),
+        },
+        DiagEntry::Parity2q {
+            q0: 5,
+            q1: 13,
+            same: Complex64::from_polar(1.0, -0.33),
+            diff: Complex64::from_polar(1.0, 0.33),
+        },
+    ];
+
+    let mut backend = StatevectorBackend::new(42);
+    backend.init(n, 0).unwrap();
+    for q in 0..n {
+        let targets: SmallVec<[usize; 4]> = smallvec![q];
+        backend
+            .apply(&Instruction::Gate {
+                gate: Gate::H,
+                targets,
+            })
+            .unwrap();
+    }
+    let targets: SmallVec<[usize; 4]> = (0..n).collect();
+    backend
+        .apply(&Instruction::Gate {
+            gate: Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+                entries: entries.clone(),
+            })),
+            targets,
+        })
+        .unwrap();
+    let got = backend.export_statevector().unwrap();
+
+    let amp0 = Complex64::new((1.0 / (1u64 << n) as f64).sqrt(), 0.0);
+    let mut expected = vec![amp0; 1usize << n];
+    for (i, e) in expected.iter_mut().enumerate() {
+        for entry in &entries {
+            match entry {
+                DiagEntry::Phase1q { qubit, d0, d1 } => {
+                    *e *= if (i >> qubit) & 1 == 1 { *d1 } else { *d0 };
+                }
+                DiagEntry::Phase2q { q0, q1, phase } => {
+                    if (i >> q0) & 1 == 1 && (i >> q1) & 1 == 1 {
+                        *e *= phase;
+                    }
+                }
+                DiagEntry::Parity2q { q0, q1, same, diff } => {
+                    let parity = ((i >> q0) ^ (i >> q1)) & 1;
+                    *e *= if parity == 0 { *same } else { *diff };
+                }
+            }
+        }
+    }
+    assert_state_close(&got, &expected, 1e-12);
+}
+
 #[cfg(feature = "gpu")]
 mod gpu_scaffold {
     use super::*;

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -197,6 +197,43 @@ pub fn qaoa_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
     c
 }
 
+/// Build a mixed diagonal-phase circuit: one H layer, then `layers` of random
+/// 1q diagonals (Rz, T, P) plus long-range CZ/CPhase/Rzz pairs at a per-layer
+/// stride. The long-range strides keep the pairs out of the same-pair 2q fusion
+/// blocks, so the runs collapse into `DiagonalBatch` instructions at 16 qubits
+/// and above.
+///
+/// # Panics
+/// Panics if `n < 2` (stride selection divides by `n / 2`).
+pub fn diagonal_mixed_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for layer in 0..layers {
+        for q in 0..n {
+            let theta = rng.random::<f64>() * std::f64::consts::TAU;
+            match rng.random_range(0..3) {
+                0 => c.add_gate(Gate::Rz(theta), &[q]),
+                1 => c.add_gate(Gate::T, &[q]),
+                _ => c.add_gate(Gate::P(theta), &[q]),
+            }
+        }
+        let stride = 1 + layer % (n / 2);
+        for q in 0..n / 2 {
+            let q1 = q + stride;
+            let theta = rng.random::<f64>() * std::f64::consts::TAU;
+            match rng.random_range(0..3) {
+                0 => c.add_gate(Gate::Cz, &[q, q1]),
+                1 => c.add_gate(Gate::cphase(theta), &[q, q1]),
+                _ => c.add_gate(Gate::Rzz(theta), &[q, q1]),
+            }
+        }
+    }
+    c
+}
+
 /// Build a circuit with only single-qubit rotation gates (no entanglement).
 ///
 /// `depth` layers of random Rx/Ry/Rz on every qubit. Useful for benchmarking

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -350,6 +350,29 @@ fn push_unique_qubit(seen: &mut SmallVec<[usize; 8]>, qubit: usize) {
     }
 }
 
+/// Combined phase factor `entries` apply to the basis state `index`.
+#[inline]
+pub(crate) fn diag_entries_phase(index: usize, entries: &[DiagEntry]) -> Complex64 {
+    let mut combined = Complex64::new(1.0, 0.0);
+    for entry in entries {
+        match entry {
+            DiagEntry::Phase1q { qubit, d0, d1 } => {
+                combined *= if (index >> qubit) & 1 == 1 { *d1 } else { *d0 };
+            }
+            DiagEntry::Phase2q { q0, q1, phase } => {
+                if (index >> q0) & 1 == 1 && (index >> q1) & 1 == 1 {
+                    combined *= phase;
+                }
+            }
+            DiagEntry::Parity2q { q0, q1, same, diff } => {
+                let parity = ((index >> q0) ^ (index >> q1)) & 1;
+                combined *= if parity == 0 { *same } else { *diff };
+            }
+        }
+    }
+    combined
+}
+
 #[inline]
 fn count_unique_diag_qubits(entries: &[DiagEntry]) -> usize {
     let mut seen: SmallVec<[usize; 8]> = SmallVec::new();

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -62,15 +62,23 @@ pub(super) fn stabilizer_rank_budget(num_qubits: usize) -> usize {
 // dispatch layer calls `crate::gpu::min_qubits()` directly; there is no
 // private duplicate.
 
-/// Automatically select the optimal backend based on circuit analysis.
+/// Backend selection for a simulation run.
 ///
-/// Decision tree:
+/// `Auto` resolves per call from circuit shape. Two routes run before the
+/// family tree: circuits that decompose into independent blocks run per block
+/// (Clifford-only circuits at 128 qubits and above with a 16+ qubit block use
+/// FactoredStabilizer), and Clifford+T circuits up to 25 qubits route through
+/// StabilizerRank (exact to 18 T gates, sparse approximation to 28, shot
+/// paths to 40; the `MAX_AUTO_T_COUNT_*` constants above); marginal queries
+/// on Clifford+T circuits at 12 qubits and above answer via Sparse Pauli
+/// Dynamics. The remaining tree:
+///
 /// 1. No entangling gates        → ProductState (O(n))
 /// 2. All Clifford gates         → Stabilizer (O(n²))
-/// 3. Clifford+T, t ≤ 12        → StabilizerRank (O(2^t · n²))
-/// 4. Above memory limit:
+/// 3. Above the statevector memory cap:
 ///    a. Sparse-friendly         → Sparse (O(k) where k = non-zero amplitudes)
 ///    b. Otherwise               → MPS (bounded bond dimension)
+/// 4. Partial independence       → Factored (per-group dense sub-states)
 /// 5. Otherwise                  → Statevector (exact, general-purpose)
 #[derive(Debug, Clone)]
 pub enum BackendKind {

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -878,6 +878,36 @@ fn fusion_diagonal_batch_respects_non_diagonal_barrier() {
     }
 }
 
+// Pins the fused form for the `statevector/diag_mixed_l6` bench rows: the rows
+// measure the `DiagonalBatch` sweep, so the batch must actually appear. Sizes
+// cross the parallel threshold, so the state comparison also exercises the
+// parallel sweep against the sequential per-gate reference.
+#[test]
+fn fusion_diag_mixed_batches_and_matches_unfused() {
+    for &n in &[16usize, 20] {
+        let c = circuits::diagonal_mixed_circuit(n, 6, common::SEED);
+        let fused = prism_q::circuit::fusion::fuse_circuit(&c, true);
+        let batches = fused
+            .instructions
+            .iter()
+            .filter(|inst| {
+                matches!(
+                    inst,
+                    Instruction::Gate {
+                        gate: Gate::DiagonalBatch(_),
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(
+            batches > 0,
+            "expected a DiagonalBatch in the fused stream at {n}q"
+        );
+        assert_fusion_preserves_state(&c);
+    }
+}
+
 // Seeded sweep over the gate mix that exposed both batching reorder bugs. The
 // deterministic cases above pin the two known shapes; this covers the class,
 // which stayed hidden because the generated bench circuits never produce it.


### PR DESCRIPTION
## Summary

Fold runs of diagonal gates into a single pass over the state on two backends.
`apply_diagonal_batch` was the last batched statevector kernel with no parallel
variant, although fusion only builds a `DiagonalBatch` at 16 qubits and its two
siblings (`apply_batch_rzz`, `apply_batch_phase`) tile at 14, so every firing was
already past the threshold and ran single-threaded. On the sparse backend the module
header claimed diagonal gates scale amplitudes in place; they did not. Plain 1q
diagonals fell through `apply_single_qubit` and rebuilt the whole map with a
zero-coefficient partner per entry, and `BatchRzz` and `DiagonalBatch` walked the map
once per edge or entry. The documentation half of the PR corrects the backend roster
and dispatch descriptions, which had drifted from the code across five pages.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

No existing benchmark family builds a `DiagonalBatch`: the fused streams of
`random_d10`, `qaoa_l3`, `clifford_d10`, and `hea_l5` carry zero at 16 and 20 qubits
(QAOA fuses to `BatchRzz` instead). This PR adds `circuits::diagonal_mixed_circuit`
and the `statevector/diag_mixed_l6/{16,20}` rows, with
`fusion_diag_mixed_batches_and_matches_unfused` asserting the fused form actually
contains the batch, so the rows cannot silently stop measuring the kernel.

Three adjacent-binary A/B pairs via `./scripts/bench_ab.sh`, against a reference
carrying the new bench rows and none of the kernel changes, so the rows exist on both
sides. Every row below holds its sign across all three pairs. The host's same-code
control spread ran 3% to 34% throughout, so these are reproduced signs and
magnitudes, not gate-resolved numbers.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `statevector/diag_mixed_l6/16` | 5.44 ms | 3.46 ms | -36.4% (-29.5%, -34.9% in pairs 1-2) | -20.5% / -3.5% | Improvement; host cannot resolve the gate |
| `statevector/diag_mixed_l6/20` | 6.28 ms | 4.12 ms | -34.4% (-31.5%, -43.7%) | -10.0% / -7.1% | Improvement; host cannot resolve the gate |
| `sparse/random_d10/16` | 7.03 ms | 3.16 ms | -55.0% (-60.7%, -55.1%) | -31.2% / -6.4% | Improvement; host cannot resolve the gate |
| `sparse/random_d10/20` | 758.17 us | 644.86 us | -14.9% (-14.6%, -2.7%) | -25.7% / +3.0% | Improvement; host cannot resolve the gate |
| `compare/general_d10/sparse/16` | 6.47 ms | 2.84 ms | -56.0% (-45.7%, -53.2%) | -20.2% / -8.9% | Improvement; host cannot resolve the gate |
| `compare/clifford_d10/sparse/16` | 2.85 ms | 2.53 ms | -11.3% (-28.5%, -26.4%) | -22.5% / -2.9% | Improvement; host cannot resolve the gate |
| `compare/clifford_d10/sparse/20` | 467.33 us | 317.82 us | -32.0% (-14.0%, -20.7%) | -34.2% / -10.9% | Improvement; host cannot resolve the gate |
| `compare/general_d10/sparse/20` | 652.99 us | 614.86 us | -5.8% (-8.5%, +10.2%) | -22.0% / -11.4% | Sign flipped across pairs; not claimed |
| `statevector/qaoa_l3/16` | 2.45 ms | 2.30 ms | -6.2% (-0.5%, +13.3%) | +4.9% / +2.2% | No consistent sign; no path changed |

Two rows are deliberately not claimed as wins. `compare/general_d10/sparse/20`
flipped sign across the three pairs. `statevector/qaoa_l3/16` read +13.3% with tight
controls in pair 2, which looked like a regression until a third isolated pair read
-6.2% with equally tight controls; three readings of -0.5%, +13.3%, -6.2% have no
consistent sign, and QAOA fuses to `BatchRzz` rather than `DiagonalBatch`, so there
is no mechanism by which this PR could touch it.

Environment: Intel i7-6700K @ 4.00GHz, MINGW64_NT-10.0-19045, rustc 1.97.0,
`--features parallel`, `lto = "fat"`, `codegen-units = 1`, 100 samples per row.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2008 tests)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry, and stay concise; none restate the signature
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Feature set note: the checkboxes above were run at `parallel gpu distributed` rather
than `--all-features`. The diff touches no MPI code or feature wiring, and
`--all-features` pulls `distributed-mpi`, which needs `LIBCLANG_PATH` plus the MSVC
environment.

New and changed tests:

- `diagonal_batch_par_matches_independent_reference` (14 qubits, all three
  `DiagEntry` kinds, qubits spread across more than one group) compares the parallel
  sweep against a hand-computed reference. It is the paired per-tier test required by
  the `#[target_feature]` kernel count pin in `backend/simd.rs`, which the new BMI2
  tile kernel trips; BMI2 hosts route through `diagonal_batch_tile_bmi2` and the rest
  through `diagonal_batch_tile_scalar`.
- `fusion_diag_mixed_batches_and_matches_unfused` asserts a `DiagonalBatch` is present
  in the fused stream at 16 and 20 qubits and compares fused against unfused state.
- Three sparse unit tests (`test_diagonal_1q_in_place`,
  `test_batch_rzz_matches_individual`, `test_diagonal_batch_matches_individual`) pin
  the folded paths against the per-gate path.
- `target_feature_kernel_count_is_pinned` moves from 10 to 11 for
  `statevector/kernels.rs`.

## Hotspot notes

Functions on the hot path:

- `StatevectorBackend::apply_diagonal_batch` gains a parallel arm at
  `PARALLEL_THRESHOLD_QUBITS`, dispatching to `diagonal_batch_tile_bmi2` (new,
  mirroring `batch_rzz_tile_bmi2`) or `diagonal_batch_tile_scalar`. The sequential
  `apply_diagonal_batch_scalar` is now a thin wrapper over the same tile helper, so
  the two paths share one definition instead of two copies of the bit-extraction loop.
- `SparseBackend::apply_single_qubit` intercepts any diagonal 2x2 and routes to a new
  `apply_diagonal_1q` that scales in place. This also catches fused and Kraus
  diagonals, not just the named gates. Only a sub-unit diagonal, which can shrink an
  amplitude below epsilon, pays the prune pass.
- `SparseBackend` `BatchRzz` and `DiagonalBatch` arms fold their combined phase in one
  walk. `BatchRzz` precomputes the per-edge phase pair once instead of two
  `from_polar` calls per edge per walk.
- `gates::diag_entries_phase` is the single definition of the phase a `DiagEntry` run
  applies to a basis state, consumed by both backends.

No profiler output attached: the change removes passes over the state rather than
retuning one, and the pass count is readable from the source. The bench rows above are
the measurement.

## Architecture or design changes

- [x] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

The documentation half corrects drift rather than describing new structure:

- Roster wording is now nine CPU backends, a CUDA attach on statevector and
  stabilizer, and a feature-gated distributed statevector, consistent across
  `docs/architecture/backends.md`, `docs/guides/backends.md`, and
  `docs/guides/capabilities.md`.
- `docs/guides/capabilities.md` splits the three Clifford+T engines out of the backend
  table, since they are not `Backend` implementations, and cuts the `Planned` cells to
  what the roadmap carries (ROCm on the two backends that have CUDA kernels to port,
  distributed on the statevector only). The rest are `No`.
- README gains FactoredStabilizer, DensityMatrix, and Distributed in the backend
  table; its dispatch paragraph now matches `select_auto_backend_choice`; the claim
  that `Auto` does not route to GPU is replaced by `gpu_auto`; and the roadmap section
  drops the three items that shipped.
- The `BackendKind` decision tree names the routes taken before the family tree
  (independent-block decomposition, FactoredStabilizer, StabilizerRank, SPD marginals)
  and the real T-count constants: 18 exact, 28 approximate, 40 shots, against a stale
  `t <= 12`.
- `docs/guides/gpu.md` gains the `AutoGpu` entry point and `kernels/bts.rs`, names
  `stab_apply_word_grouped` instead of `stab_apply_batch`, which does not exist, and
  replaces the two Current limits that `LauncherScratch` closed with the three that
  are open.

## Breaking changes

None. No public API signatures change. `circuits::diagonal_mixed_circuit` is additive.
Numerical results are unchanged: the folded paths multiply the same factors in the
same order per amplitude, and the parallel sweep is elementwise with no cross-chunk
reduction, so there is no reassociation.

## Risks and rollback

Blast radius is two gate-application paths.

- Statevector: the parallel arm is behind both `#[cfg(feature = "parallel")]` and
  `num_qubits >= PARALLEL_THRESHOLD_QUBITS`. Deleting the arm restores the previous
  behavior exactly; the sequential path below it is unchanged apart from sharing the
  tile helper.
- Sparse: the diagonal interception in `apply_single_qubit` is the widest-reaching
  change, because it now catches any diagonal 2x2 including fused and Kraus operators
  rather than only the named diagonal gates. The prune condition is the thing to watch
  if a sparsity regression appears: a unitary diagonal cannot shrink an amplitude, so
  it skips the prune, and the sub-unit case still pays it.
- No dispatch guard or feature flag gates the sparse change; rolling it back means
  reverting the `sparse.rs` hunks.

Documentation changes carry no runtime risk.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed as an issue or noted above
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
