### PR TITLE
perf(backend): parallelize the full-state passes that still ran serial

### DIFF
--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -283,6 +283,69 @@ fn bench_measurement(c: &mut Criterion) {
         );
     }
 
+    // The measurement family chunks by 2^(qubit+1), so a top-qubit target is one
+    // chunk over the whole state where qubit 0 is 2^(n-1) of them. Both rows walk
+    // the same 2^n amplitudes; only the chunking differs, so q0 is the control.
+    //
+    // The read and collapse rows hold one backend for the whole row: the reads
+    // do not mutate, and a repeated collapse on an already collapsed state walks
+    // the same amplitudes. Rebuilding a 16 MB backend per iteration would put an
+    // allocate-and-zero pass beside every measured one.
+    const N: usize = 20;
+    let hi = N - 1;
+
+    let prepared = |target: usize, classical: usize| {
+        let mut backend = StatevectorBackend::new(42);
+        backend.init(N, classical).unwrap();
+        let mut prep = Circuit::new(N, classical);
+        prep.add_gate(Gate::X, &[target]);
+        backend.apply(&prep.instructions[0]).unwrap();
+        backend
+    };
+
+    for &(target, label) in &[(0usize, "prob_one_q0_n20"), (hi, "prob_one_q19_n20")] {
+        group.bench_function(label, |b| {
+            let backend = prepared(target, 0);
+            b.iter(|| black_box(backend.qubit_probability(target).unwrap()));
+        });
+    }
+
+    for &(target, label) in &[(0usize, "rdm_q0_n20"), (hi, "rdm_q19_n20")] {
+        group.bench_function(label, |b| {
+            let backend = prepared(target, 0);
+            b.iter(|| black_box(backend.reduced_density_matrix_1q(target).unwrap()));
+        });
+    }
+
+    for &(target, label) in &[(0usize, "measure_q0_n20"), (hi, "measure_q19_n20")] {
+        let measure = prism_q::Instruction::Measure {
+            qubit: target,
+            classical_bit: 0,
+        };
+        group.bench_function(label, |b| {
+            let mut backend = prepared(target, 1);
+            b.iter(|| backend.apply(&measure).unwrap());
+        });
+    }
+
+    // Reset is the one row that cannot reuse its state: once the qubit is |0>
+    // the fold stops copying, so each iteration needs a state with weight on the
+    // |1> branch. `PerIteration` keeps that to one live backend at a time.
+    for &(target, label) in &[(0usize, "reset_q0_n20"), (hi, "reset_q19_n20")] {
+        let mut circuit = Circuit::new(N, 0);
+        circuit.add_reset(target);
+        group.bench_function(label, |b| {
+            b.iter_batched(
+                || prepared(target, 0),
+                |mut backend| {
+                    backend.apply(&circuit.instructions[0]).unwrap();
+                    black_box(backend.state_vector());
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
     group.finish();
 }
 
@@ -338,6 +401,21 @@ fn bench_high_target_qubit(c: &mut Criterion) {
             b.iter(|| {
                 run_with(BackendKind::Statevector, &circuit, 42).unwrap();
             });
+        });
+    }
+
+    // Diagonal counterpart of the rows above. The diagonal pass tiles by
+    // 2^(target+1), so at n=20 target 19 leaves one tile and target 17 leaves
+    // four, while the general 1q kernel splits either. Rz scales both halves,
+    // where P leaves the |0> half alone. Rz is unitary, so one backend serves
+    // the whole row and no allocation lands beside a measured pass.
+    for &(n_qubits, target) in &[(20, 17), (20, 19)] {
+        let mut circuit = Circuit::new(n_qubits, 0);
+        circuit.add_gate(Gate::Rz(0.7), &[target]);
+        group.bench_function(format!("rz_q{}_n{}", target, n_qubits), |b| {
+            let mut backend = StatevectorBackend::new(42);
+            backend.init(n_qubits, 0).unwrap();
+            b.iter(|| backend.apply(&circuit.instructions[0]).unwrap());
         });
     }
 

--- a/benches/bench_shots_perf.rs
+++ b/benches/bench_shots_perf.rs
@@ -101,6 +101,25 @@ fn non_clifford_terminal_circuit(n_qubits: usize, measured_qubits: usize) -> Cir
     c
 }
 
+/// Non-Clifford circuit whose measurement sits mid-circuit on `measured`, so
+/// every shot replays the whole circuit and pays one measurement collapse.
+/// Choosing a top qubit puts that collapse on the single-chunk end of the
+/// measurement family's `2^(qubit+1)` chunking.
+fn midcircuit_measure_circuit(n_qubits: usize, measured: usize) -> Circuit {
+    let mut c = Circuit::new(n_qubits, 1);
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Ry(0.17 + q as f64 * 0.013), &[q]);
+    }
+    for q in 0..n_qubits - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c.add_measure(measured, 0);
+    for q in 0..n_qubits {
+        c.add_gate(Gate::Rx(0.11 + q as f64 * 0.019), &[q]);
+    }
+    c
+}
+
 fn api_redesign_circuit(n_qubits: usize, with_measurements: bool) -> Circuit {
     let mut c = Circuit::new(n_qubits, if with_measurements { n_qubits } else { 0 });
     for q in 0..n_qubits {
@@ -229,6 +248,13 @@ fn bench_run_shots(c: &mut Criterion) {
                 b.iter(|| run_shots_with(BackendKind::Auto, &circuit, shots, SEED).unwrap());
             },
         );
+    }
+
+    for &(measured, label) in &[(0usize, "midcircuit_18q_q0"), (17, "midcircuit_18q_q17")] {
+        let circuit = midcircuit_measure_circuit(18, measured);
+        group.bench_with_input(BenchmarkId::new(label, 200), &200usize, |b, &shots| {
+            b.iter(|| run_shots_with(BackendKind::Statevector, &circuit, shots, SEED).unwrap());
+        });
     }
 
     group.finish();

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -4,6 +4,7 @@
 //! measurement time. Omit for the full suite with default Criterion timing.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
 use prism_q::circuit::{Circuit, SmallVec};
@@ -1810,6 +1811,93 @@ fn bench_density_matrix_unitary_layers(c: &mut Criterion) {
     group.finish();
 }
 
