### PR TITLE
fix(fusion): bound the fused-batch payloads to the kernel tables

### DIFF
--- a/docs/architecture/fusion.md
+++ b/docs/architecture/fusion.md
@@ -35,6 +35,28 @@ flowchart TD
 | `MIN_QUBITS_FOR_2Q_FUSION` | 12 | Benchmarked QV and random sweeps show memory-pass reduction wins from 12q |
 | `MIN_QUBITS_FOR_MULTI_2Q_FUSION` | 12 | Same as 2q fusion |
 
+## Payload capacities
+
+The batched gates carry a lookup table sized at compile time, so the pass that emits
+them is what keeps the payload inside it. Both caps are declared on the gate payload
+(`BatchRzzData::MAX_EDGES`, `BatchPhaseData::MAX_PHASES`) and pinned to the kernel
+table shape by a compile-time assertion; the kernels assert on entry in release builds
+as well, so a producer that outgrows a table fails loudly instead of dropping work.
+
+| Payload      | Cap        | Producer behavior past the cap                                     |
+|--------------|------------|--------------------------------------------------------------------|
+| `BatchRzz`   | 32 edges   | `fuse_batch_rzz` splits the run into consecutive batches           |
+| `BatchPhase` | 40 entries | `fuse_controlled_phases` splits the chain into consecutive batches |
+
+Splitting is sound because both payloads hold mutually commuting diagonal terms. A
+repeated `(control, target)` pair folds into the entry already present rather than
+adding a second one, which both keeps the two paths in agreement (the BMI2 kernel
+indexes one bit per distinct qubit, so a repeated target has no bit of its own) and
+bounds a chain by the qubit count.
+
+`DiagonalBatch` instead declines at the kernel: `build_diagonal_batch_tables` returns
+`None` when the grouping does not fit and the backend runs the per-element path.
+
 ```admonish tip
 Fusion is not on the hot path. Worst-case fusion cost is on the order of microseconds
 against tens of milliseconds of gate application, so these passes are tuned for

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -43,7 +43,7 @@ use crate::backend::memory::dense_statevector_len;
 use crate::backend::simd;
 use crate::backend::statevector::insert_zero_bit;
 use crate::backend::{
-    Backend, BasisSamples, is_phase_one, measurement_inv_norm, sorted_mcu_qubits,
+    Backend, BasisSamples, MCU_QUBIT_BUF, is_phase_one, measurement_inv_norm, sorted_mcu_qubits,
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
@@ -1080,7 +1080,7 @@ fn apply_mcu_seq(
 ) {
     let ctrl_mask: usize = controls.iter().map(|&q| 1usize << q).fold(0, |a, b| a | b);
     let tgt_mask = 1usize << target;
-    let mut sorted_buf = [0usize; 10];
+    let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
     let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
     let sorted = &sorted_buf[..num_special];
 
@@ -1115,7 +1115,7 @@ fn apply_mcu_phase_seq(
         .chain(std::iter::once(&target))
         .map(|&q| 1usize << q)
         .fold(0, |a, b| a | b);
-    let mut sorted_buf = [0usize; 10];
+    let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
     let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
     let sorted = &sorted_buf[..num_special];
 
@@ -1402,7 +1402,7 @@ fn par_apply_mcu(
 ) {
     let ctrl_mask: usize = controls.iter().map(|&q| 1usize << q).fold(0, |a, b| a | b);
     let tgt_mask = 1usize << target;
-    let mut sorted_buf = [0usize; 10];
+    let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
     let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
     let sorted = &sorted_buf[..num_special];
 
@@ -1444,7 +1444,7 @@ fn par_apply_mcu_phase(
         .chain(std::iter::once(&target))
         .map(|&q| 1usize << q)
         .fold(0, |a, b| a | b);
-    let mut sorted_buf = [0usize; 10];
+    let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
     let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
     let sorted = &sorted_buf[..num_special];
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -198,9 +198,18 @@ pub(crate) fn init_thread_pool() {
     });
 }
 
+/// Buffer width for [`sorted_mcu_qubits`]. A dense state indexes amplitudes with a
+/// `usize` shift, so it never holds more than 63 qubits and an `Mcu` on one never
+/// names more than that many.
+pub(crate) const MCU_QUBIT_BUF: usize = 64;
+
 /// Write `controls` plus `target` into `buf` sorted ascending, returning the count.
 #[inline(always)]
-pub(crate) fn sorted_mcu_qubits(controls: &[usize], target: usize, buf: &mut [usize; 10]) -> usize {
+pub(crate) fn sorted_mcu_qubits(
+    controls: &[usize],
+    target: usize,
+    buf: &mut [usize; MCU_QUBIT_BUF],
+) -> usize {
     let n = controls.len() + 1;
     buf[..controls.len()].copy_from_slice(controls);
     buf[controls.len()] = target;

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -14,9 +14,9 @@ use super::insert_zero_bit;
 #[cfg(feature = "parallel")]
 use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS, SendPtr};
 use crate::backend::simd;
-use crate::backend::{is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
+use crate::backend::{MCU_QUBIT_BUF, is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
 use crate::circuit::{QftTextbookStep, qft_textbook_steps};
-use crate::gates::{DiagEntry, Gate, diag_entries_phase};
+use crate::gates::{BatchPhaseData, BatchRzzData, DiagEntry, Gate, diag_entries_phase};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -129,6 +129,12 @@ pub(crate) const MAX_BATCH_RZZ_GROUPS: usize = 4;
 const BATCH_RZZ_BMI2_MAX_UNIQUE: usize = 10;
 #[cfg(target_arch = "x86_64")]
 const BATCH_RZZ_BMI2_TABLE_SIZE: usize = 1024;
+
+const _: () = assert!(
+    MAX_BATCH_PHASE_GROUPS * BATCH_PHASE_GROUP_SIZE == BatchPhaseData::MAX_PHASES
+        && MAX_BATCH_RZZ_GROUPS * BATCH_RZZ_GROUP_SIZE == BatchRzzData::MAX_EDGES,
+    "fusion splits these runs against the gate-level cap, which must match the table shape"
+);
 
 pub(crate) const DIAG_BATCH_MAX_QUBITS_PER_GROUP: usize = 10;
 pub(crate) const DIAG_BATCH_TABLE_SIZE: usize = 1024; // 2^10
@@ -311,7 +317,12 @@ pub(crate) fn build_batch_rzz_tables(
     groups: &mut [BatchRzzGroup; MAX_BATCH_RZZ_GROUPS],
 ) -> usize {
     let num_groups = edges.len().div_ceil(BATCH_RZZ_GROUP_SIZE);
-    debug_assert!(num_groups <= MAX_BATCH_RZZ_GROUPS);
+    assert!(
+        num_groups <= MAX_BATCH_RZZ_GROUPS,
+        "BatchRzz carries {} edges, past the {} the group tables hold",
+        edges.len(),
+        BatchRzzData::MAX_EDGES
+    );
 
     for (g, group) in groups.iter_mut().enumerate().take(num_groups) {
         let start = g * BATCH_RZZ_GROUP_SIZE;
@@ -470,7 +481,12 @@ pub(crate) fn build_batch_phase_tables(
 ) -> usize {
     let one = Complex64::new(1.0, 0.0);
     let num_groups = phases.len().div_ceil(BATCH_PHASE_GROUP_SIZE);
-    debug_assert!(num_groups <= MAX_BATCH_PHASE_GROUPS);
+    assert!(
+        num_groups <= MAX_BATCH_PHASE_GROUPS,
+        "BatchPhase carries {} entries, past the {} the group tables hold",
+        phases.len(),
+        BatchPhaseData::MAX_PHASES
+    );
 
     for (g, group) in groups.iter_mut().enumerate().take(num_groups) {
         let start = g * BATCH_PHASE_GROUP_SIZE;
@@ -2014,7 +2030,7 @@ impl StatevectorBackend {
 
         let ctrl_mask: usize = controls.iter().map(|&q| 1usize << q).fold(0, |a, b| a | b);
         let tgt_mask = 1usize << target;
-        let mut sorted_buf = [0usize; 10];
+        let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
         let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
         let sorted = &sorted_buf[..num_special];
 
@@ -2041,7 +2057,7 @@ impl StatevectorBackend {
     fn apply_mcu_par(&mut self, controls: &[usize], target: usize, mat: [[Complex64; 2]; 2]) {
         let ctrl_mask: usize = controls.iter().map(|&q| 1usize << q).fold(0, |a, b| a | b);
         let tgt_mask = 1usize << target;
-        let mut sorted_buf = [0usize; 10];
+        let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
         let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
         let sorted = &sorted_buf[..num_special];
 
@@ -2145,7 +2161,7 @@ impl StatevectorBackend {
             .chain(std::iter::once(&target))
             .map(|&q| 1usize << q)
             .fold(0, |a, b| a | b);
-        let mut sorted_buf = [0usize; 10];
+        let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
         let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
         let sorted = &sorted_buf[..num_special];
 
@@ -2167,7 +2183,7 @@ impl StatevectorBackend {
             .chain(std::iter::once(&target))
             .map(|&q| 1usize << q)
             .fold(0, |a, b| a | b);
-        let mut sorted_buf = [0usize; 10];
+        let mut sorted_buf = [0usize; MCU_QUBIT_BUF];
         let num_special = sorted_mcu_qubits(controls, target, &mut sorted_buf);
         let sorted = &sorted_buf[..num_special];
 
@@ -3396,4 +3412,130 @@ fn apply_diagonal_batch_scalar(
 ) {
     let group_shifts = diag_batch_group_shifts(unique_qubits);
     diagonal_batch_tile_scalar(state, 0, tables, &group_shifts, group_sizes, num_groups);
+}
+
+#[cfg(all(test, target_arch = "x86_64"))]
+mod pext_agreement_tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    const NUM_QUBITS: usize = 12;
+
+    // The scalar and BMI2 kernels index their tables differently (shift loop vs
+    // PEXT over a mask), so a table shape that indexes one bit per unique qubit
+    // silently diverges from a producer that emits a repeated qubit. Both batch
+    // families are checked against the same amplitude for every basis index.
+    fn combined_phase_scalar_batch_phase(
+        idx: usize,
+        groups: &[BatchPhaseGroup],
+        n: usize,
+    ) -> Complex64 {
+        let mut combined = Complex64::new(1.0, 0.0);
+        for group in groups.iter().take(n) {
+            combined *= group.table[extract_bits(idx, &group.shifts, group.len)];
+        }
+        combined
+    }
+
+    #[test]
+    fn batch_phase_pext_matches_scalar_lookup() {
+        if !std::is_x86_feature_detected!("bmi2") {
+            panic!("bmi2 is required to check the PEXT path against the scalar path");
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let one = Complex64::new(1.0, 0.0);
+
+        for case in 0..64 {
+            let len = 1 + case % BatchPhaseData::MAX_PHASES.min(NUM_QUBITS - 1);
+            let mut targets: Vec<usize> = (1..NUM_QUBITS).collect();
+            for i in (1..targets.len()).rev() {
+                targets.swap(i, rng.random_range(0..=i));
+            }
+            let phases: Vec<(usize, Complex64)> = targets[..len]
+                .iter()
+                .map(|&q| (q, Complex64::from_polar(1.0, rng.random_range(-3.0..3.0))))
+                .collect();
+
+            let mut groups = [BatchPhaseGroup {
+                table: [one; BATCH_PHASE_TABLE_SIZE],
+                shifts: [0; BATCH_PHASE_GROUP_SIZE],
+                len: 0,
+                pext_mask: 0,
+            }; MAX_BATCH_PHASE_GROUPS];
+            let num_groups = build_batch_phase_tables(&phases, &mut groups);
+
+            for idx in 0..(1usize << NUM_QUBITS) {
+                let scalar = combined_phase_scalar_batch_phase(idx, &groups, num_groups);
+                let mut pext = one;
+                for group in groups.iter().take(num_groups) {
+                    // SAFETY: BMI2 checked above.
+                    let bits = unsafe { std::arch::x86_64::_pext_u64(idx as u64, group.pext_mask) };
+                    pext *= group.table[bits as usize];
+                }
+                assert!(
+                    (scalar - pext).norm() < 1e-12,
+                    "case {case} idx {idx}: scalar {scalar} vs pext {pext}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn batch_rzz_pext_matches_scalar_lookup() {
+        if !std::is_x86_feature_detected!("bmi2") {
+            panic!("bmi2 is required to check the PEXT path against the scalar path");
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let one = Complex64::new(1.0, 0.0);
+
+        for case in 0..64 {
+            let num_edges = 1 + case % BatchRzzData::MAX_EDGES;
+            let edges: Vec<(usize, usize, f64)> = (0..num_edges)
+                .map(|_| {
+                    let q0 = rng.random_range(0..NUM_QUBITS);
+                    let mut q1 = rng.random_range(0..NUM_QUBITS);
+                    while q1 == q0 {
+                        q1 = rng.random_range(0..NUM_QUBITS);
+                    }
+                    (q0, q1, rng.random_range(-3.0..3.0))
+                })
+                .collect();
+
+            let mut scalar_groups = [BatchRzzGroup {
+                table: [one; BATCH_RZZ_TABLE_SIZE],
+                q0s: [0; BATCH_RZZ_GROUP_SIZE],
+                q1s: [0; BATCH_RZZ_GROUP_SIZE],
+                len: 0,
+            }; MAX_BATCH_RZZ_GROUPS];
+            let num_groups = build_batch_rzz_tables(&edges, &mut scalar_groups);
+
+            let mut bmi2_groups = [BatchRzzBmi2Group {
+                table: [one; BATCH_RZZ_BMI2_TABLE_SIZE],
+                pext_mask: 0,
+            }; MAX_BATCH_RZZ_GROUPS];
+            let Some(bmi2_num_groups) = build_batch_rzz_bmi2_tables(&edges, &mut bmi2_groups)
+            else {
+                continue;
+            };
+            assert_eq!(num_groups, bmi2_num_groups);
+
+            for idx in 0..(1usize << NUM_QUBITS) {
+                let mut scalar = one;
+                for group in scalar_groups.iter().take(num_groups) {
+                    scalar *= group.table[extract_rzz_bits(idx, group)];
+                }
+                let mut pext = one;
+                for group in bmi2_groups.iter().take(num_groups) {
+                    // SAFETY: BMI2 checked above.
+                    let bits = unsafe { std::arch::x86_64::_pext_u64(idx as u64, group.pext_mask) };
+                    pext *= group.table[bits as usize];
+                }
+                assert!(
+                    (scalar - pext).norm() < 1e-12,
+                    "case {case} idx {idx}: scalar {scalar} vs pext {pext}"
+                );
+            }
+        }
+    }
 }

--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -159,16 +159,22 @@ impl CircuitBuilder {
 
     /// Append a multi-controlled unitary applying `mat` to `target` when every
     /// qubit in `controls` is |1⟩.
+    ///
+    /// # Panics
+    /// Panics if `controls` holds more than `u8::MAX` entries, the width
+    /// [`McuData::num_controls`](crate::gates::McuData::num_controls) can carry.
     pub fn mcu(
         &mut self,
         mat: [[Complex64; 2]; 2],
         controls: &[usize],
         target: usize,
     ) -> &mut Self {
+        let num_controls =
+            u8::try_from(controls.len()).expect("mcu supports at most u8::MAX control qubits");
         let mut targets: SmallVec<[usize; 4]> = controls.into();
         targets.push(target);
         self.circuit.instructions.push(Instruction::Gate {
-            gate: Gate::mcu(mat, controls.len() as u8),
+            gate: Gate::mcu(mat, num_controls),
             targets,
         });
         self

--- a/src/circuit/fusion_phase.rs
+++ b/src/circuit/fusion_phase.rs
@@ -35,6 +35,23 @@ fn emit_phase_chain(
     output: &mut Vec<Instruction>,
     changed: &mut bool,
 ) {
+    // Every entry is diagonal on the same control, so a chain longer than the
+    // kernel group tables hold splits into consecutive batches.
+    if phases.len() > BatchPhaseData::MAX_PHASES {
+        for chunk in phases.chunks(BatchPhaseData::MAX_PHASES) {
+            emit_phase_batch(control, PhaseVec::from_slice(chunk), output, changed);
+        }
+        return;
+    }
+    emit_phase_batch(control, phases, output, changed);
+}
+
+fn emit_phase_batch(
+    control: usize,
+    phases: PhaseVec,
+    output: &mut Vec<Instruction>,
+    changed: &mut bool,
+) {
     if phases.len() >= MIN_BATCH_PHASES {
         output.push(Instruction::Gate {
             gate: Gate::BatchPhase(Box::new(BatchPhaseData { phases })),
@@ -77,17 +94,19 @@ fn push_pending_phase(
     pending: &mut [Option<PhaseVec>],
     target_users: &mut [TargetUserVec],
 ) {
-    let already_indexed = pending[control]
-        .as_ref()
-        .is_some_and(|phases| phases.iter().any(|&(t, _)| t == target));
-    if !already_indexed {
-        target_users[target].push(control);
-    }
-
+    // The kernel indexes one bit per distinct target, so a repeated pair has to
+    // fold into the entry already there rather than push a second one.
     match &mut pending[control] {
-        Some(v) => v.push((target, phase)),
+        Some(v) => {
+            if let Some(entry) = v.iter_mut().find(|(t, _)| *t == target) {
+                entry.1 *= phase;
+                return;
+            }
+            v.push((target, phase));
+        }
         slot => *slot = Some(smallvec![(target, phase)]),
     }
+    target_users[target].push(control);
 }
 
 fn flush_phase_target_conflicts(

--- a/src/circuit/fusion_rzz.rs
+++ b/src/circuit/fusion_rzz.rs
@@ -157,28 +157,37 @@ fn flush_rzz_run(
     rzz_qubits: &mut [bool],
     deferred_qubits: &mut [bool],
 ) {
-    if rzz_run.len() >= 2 {
-        let mut tgts: SmallVec<[usize; 4]> = SmallVec::new();
-        for &(q0, q1, _) in rzz_run.iter() {
-            push_unique(&mut tgts, q0);
-            push_unique(&mut tgts, q1);
-        }
-        output.push(Instruction::Gate {
-            gate: Gate::BatchRzz(Box::new(BatchRzzData {
-                edges: rzz_run.clone(),
-            })),
-            targets: tgts,
-        });
-    } else {
-        for &(q0, q1, theta) in rzz_run.iter() {
-            output.push(Instruction::Gate {
-                gate: Gate::Rzz(theta),
-                targets: smallvec![q0, q1],
-            });
-        }
+    // Rzz gates are diagonal and mutually commuting, so a run longer than the
+    // kernel group tables hold splits into consecutive batches.
+    for chunk in rzz_run.chunks(BatchRzzData::MAX_EDGES) {
+        emit_rzz_chunk(output, chunk);
     }
     output.append(deferred);
     rzz_run.clear();
     rzz_qubits.fill(false);
     deferred_qubits.fill(false);
+}
+
+fn emit_rzz_chunk(output: &mut Vec<Instruction>, chunk: &[(usize, usize, f64)]) {
+    if chunk.len() < 2 {
+        for &(q0, q1, theta) in chunk {
+            output.push(Instruction::Gate {
+                gate: Gate::Rzz(theta),
+                targets: smallvec![q0, q1],
+            });
+        }
+        return;
+    }
+
+    let mut tgts: SmallVec<[usize; 4]> = SmallVec::new();
+    for &(q0, q1, _) in chunk {
+        push_unique(&mut tgts, q0);
+        push_unique(&mut tgts, q1);
+    }
+    output.push(Instruction::Gate {
+        gate: Gate::BatchRzz(Box::new(BatchRzzData {
+            edges: chunk.to_vec(),
+        })),
+        targets: tgts,
+    });
 }

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -1835,7 +1835,15 @@ impl<'a> Parser<'a> {
                 Gate::Cu(mat) => Ok(Gate::mcu(**mat, 2)),
                 Gate::Cx => Ok(Gate::mcu(Gate::X.matrix_2x2(), 2)),
                 Gate::Cz => Ok(Gate::mcu(Gate::Z.matrix_2x2(), 2)),
-                Gate::Mcu(data) => Ok(Gate::mcu(data.mat, data.num_controls + 1)),
+                Gate::Mcu(data) => {
+                    let num_controls = data.num_controls.checked_add(1).ok_or_else(|| {
+                        PrismError::UnsupportedConstruct {
+                            construct: format!("ctrl @ chain past {} controls", u8::MAX),
+                            line: line_num,
+                        }
+                    })?;
+                    Ok(Gate::mcu(data.mat, num_controls))
+                }
                 _ => Err(PrismError::UnsupportedConstruct {
                     construct: format!("ctrl @ {} (unsupported gate type)", gate.name()),
                     line: line_num,

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -169,6 +169,13 @@ pub struct BatchPhaseData {
     pub phases: SmallVec<[(usize, Complex64); 8]>,
 }
 
+impl BatchPhaseData {
+    /// Entry cap the fusion pass splits on, matching the kernel group tables.
+    /// Targets are distinct within one payload, so a repeated `(control, target)`
+    /// pair folds into a single entry rather than adding one.
+    pub const MAX_PHASES: usize = 40;
+}
+
 /// Data for batched ZZ rotations.
 ///
 /// Multiple Rzz gates batched into a single pass over the statevector.
@@ -177,6 +184,11 @@ pub struct BatchPhaseData {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BatchRzzData {
     pub edges: Vec<(usize, usize, f64)>,
+}
+
+impl BatchRzzData {
+    /// Edge cap the fusion pass splits on, matching the kernel group tables.
+    pub const MAX_EDGES: usize = 32;
 }
 
 /// An individual diagonal phase contribution in a [`DiagonalBatchData`].

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -1093,3 +1093,96 @@ fn fusion_multi_2q_threshold_12q_active() {
     assert!(has_2q_fusion(&circuit), "12q QV should use Multi2q fusion");
     assert_fusion_preserves_correctness(&circuit);
 }
+
+// ===== Fused-batch producer bounds =====
+
+// A dense Rzz layer is unbounded in edge count while the kernel group tables
+// are not, so the producer has to split the run.
+fn dense_rzz_layer_circuit(num_qubits: usize, span: usize) -> Circuit {
+    let mut c = Circuit::new(num_qubits, 0);
+    for q in 0..num_qubits {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for a in 0..span {
+        for b in (a + 1)..span {
+            c.add_gate(Gate::Rzz(0.13 * (a + b + 1) as f64), &[a, b]);
+        }
+    }
+    for q in 0..num_qubits {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c
+}
+
+#[test]
+fn fusion_batch_rzz_beyond_group_capacity() {
+    let circuit = dense_rzz_layer_circuit(16, 10);
+    let unfused = run_unfused(&circuit);
+    let fused = run_fused(&circuit);
+    assert_probs_close(&fused, &unfused, EPS);
+}
+
+#[test]
+fn fusion_batch_rzz_splits_oversize_run() {
+    let circuit = dense_rzz_layer_circuit(16, 10);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+    let mut edges = 0usize;
+    for inst in &fused.instructions {
+        if let prism_q::circuit::Instruction::Gate {
+            gate: Gate::BatchRzz(data),
+            ..
+        } = inst
+        {
+            assert!(
+                data.edges.len() <= 32,
+                "BatchRzz carries {} edges, past the kernel group capacity",
+                data.edges.len()
+            );
+            edges += data.edges.len();
+        }
+    }
+    assert_eq!(edges, 45, "every Rzz edge should survive the split");
+}
+
+// Two cphase gates on the same (control, target) pair index one bit of the
+// PEXT mask, so the second phase is dropped unless the producer folds it in.
+fn stacked_cphase_circuit(num_qubits: usize) -> Circuit {
+    let mut c = Circuit::new(num_qubits, 0);
+    for q in 0..num_qubits {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c.add_gate(Gate::cphase(0.4), &[0, 1]);
+    c.add_gate(Gate::cphase(0.7), &[0, 1]);
+    c.add_gate(Gate::cphase(1.1), &[0, 2]);
+    for q in 0..num_qubits {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c
+}
+
+#[test]
+fn fusion_batch_phase_duplicate_pair() {
+    let circuit = stacked_cphase_circuit(16);
+    let unfused = run_unfused(&circuit);
+    let fused = run_fused(&circuit);
+    assert_probs_close(&fused, &unfused, EPS);
+}
+
+#[test]
+fn fusion_batch_phase_folds_duplicate_pair() {
+    let circuit = stacked_cphase_circuit(16);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+    for inst in &fused.instructions {
+        if let prism_q::circuit::Instruction::Gate {
+            gate: Gate::BatchPhase(data),
+            ..
+        } = inst
+        {
+            let mut seen: Vec<usize> = data.phases.iter().map(|&(t, _)| t).collect();
+            seen.sort_unstable();
+            let len = seen.len();
+            seen.dedup();
+            assert_eq!(len, seen.len(), "BatchPhase repeats a target qubit");
+        }
+    }
+}

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -9,6 +9,7 @@ mod common;
 
 use common::{assert_probs_close, run_fused_probs};
 use num_complex::Complex64;
+use prism_q::CircuitBuilder;
 use prism_q::Instruction;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
@@ -471,6 +472,36 @@ fn mcu_inv_ctrl_ctrl_rz() {
     let amp = 1.0 / 2.0_f64.sqrt();
     assert_amplitude(sv[0b011], Complex64::new(amp, 0.0), "|011⟩");
     assert_amplitude(sv[0b111], Complex64::new(amp, 0.0), "|111⟩");
+}
+
+#[test]
+fn mcu_10ctrl_x_builder() {
+    let mut builder = CircuitBuilder::new(11);
+    for q in 0..10 {
+        builder.x(q);
+    }
+    builder.mcu(Gate::X.matrix_2x2(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 10);
+    let probs = run_and_probs(&builder.build());
+    assert!(
+        (probs[0b111_1111_1111] - 1.0).abs() < EPS,
+        "10 active controls should flip the target"
+    );
+}
+
+#[test]
+fn mcu_10ctrl_x_openqasm_chain() {
+    let mut qasm = String::from("OPENQASM 3.0;\nqubit[11] q;\n");
+    for q in 0..10 {
+        qasm.push_str(&format!("x q[{q}];\n"));
+    }
+    qasm.push_str(&"ctrl @ ".repeat(10));
+    qasm.push_str("x q[0], q[1], q[2], q[3], q[4], q[5], q[6], q[7], q[8], q[9], q[10];\n");
+    let c = prism_q::circuit::openqasm::parse(&qasm).unwrap();
+    let probs = run_and_probs(&c);
+    assert!(
+        (probs[0b111_1111_1111] - 1.0).abs() < EPS,
+        "10 active controls should flip the target"
+    );
 }
 
 // ---- Product state backend ----


### PR DESCRIPTION
## Summary

Three release-build defects shared one shape: a kernel holds a fixed-size table or
buffer and the producer that fills it is unbounded. `BatchRzz` dropped every edge past
the 32nd, so a dense QAOA cost layer at 16q+ returned wrong probabilities. `BatchPhase`
gave a repeated `(control, target)` pair no bit of its own in the PEXT mask, so the
second phase was lost on every BMI2 host. `Mcu` with ten or more controls indexed past
a ten-entry buffer and panicked, which rejected an ordinary 11-qubit Grover diffusion.
All three are fixed at the producer, and both batch caps now live on the gate payload
where every consumer can see them.

## Scope

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

The fused instruction stream is byte identical to the base commit on all 63 benchmark
circuits (9 families x 7 sizes, dumped and diffed), so apply cost is unchanged by
construction: the producers only act past caps no benchmark circuit reaches.

Six adjacent-binary pairs were still run, because fusion executes inside the measured
region. The first three found a real regression the identical-stream argument does not
cover: the rewritten `emit_phase_chain` copied the `PhaseVec` on every chain, which is
invisible against a 50 ms row and visible against a 1 ms one. `qft_textbook/16` read
+12.7%, +9.3%, +0.6%, the only sign-consistent row, with +12.7% from the pair holding
the tightest controls. The chain now moves whole unless it exceeds 40 entries, and
three further pairs were taken. Table is pair 6, the tightest of those (worst same-code
control spread 5.6%):

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `statevector/diag_mixed_l6/16` | 3.08 ms | 3.10 ms | +0.4% | +0.6% / +1.0% | yes |
| `statevector/diag_mixed_l6/20` | 3.54 ms | 3.57 ms | +0.9% | +0.3% / -1.8% | yes |
| `statevector/qaoa_l3/16` | 2.30 ms | 2.32 ms | +0.9% | -0.5% / +0.5% | yes |
| `statevector/qaoa_l3/20` | 49.17 ms | 50.24 ms | +2.2% | -2.0% / -5.6% | unresolvable |
| `statevector/qft_textbook/16` | 1.05 ms | 994.72 us | -5.2% | -2.1% / -0.3% | yes |
| `statevector/qft_textbook/20` | 31.94 ms | 32.00 ms | +0.2% | -0.4% / -1.0% | yes |

Only `qaoa_l3/16` holds its sign across all three post-fix pairs (+1.5%, +3.2%, +0.9%),
inside the gate throughout. Every other row flipped sign between pairs with controls
running to 24%, so those rows are unmeasured on this host rather than neutral, and no
change is claimed for them. Host was not quiet: baseline load 34-63% from unrelated
processes, which cost one of the six pairs.

Regression verdict: PASS

## Correctness

- [x] Test suite passes locally, 2034 tests at `--features "parallel gpu distributed"`
      plus doctests. `--all-features` was not used: the diff touches no MPI code or
      feature wiring, and that build needs the MSVC environment
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings
      -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes under
      `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry, and stay concise; none restate the signature
