### PR TITLE
feat(sim): route noise to the density matrix across the terminals

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1898,6 +1898,31 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
     group.finish();
 }
 
+/// The exact noisy route, reachable through `Simulate` since the noise model
+/// reached this backend. One mixed-state evolution then a draw per shot, so the
+/// row tracks the `4^n` sweep count and is nearly flat in the shot count.
+fn bench_density_matrix_noisy_shots(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/noisy_shots");
+    configure_group(&mut group);
+
+    for &n in &[8, 10] {
+        let mut circuit = circuits::random_circuit(n, 4, SEED);
+        circuit.num_classical_bits = n;
+        for q in 0..n {
+            circuit.add_measure(q, q);
+        }
+        let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                run_shots_with_noise(BackendKind::DensityMatrix, &circuit, &noise, 1024, SEED)
+                    .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 /// Neutrality row: an untouched statevector row re-run under a density-matrix
 /// group name. The density-matrix backend shares no kernels with the
 /// statevector path, so this must stay within the 5% regression gate.
@@ -2001,6 +2026,7 @@ criterion_group! {
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
     bench_density_matrix_noisy_channels,
+    bench_density_matrix_noisy_shots,
     bench_density_matrix_neutrality
 }
 criterion_main!(benches);

--- a/bindings/python/src/sim.rs
+++ b/bindings/python/src/sim.rs
@@ -51,7 +51,11 @@ impl PySimulation {
         slf
     }
 
-    /// Attach a noise model. Only `.shots()` and `.sample_counts()` honor noise.
+    /// Attach a noise model.
+    ///
+    /// `.shots()` and `.sample_counts()` average trajectories. `.run()`,
+    /// `.marginals()`, and `.expectation_values()` answer from the exact
+    /// mixture, which requires `BackendKind.density_matrix()`.
     fn noise(mut slf: PyRefMut<'_, Self>, model: Py<PyNoiseModel>) -> PyRefMut<'_, Self> {
         slf.noise = Some(model);
         slf
@@ -59,18 +63,17 @@ impl PySimulation {
 
     /// Run once and return classical bits plus the probability distribution.
     fn run(&self, py: Python<'_>) -> PyPrismResult<PyRunOutcome> {
-        if self.noise.is_some() {
-            return Err(invalid(
-                "run() does not support noise; use shots() or sample_counts()",
-            ));
-        }
         let seed = self.seed.unwrap_or(DEFAULT_SEED);
         let kind = self.kind.clone();
         let circuit = &self.circuit;
+        let owned_noise = self.owned_noise(py);
         let outcome: RunOutcome = py.detach(|| {
             let mut sim = core_simulate(circuit);
             if let Some(k) = &kind {
                 sim = sim.backend(k.clone());
+            }
+            if let Some(nm) = &owned_noise {
+                sim = sim.noise(nm);
             }
             sim.seed(seed).run()
         })?;
@@ -120,16 +123,17 @@ impl PySimulation {
 
     /// Per-qubit marginal probabilities `(p0, p1)`.
     fn marginals(&self, py: Python<'_>) -> PyPrismResult<Vec<(f64, f64)>> {
-        if self.noise.is_some() {
-            return Err(invalid("marginals() does not support noise; use shots()"));
-        }
         let seed = self.seed.unwrap_or(DEFAULT_SEED);
         let kind = self.kind.clone();
         let circuit = &self.circuit;
+        let owned_noise = self.owned_noise(py);
         let result: MarginalsResult = py.detach(|| {
             let mut sim = core_simulate(circuit);
             if let Some(k) = &kind {
                 sim = sim.backend(k.clone());
+            }
+            if let Some(nm) = &owned_noise {
+                sim = sim.noise(nm);
             }
             sim.seed(seed).marginals()
         })?;
@@ -142,7 +146,9 @@ impl PySimulation {
     /// does not support an attached noise model.
     fn state_vector<'py>(&self, py: Python<'py>) -> PyPrismResult<Bound<'py, PyArray1<Complex64>>> {
         if self.noise.is_some() {
-            return Err(invalid("state_vector() does not support noise"));
+            return Err(invalid(
+                "state_vector() does not support noise; a mixture has no statevector,                  so read run().probabilities on the density-matrix backend instead",
+            ));
         }
         let seed = self.seed.unwrap_or(DEFAULT_SEED);
         let circuit = &self.circuit;
@@ -201,26 +207,26 @@ impl PySimulation {
     ///
     /// Each observable is a list of `(qubit, axis)` factors, where `axis` is one
     /// of `"X"`, `"Y"`, `"Z"` and identity factors are omitted. The circuit must
-    /// be unitary, and no noise model may be attached.
+    /// be unitary. With a noise model attached the value is the exact
+    /// `Tr(rho P)`, which requires `BackendKind.density_matrix()`.
     #[pyo3(signature = (observables))]
     fn expectation_values(
         &self,
         py: Python<'_>,
         observables: Vec<Vec<(usize, String)>>,
     ) -> PyPrismResult<Vec<f64>> {
-        if self.noise.is_some() {
-            return Err(invalid(
-                "expectation_values() does not support noise; use density_matrix_expectation_values()",
-            ));
-        }
         let observables = parse_observables(observables)?;
         let seed = self.seed.unwrap_or(DEFAULT_SEED);
         let kind = self.kind.clone();
         let circuit = &self.circuit;
+        let owned_noise = self.owned_noise(py);
         let values = py.detach(|| {
             let mut sim = core_simulate(circuit);
             if let Some(k) = &kind {
                 sim = sim.backend(k.clone());
+            }
+            if let Some(nm) = &owned_noise {
+                sim = sim.noise(nm);
             }
             sim.seed(seed).expectation_values(&observables)
         })?;

--- a/bindings/python/tests/test_density_matrix.py
+++ b/bindings/python/tests/test_density_matrix.py
@@ -77,16 +77,40 @@ def test_oversize_circuit_reports_the_qubit_cap():
     circuit = CircuitBuilder(40).h(0).build()
     with pytest.raises(prism_q.PrismError) as excinfo:
         simulate(circuit).seed(SEED).density_matrix_expectation_values([[(0, "Z")]])
-    assert "density-matrix cap" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "density_matrix" in message
+    assert "exceeding the cap" in message
+    # Both variables bind: the 4^n state is allocated as a 2n-qubit statevector.
+    assert "PRISM_MAX_DM_QUBITS and PRISM_MAX_SV_QUBITS" in message
 
 
-def test_noisy_shot_sampling_is_rejected():
+def test_noisy_shots_sample_the_exact_distribution():
     circuit = CircuitBuilder(2, 2).h(0).cx(0, 1).measure_all().build()
     model = NoiseModel.uniform_depolarizing(circuit, 0.01)
     sim = simulate(circuit).backend(BackendKind.density_matrix()).seed(SEED).noise(model)
-    with pytest.raises(prism_q.PrismError) as excinfo:
-        sim.shots(100)
-    assert "noisy per-shot simulation" in str(excinfo.value)
+    counts = sim.shots(4000).counts()
+    assert sum(counts.values()) == 4000
+    assert set(counts) <= {"00", "01", "10", "11"}
+    # Light depolarizing leaks a little weight onto the odd-parity outcomes and
+    # leaves the Bell pair dominant.
+    assert counts["00"] + counts["11"] > 3 * (counts.get("01", 0) + counts.get("10", 0))
+
+
+def test_noisy_run_probabilities_are_seed_independent():
+    circuit = CircuitBuilder(2, 2).h(0).cx(0, 1).measure_all().build()
+    model = NoiseModel.uniform_depolarizing(circuit, 0.05)
+    runs = [
+        simulate(circuit)
+        .backend(BackendKind.density_matrix())
+        .seed(seed)
+        .noise(model)
+        .run()
+        .probabilities
+        for seed in (SEED, SEED + 1, SEED + 7)
+    ]
+    for other in runs[1:]:
+        for i, (a, b) in enumerate(zip(other, runs[0])):
+            assert abs(a - b) < DM_EPS, f"basis state {i}: {a} vs {b}"
 
 
 def test_mismatched_noise_model_is_rejected():
@@ -98,7 +122,7 @@ def test_mismatched_noise_model_is_rejected():
     assert "noise model length" in str(excinfo.value)
 
 
-def test_expectation_values_rejects_noise():
+def test_expectation_values_rejects_noise_without_a_mixture():
     circuit = CircuitBuilder(1).h(0).build()
     model = NoiseModel.uniform_depolarizing(circuit, 0.01)
     with pytest.raises(prism_q.PrismError):

--- a/bindings/python/tests/test_noise.py
+++ b/bindings/python/tests/test_noise.py
@@ -49,7 +49,8 @@ def test_readout_error_applies():
 
 
 @pytest.mark.parametrize("terminal", ["run", "marginals", "state_vector"])
-def test_noise_rejected_on_non_shot_terminals(terminal):
+def test_noise_rejected_on_backends_without_a_mixture(terminal):
+    # Auto dispatch never selects the density matrix, so no mixture exists here.
     bell = CircuitBuilder(2).h(0).cx(0, 1).build()
     model = NoiseModel.uniform_depolarizing(bell, 0.01)
     sim = simulate(bell).noise(model)

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -44,14 +44,17 @@ through dispatch.
 | Cap | Variable | Default |
 |-----|----------|---------|
 | Statevector state | `PRISM_MAX_SV_QUBITS` | Largest `2^n` `Complex64` state fitting half of detected physical memory |
-| Density-matrix state | `PRISM_MAX_DM_QUBITS` | `floor(cap_sv / 2)`, since a density matrix of `n` qubits is a `2n`-qubit statevector |
+| Density-matrix state | `PRISM_MAX_DM_QUBITS`, bounded by `PRISM_MAX_SV_QUBITS` | `floor(cap_sv / 2)`, since a density matrix of `n` qubits is a `2n`-qubit statevector |
 | Dense probability output | `PRISM_MAX_PROB_QUBITS` | Same budget over `f64` |
 | Dense statevector export | `PRISM_MAX_EXPORT_QUBITS` | Same budget over `Complex64` |
 | Dense outcome sampling | `PRISM_MAX_DENSE_OUTCOME_BITS` | Same budget over two `f64` per outcome |
 
-The density-matrix backend applies the tighter of its own cap and half the statevector
-cap, so it reports the rejection itself rather than surfacing an error naming the
-statevector it allocates internally. When physical memory cannot be detected the caps are
+The density-matrix cap is the tighter of its own override and half the statevector cap,
+computed in one place so dispatch-time validation and the backend's `init` guard cannot
+disagree about where the ceiling is. Raising `PRISM_MAX_DM_QUBITS` past that bound needs
+`PRISM_MAX_SV_QUBITS` raised with it, which is what the rejection says: the backend
+reports it itself rather than surfacing an error naming the statevector it allocates
+internally. When physical memory cannot be detected the caps are
 disabled and a warning is printed, because guessing a budget is worse than saying the
 budget is unknown.
 
@@ -125,8 +128,13 @@ kernels with no new gate math. A unitary `U` on the ket register gives the left 
 `rho U^dagger`, so `U rho U^dagger` costs two statevector passes and two conjugations.
 
 Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host and 15 on
-32 GiB (`PRISM_MAX_DM_QUBITS` overrides). This backend is CPU-only and explicit-dispatch
-only; `Auto` never selects it.
+32 GiB (`PRISM_MAX_DM_QUBITS` moves it within the statevector budget). This backend is
+CPU-only and explicit-dispatch only; `Auto` never selects it.
+
+Selecting it with a noise model attached is the exact route for every `Simulate`
+terminal: the mixture is evolved once and observables, marginals, probabilities, and
+shots all read that one evolution. See [Noise across the terminals](./engine.md) for
+what that route accepts and what stays on trajectory averaging.
 
 The [GPU backend](../guides/gpu.md) is documented as a user guide. The distributed
 statevector backend is covered in the

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -31,6 +31,9 @@ Orchestration layer in `src/sim/mod.rs`.
 | `simulate(circuit).seed(seed).shots(shots)` | Multi-shot sampling |
 | `simulate(circuit).backend(kind).seed(seed).shots(shots)` | Multi-shot with backend selection |
 | `simulate(circuit).backend(kind).noise(noise).seed(seed).shots(shots)` | Noisy multi-shot |
+| `simulate(circuit).backend(density_matrix).noise(noise).seed(seed).run()` | Exact noisy distribution |
+| `simulate(circuit).backend(density_matrix).noise(noise).seed(seed).marginals()` | Exact noisy marginals |
+| `simulate(circuit).backend(density_matrix).noise(noise).seed(seed).expectation_values(obs)` | Exact `Tr(rho P_k)` |
 | `simulate(circuit).seed(seed).sample_counts(shots)` | Auto-dispatched frequency histogram |
 | `simulate(circuit).backend(kind).seed(seed).sample_counts(shots)` | Frequency histogram with backend selection |
 | `simulate(circuit).seed(seed).marginals()` | Auto-dispatched per-qubit marginal probabilities |
@@ -49,6 +52,34 @@ either a direct Pauli marginal route or backend probability output; it returns
 is available. Stochastic and deterministic Pauli marginal backends accept only
 unitary Clifford+T circuits without measurement, reset, or conditional
 instructions.
+
+## Noise across the terminals
+
+A noise model reaches a terminal by one of two routes, and which one applies is fixed by
+the selected backend rather than by the terminal.
+
+Backends holding a per-shot pure state average trajectories: each shot re-evolves the
+circuit with the channels sampled, so a distribution converges as `1/sqrt(shots)`. Only
+`shots` and `sample_counts` take that route, since a single trajectory is not an answer
+to `run`, `marginals`, or `expectation_values`.
+
+The density matrix holds the mixture instead of a trajectory, so `shots` cannot mean
+"replay the circuit per shot". It means one exact evolution followed by a draw per shot
+from the resulting distribution. Every terminal reads that one evolution: `run` and
+`marginals` return the exact noisy distribution, `expectation_values` returns the exact
+`Tr(rho P)`, and `shots` and `sample_counts` carry sampling noise but no trajectory
+variance. Readout error is applied to the drawn outcomes rather than to the state, on an
+RNG stream of its own.
+
+The mixture holds every measurement branch at once, which is what makes it exact and also
+what it cannot undo. A noisy circuit with mid-circuit measurement or classical
+conditioning is rejected on this route: the outcome that a later gate would have been
+conditioned on was never fixed. Those circuits stay on trajectory averaging. This is the
+same property that makes the density matrix the mixture oracle rather than a comparable
+participant in the branching families of `tests/conformance_matrix.rs`.
+
+`expectation_gradient` rejects a noise model on every backend, because the adjoint method
+backpropagates through a pure state.
 
 ## Auto-dispatch decision tree
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -106,18 +106,27 @@ outcome = sim.run()
 
 | Terminal | Returns | Honors `.noise()` |
 |----------|---------|-------------------|
-| `run()` | `RunOutcome`: classical bits and the full probability array | no |
+| `run()` | `RunOutcome`: classical bits and the full probability array | density matrix only |
 | `shots(n)` | `ShotsResult`: per-shot measurement records | yes |
 | `sample_counts(n)` | `CountsResult`: frequency histogram | yes |
-| `marginals()` | `list[tuple[float, float]]`, per-qubit `(p0, p1)` | no |
+| `marginals()` | `list[tuple[float, float]]`, per-qubit `(p0, p1)` | density matrix only |
 | `state_vector()` | `complex128` amplitudes | no |
-| `expectation_values(obs)` | `list[float]`, `⟨ψ\|P\|ψ⟩` per observable | no |
+| `expectation_values(obs)` | `list[float]`, `⟨ψ\|P\|ψ⟩` per observable | density matrix only |
 | `density_matrix_expectation_values(obs)` | `list[float]`, exact `Tr(rho P)` | yes |
 | `expectation_gradient(h, params)` | `(value, gradient)` via the adjoint method | no |
 
-Terminals that do not support noise raise `PrismError` when a model is attached,
-rather than silently ignoring it. `state_vector()` always uses the statevector
-backend and `density_matrix_expectation_values()` always uses the density-matrix
+`shots()` and `sample_counts()` average trajectories on any backend holding a
+per-shot pure state. The three rows marked "density matrix only" read the exact
+mixed state instead, so they need
+`.backend(BackendKind.density_matrix())`; auto dispatch never selects it. There
+the mixture is evolved once and every terminal reads that one evolution, so the
+probabilities are seed independent and the observables carry no sampling error.
+Circuits with mid-circuit measurement or classical conditioning are rejected on
+that route, since the mixture holds every measurement branch at once.
+
+Terminals that cannot honor a model raise `PrismError` naming the reason, rather
+than silently ignoring it. `state_vector()` always uses the statevector backend
+and `density_matrix_expectation_values()` always uses the density-matrix
 backend, both regardless of `.backend(...)`.
 
 `ShotsResult` and `CountsResult` both expose `counts()`, returning a dict keyed

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -21,14 +21,17 @@
 //! reduced density matrix, projective measurement with stochastic collapse,
 //! reset, classically-conditioned gates, exact one-qubit Kraus channels
 //! (`apply_1q_kraus`), two-qubit depolarizing (`apply_2q_depolarizing`), and
-//! exact `Tr(rho P)` expectation (`expectation_pauli`). Fusion is disabled
-//! (`supports_fused_gates` returns `false`) so every instruction reaching the
-//! backend is a primitive whose qubits live in the instruction targets.
+//! exact `Tr(rho P)` expectation (`expectation_pauli`, reachable through
+//! `pauli_expectations`). Fusion is disabled (`supports_fused_gates` returns
+//! `false`) so every instruction reaching the backend is a primitive whose
+//! qubits live in the instruction targets.
 //!
 //! # When to prefer this backend
 //!
 //! - Exact noise-channel evolution: one run yields the exact mixed state,
-//!   where trajectory averaging converges as `1/sqrt(shots)`.
+//!   where trajectory averaging converges as `1/sqrt(shots)`. Selecting it
+//!   with a noise model attached routes every `Simulate` terminal to that one
+//!   evolution.
 //! - Mixed-state diagnostics: purity and exact `Tr(rho P)` observables.
 //!
 //! # When NOT to use this backend
@@ -37,6 +40,9 @@
 //!   memory.
 //! - Qubit counts past the `4^n` ceiling; trajectory sampling on a pure-state
 //!   backend scales further.
+//! - Noisy circuits with mid-circuit measurement or classical conditioning.
+//!   The mixture holds every branch at once, so per-shot feedback cannot be
+//!   replayed from it and the noisy terminals reject those shapes.
 
 use num_complex::Complex64;
 use rand::{RngExt, SeedableRng};
@@ -50,6 +56,7 @@ use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
 use crate::gates::{Gate, McuData};
 use crate::sim::i_pow;
+use crate::sim::unified_pauli::PauliTerm;
 
 /// Compile a one-qubit Kraus set into the 4x4 superoperator acting on the
 /// `(row-bit, col-bit)` block of `rho`, where block index `i = 2*a + b` orders
@@ -552,15 +559,11 @@ impl Backend for DensityMatrixBackend {
     }
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
-        // The state is a 2n-qubit statevector, so the statevector cap binds at
-        // half its value. Taking the tighter of the two here keeps this backend
-        // the one that reports the rejection, whatever the two caps are set to.
         crate::backend::check_state_allocation(
             "density_matrix",
             num_qubits,
-            crate::backend::max_density_matrix_qubits()
-                .min(crate::backend::max_statevector_qubits() / 2),
-            "PRISM_MAX_DM_QUBITS",
+            crate::backend::max_density_matrix_qubits(),
+            crate::backend::DM_QUBIT_CAP_ENV,
         )?;
 
         self.num_qubits = num_qubits;
@@ -619,6 +622,23 @@ impl Backend for DensityMatrixBackend {
     fn reset(&mut self, qubit: usize) -> Result<()> {
         self.apply_reset(qubit);
         Ok(())
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// `Tr(rho P_k)` per observable, the mixed-state reading of the trait's
+    /// `<psi|P_k|psi>`. `rho` is trace-one by construction, so no
+    /// normalization divide is needed.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        observables
+            .iter()
+            .map(|observable| {
+                let (xmask, zmask, num_y) = crate::sim::pauli_masks(observable, self.num_qubits)?;
+                Ok(self.expectation_pauli(xmask, zmask, num_y))
+            })
+            .collect()
     }
 
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -20,14 +20,23 @@ pub(crate) fn max_statevector_qubits() -> usize {
     })
 }
 
+/// Environment advice for the density-matrix cap. Both variables bind: the
+/// backend allocates its `4^n` state as a `2n`-qubit statevector, so
+/// `PRISM_MAX_DM_QUBITS` raises the cap only as far as half the statevector
+/// cap, and going past that needs `PRISM_MAX_SV_QUBITS` raised with it.
+pub(crate) const DM_QUBIT_CAP_ENV: &str = "PRISM_MAX_DM_QUBITS and PRISM_MAX_SV_QUBITS";
+
 /// Qubit cap for the exact density-matrix backend. Its state is `4^n`
 /// `Complex64` entries, the element count of a `2n`-qubit statevector, so the
 /// cap is `floor(cap_sv / 2)`: 14 on a 16 GiB host, 15 on 32 GiB.
-/// `PRISM_MAX_DM_QUBITS` overrides unconditionally.
+/// `PRISM_MAX_DM_QUBITS` moves it within that bound; see [`DM_QUBIT_CAP_ENV`].
+/// This is the only density-matrix cap, so dispatch-time validation and the
+/// backend's own `init` guard cannot disagree about where the ceiling is.
 pub(crate) fn max_density_matrix_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
-        env_qubit_override("PRISM_MAX_DM_QUBITS").unwrap_or(max_statevector_qubits() / 2)
+        let budget = max_statevector_qubits() / 2;
+        env_qubit_override("PRISM_MAX_DM_QUBITS").map_or(budget, |n| n.min(budget))
     })
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -148,9 +148,9 @@ pub(crate) const NORM_CLAMP_MIN: f64 = 1e-30;
 pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) use memory::{
-    check_state_allocation, dense_probability_len, dense_statevector_len, max_dense_outcome_bits,
-    max_density_matrix_qubits, max_statevector_qubits, reserve_dense_output,
-    tensor_probability_len,
+    DM_QUBIT_CAP_ENV, check_state_allocation, dense_probability_len, dense_statevector_len,
+    max_dense_outcome_bits, max_density_matrix_qubits, max_statevector_qubits,
+    reserve_dense_output, tensor_probability_len,
 };
 
 /// Whether `phase` equals `1+0i` within [`PHASE_IS_ONE_EPS`].

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -10,7 +10,10 @@ use crate::backend::sparse::SparseBackend;
 use crate::backend::stabilizer::StabilizerBackend;
 use crate::backend::statevector::StatevectorBackend;
 use crate::backend::tensornetwork::TensorNetworkBackend;
-use crate::backend::{Backend, max_density_matrix_qubits, max_statevector_qubits};
+use crate::backend::{
+    Backend, DM_QUBIT_CAP_ENV, check_state_allocation, max_density_matrix_qubits,
+    max_statevector_qubits,
+};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 
@@ -106,10 +109,14 @@ pub enum BackendKind {
     ///
     /// Explicit-dispatch only: [`BackendKind::Auto`] never selects it. Stores
     /// `4^n` `Complex64` amplitudes, so the qubit ceiling is roughly half the
-    /// statevector cap (14 on a 16 GiB host); `PRISM_MAX_DM_QUBITS` overrides.
-    /// Fusion is skipped for this backend because batched and fused gate
-    /// variants carry qubit indices in their payload that the ket-register
-    /// offset cannot relocate.
+    /// statevector cap (14 on a 16 GiB host); `PRISM_MAX_DM_QUBITS` moves it
+    /// within that bound. Fusion is skipped for this backend because batched
+    /// and fused gate variants carry qubit indices in their payload that the
+    /// ket-register offset cannot relocate.
+    ///
+    /// Under an attached noise model this is the exact route: the mixture is
+    /// evolved once and every terminal reads it, so shot counts carry sampling
+    /// noise only and observables carry none.
     DensityMatrix,
     /// Stochastic Pauli propagation (SPP); serves marginal and observable
     /// queries only.
@@ -207,7 +214,10 @@ impl BackendKind {
     }
 
     /// False for the engines without a per-shot pure state: stabilizer rank,
-    /// Pauli propagation, density matrix.
+    /// Pauli propagation, density matrix. The density matrix still serves a
+    /// noise model, by evolving the mixture once and sampling the exact
+    /// distribution, so its noisy terminals route around the trajectory engine
+    /// rather than through it.
     pub fn supports_noisy_per_shot(&self) -> bool {
         !matches!(
             self,
@@ -219,7 +229,8 @@ impl BackendKind {
     }
 
     /// True for kinds that can run non-Pauli channels (damping, thermal
-    /// relaxation, custom Kraus) through the trajectory engine.
+    /// relaxation, custom Kraus): the trajectory engine everywhere except the
+    /// density matrix, which applies the channel to the mixture instead.
     pub fn supports_general_noise(&self) -> bool {
         match self {
             BackendKind::Auto
@@ -227,7 +238,8 @@ impl BackendKind {
             | BackendKind::Sparse
             | BackendKind::Mps { .. }
             | BackendKind::ProductState
-            | BackendKind::Factored => true,
+            | BackendKind::Factored
+            | BackendKind::DensityMatrix => true,
             #[cfg(feature = "gpu")]
             BackendKind::AutoGpu { .. } | BackendKind::StatevectorGpu { .. } => true,
             _ => false,
@@ -253,11 +265,11 @@ impl BackendKind {
     pub(crate) fn general_noise_backend_names() -> &'static str {
         #[cfg(feature = "gpu")]
         {
-            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, or Factored"
+            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, Factored, or DensityMatrix"
         }
         #[cfg(not(feature = "gpu"))]
         {
-            "Auto, Statevector, Sparse, Mps, ProductState, or Factored"
+            "Auto, Statevector, Sparse, Mps, ProductState, Factored, or DensityMatrix"
         }
     }
 }
@@ -282,15 +294,13 @@ pub(super) fn validate_explicit_backend(kind: &BackendKind, circuit: &Circuit) -
                 reason: "circuit has no T gates; use Stabilizer instead".into(),
             });
         }
-        BackendKind::DensityMatrix if circuit.num_qubits > max_density_matrix_qubits() => {
-            return Err(PrismError::IncompatibleBackend {
-                backend: "density_matrix".into(),
-                reason: format!(
-                    "circuit has {} qubits, exceeding the density-matrix cap of {} on this machine (set PRISM_MAX_DM_QUBITS to override)",
-                    circuit.num_qubits,
-                    max_density_matrix_qubits()
-                ),
-            });
+        BackendKind::DensityMatrix => {
+            check_state_allocation(
+                "density_matrix",
+                circuit.num_qubits,
+                max_density_matrix_qubits(),
+                DM_QUBIT_CAP_ENV,
+            )?;
         }
         _ => {}
     }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -140,8 +140,15 @@ impl<'c, SeedState> Simulate<'c, SeedState> {
         self
     }
 
-    /// Attach a noise model. Only [`Simulate::shots`] and
-    /// [`Simulate::sample_counts`] accept one; other queries reject it.
+    /// Attach a noise model.
+    ///
+    /// [`Simulate::shots`] and [`Simulate::sample_counts`] accept one on any
+    /// backend with a per-shot pure state, averaging trajectories.
+    /// [`Simulate::run`], [`Simulate::marginals`], and
+    /// [`Simulate::expectation_values`] answer from the exact mixture instead,
+    /// which only [`BackendKind::DensityMatrix`] holds, so they require that
+    /// backend. [`Simulate::expectation_gradient`] rejects a noise model on
+    /// every backend.
     #[inline]
     pub fn noise(mut self, model: &'c noise::NoiseModel) -> Self {
         self.noise_model = Some(model);
@@ -198,15 +205,24 @@ impl<'c> Simulate<'c, Seeded> {
         self.seed.seed
     }
 
-    /// Execute the circuit once. Rejects an attached noise model; noisy
-    /// simulation runs through [`Simulate::shots`].
+    /// Execute the circuit once.
+    ///
+    /// With a noise model attached the probabilities are the exact noisy
+    /// distribution rather than one trajectory, so the run needs the
+    /// density-matrix backend; the classical bits are one draw from that
+    /// distribution, matching `shots(1)`.
     #[inline]
     pub fn run(self) -> Result<RunOutcome> {
         let seed = self.seed_value();
-        if self.noise_model.is_some() {
-            return Err(crate::error::PrismError::BackendUnsupported {
-                backend: format!("{:?}", self.kind),
-                operation: "single-run noisy simulation through `run`".into(),
+        if let Some(noise_model) = self.noise_model {
+            require_exact_mixture(&self.kind, "a single run")?;
+            let probabilities = exact_noisy_probabilities(self.circuit, noise_model, seed)?;
+            let classical_bits =
+                sample_exact_noisy_shots(&probabilities, self.circuit, noise_model, 1, seed)
+                    .swap_remove(0);
+            return Ok(RunOutcome {
+                classical_bits,
+                probabilities: Some(probabilities),
             });
         }
         run_with_internal(self.kind, self.circuit, seed, SimOptions::default())
@@ -244,15 +260,18 @@ impl<'c> Simulate<'c, Seeded> {
         })
     }
 
-    /// Per-qubit marginal probabilities as `(P(0), P(1))` pairs. Rejects an
-    /// attached noise model and backends without probability output.
+    /// Per-qubit marginal probabilities as `(P(0), P(1))` pairs. Rejects
+    /// backends without probability output, and with a noise model attached
+    /// answers exactly from the mixture, which needs the density-matrix
+    /// backend.
     #[inline]
     pub fn marginals(self) -> Result<MarginalsResult> {
         let seed = self.seed_value();
-        if self.noise_model.is_some() {
-            return Err(crate::error::PrismError::BackendUnsupported {
-                backend: format!("{:?}", self.kind),
-                operation: "marginals with inline noise model".into(),
+        if let Some(noise_model) = self.noise_model {
+            require_exact_mixture(&self.kind, "marginals")?;
+            let probs = exact_noisy_probabilities(self.circuit, noise_model, seed)?;
+            return Ok(MarginalsResult {
+                marginals: probs.marginals(),
             });
         }
         run_marginals_result_with(self.kind, self.circuit, seed)
@@ -267,14 +286,21 @@ impl<'c> Simulate<'c, Seeded> {
     /// fit it; above that cap the selected backend evaluates the observable on
     /// its own representation, and a backend without one reports
     /// `BackendUnsupported` naming itself.
+    ///
+    /// With a noise model attached the value is the exact `Tr(rho P)` on the
+    /// evolved mixture, which needs the density-matrix backend.
     #[inline]
     pub fn expectation_values(self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
         let seed = self.seed_value();
-        if self.noise_model.is_some() {
-            return Err(PrismError::BackendUnsupported {
-                backend: format!("{:?}", self.kind),
-                operation: "expectation values with an inline noise model".into(),
-            });
+        if let Some(noise_model) = self.noise_model {
+            require_exact_mixture(&self.kind, "expectation values")?;
+            require_unitary_circuit(&self.kind, self.circuit)?;
+            return noise::density_matrix_expectation_values(
+                self.circuit,
+                observables,
+                Some(noise_model),
+                seed,
+            );
         }
         run_expectation_values_with(self.kind, self.circuit, observables, seed)
     }
@@ -295,9 +321,12 @@ impl<'c> Simulate<'c, Seeded> {
     ) -> Result<gradient::ExpectationGradient> {
         let seed = self.seed_value();
         if self.noise_model.is_some() {
-            return Err(PrismError::BackendUnsupported {
+            return Err(PrismError::IncompatibleBackend {
                 backend: format!("{:?}", self.kind),
-                operation: "expectation gradients with an inline noise model".into(),
+                reason: "the adjoint method backpropagates through a pure state, so no backend \
+                         has a noisy gradient path; drop the noise model, or differentiate noisy \
+                         `expectation_values` numerically"
+                    .into(),
             });
         }
         if !(self.kind.is_auto() || matches!(self.kind, BackendKind::Statevector)) {
@@ -341,6 +370,80 @@ pub fn simulate(circuit: &Circuit) -> Simulate<'_, Unseeded> {
         seed: Unseeded,
         noise_model: None,
     }
+}
+
+/// Gate for the terminals that answer a noise model from the exact mixture.
+/// Only the density matrix holds one, so every other kind is rejected here
+/// naming that route and the trajectory alternative.
+fn require_exact_mixture(kind: &BackendKind, terminal: &str) -> Result<()> {
+    if matches!(kind, BackendKind::DensityMatrix) {
+        return Ok(());
+    }
+    Err(PrismError::IncompatibleBackend {
+        backend: format!("{kind:?}"),
+        reason: format!(
+            "{terminal} under a noise model reads the exact mixed state, which only the \
+             density-matrix backend holds; select it, or average trajectories through `shots` \
+             or `sample_counts`"
+        ),
+    })
+}
+
+fn require_unitary_circuit(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
+    if has_nonunitary_or_classical_ops(circuit) {
+        return Err(PrismError::IncompatibleBackend {
+            backend: format!("{kind:?}"),
+            reason: "expectation values require a unitary circuit without measurements, resets, or conditionals".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Exact output distribution of `circuit` under `noise_model`, evolved once on
+/// the density matrix. The mixture carries every measurement branch at once,
+/// so it answers for a whole shot only when the measurements are terminal.
+fn exact_noisy_probabilities(
+    circuit: &Circuit,
+    noise_model: &noise::NoiseModel,
+    seed: u64,
+) -> Result<Probabilities> {
+    if !circuit.has_terminal_measurements_only() {
+        return Err(PrismError::IncompatibleBackend {
+            backend: "density_matrix".into(),
+            reason: "the mixture holds every measurement branch at once, so mid-circuit \
+                     measurement and classical conditioning cannot be replayed from it; move the \
+                     measurements to the end of the circuit, or run trajectories on a backend \
+                     with a per-shot pure state"
+                .into(),
+        });
+    }
+    Ok(Probabilities::Dense(noise::density_matrix_probabilities(
+        circuit,
+        noise_model,
+        seed,
+    )?))
+}
+
+/// Draw classical bits from the exact noisy distribution, then apply readout
+/// error. Readout acts on the outcome rather than on the state, so it is not
+/// carried by the distribution and has to be applied per draw, on a stream of
+/// its own so it does not track the state draws.
+fn sample_exact_noisy_shots(
+    probs: &Probabilities,
+    circuit: &Circuit,
+    noise_model: &noise::NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> Vec<Vec<bool>> {
+    let bits = circuit.num_classical_bits;
+    let mut shots = sample_shots(probs, &circuit.measurement_map(), bits, num_shots, seed);
+    if noise_model.readout.iter().any(Option::is_some) {
+        let mut rng = trajectory::noise_rng(seed);
+        for shot in &mut shots {
+            trajectory::apply_readout_errors(shot, &noise_model.readout, &mut rng);
+        }
+    }
+    shots
 }
 
 #[inline]
@@ -1067,12 +1170,7 @@ fn run_expectation_values_with(
     observables: &[Vec<PauliTerm>],
     seed: u64,
 ) -> Result<Vec<f64>> {
-    if has_nonunitary_or_classical_ops(circuit) {
-        return Err(PrismError::IncompatibleBackend {
-            backend: format!("{kind:?}"),
-            reason: "expectation values require a unitary circuit without measurements, resets, or conditionals".into(),
-        });
-    }
+    require_unitary_circuit(&kind, circuit)?;
 
     match &kind {
         BackendKind::StochasticPauli { num_samples } => observables
@@ -1625,10 +1723,21 @@ pub(crate) fn run_shots_with_noise(
         });
     }
 
+    if matches!(kind, BackendKind::DensityMatrix) {
+        let probs = exact_noisy_probabilities(circuit, noise_model, seed)?;
+        return Ok(ShotsResult::from_shots(
+            sample_exact_noisy_shots(&probs, circuit, noise_model, num_shots, seed),
+            circuit.num_classical_bits,
+        ));
+    }
+
     if !kind.supports_noisy_per_shot() {
         return Err(crate::error::PrismError::IncompatibleBackend {
             backend: format!("{kind:?}"),
-            reason: "this backend does not support noisy per-shot simulation".into(),
+            reason: "this backend holds no per-shot pure state to inject noise into; select \
+                     DensityMatrix for the exact mixed state, or a backend that evolves one \
+                     state per trajectory"
+                .into(),
         });
     }
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -372,9 +372,8 @@ pub fn simulate(circuit: &Circuit) -> Simulate<'_, Unseeded> {
     }
 }
 
-/// Gate for the terminals that answer a noise model from the exact mixture.
-/// Only the density matrix holds one, so every other kind is rejected here
-/// naming that route and the trajectory alternative.
+/// Gate for the terminals that answer a noise model from the exact mixture,
+/// which only the density matrix holds.
 fn require_exact_mixture(kind: &BackendKind, terminal: &str) -> Result<()> {
     if matches!(kind, BackendKind::DensityMatrix) {
         return Ok(());

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -2481,16 +2481,12 @@ fn evolve_density_matrix(
     noise: Option<&NoiseModel>,
     seed: u64,
 ) -> Result<DensityMatrixBackend> {
-    let cap = crate::backend::max_density_matrix_qubits();
-    if circuit.num_qubits > cap {
-        return Err(crate::error::PrismError::IncompatibleBackend {
-            backend: "density_matrix".into(),
-            reason: format!(
-                "circuit has {} qubits, exceeding the density-matrix cap of {cap} on this machine (set PRISM_MAX_DM_QUBITS to override)",
-                circuit.num_qubits
-            ),
-        });
-    }
+    crate::backend::check_state_allocation(
+        "density_matrix",
+        circuit.num_qubits,
+        crate::backend::max_density_matrix_qubits(),
+        crate::backend::DM_QUBIT_CAP_ENV,
+    )?;
     if let Some(noise) = noise {
         if noise.after_gate.len() != circuit.instructions.len() {
             return Err(crate::error::PrismError::InvalidParameter {
@@ -2514,6 +2510,18 @@ fn evolve_density_matrix(
         }
     }
     Ok(dm)
+}
+
+/// Exact output distribution of `circuit` under `noise`, read off the diagonal
+/// of the evolved mixture. Measurements are not collapsed during evolution, so
+/// the distribution answers for a whole shot only when every measurement is
+/// terminal; callers gate on that shape.
+pub(crate) fn density_matrix_probabilities(
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    seed: u64,
+) -> Result<Vec<f64>> {
+    evolve_density_matrix(circuit, Some(noise), seed)?.probabilities()
 }
 
 /// Exact per-classical-bit measurement marginals under a noise model, evolved

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -325,7 +325,7 @@ fn apply_noise_event(
     }
 }
 
-fn apply_readout_errors(
+pub(crate) fn apply_readout_errors(
     results: &mut [bool],
     readout: &[Option<crate::sim::noise::ReadoutError>],
     rng: &mut ChaCha8Rng,

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -217,23 +217,342 @@ fn dm_explicit_dispatch_matches_statevector() {
     assert_probs_close(&probs, &statevector_probs(&c), DM_EPS, "explicit dispatch");
 }
 
-#[test]
-fn dm_noisy_shot_sampling_is_rejected() {
-    use prism_q::{BackendKind, NoiseModel};
-    // Density matrix is an exact backend, not a per-shot sampler. Noisy shot
-    // sampling must fail cleanly; exact noisy expectation goes through
-    // density_matrix_expectation_values instead.
-    let mut c = Circuit::new(2, 2);
-    c.add_gate(Gate::H, &[0]);
-    c.add_gate(Gate::Cx, &[0, 1]);
+const NOISY_N: usize = 4;
+const NOISY_SEEDS: u64 = 64;
+const DEPOLARIZING_P: f64 = 0.02;
+
+/// Entangled non-Clifford circuit with terminal measurements, the shape the
+/// exact noisy route accepts.
+fn noisy_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, n);
+    for q in 0..n {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        c.add_gate(Gate::T, &[q]);
+        c.add_gate(Gate::Ry(0.3 + 0.1 * q as f64), &[q]);
+    }
     c.measure_all();
-    let noise = NoiseModel::uniform_depolarizing(&c, 0.01);
-    let result = sim::simulate(&c)
+    c
+}
+
+fn dm_noisy_probs(circuit: &Circuit, noise: &prism_q::NoiseModel, seed: u64) -> Vec<f64> {
+    sim::simulate(circuit)
+        .backend(prism_q::BackendKind::DensityMatrix)
+        .noise(noise)
+        .seed(seed)
+        .run()
+        .unwrap()
+        .probabilities
+        .unwrap()
+        .to_vec()
+}
+
+/// Classical-bit pattern as a basis-state index, which is the same number only
+/// because `noisy_circuit` measures qubit `q` into bit `q`.
+fn outcome_index(shot: &[bool]) -> usize {
+    shot.iter()
+        .enumerate()
+        .filter(|&(_, &b)| b)
+        .fold(0usize, |acc, (bit, _)| acc | (1 << bit))
+}
+
+fn histogram(shots: &[Vec<bool>], num_outcomes: usize) -> Vec<u64> {
+    let mut counts = vec![0u64; num_outcomes];
+    for shot in shots {
+        counts[outcome_index(shot)] += 1;
+    }
+    counts
+}
+
+fn assert_within_5_sigma(counts: &[u64], exact: &[f64], total: f64, label: &str) {
+    for (idx, &count) in counts.iter().enumerate() {
+        let p = exact[idx];
+        let sigma = (p * (1.0 - p) / total).sqrt();
+        let observed = count as f64 / total;
+        assert!(
+            (observed - p).abs() <= 5.0 * sigma,
+            "{label}: outcome {idx} exact {p}, sampled {observed}, tolerance {}",
+            5.0 * sigma
+        );
+    }
+}
+
+#[test]
+fn dm_exact_noisy_distribution_is_seed_independent_and_matches_the_trajectory_mean() {
+    use prism_q::{BackendKind, NoiseModel};
+    let circuit = noisy_circuit(NOISY_N);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+
+    let exact = dm_noisy_probs(&circuit, &noise, SEED);
+    for offset in 0..NOISY_SEEDS {
+        let repeat = dm_noisy_probs(&circuit, &noise, SEED + offset);
+        assert_probs_close(&repeat, &exact, DM_EPS, "exact noisy distribution per seed");
+    }
+
+    // Shot `i` of a run seeded `s` draws on `s + i`, so the bases are spaced by
+    // the shot count; adjacent ones would replay the same trajectories.
+    let shots_per_seed = 250;
+    let mut counts = vec![0u64; 1 << NOISY_N];
+    for offset in 0..NOISY_SEEDS {
+        let result = sim::simulate(&circuit)
+            .backend(BackendKind::Statevector)
+            .noise(&noise)
+            .seed(SEED + offset * shots_per_seed as u64)
+            .shots(shots_per_seed)
+            .unwrap();
+        for (idx, count) in histogram(&result.shots, counts.len()).iter().enumerate() {
+            counts[idx] += count;
+        }
+    }
+    let total = (NOISY_SEEDS * shots_per_seed as u64) as f64;
+    assert_within_5_sigma(&counts, &exact, total, "trajectory mean vs exact mixture");
+}
+
+#[test]
+fn dm_noisy_shots_and_counts_sample_the_exact_distribution() {
+    use prism_q::{BackendKind, NoiseModel};
+    let circuit = noisy_circuit(NOISY_N);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+    let exact = dm_noisy_probs(&circuit, &noise, SEED);
+
+    let num_shots = 20_000;
+    let shots = sim::simulate(&circuit)
         .backend(BackendKind::DensityMatrix)
         .noise(&noise)
         .seed(SEED)
-        .shots(100);
-    assert!(result.is_err(), "noisy DM shot sampling should be rejected");
+        .shots(num_shots)
+        .unwrap();
+    assert_eq!(shots.num_shots(), num_shots);
+    assert_within_5_sigma(
+        &histogram(&shots.shots, exact.len()),
+        &exact,
+        num_shots as f64,
+        "density-matrix shots",
+    );
+
+    // Both terminals draw from the one evolution with the same seed, so unlike
+    // the noiseless route the histograms must agree exactly, not just in
+    // distribution.
+    let counts = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .sample_counts(num_shots)
+        .unwrap();
+    assert_eq!(counts.counts, shots.counts());
+    assert_eq!(counts.counts.values().sum::<u64>(), num_shots as u64);
+}
+
+#[test]
+fn dm_noisy_marginals_agree_with_the_exact_distribution() {
+    use prism_q::{BackendKind, NoiseModel};
+    let circuit = noisy_circuit(NOISY_N);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+    let exact = dm_noisy_probs(&circuit, &noise, SEED);
+
+    let marginals = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .marginals()
+        .unwrap()
+        .into_vec();
+
+    for (qubit, &(p0, p1)) in marginals.iter().enumerate() {
+        let want: f64 = exact
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| (idx >> qubit) & 1 == 1)
+            .map(|(_, p)| p)
+            .sum();
+        assert!(
+            (p1 - want).abs() < DM_EPS && (p0 + p1 - 1.0).abs() < DM_EPS,
+            "qubit {qubit}: marginal ({p0}, {p1}) against exact P(1) = {want}"
+        );
+    }
+}
+
+#[test]
+fn dm_expectation_values_agree_with_the_free_function() {
+    use prism_q::{BackendKind, NoiseModel, PauliAxis, PauliTerm};
+    let mut circuit = Circuit::new(NOISY_N, 0);
+    for q in 0..NOISY_N {
+        circuit.add_gate(Gate::H, &[q]);
+        circuit.add_gate(Gate::T, &[q]);
+    }
+    for q in 0..NOISY_N - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    let observables: Vec<Vec<PauliTerm>> = (0..NOISY_N)
+        .flat_map(|q| {
+            [PauliAxis::X, PauliAxis::Y, PauliAxis::Z]
+                .into_iter()
+                .map(move |axis| vec![PauliTerm::new(q, axis)])
+        })
+        .chain([vec![PauliTerm::z(0), PauliTerm::x(NOISY_N - 1)]])
+        .collect();
+
+    let builder = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    let direct =
+        prism_q::density_matrix_expectation_values(&circuit, &observables, None, SEED).unwrap();
+    assert_probs_close(&builder, &direct, DM_EPS, "noiseless expectation values");
+
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+    let builder_noisy = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    let direct_noisy =
+        prism_q::density_matrix_expectation_values(&circuit, &observables, Some(&noise), SEED)
+            .unwrap();
+    assert_probs_close(
+        &builder_noisy,
+        &direct_noisy,
+        DM_EPS,
+        "noisy expectation values",
+    );
+}
+
+#[test]
+fn dm_noisy_terminals_reject_branching_circuits_naming_the_mixture() {
+    use prism_q::{BackendKind, NoiseModel};
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_measure(1, 1);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+
+    let err = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(16)
+        .unwrap_err();
+    match err {
+        prism_q::PrismError::IncompatibleBackend { backend, reason } => {
+            assert_eq!(backend, "density_matrix");
+            assert!(
+                reason.contains("every measurement branch at once"),
+                "the rejection must name the mixture, got {reason}"
+            );
+        }
+        other => panic!("expected a named rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn noisy_exact_terminals_without_a_mixture_name_the_density_matrix() {
+    use prism_q::{BackendKind, NoiseModel, PauliTerm};
+    let circuit = noisy_circuit(3);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+    let unitary = {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c
+    };
+    let unitary_noise = NoiseModel::uniform_depolarizing(&unitary, DEPOLARIZING_P);
+
+    let cases: Vec<(&str, prism_q::PrismError)> = vec![
+        (
+            "run",
+            sim::simulate(&circuit)
+                .backend(BackendKind::Statevector)
+                .noise(&noise)
+                .seed(SEED)
+                .run()
+                .unwrap_err(),
+        ),
+        (
+            "marginals",
+            sim::simulate(&circuit)
+                .backend(BackendKind::Statevector)
+                .noise(&noise)
+                .seed(SEED)
+                .marginals()
+                .unwrap_err(),
+        ),
+        (
+            "expectation_values",
+            sim::simulate(&unitary)
+                .backend(BackendKind::Statevector)
+                .noise(&unitary_noise)
+                .seed(SEED)
+                .expectation_values(&[vec![PauliTerm::z(0)]])
+                .unwrap_err(),
+        ),
+    ];
+
+    for (terminal, err) in cases {
+        match err {
+            prism_q::PrismError::IncompatibleBackend { reason, .. } => assert!(
+                reason.contains("density-matrix backend"),
+                "{terminal}: the rejection must name the exact route, got {reason}"
+            ),
+            other => panic!("{terminal}: expected a named rejection, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn noisy_expectation_gradient_is_rejected_naming_the_adjoint() {
+    use prism_q::{NoiseModel, PauliTerm};
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::Ry(0.4), &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, DEPOLARIZING_P);
+
+    let err = sim::simulate(&circuit)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient(
+            &[(1.0, vec![PauliTerm::z(0)])],
+            &prism_q::sim::gradient::ParameterMap::new(),
+        )
+        .unwrap_err();
+    match err {
+        prism_q::PrismError::IncompatibleBackend { reason, .. } => assert!(
+            reason.contains("adjoint"),
+            "the rejection must name the adjoint method, got {reason}"
+        ),
+        other => panic!("expected a named rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn dm_noisy_readout_error_flips_sampled_bits() {
+    use prism_q::{BackendKind, NoiseModel};
+    // The exact distribution describes the state, not the classical outcome, so
+    // readout error has to reach the draw rather than the evolution.
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Id, &[0]);
+    circuit.add_gate(Gate::Id, &[1]);
+    circuit.measure_all();
+    let mut noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+    noise.with_readout_error(0.3, 0.0);
+
+    let shots = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(20_000)
+        .unwrap();
+    let ones = shots.shots.iter().filter(|s| s[0]).count() as f64 / 20_000.0;
+    assert!(
+        (ones - 0.3).abs() < 0.02,
+        "readout p01 = 0.3 should flip about 30% of zero outcomes, got {ones}"
+    );
 }
 
 #[test]

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -349,23 +349,16 @@ fn product_expectation_values_cover_each_axis_eigenstate() {
 fn backends_without_a_native_path_name_themselves() {
     let c = entangled_non_clifford(5);
     let observables = [vec![PauliTerm::z(0)]];
-    for (backend, name) in [
-        (BackendKind::TensorNetwork, "tensornetwork"),
-        (BackendKind::DensityMatrix, "density_matrix"),
-    ] {
-        let err = simulate(&c)
-            .backend(backend.clone())
-            .seed(42)
-            .expectation_values(&observables)
-            .unwrap_err();
-        match err {
-            prism_q::PrismError::BackendUnsupported {
-                backend: reported, ..
-            } => assert_eq!(reported, name, "{backend:?} reported the wrong backend"),
-            other => {
-                panic!("{backend:?}: expected a BackendUnsupported naming {name}, got {other:?}")
-            }
-        }
+    let err = simulate(&c)
+        .backend(BackendKind::TensorNetwork)
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap_err();
+    match err {
+        prism_q::PrismError::BackendUnsupported {
+            backend: reported, ..
+        } => assert_eq!(reported, "tensornetwork"),
+        other => panic!("expected a BackendUnsupported naming tensornetwork, got {other:?}"),
     }
 }
 

--- a/tests/memory_budget_oversize.rs
+++ b/tests/memory_budget_oversize.rs
@@ -9,13 +9,15 @@ use std::sync::Once;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
 use prism_q::gates::Gate;
-use prism_q::{Circuit, PrismError, StatevectorBackend, run_on};
+use prism_q::{BackendKind, Circuit, PrismError, StatevectorBackend, run_on, simulate};
 
-/// Caps keep the default relationship, where a density matrix of `n` qubits is
-/// a `2n`-qubit statevector, so neither backend's guard depends on the other
-/// being set inconsistently.
+/// A density matrix of `n` qubits is a `2n`-qubit statevector, so the effective
+/// density-matrix cap is half the statevector cap. `PRISM_MAX_DM_QUBITS` is set
+/// deliberately above that bound here, which is the case where an override that
+/// looks accepted has no room to be honored.
 const SV_CAP: usize = 8;
 const DM_CAP: usize = SV_CAP / 2;
+const DM_OVERRIDE: usize = DM_CAP + 2;
 
 fn small_caps() {
     static SET: Once = Once::new();
@@ -24,7 +26,7 @@ fn small_caps() {
         // behind this `Once`, so no thread queries a cap while it is written.
         unsafe {
             std::env::set_var("PRISM_MAX_SV_QUBITS", "8");
-            std::env::set_var("PRISM_MAX_DM_QUBITS", "4");
+            std::env::set_var("PRISM_MAX_DM_QUBITS", "6");
         }
     });
 }
@@ -94,6 +96,45 @@ fn density_matrix_init_at_the_cap_still_runs() {
         .init(DM_CAP, 0)
         .expect("a circuit at the cap must still run");
     assert_eq!(backend.num_qubits(), DM_CAP);
+}
+
+// Between the clamp and the override, dispatch used to accept a width that
+// `init` then rejected, advising an override the caller had already set.
+#[test]
+fn density_matrix_override_above_the_clamp_is_rejected_identically_at_both_gates() {
+    small_caps();
+    for width in [DM_CAP + 1, DM_OVERRIDE + 1] {
+        let dispatched = simulate(&entangling_circuit(width))
+            .backend(BackendKind::DensityMatrix)
+            .seed(42)
+            .run()
+            .expect_err("dispatch must reject a width the backend cannot allocate");
+        let initialized = DensityMatrixBackend::new(42)
+            .init(width, 0)
+            .expect_err("init must reject the same width");
+
+        for (gate, err) in [("dispatch", &dispatched), ("init", &initialized)] {
+            match err {
+                PrismError::IncompatibleBackend { backend, reason } => {
+                    assert_eq!(backend, "density_matrix", "{gate} named the wrong backend");
+                    assert!(
+                        reason.contains(&format!("exceeding the cap of {DM_CAP}")),
+                        "{width}q {gate} must report the clamped cap, got {reason}"
+                    );
+                    assert!(
+                        reason.contains("PRISM_MAX_DM_QUBITS and PRISM_MAX_SV_QUBITS"),
+                        "{width}q {gate} must name both variables that bind, got {reason}"
+                    );
+                }
+                other => panic!("{width}q {gate}: expected a clean cap error, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            format!("{dispatched:?}"),
+            format!("{initialized:?}"),
+            "{width}q: dispatch and init must report the same cap rejection"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The exact mixed-state backend and the exact noisy distribution never met. The
density matrix was excluded from every noisy path, and four of the six `Simulate`
terminals rejected a noise model outright, so the only noisy entry point was a
free function. Selecting the density-matrix backend with a model attached now
evolves the mixture once and answers `run`, `shots`, `sample_counts`,
`marginals`, and `expectation_values` from that single evolution: shot counts
carry sampling noise only, observables carry none.

## Scope

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

Untouched-path gate via `scripts/bench_ab.sh` against the base, quoting the
tightest of three pairs (worst same-code control 3.1%).

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `density_matrix/unitary_layers/10` | 179.75 ms | 179.10 ms | -0.4% | +0.1% / +0.3% | Yes |
| `density_matrix/unitary_layers/8` | 6.51 ms | 6.58 ms | +1.0% | +0.9% / -3.1% | Yes |
| `noisy_sampling/trajectory_pauli/non_clifford_12q_512` | 62.50 ms | 62.52 ms | +0.0% | -0.4% / +0.3% | Yes |
| `density_matrix/noisy_shots/8` | n/a | 6.23 ms | new row | n/a | n/a |
| `density_matrix/noisy_shots/10` | n/a | 158.55 ms | new row | n/a | n/a |

The two `noisy_shots` rows have no before: the call they measure returns an error
on the base commit. They are recorded as establishing absolutes (1024 shots each,
both budget-bound at 840 and 40 iterations) rather than claimed as a change.

Not claimed: an earlier pair was discarded with every control between -84% and
-95% on a loaded host, and a second pair resolved only `unitary_layers/10`
(-0.8% against -1.9% / -0.8%, same sign as above) while leaving the other two
rows at 34% and 25% control spread. Nothing in the diff sits on a hot path, so
neutrality is the expected result rather than a finding.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes (2026 tests).
      `--all-features` not run: no MPI code or feature wiring is touched
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry
- [x] Golden tests: the exact noisy distribution is pinned seed independent, and
      the trajectory mean lands within 5 sigma of it over 64 spaced seeds
- [ ] N/A, no GPU-affecting change

New coverage in `tests/density_matrix_correctness.rs`: exact-versus-trajectory
agreement, shots and counts sampling the exact distribution, marginals against
it, the builder observable route matching the free function at 1e-12, readout
error reaching the draw, and a named rejection per terminal that still declines a
model. `tests/memory_budget_oversize.rs` pins the cap rejection at both gates
with the override set above the clamp.

## Hotspot notes

N/A. The routing adds one discriminant compare per call, not per shot, and the
cap change is one cached read per `init`.

## Architecture or design changes

- [x] `docs/architecture/engine.md` gains a "Noise across the terminals" section
- [x] `docs/architecture/backends.md` updated for the exact route and the cap

Design decision recorded there: the mixture is not a trajectory, so `shots` means
one exact evolution followed by a draw per shot, not a replay. Sampling stays at
the sim layer on the existing path rather than becoming a `Backend` hook, because
noise events are applied by the sim layer and a `sample_basis_states` override
could not see them. `supports_noisy_per_shot` still excludes the density matrix,
which remains correct (there is no per-shot pure state to inject into); the exact
route runs before that gate rather than through it. `supports_general_noise` does
gain the backend, since it holds both halves of that capability.

Circuits with mid-circuit measurement or classical conditioning are rejected on
the exact route and stay on trajectory averaging: the mixture holds every branch
at once, so an outcome a later gate would condition on was never fixed.

## Breaking changes

- `run`, `marginals`, `expectation_values`, and `expectation_gradient` with a
  noise model attached now return `PrismError::IncompatibleBackend` carrying a
  reason, where they previously returned `PrismError::BackendUnsupported`.
  Callers matching on the variant need updating; callers using `?` or `is_err()`
  are unaffected.
- The same three terminals now succeed instead of erroring when the
  density-matrix backend is selected.
- `PRISM_MAX_DM_QUBITS` is now bounded by half `PRISM_MAX_SV_QUBITS` in one
  place. A value above that bound previously passed dispatch and then failed at
  init advising a variable that could not lift the cap; it is now rejected at
  both gates with a message naming both variables.

## Risks and rollback

Blast radius is narrow. The exact route is reachable only by explicitly selecting
the density-matrix backend, which automatic dispatch never chooses, so no
existing route changes shape. The cap change can only tighten an override that
was already unusable. Revert the commit to roll back; there is no feature flag
because there is no new dependency or optional path.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green (not yet pushed)