+/// Kraus set for amplitude damping at rate `gamma`.
+fn amplitude_damping_kraus(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let c = |re: f64| Complex64::new(re, 0.0);
+    let zero = c(0.0);
+    vec![
+        [[c(1.0), zero], [zero, c((1.0 - gamma).sqrt())]],
+        [[zero, c(gamma.sqrt())], [zero, zero]],
+    ]
+}
+
+/// Kraus set for symmetric one-qubit depolarizing at rate `p`.
+fn depolarizing_kraus(p: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let c = |re: f64| Complex64::new(re, 0.0);
+    let zero = c(0.0);
+    let w = c((p / 3.0).sqrt());
+    let iw = Complex64::new(0.0, (p / 3.0).sqrt());
+    vec![
+        [[c((1.0 - p).sqrt()), zero], [zero, c((1.0 - p).sqrt())]],
+        [[zero, w], [w, zero]],
+        [[zero, -iw], [iw, zero]],
+        [[w, zero], [zero, -w]],
+    ]
+}
+
+fn dm_backend(n: usize) -> DensityMatrixBackend {
+    let circuit = circuits::random_circuit(n, 2, SEED);
+    let mut backend = DensityMatrixBackend::new(42);
+    backend.init(n, 1).unwrap();
+    backend.apply_instructions(&circuit.instructions).unwrap();
+    backend
+}
+
+/// Channel, measurement, and diagnostic sweeps over the `4^n` buffer.
+///
+/// The channel mix is amplitude damping and symmetric depolarizing through
+/// `apply_1q_kraus`, plus symmetric two-qubit depolarizing. Measure and reset
+/// run at qubit 0 and at the top qubit, the two ends of the `2^(qubit+n)` row
+/// stride. Widths stop at 12: `4^14` is 4.3 GB per buffer, too large to iterate.
+fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/noisy_channels");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let amp_damp = amplitude_damping_kraus(0.05);
+        group.bench_with_input(BenchmarkId::new("kraus_amp_damp", n), &n, |b, &n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_1q_kraus(0, &amp_damp));
+        });
+
+        let depol = depolarizing_kraus(0.02);
+        group.bench_with_input(BenchmarkId::new("kraus_depolarizing", n), &n, |b, &n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_1q_kraus(n - 1, &depol));
+        });
+
+        group.bench_with_input(BenchmarkId::new("depolarizing_2q", n), &n, |b, &n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_depolarizing(0, n - 1, 0.02));
+        });
+
+        for &(qubit, label) in &[(0usize, "measure_q0"), (n - 1, "measure_qtop")] {
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, &n| {
+                let mut backend = dm_backend(n);
+                let measure = Instruction::Measure {
+                    qubit,
+                    classical_bit: 0,
+                };
+                b.iter(|| backend.apply(&measure).unwrap());
+            });
+        }
+
+        for &(qubit, label) in &[(0usize, "reset_q0"), (n - 1, "reset_qtop")] {
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, &n| {
+                let mut backend = dm_backend(n);
+                b.iter(|| backend.reset(qubit).unwrap());
+            });
+        }
+
+        group.bench_with_input(BenchmarkId::new("purity", n), &n, |b, &n| {
+            let backend = dm_backend(n);
+            b.iter(|| black_box(backend.purity()));
+        });
+    }
+
+    group.finish();
+}
+
 /// Neutrality row: an untouched statevector row re-run under a density-matrix
 /// group name. The density-matrix backend shares no kernels with the
 /// statevector path, so this must stay within the 5% regression gate.
@@ -1912,6 +2000,7 @@ criterion_group! {
     bench_coalesce_baseline,
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
+    bench_density_matrix_noisy_channels,
     bench_density_matrix_neutrality
 }
 criterion_main!(benches);

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -116,6 +116,15 @@ fn reset_fold_pair(r0: &mut [Complex64], r1: &mut [Complex64], cmask: usize) {
     simd::zero_slice(r1);
 }
 