- [x] Fusion-pass changes carry fused-versus-unfused tests, and the `Mcu` width is
      pinned by closed-form goldens through both the builder and an OpenQASM
      `ctrl @` chain. All six new integration cases fail on the base commit in a
      release build
- [x] `golden_gpu` ran under `PRISM_REQUIRE_GPU=1`; the GPU path shares
      `build_batch_rzz_tables` with the CPU kernels

New unit tests assert that PEXT-indexed lookup equals the scalar `extract_bits` lookup
on random tables for both batch families, which closes the scalar-versus-PEXT
divergence class rather than the one reported instance. Python bindings were rebuilt
and `pytest bindings/python/tests` passes (53 tests); the binding guard rejects at
`u8::MAX` rather than shadowing the core contract.

## Hotspot notes

`fuse_batch_rzz`, `fuse_controlled_phases`, and `sorted_mcu_qubits` are the functions
touched. None sit in a gate-application inner loop: the fusion passes run once per
circuit and `sorted_mcu_qubits` once per gate application, outside the amplitude sweep.
The two table builders gained one release assertion each, on the same per-application
path. The measured risk was never apply cost but fusion cost against the small rows,
addressed above.

## Architecture or design changes

- [x] `docs/architecture/fusion.md` gains a payload-capacity section: the two caps,
      what each producer does past them, why splitting is sound, and how
      `DiagonalBatch` differs by declining at the kernel instead
- [ ] Design or research notes added where required for new subsystems

## Breaking changes

- `Mcu` with 10 to 63 controls now simulates instead of panicking on the statevector
  and factored backends. Previously reachable through `CircuitBuilder::mcu`, an
  OpenQASM `ctrl @` chain, and the Python surface.
- `CircuitBuilder::mcu` panics past 255 controls, documented under `# Panics`. It
  previously truncated the count silently through an `as u8` cast.
- An OpenQASM `ctrl @` chain past 255 controls returns `UnsupportedConstruct` instead
  of wrapping the count.

## Risks and rollback

Blast radius is the two fusion producers and the MCU qubit buffer. No feature flag or
dispatch guard gates the change, so rollback is a revert of the single commit.

The two new release assertions are new panic sites on paths that previously computed a
wrong answer. Both are unreachable given the producers, and a compile-time assertion
ties each cap to its table shape so the two cannot drift apart silently.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers. One related site is deferred and tracked, not fixed
      here: `dispatch_gate` in `src/backend/sparse.rs` has a `debug_assert!` on
      `targets.len() == 1` above a path that would apply a multi-qubit gate to
      `targets[0]` alone. It may be unreachable given the dispatch above it, which is
      the question to settle before changing it
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