+/// Tile size for a parallel sweep over `rho` whose body reads the qubit's row
+/// class from the tile's own base index. Both `rmask` and `2 * cmask` are powers
+/// of two and `rmask >= 2 * cmask`, so the result is a multiple of the column run
+/// that divides `rmask`: a tile can never straddle the row bit.
+#[cfg(feature = "parallel")]
+fn row_aligned_tile(cmask: usize, rmask: usize) -> usize {
+    (cmask << 1).max(crate::backend::MIN_PAR_ELEMS).min(rmask)
+}
+
 fn conjugate_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
     [
         [m[0][0].conj(), m[0][1].conj()],
@@ -313,7 +322,7 @@ impl DensityMatrixBackend {
 
         #[cfg(feature = "parallel")]
         if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
-            use crate::backend::{MIN_PAR_ELEMS, chunk_min_len};
+            use crate::backend::chunk_min_len;
             use rayon::prelude::*;
 
             if self.sv.state.len() / block_size >= 4 {
@@ -328,7 +337,7 @@ impl DensityMatrixBackend {
                 return;
             }
 
-            let tile = (cmask << 1).max(MIN_PAR_ELEMS).min(rmask);
+            let tile = row_aligned_tile(cmask, rmask);
             for block in self.sv.state.chunks_mut(block_size) {
                 let (r0, r1) = block.split_at_mut(rmask);
                 r0.par_chunks_mut(tile)
@@ -354,10 +363,10 @@ impl DensityMatrixBackend {
 
         #[cfg(feature = "parallel")]
         if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
-            use crate::backend::{MIN_PAR_ELEMS, chunk_min_len};
+            use crate::backend::chunk_min_len;
             use rayon::prelude::*;
 
-            let tile = (cmask << 1).max(MIN_PAR_ELEMS).min(rmask);
+            let tile = row_aligned_tile(cmask, rmask);
             self.sv
                 .state
                 .par_chunks_mut(tile)

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -43,6 +43,7 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
+use crate::backend::simd;
 use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
@@ -70,6 +71,49 @@ fn block_superoperator(kraus: &[[[Complex64; 2]; 2]]) -> [[Complex64; 4]; 4] {
         }
     }
     s
+}
+
+/// Collapse one tile of `rho` onto the `outcome` subspace of the qubit whose
+/// row and column bits in the buffer index are `rmask` and `cmask`, scaling the
+/// survivors by `scale`. `base` is the tile's buffer index, and the tile must
+/// not straddle `rmask`, so one test fixes its row class: a tile on the
+/// eliminated row is a contiguous zero fill, and only the surviving row pays a
+/// per-entry column test.
+fn project_tile(
+    tile: &mut [Complex64],
+    base: usize,
+    rmask: usize,
+    cmask: usize,
+    outcome: bool,
+    scale: Complex64,
+) {
+    if ((base & rmask) != 0) != outcome {
+        simd::zero_slice(tile);
+        return;
+    }
+    let zero = Complex64::new(0.0, 0.0);
+    for (j, amp) in tile.iter_mut().enumerate() {
+        *amp = if (((base + j) & cmask) != 0) == outcome {
+            *amp * scale
+        } else {
+            zero
+        };
+    }
+}
+
+/// Fold the row-set half of one `2 * rmask` block of `rho` onto the row-clear
+/// half, then clear it. `r0` and `r1` are the two halves, or matching sub-tiles
+/// of them, and `cmask` is the qubit's column bit.
+fn reset_fold_pair(r0: &mut [Complex64], r1: &mut [Complex64], cmask: usize) {
+    let zero = Complex64::new(0.0, 0.0);
+    for (j, amp) in r0.iter_mut().enumerate() {
+        *amp = if j & cmask == 0 {
+            *amp + r1[j | cmask]
+        } else {
+            zero
+        };
+    }
+    simd::zero_slice(r1);
 }
 
 fn conjugate_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
@@ -143,7 +187,7 @@ impl DensityMatrixBackend {
 
     /// Purity `Tr(rho^2)`, equal to `1` for a pure state and less otherwise.
     pub fn purity(&self) -> f64 {
-        self.sv.state.iter().map(Complex64::norm_sqr).sum()
+        crate::backend::state_norm_sqr(&self.sv.state)
     }
 
     #[inline]
@@ -258,22 +302,45 @@ impl DensityMatrixBackend {
 
     /// Deterministic reset `rho -> |0><0| (x) tr_q rho`: fold the block with
     /// `qubit` set on both row and column into the block with it clear on both,
-    /// then zero the three sibling entries that still touch `qubit`. One pass
-    /// over the `d*d/4` block bases.
+    /// then zero the three sibling entries that still touch `qubit`. The four
+    /// entry classes are contiguous runs of the buffer, so the pass walks
+    /// `2 * rmask` blocks rather than scattering per block base.
     fn apply_reset(&mut self, qubit: usize) {
         let n = self.num_qubits;
-        let d = self.dim();
         let rmask = 1usize << (qubit + n);
         let cmask = 1usize << qubit;
-        let both = rmask | cmask;
-        let zero = Complex64::new(0.0, 0.0);
-        for m in 0..((d * d) >> 2) {
-            let base = insert_zero_bit(insert_zero_bit(m, qubit), qubit + n);
-            let folded = self.sv.state[base | both];
-            self.sv.state[base] += folded;
-            self.sv.state[base | rmask] = zero;
-            self.sv.state[base | cmask] = zero;
-            self.sv.state[base | both] = zero;
+        let block_size = rmask << 1;
+
+        #[cfg(feature = "parallel")]
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::{MIN_PAR_ELEMS, chunk_min_len};
+            use rayon::prelude::*;
+
+            if self.sv.state.len() / block_size >= 4 {
+                self.sv
+                    .state
+                    .par_chunks_mut(block_size)
+                    .with_min_len(chunk_min_len(block_size))
+                    .for_each(|block| {
+                        let (r0, r1) = block.split_at_mut(rmask);
+                        reset_fold_pair(r0, r1, cmask);
+                    });
+                return;
+            }
+
+            let tile = (cmask << 1).max(MIN_PAR_ELEMS).min(rmask);
+            for block in self.sv.state.chunks_mut(block_size) {
+                let (r0, r1) = block.split_at_mut(rmask);
+                r0.par_chunks_mut(tile)
+                    .zip(r1.par_chunks_mut(tile))
+                    .for_each(|(t0, t1)| reset_fold_pair(t0, t1, cmask));
+            }
+            return;
+        }
+
+        for block in self.sv.state.chunks_mut(block_size) {
+            let (r0, r1) = block.split_at_mut(rmask);
+            reset_fold_pair(r0, r1, cmask);
         }
     }
 
@@ -281,17 +348,29 @@ impl DensityMatrixBackend {
     /// probability `p`, renormalizing the survivors to unit trace.
     fn project(&mut self, qubit: usize, outcome: bool, p: f64) {
         let n = self.num_qubits;
-        let d = self.dim();
         let rmask = 1usize << (qubit + n);
         let cmask = 1usize << qubit;
-        let keep = if outcome { rmask | cmask } else { 0 };
-        let inv = 1.0 / p.clamp(NORM_CLAMP_MIN, 1.0);
-        for idx in 0..d * d {
-            if idx & (rmask | cmask) == keep {
-                self.sv.state[idx] *= inv;
-            } else {
-                self.sv.state[idx] = Complex64::new(0.0, 0.0);
-            }
+        let scale = Complex64::new(1.0 / p.clamp(NORM_CLAMP_MIN, 1.0), 0.0);
+
+        #[cfg(feature = "parallel")]
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::{MIN_PAR_ELEMS, chunk_min_len};
+            use rayon::prelude::*;
+
+            let tile = (cmask << 1).max(MIN_PAR_ELEMS).min(rmask);
+            self.sv
+                .state
+                .par_chunks_mut(tile)
+                .with_min_len(chunk_min_len(tile))
+                .enumerate()
+                .for_each(|(t, chunk)| {
+                    project_tile(chunk, t * tile, rmask, cmask, outcome, scale);
+                });
+            return;
+        }
+
+        for (t, chunk) in self.sv.state.chunks_mut(rmask).enumerate() {
+            project_tile(chunk, t * rmask, rmask, cmask, outcome, scale);
         }
     }
 
@@ -380,7 +459,47 @@ impl DensityMatrixBackend {
             }
         }
 
-        for m in 0..((d * d) >> 4) {
+        let num_groups = (d * d) >> 4;
+
+        #[cfg(feature = "parallel")]
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::MIN_PAR_ITERS;
+            use crate::backend::statevector::SendPtr;
+            use rayon::prelude::*;
+
+            let ptr = SendPtr(self.sv.state.as_mut_ptr());
+            (0..num_groups)
+                .into_par_iter()
+                .with_min_len(MIN_PAR_ITERS)
+                .for_each(move |m| {
+                    let mut base = m;
+                    for &pos in &positions {
+                        base = insert_zero_bit(base, pos);
+                    }
+                    let mut v = [Complex64::new(0.0, 0.0); 16];
+                    // SAFETY: inserting a zero bit at each of the four block
+                    // positions is a bijection from `m` onto the block bases, so
+                    // the 16 offsets one iteration touches are disjoint from
+                    // every other iteration's. The safe alternative needs the
+                    // 16 entries as disjoint sub-slices, which they are not:
+                    // they are strided across four independent bit positions.
+                    unsafe {
+                        for (k, &off) in flats.iter().enumerate() {
+                            v[k] = ptr.load(base | off);
+                        }
+                        for (i, &off) in flats.iter().enumerate() {
+                            let mut acc = Complex64::new(0.0, 0.0);
+                            for j in 0..16 {
+                                acc += s[i][j] * v[j];
+                            }
+                            ptr.store(base | off, acc);
+                        }
+                    }
+                });
+            return;
+        }
+
+        for m in 0..num_groups {
             let mut base = m;
             for &pos in &positions {
                 base = insert_zero_bit(base, pos);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -84,6 +84,48 @@ pub(crate) fn chunk_min_len(chunk_size: usize) -> usize {
 #[cfg(feature = "parallel")]
 pub(crate) const MIN_PAR_ITERS: usize = 2048;
 
+/// Element count above which a full-buffer reduction is worth Rayon fan-out.
+/// Higher than [`PARALLEL_THRESHOLD_QUBITS`] because a reduction is one
+/// lightweight streaming pass, so the fan-out only pays past `2^16`.
+#[cfg(feature = "parallel")]
+pub(crate) const MIN_PAR_REDUCE_ELEMS: usize = 1 << 16;
+
+/// `sum |a|^2` over a dense amplitude buffer, SIMD per chunk and parallel above
+/// [`MIN_PAR_REDUCE_ELEMS`].
+pub(crate) fn state_norm_sqr(state: &[Complex64]) -> f64 {
+    #[cfg(feature = "parallel")]
+    if state.len() >= MIN_PAR_REDUCE_ELEMS {
+        use rayon::prelude::*;
+        return state
+            .par_chunks(MIN_PAR_ELEMS)
+            .map(simd::norm_sqr_sum)
+            .sum();
+    }
+    simd::norm_sqr_sum(state)
+}
+
+#[cfg(test)]
+mod norm_tests {
+    use super::state_norm_sqr;
+    use num_complex::Complex64;
+
+    // Both sides of the reduction's parallel threshold against a scalar sum.
+    #[test]
+    fn state_norm_sqr_matches_scalar_sum_across_the_parallel_threshold() {
+        for len in [1usize, 3, 4096, (1 << 16) - 1, 1 << 16, (1 << 17) + 5] {
+            let state: Vec<Complex64> = (0..len)
+                .map(|i| Complex64::new(0.001 * i as f64 - 0.5, 0.002 * i as f64 + 0.25))
+                .collect();
+            let scalar: f64 = state.iter().map(Complex64::norm_sqr).sum();
+            let got = state_norm_sqr(&state);
+            assert!(
+                (got - scalar).abs() <= 1e-9 * scalar.max(1.0),
+                "len {len}: expected {scalar}, got {got}"
+            );
+        }
+    }
+}
+
 /// Tableau size at which stabilizer row loops parallelize.
 #[cfg(feature = "parallel")]
 pub(crate) const MIN_QUBITS_FOR_PAR_GATES: usize = 128;

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -1292,10 +1292,7 @@ pub(crate) fn norm_sqr_to_slice_scaled(src: &[Complex64], dst: &mut [f64], scale
     }
 }
 
-#[cfg(all(
-    target_arch = "x86_64",
-    any(feature = "parallel", feature = "distributed", test)
-))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn zero_slice_avx2(slice: &mut [Complex64]) {
     // SAFETY: same contract as the enclosing unsafe fn.
@@ -1312,7 +1309,6 @@ unsafe fn zero_slice_avx2(slice: &mut [Complex64]) {
     }
 }
 
-#[cfg(any(feature = "parallel", feature = "distributed", test))]
 pub(crate) fn zero_slice(slice: &mut [Complex64]) {
     #[cfg(target_arch = "x86_64")]
     if slice.len() >= MIN_SIMD_SLICE && has_avx2_fma() {

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -1593,15 +1593,16 @@ impl StatevectorBackend {
     fn apply_diagonal_gate_par(&mut self, target: usize, d0: Complex64, d1: Complex64) {
         let skip_lo = is_phase_one(d0);
 
-        const MIN_TILE: usize = 8192;
         let half = 1usize << target;
         let block_size = half << 1;
+        let num_blocks = self.state.len() / block_size;
 
-        if self.state.len() / block_size < 4 {
+        if num_blocks < 4 {
             apply_diagonal_high_target_par(&mut self.state, target, d0, d1, skip_lo);
             return;
         }
 
+        const MIN_TILE: usize = 8192;
         let tile_size = MIN_TILE.max(block_size);
         self.state.par_chunks_mut(tile_size).for_each(|tile| {
             simd::apply_diagonal_sequential(tile, target, d0, d1, skip_lo);
@@ -3024,7 +3025,8 @@ impl StatevectorBackend {
         for (target, d0, d1) in large_gates {
             let skip_lo = is_phase_one(d0);
             let block_size = 1usize << (target + 1);
-            if self.state.len() / block_size < 4 {
+            let num_blocks = self.state.len() / block_size;
+            if num_blocks < 4 {
                 apply_diagonal_high_target_par(&mut self.state, target, d0, d1, skip_lo);
                 continue;
             }
@@ -3161,7 +3163,8 @@ impl StatevectorBackend {
 
         let half = 1usize << qubit;
         let block_size = half << 1;
-        if self.state.len() / block_size >= 4 {
+        let num_blocks = self.state.len() / block_size;
+        if num_blocks >= 4 {
             self.state
                 .par_chunks_mut(block_size)
                 .with_min_len(chunk_min_len(block_size))
@@ -3186,8 +3189,9 @@ impl StatevectorBackend {
     fn fold_reset_par(&mut self, qubit: usize, outcome: bool) {
         let half = 1usize << qubit;
         let block_size = half << 1;
+        let num_blocks = self.state.len() / block_size;
 
-        if self.state.len() / block_size >= 4 {
+        if num_blocks >= 4 {
             self.state
                 .par_chunks_mut(block_size)
                 .with_min_len(chunk_min_len(block_size))

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -80,6 +80,44 @@ fn negate_slice_kernel(slice: &mut [Complex64]) {
     }
 }
 
+/// Fold the `|1>` branch of a reset onto the `|0>` branch over one aligned
+/// `(lo, hi)` pair, then clear `hi`. Shared by the block and sub-tile arms of
+/// [`StatevectorBackend::fold_reset_par`], which differ only in what they pass.
+#[cfg(feature = "parallel")]
+#[inline(always)]
+fn fold_reset_pair(lo: &mut [Complex64], hi: &mut [Complex64], outcome: bool) {
+    if outcome {
+        lo.copy_from_slice(hi);
+    }
+    simd::zero_slice(hi);
+}
+
+/// Diagonal `(d0, d1)` on `target` when the state holds fewer than four
+/// `2^(target+1)` blocks, where tiling by the block leaves at most three Rayon
+/// tasks. Scales each half of every block in parallel sub-tiles instead.
+#[cfg(feature = "parallel")]
+#[inline(always)]
+fn apply_diagonal_high_target_par(
+    state: &mut [Complex64],
+    target: usize,
+    d0: Complex64,
+    d1: Complex64,
+    skip_lo: bool,
+) {
+    let half = 1usize << target;
+    for block in state.chunks_mut(half << 1) {
+        let (lo, hi) = block.split_at_mut(half);
+        lo.par_chunks_mut(MIN_PAR_ELEMS)
+            .zip(hi.par_chunks_mut(MIN_PAR_ELEMS))
+            .for_each(|(lo_t, hi_t)| {
+                if !skip_lo {
+                    simd::scale_complex_slice(lo_t, d0);
+                }
+                simd::scale_complex_slice(hi_t, d1);
+            });
+    }
+}
+
 pub(crate) const BATCH_PHASE_GROUP_SIZE: usize = 10;
 pub(crate) const BATCH_PHASE_TABLE_SIZE: usize = 1024;
 pub(crate) const MAX_BATCH_PHASE_GROUPS: usize = 4;
@@ -1558,8 +1596,13 @@ impl StatevectorBackend {
         const MIN_TILE: usize = 8192;
         let half = 1usize << target;
         let block_size = half << 1;
-        let tile_size = MIN_TILE.max(block_size);
 
+        if self.state.len() / block_size < 4 {
+            apply_diagonal_high_target_par(&mut self.state, target, d0, d1, skip_lo);
+            return;
+        }
+
+        let tile_size = MIN_TILE.max(block_size);
         self.state.par_chunks_mut(tile_size).for_each(|tile| {
             simd::apply_diagonal_sequential(tile, target, d0, d1, skip_lo);
         });
@@ -2647,13 +2690,26 @@ impl StatevectorBackend {
         let half = 1usize << qubit;
         let block_size = half << 1;
         let norm_sq = self.pending_norm * self.pending_norm;
+        let num_blocks = self.state.len() / block_size;
 
-        self.state
-            .par_chunks(block_size)
-            .with_min_len(chunk_min_len(block_size))
-            .map(|chunk| simd::norm_sqr_sum(&chunk[half..]))
-            .sum::<f64>()
-            * norm_sq
+        let prob_one = if num_blocks >= 4 {
+            self.state
+                .par_chunks(block_size)
+                .with_min_len(chunk_min_len(block_size))
+                .map(|chunk| simd::norm_sqr_sum(&chunk[half..]))
+                .sum::<f64>()
+        } else {
+            self.state
+                .chunks(block_size)
+                .map(|chunk| {
+                    chunk[half..]
+                        .par_chunks(MIN_PAR_ELEMS)
+                        .map(simd::norm_sqr_sum)
+                        .sum::<f64>()
+                })
+                .sum::<f64>()
+        };
+        prob_one * norm_sq
     }
 
     #[inline(always)]
@@ -2690,16 +2746,27 @@ impl StatevectorBackend {
         let half = 1usize << qubit;
         let block_size = half << 1;
         let norm_sq = self.pending_norm * self.pending_norm;
+        let num_blocks = self.state.len() / block_size;
+        let zero_sums = || (0.0, 0.0, Complex64::new(0.0, 0.0));
 
-        let (p0, p1, r) = self
-            .state
-            .par_chunks(block_size)
-            .with_min_len(chunk_min_len(block_size))
-            .map(|block| super::rdm_block_sums(block, half))
-            .reduce(
-                || (0.0, 0.0, Complex64::new(0.0, 0.0)),
-                |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
-            );
+        let (p0, p1, r) = if num_blocks >= 4 {
+            self.state
+                .par_chunks(block_size)
+                .with_min_len(chunk_min_len(block_size))
+                .map(|block| super::rdm_block_sums(block, half))
+                .reduce(zero_sums, super::rdm_sum_add)
+        } else {
+            self.state
+                .chunks(block_size)
+                .map(|block| {
+                    let (lo, hi) = block.split_at(half);
+                    lo.par_chunks(MIN_PAR_ELEMS)
+                        .zip(hi.par_chunks(MIN_PAR_ELEMS))
+                        .map(|(lo_t, hi_t)| super::rdm_pair_sums(lo_t, hi_t))
+                        .reduce(zero_sums, super::rdm_sum_add)
+                })
+                .fold(zero_sums(), super::rdm_sum_add)
+        };
 
         let scale = Complex64::new(norm_sq, 0.0);
         let r = r * scale;
@@ -2956,8 +3023,12 @@ impl StatevectorBackend {
 
         for (target, d0, d1) in large_gates {
             let skip_lo = is_phase_one(d0);
-            let min_tile = 1usize << (target + 1);
-            let tile_size = min_tile.max(MIN_PAR_ELEMS);
+            let block_size = 1usize << (target + 1);
+            if self.state.len() / block_size < 4 {
+                apply_diagonal_high_target_par(&mut self.state, target, d0, d1, skip_lo);
+                continue;
+            }
+            let tile_size = block_size.max(MIN_PAR_ELEMS);
             self.state.par_chunks_mut(tile_size).for_each(|tile| {
                 simd::apply_diagonal_sequential(tile, target, d0, d1, skip_lo);
             });
@@ -3084,52 +3155,55 @@ impl StatevectorBackend {
     #[cfg(feature = "parallel")]
     #[inline(always)]
     fn apply_measure_par(&mut self, qubit: usize, classical_bit: usize) {
-        let half = 1usize << qubit;
-        let block_size = half << 1;
-        let norm_sq = self.pending_norm * self.pending_norm;
-
-        let prob_one: f64 = self
-            .state
-            .par_chunks(block_size)
-            .with_min_len(chunk_min_len(block_size))
-            .map(|chunk| simd::norm_sqr_sum(&chunk[half..]))
-            .sum::<f64>()
-            * norm_sq;
-
+        let prob_one = self.qubit_probability_one_par(qubit);
         let outcome = self.rng.random::<f64>() < prob_one;
         self.classical_bits[classical_bit] = outcome;
 
-        let inv_norm = measurement_inv_norm(outcome, prob_one);
-
-        self.state
-            .par_chunks_mut(block_size)
-            .with_min_len(chunk_min_len(block_size))
-            .for_each(|chunk| {
+        let half = 1usize << qubit;
+        let block_size = half << 1;
+        if self.state.len() / block_size >= 4 {
+            self.state
+                .par_chunks_mut(block_size)
+                .with_min_len(chunk_min_len(block_size))
+                .for_each(|chunk| {
+                    let (lo, hi) = chunk.split_at_mut(half);
+                    simd::zero_slice(if outcome { lo } else { hi });
+                });
+        } else {
+            for chunk in self.state.chunks_mut(block_size) {
                 let (lo, hi) = chunk.split_at_mut(half);
-                if outcome {
-                    simd::zero_slice(lo);
-                } else {
-                    simd::zero_slice(hi);
-                }
-            });
+                let dropped = if outcome { lo } else { hi };
+                dropped
+                    .par_chunks_mut(MIN_PAR_ELEMS)
+                    .for_each(simd::zero_slice);
+            }
+        }
 
-        self.pending_norm *= inv_norm;
+        self.pending_norm *= measurement_inv_norm(outcome, prob_one);
     }
 
     #[cfg(feature = "parallel")]
     fn fold_reset_par(&mut self, qubit: usize, outcome: bool) {
         let half = 1usize << qubit;
         let block_size = half << 1;
-        self.state
-            .par_chunks_mut(block_size)
-            .with_min_len(chunk_min_len(block_size))
-            .for_each(|chunk| {
-                let (lo, hi) = chunk.split_at_mut(half);
-                if outcome {
-                    lo.copy_from_slice(hi);
-                }
-                simd::zero_slice(hi);
-            });
+
+        if self.state.len() / block_size >= 4 {
+            self.state
+                .par_chunks_mut(block_size)
+                .with_min_len(chunk_min_len(block_size))
+                .for_each(|chunk| {
+                    let (lo, hi) = chunk.split_at_mut(half);
+                    fold_reset_pair(lo, hi, outcome);
+                });
+            return;
+        }
+
+        for chunk in self.state.chunks_mut(block_size) {
+            let (lo, hi) = chunk.split_at_mut(half);
+            lo.par_chunks_mut(MIN_PAR_ELEMS)
+                .zip(hi.par_chunks_mut(MIN_PAR_ELEMS))
+                .for_each(|(lo_t, hi_t)| fold_reset_pair(lo_t, hi_t, outcome));
+        }
     }
 
     pub(super) fn apply_diagonal_batch(&mut self, entries: &[DiagEntry]) {

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -91,17 +91,32 @@ pub(crate) use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS};
 #[inline(always)]
 pub(super) fn rdm_block_sums(block: &[Complex64], half: usize) -> (f64, f64, Complex64) {
     let (lo, hi) = block.split_at(half);
+    rdm_pair_sums(lo, hi)
+}
+
+/// [`rdm_block_sums`] over an already split pair, so a sub-tile of one block
+/// contributes without re-deriving the halves.
+#[inline(always)]
+pub(super) fn rdm_pair_sums(lo: &[Complex64], hi: &[Complex64]) -> (f64, f64, Complex64) {
     let mut p0 = 0.0f64;
     let mut p1 = 0.0f64;
     let mut r = Complex64::new(0.0, 0.0);
-    for i in 0..half {
-        let a0 = lo[i];
-        let a1 = hi[i];
+    for (&a0, &a1) in lo.iter().zip(hi.iter()) {
         p0 += a0.norm_sqr();
         p1 += a1.norm_sqr();
         r += a1 * a0.conj();
     }
     (p0, p1, r)
+}
+
+/// Sum of `(p0, p1, r)` triples, the reduction [`rdm_pair_sums`] folds under.
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(super) fn rdm_sum_add(
+    a: (f64, f64, Complex64),
+    b: (f64, f64, Complex64),
+) -> (f64, f64, Complex64) {
+    (a.0 + b.0, a.1 + b.1, a.2 + b.2)
 }
 
 #[cfg(feature = "gpu")]

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1477,6 +1477,244 @@ fn diagonal_batch_par_matches_independent_reference() {
     assert_state_close(&got, &expected, 1e-12);
 }
 
+// Setup shared by the high-target rows below: a state with distinct amplitudes
+// on every basis index, past the parallel threshold.
+#[cfg(feature = "parallel")]
+fn spread_state_backend(n: usize) -> StatevectorBackend {
+    use crate::circuit::{Instruction, SmallVec, smallvec};
+    use crate::gates::Gate;
+
+    let mut backend = StatevectorBackend::new(42);
+    backend.init(n, 1).unwrap();
+    for q in 0..n {
+        let targets: SmallVec<[usize; 4]> = smallvec![q];
+        backend
+            .apply(&Instruction::Gate {
+                gate: Gate::Ry(0.31 + 0.07 * q as f64),
+                targets,
+            })
+            .unwrap();
+    }
+    for q in 0..n - 1 {
+        let targets: SmallVec<[usize; 4]> = smallvec![q, q + 1];
+        backend
+            .apply(&Instruction::Gate {
+                gate: Gate::Cx,
+                targets,
+            })
+            .unwrap();
+    }
+    backend
+}
+
+// The measurement family chunks by `2^(qubit+1)`, so at n = 16 the top two
+// qubits leave fewer than four chunks and take the inner split while qubit 0
+// and qubit 13 keep the per-chunk path. Both must agree with a scalar sweep.
+#[cfg(feature = "parallel")]
+#[test]
+fn measurement_reads_match_independent_reference_at_every_target() {
+    let n = 16usize;
+    let backend = spread_state_backend(n);
+    let state = backend.export_statevector().unwrap();
+
+    for qubit in [0usize, 13, 14, 15] {
+        let bit = 1usize << qubit;
+        let mut p1 = 0.0f64;
+        let mut r00 = 0.0f64;
+        let mut r11 = 0.0f64;
+        let mut r10 = Complex64::new(0.0, 0.0);
+        for (i, amp) in state.iter().enumerate() {
+            if i & bit == 0 {
+                r00 += amp.norm_sqr();
+                r10 += state[i | bit] * amp.conj();
+            } else {
+                p1 += amp.norm_sqr();
+                r11 += amp.norm_sqr();
+            }
+        }
+
+        let got_p1 = backend.qubit_probability(qubit).unwrap();
+        assert!(
+            (got_p1 - p1).abs() < 1e-12,
+            "prob_one[{qubit}]: expected {p1}, got {got_p1}"
+        );
+
+        let rdm = backend.reduced_density_matrix_1q(qubit).unwrap();
+        let expected = [
+            [Complex64::new(r00, 0.0), r10.conj()],
+            [r10, Complex64::new(r11, 0.0)],
+        ];
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (rdm[i][j] - expected[i][j]).norm() < 1e-12,
+                    "rdm[{qubit}][{i}][{j}]: expected {}, got {}",
+                    expected[i][j],
+                    rdm[i][j]
+                );
+            }
+        }
+    }
+}
+
+// Collapse and reset on the same inner-split targets. The reference is built
+// from the pre-measurement amplitudes and the outcome the backend recorded, so
+// it does not depend on the draw.
+#[cfg(feature = "parallel")]
+#[test]
+fn collapse_and_reset_match_independent_reference_at_every_target() {
+    use crate::circuit::Instruction;
+
+    let n = 16usize;
+    for qubit in [0usize, 13, 14, 15] {
+        let bit = 1usize << qubit;
+        let before = spread_state_backend(n).export_statevector().unwrap();
+
+        let mut backend = spread_state_backend(n);
+        backend
+            .apply(&Instruction::Measure {
+                qubit,
+                classical_bit: 0,
+            })
+            .unwrap();
+        let outcome = backend.classical_results()[0];
+        let after = backend.export_statevector().unwrap();
+
+        let kept: f64 = before
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| (i & bit != 0) == outcome)
+            .map(|(_, a)| a.norm_sqr())
+            .sum();
+        let inv = 1.0 / kept.sqrt();
+        for (i, amp) in before.iter().enumerate() {
+            let expected = if (i & bit != 0) == outcome {
+                *amp * inv
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            assert!(
+                (after[i] - expected).norm() < 1e-12,
+                "collapse q{qubit} amp[{i}]: expected {expected}, got {}",
+                after[i]
+            );
+        }
+
+        let mut backend = spread_state_backend(n);
+        backend.reset(qubit).unwrap();
+        let after = backend.export_statevector().unwrap();
+        for (i, expected) in after.iter().enumerate() {
+            let source = if i & bit != 0 {
+                Complex64::new(0.0, 0.0)
+            } else if outcome {
+                before[i | bit] * inv
+            } else {
+                before[i] * inv
+            };
+            assert!(
+                (*expected - source).norm() < 1e-12,
+                "reset q{qubit} amp[{i}]: expected {source}, got {expected}"
+            );
+        }
+    }
+}
+
+// `apply_diagonal_gate` tiles by `2^(target+1)`, so at n = 16 targets 14 and 15
+// leave fewer than four tiles and take the sub-tile split. Rz scales both halves
+// of every block, where a phase gate would leave the `|0>` half alone.
+#[cfg(feature = "parallel")]
+#[test]
+fn diagonal_gate_matches_independent_reference_at_every_target() {
+    use crate::circuit::{Instruction, SmallVec, smallvec};
+    use crate::gates::Gate;
+
+    let n = 16usize;
+    let theta = 0.83f64;
+    let d0 = Complex64::from_polar(1.0, -theta / 2.0);
+    let d1 = Complex64::from_polar(1.0, theta / 2.0);
+
+    for target in [0usize, 13, 14, 15] {
+        let before = spread_state_backend(n).export_statevector().unwrap();
+        let mut backend = spread_state_backend(n);
+        let targets: SmallVec<[usize; 4]> = smallvec![target];
+        backend
+            .apply(&Instruction::Gate {
+                gate: Gate::Rz(theta),
+                targets,
+            })
+            .unwrap();
+        let after = backend.export_statevector().unwrap();
+
+        let bit = 1usize << target;
+        for (i, amp) in before.iter().enumerate() {
+            let expected = *amp * if i & bit != 0 { d1 } else { d0 };
+            assert!(
+                (after[i] - expected).norm() < 1e-12,
+                "rz q{target} amp[{i}]: expected {expected}, got {}",
+                after[i]
+            );
+        }
+    }
+}
+
+// The individual tier of `apply_multi_1q_diagonal` (targets past
+// `MULTI_GATE_MAX_L3_TARGET` = 16), where at n = 20 target 19 leaves one tile
+// and takes the sub-tile split while target 17 leaves eight and stays tiled.
+// Targets 2 and 15 hold the L2 and L3 tiers.
+#[cfg(feature = "parallel")]
+#[test]
+fn multi_1q_diagonal_matches_independent_reference_across_tiers() {
+    use crate::circuit::{Instruction, SmallVec};
+    use crate::gates::{Gate, MultiFusedData};
+
+    let n = 20usize;
+    let gates: Vec<(usize, [[Complex64; 2]; 2])> = [2usize, 15, 17, 19]
+        .into_iter()
+        .enumerate()
+        .map(|(k, target)| {
+            let theta = 0.29 + 0.13 * k as f64;
+            let zero = Complex64::new(0.0, 0.0);
+            (
+                target,
+                [
+                    [Complex64::from_polar(1.0, -theta), zero],
+                    [zero, Complex64::from_polar(1.0, theta)],
+                ],
+            )
+        })
+        .collect();
+
+    let before = spread_state_backend(n).export_statevector().unwrap();
+    let mut backend = spread_state_backend(n);
+    let targets: SmallVec<[usize; 4]> = gates.iter().map(|&(t, _)| t).collect();
+    backend
+        .apply(&Instruction::Gate {
+            gate: Gate::MultiFused(Box::new(MultiFusedData {
+                gates: gates.clone(),
+                all_diagonal: true,
+            })),
+            targets,
+        })
+        .unwrap();
+    let after = backend.export_statevector().unwrap();
+
+    for (i, amp) in before.iter().enumerate() {
+        let mut expected = *amp;
+        for &(target, mat) in &gates {
+            expected *= if (i >> target) & 1 == 1 {
+                mat[1][1]
+            } else {
+                mat[0][0]
+            };
+        }
+        assert!(
+            (after[i] - expected).norm() < 1e-12,
+            "multi diagonal amp[{i}]: expected {expected}, got {}",
+            after[i]
+        );
+    }
+}
+
 #[cfg(feature = "gpu")]
 mod gpu_scaffold {
     use super::*;

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -561,7 +561,7 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
             if accepted {
                 exp_val_accepted += 1;
                 let state = backend.state_vector();
-                let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+                let norm = crate::backend::state_norm_sqr(state);
                 for (slot, &((xmask, zmask, num_y), coefficient)) in
                     exp_val_masks.iter().enumerate()
                 {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1076,7 +1076,7 @@ fn expectation_values_statevector(
     } else {
         backend.state_vector()
     };
-    let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+    let norm = crate::backend::state_norm_sqr(state);
     Ok(masks
         .iter()
         .map(|&(xmask, zmask, num_y)| {

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -498,3 +498,197 @@ fn dm_apply_1q_matrix_matches_fused_gate_route() {
         }
     }
 }
+
+// `project`, `apply_reset`, and `apply_2q_depolarizing` walk the `4^n` buffer in
+// row-major runs whose stride is the qubit's row bit, and parallelize above the
+// embedded statevector's threshold (`2n >= 14`, so n >= 7). At n = 7 the top two
+// qubits leave fewer than four row blocks, which is the arm that splits inside a
+// block. Each case checks the low qubit and the top qubit.
+const PAR_N: usize = 7;
+
+fn pure_reference_state(circuit: &Circuit) -> Vec<Complex64> {
+    let mut backend = StatevectorBackend::new(SEED);
+    sim::run_on(&mut backend, circuit).unwrap();
+    backend.export_statevector().unwrap()
+}
+
+/// `run_dm` with a classical bit, which the shared circuit fixtures do not
+/// declare because they carry no measurement.
+fn run_dm_with_bit(circuit: &Circuit) -> DensityMatrixBackend {
+    let mut backend = DensityMatrixBackend::new(SEED);
+    backend.init(circuit.num_qubits, 1).unwrap();
+    backend.apply_instructions(&circuit.instructions).unwrap();
+    backend
+}
+
+#[test]
+fn dm_measure_collapse_matches_scalar_reference_at_every_target() {
+    let circuit = circuits::random_circuit(PAR_N, 4, SEED);
+    let state = pure_reference_state(&circuit);
+
+    for target in [0usize, PAR_N - 2, PAR_N - 1] {
+        let bit = 1usize << target;
+        let mut backend = run_dm_with_bit(&circuit);
+        backend
+            .apply(&prism_q::circuit::Instruction::Measure {
+                qubit: target,
+                classical_bit: 0,
+            })
+            .unwrap();
+        let outcome = backend.classical_results()[0];
+
+        let kept: f64 = state
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| (i & bit != 0) == outcome)
+            .map(|(_, a)| a.norm_sqr())
+            .sum();
+        let expected: Vec<f64> = state
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                if (i & bit != 0) == outcome {
+                    a.norm_sqr() / kept
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        assert_probs_close(
+            &backend.probabilities().unwrap(),
+            &expected,
+            DM_EPS,
+            &format!("collapse on q{target}"),
+        );
+
+        // A projected pure state is still pure, which the diagonal alone cannot
+        // show: it fails if the off-diagonal runs are scaled or zeroed wrongly.
+        assert!(
+            (backend.purity() - 1.0).abs() < DM_EPS,
+            "collapse on q{target} left purity {}",
+            backend.purity()
+        );
+        let rdm = backend.reduced_density_matrix_1q(target).unwrap();
+        let population = if outcome { rdm[1][1].re } else { rdm[0][0].re };
+        assert!(
+            (population - 1.0).abs() < DM_EPS,
+            "collapse on q{target} population {population}"
+        );
+    }
+}
+
+#[test]
+fn dm_reset_matches_scalar_reference_at_every_target() {
+    let circuit = circuits::random_circuit(PAR_N, 4, SEED);
+    let state = pure_reference_state(&circuit);
+
+    for target in [0usize, PAR_N - 2, PAR_N - 1] {
+        let bit = 1usize << target;
+        let mut backend = run_dm(&circuit);
+        backend.reset(target).unwrap();
+
+        // Reset traces the qubit out and reinserts |0>, so the two diagonal
+        // entries of each row pair merge into the one with the bit clear.
+        let expected: Vec<f64> = state
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                if i & bit != 0 {
+                    0.0
+                } else {
+                    a.norm_sqr() + state[i | bit].norm_sqr()
+                }
+            })
+            .collect();
+        assert_probs_close(
+            &backend.probabilities().unwrap(),
+            &expected,
+            DM_EPS,
+            &format!("reset on q{target}"),
+        );
+
+        let rdm = backend.reduced_density_matrix_1q(target).unwrap();
+        assert!(
+            (rdm[0][0].re - 1.0).abs() < DM_EPS && rdm[0][1].norm() < DM_EPS,
+            "reset on q{target} left rdm {rdm:?}"
+        );
+
+        // Tracing one qubit out cannot change any other qubit's reduced state.
+        let mut sv = StatevectorBackend::new(SEED);
+        sim::run_on(&mut sv, &circuit).unwrap();
+        for q in (0..PAR_N).filter(|&q| q != target) {
+            let a = backend.reduced_density_matrix_1q(q).unwrap();
+            let b = sv.reduced_density_matrix_1q(q).unwrap();
+            for i in 0..2 {
+                for j in 0..2 {
+                    assert!(
+                        (a[i][j] - b[i][j]).norm() < DM_EPS,
+                        "reset on q{target}: rdm[{q}][{i}][{j}] dm={} sv={}",
+                        a[i][j],
+                        b[i][j]
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn dm_two_qubit_depolarizing_matches_analytic_above_parallel_threshold() {
+    // The Pauli twirl gives rho -> (1-lambda) rho + lambda (I/4) (x) tr_{q0,q1} rho
+    // with lambda = 16p/15, so each reduced state mixes toward I/2 by lambda and
+    // qubits outside the pair are untouched.
+    let p = 0.3;
+    let lambda = 16.0 * p / 15.0;
+    let circuit = circuits::random_circuit(PAR_N, 4, SEED);
+
+    for (q0, q1) in [(0usize, 1usize), (0, PAR_N - 1)] {
+        let mut sv = StatevectorBackend::new(SEED);
+        sim::run_on(&mut sv, &circuit).unwrap();
+
+        let mut backend = run_dm(&circuit);
+        backend.apply_2q_depolarizing(q0, q1, p);
+
+        for q in 0..PAR_N {
+            let before = sv.reduced_density_matrix_1q(q).unwrap();
+            let after = backend.reduced_density_matrix_1q(q).unwrap();
+            for i in 0..2 {
+                for j in 0..2 {
+                    let mixed = if i == j { c(0.5, 0.0) } else { c(0.0, 0.0) };
+                    let expected = if q == q0 || q == q1 {
+                        before[i][j] * (1.0 - lambda) + mixed * lambda
+                    } else {
+                        before[i][j]
+                    };
+                    assert!(
+                        (after[i][j] - expected).norm() < DM_EPS,
+                        "depolarizing({q0},{q1}): rdm[{q}][{i}][{j}] expected {expected}, \
+                         got {}",
+                        after[i][j]
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn dm_purity_matches_analytic_above_parallel_reduce_threshold() {
+    // 4^8 entries clears the reduction's parallel threshold. One qubit fully
+    // depolarized against seven in |0> gives rho = (I/2) (x) |0><0|^7, purity 1/2.
+    let n = 8usize;
+    let mut backend = DensityMatrixBackend::new(SEED);
+    backend.init(n, 0).unwrap();
+    assert!(
+        (backend.purity() - 1.0).abs() < DM_EPS,
+        "pure |0...0> purity {}",
+        backend.purity()
+    );
+
+    backend.apply_1q_kraus(0, &depolarizing(0.75));
+    assert!(
+        (backend.purity() - 0.5).abs() < DM_EPS,
+        "one maximally mixed qubit gives purity 1/2, got {}",
+        backend.purity()
+    );
+}

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -395,3 +395,45 @@ fn invalid_observable_is_rejected_on_the_native_path() {
         InvalidParameter { .. }
     ));
 }
+
+#[test]
+fn statevector_route_matches_scalar_reference_above_the_parallel_norm_threshold() {
+    // 2^16 amplitudes is where the dense route's normalization pass switches to
+    // a parallel SIMD reduction, and 2^12 is below it. Both must agree with a
+    // scalar sweep of the exported amplitudes.
+    use prism_q::backend::Backend;
+    use prism_q::backend::statevector::StatevectorBackend;
+    use prism_q::circuits;
+
+    for n in [12usize, 16] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, 42);
+        let observables: Vec<Vec<PauliTerm>> = vec![
+            vec![PauliTerm::z(0), PauliTerm::z(n - 1)],
+            vec![PauliTerm::x(n / 2)],
+        ];
+        let got = run_expectation_values(&circuit, &observables, 42).unwrap();
+
+        let mut backend = StatevectorBackend::new(42);
+        prism_q::sim::run_on(&mut backend, &circuit).unwrap();
+        let state = backend.export_statevector().unwrap();
+        let norm: f64 = state.iter().map(|a| a.norm_sqr()).sum();
+
+        let zz = 1usize | (1usize << (n - 1));
+        let mut expect_zz = 0.0f64;
+        for (i, amp) in state.iter().enumerate() {
+            let sign = if (i & zz).count_ones() & 1 == 1 {
+                -1.0
+            } else {
+                1.0
+            };
+            expect_zz += sign * amp.norm_sqr();
+        }
+        let xmask = 1usize << (n / 2);
+        let mut expect_x = 0.0f64;
+        for (i, amp) in state.iter().enumerate() {
+            expect_x += (state[i ^ xmask].conj() * amp).re;
+        }
+
+        assert_close(&got, &[expect_zz / norm, expect_x / norm], TOL);
+    }
+}


### PR DESCRIPTION
## Summary

Several full-state passes ran serial or scalar while a parallel or SIMD sibling
already existed beside them in the same file. The statevector measurement family
and the high-target diagonal passes chunk by `2^(qubit+1)`, so a target on the top
qubit leaves a single chunk and the parallel path runs one serial task over the
whole state, 128 MB at 24 qubits; the gate kernels already carried the sub-block
split these lacked. On the density matrix, `project`, `apply_reset`,
`apply_2q_depolarizing`, and `purity` walked the whole `4^n` buffer single-threaded
while the unitary path went parallel from n = 7.

## Scope

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

Three adjacent-binary A/B pairs per bench binary against a reference carrying the
new bench rows and none of the kernel work. Every claimed row keeps its sign across
all three pairs and has at least one pair whose same-code controls sit inside the 5%
gate. Figures below are from that clean pair, not from the pair that flattered the
row most: `rz_q19_n20` read -58.4% in a noisy pair only because that pair's
reference measured 3.11 ms against 1.52 ms in the other two.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `density_matrix/noisy_channels/depolarizing_2q/10` | 11.76 ms | 2.98 ms | -74.7% | +0.7% / +1.1% | Yes, improvement |
| `measurement/prob_one_q19_n20` | 327.20 us | 142.21 us | -56.5% | -0.7% / -5.3% | Yes, improvement |
| `density_matrix/noisy_channels/purity/10` | 1.29 ms | 592.95 us | -53.9% | +0.0% / -0.6% | Yes, improvement |
| `high_target_qubit/rz_q19_n20` | 1.55 ms | 1.36 ms | -12.6% | -3.2% / -0.0% | Yes, improvement |
| `density_matrix/noisy_channels/measure_qtop/10` | 1.43 ms | 1.27 ms | -10.8% | +0.0% / -0.1% | Yes, improvement |
| `density_matrix/noisy_channels/kraus_depolarizing/10` | 1.52 ms | 1.52 ms | +0.5% | -1.1% / -0.2% | Yes, neutral control |
| `measurement/prob_one_q0_n20` | 650.46 us | 643.82 us | -1.0% | -0.7% / +1.8% | Yes, neutral control |
| `high_target_qubit/rz_q17_n20` | 1.49 ms | 1.48 ms | -0.1% | +1.1% / +0.5% | Yes, neutral control |
| `expectation/pauli_sum/16` | 2.80 ms | 2.73 ms | -2.5% | +0.5% / -1.5% | Yes, under gate, not claimed |

The three neutral rows sit on paths this change does not touch and are what license
the rest of the table. `kraus_depolarizing` routes through
`apply_block_superoperator`; `prob_one_q0_n20` and `rz_q17_n20` are the low-target
twins of claimed rows, so they also confirm the new split fires only where intended.

`expectation/pauli_sum/16` is not claimed. It read -19.0%, then -5.0%, then -2.5% as
its controls tightened from 47.8% to 1.5%, which is the shape of drift rather than a
win, and the residual sits under the gate. The parallel norm it exercises replaces a
serial scalar pass sitting beside an already parallel `pauli_sandwich`, so the
circuit-level share was always going to be small. It ships as a correctness-neutral
change with no performance claim.

Rows present and tested but not A/B gated, for run time: `reset_qtop`, `measure_q0`,
the `rdm` pair, and `run_shots/midcircuit`.

Regression verdict: PASS

## Correctness

- [ ] `cargo test --all-features` passes locally
- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes (CI denies
      rustdoc warnings)
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry, and stay concise; none restate the signature
- [x] New gate, backend, or fusion pass has golden tests against the statevector backend
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

The two `--all-features` boxes are unchecked deliberately. This diff touches no MPI
code and no feature wiring in `Cargo.toml`, so the gate ran at
`--features "parallel gpu distributed"` instead: 2018 tests pass, 11 doctests pass,
and clippy exits 0 with `-D warnings -D clippy::undocumented_unsafe_blocks`. The GPU
run used `PRISM_REQUIRE_GPU=1` so a missing device would fail rather than skip; 64
golden tests passed with 0 skipped.

New tests assert agreement with an independent scalar reference computed in the test,
not against a second simulator, at a size crossing the parallel threshold and at
qubit 0, `n-2`, and `n-1` so both sides of the new split are covered. The
density-matrix reset case additionally asserts that every other qubit's reduced
density matrix survives unchanged, which is the property separating the reset channel
from a projection and would fail if the restructuring had reintroduced one.

## Hotspot notes

Functions changed on the hot path:

- `statevector/kernels.rs`: `qubit_probability_one_par`, `apply_measure_par`,
  `fold_reset_par`, `reduced_density_matrix_one_par`, `apply_diagonal_gate_par`,
  `apply_multi_1q_diagonal_par`, plus the new shared
  `apply_diagonal_high_target_par` and `fold_reset_pair`.
- `density_matrix.rs`: `project`, `apply_reset`, `apply_2q_depolarizing`, `purity`,
  plus the new `project_tile` and `reset_fold_pair`.
- `backend/mod.rs`: new `state_norm_sqr`, also used by the dense expectation route
  and the QEC runner's per-shot norm.

No profiler output attached. The mechanism is structural rather than inferred: at a
top-qubit target `state.len() / block_size` is 1, so the pre-existing chunking
produced exactly one Rayon task. Each new branch was confirmed to execute, and each
control row confirmed to stay on the old path, with temporary counters before the
benchmarks were trusted.

## Architecture or design changes

- [ ] `docs/architecture/` updated if the change is structural
- [ ] Design or research notes added where required for new subsystems

No structural change. Kernel-internal work splitting only; no backend, trait, or
dispatch surface moved. The new `density_matrix/noisy_channels` bench group closes
the channel-apply coverage obligation the density-matrix design chapter had left
open.

## Breaking changes

None. No public API, signature, or behavior change. `simd::zero_slice` lost its
`parallel`/`distributed` cfg gate because the density matrix now calls it
unconditionally; the item is `pub(crate)`, so this is not visible to users.

## Risks and rollback

Blast radius is the statevector measurement and diagonal kernels and four
density-matrix sweeps. Every new arm is inside an existing
`#[cfg(feature = "parallel")]` block, so builds without that feature are byte-for-byte
unaffected. There is no dispatch guard or runtime flag: rollback is reverting the
commit.

The risk worth naming is numerical rather than functional. Parallel and SIMD
reductions pair partial sums in a different order than the sequential scalar loops
they replace, so `purity`, the dense expectation norm, and the QEC runner's per-shot
norm can differ in the last ulp from previous runs. Tests pass at their existing
tolerances, and analytic QEC estimates were already documented as not bit-stable
across runs for this reason, but a downstream consumer comparing floats exactly
across versions would see it.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed as an issue or noted above
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
