### PR TITLE
fix(gpu): close bound, contract, and portability holes

### DIFF
--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -88,6 +88,27 @@ the Rust constants in `src/backend/statevector/kernels.rs`, keeping CPU and GPU 
 against the CPU statevector within 1e-10. Covers every gate variant, fusion paths, and
 the `BackendKind::StatevectorGpu` public dispatch path at the crossover boundary.
 
+### Shot reproducibility
+
+Two limits bound what a seed guarantees, and neither is visible from the golden
+equality tests.
+
+- **CPU against GPU:** agreement in distribution, not bit for bit. Both paths draw the
+  same RNG stream for a given shot seed, but the device reduction that produces a
+  measurement probability sums in tree order with FMA contraction, so it can differ from
+  the host sum in the last ulp, and a uniform draw landing between the two flips that
+  outcome and every outcome after it. Where the probability is a dyadic rational (0.5,
+  1.0, and the amplitudes reachable from Clifford gates) both sums are exact and the
+  shots do match, which is what `statevector_gpu_mid_measure_shots_match_cpu` pins.
+  `statevector_gpu_shot_frequencies_match_cpu_off_dyadic` pins the general case: equal
+  frequencies within 5 sigma after `Rx(0.3)`.
+- **GPU BTS sampling:** reproducible at a fixed Rayon thread count. Above
+  `MIN_PAR_DRAWS` random bits per chunk, `fill_random_bits` seeds one stream per worker
+  and partitions the draws by `rayon::current_num_threads()`, so the same seed on a host
+  with a different worker count produces different shots. Below that threshold the
+  serial single-stream path runs and the seed reproduces outright. Pin
+  `RAYON_NUM_THREADS` when byte-identical shot payloads matter across machines.
+
 ## Current limits
 
 - Device placement is silent. Circuits below the crossover run on the host, and the

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -36,12 +36,13 @@ enum DeviceInner {
 impl GpuDevice {
     /// Open the device with the given ordinal and compile the kernel module.
     ///
-    /// PTX is compiled targeting the device's compute capability so the running NVIDIA
-    /// driver can load it regardless of the toolkit NVRTC version.
+    /// PTX is compiled targeting the newest supported arch at or below the device's
+    /// compute capability so the running NVIDIA driver can load it regardless of the
+    /// toolkit NVRTC version. A capability below 6.0 is rejected rather than targeted.
     pub fn new(device_id: usize) -> Result<Self> {
         let context = CudaContext::new(device_id).map_err(|e| Self::driver_err("init", e))?;
         let stream = context.default_stream();
-        let arch = detect_arch(&context).unwrap_or("compute_60");
+        let arch = detect_arch(&context)?;
         let opts = CompileOptions {
             arch: Some(arch),
             ..Default::default()
@@ -167,22 +168,50 @@ impl GpuDevice {
     }
 }
 
-fn detect_arch(context: &Arc<CudaContext>) -> Option<&'static str> {
-    let (major, minor) = context.compute_capability().ok()?;
-    match (major, minor) {
-        (6, 0) => Some("compute_60"),
-        (6, 1) => Some("compute_61"),
-        (6, 2) => Some("compute_62"),
-        (7, 0) => Some("compute_70"),
-        (7, 2) => Some("compute_72"),
-        (7, 5) => Some("compute_75"),
-        (8, 0) => Some("compute_80"),
-        (8, 6) => Some("compute_86"),
-        (8, 7) => Some("compute_87"),
-        (8, 9) => Some("compute_89"),
-        (9, 0) => Some("compute_90"),
-        _ => None,
-    }
+/// Virtual architectures NVRTC is asked to target, ascending by capability.
+///
+/// The ceiling tracks the newest arch the pinned `cudarc` NVRTC binding
+/// (`cuda-12040` in `Cargo.toml`) accepts. Naming a newer one fails compilation
+/// outright on a 12.x toolkit, so raise the pin before extending this table.
+const KNOWN_ARCHS: &[((i32, i32), &str)] = &[
+    ((6, 0), "compute_60"),
+    ((6, 1), "compute_61"),
+    ((6, 2), "compute_62"),
+    ((7, 0), "compute_70"),
+    ((7, 2), "compute_72"),
+    ((7, 5), "compute_75"),
+    ((8, 0), "compute_80"),
+    ((8, 6), "compute_86"),
+    ((8, 7), "compute_87"),
+    ((8, 9), "compute_89"),
+    ((9, 0), "compute_90"),
+];
+
+/// Newest entry of [`KNOWN_ARCHS`] at or below `capability`, or `None` below
+/// the oldest entry (6.0, the floor for double-precision atomics).
+///
+/// Capabilities past the table clamp down rather than fail: the driver JITs PTX
+/// forward, so an under-targeted module still runs, and the clamped string stays
+/// clear of the pre-Turing range NVRTC 13.x refuses.
+fn arch_for_capability(capability: (i32, i32)) -> Option<&'static str> {
+    KNOWN_ARCHS
+        .iter()
+        .rev()
+        .find(|&&(known, _)| known <= capability)
+        .map(|&(_, arch)| arch)
+}
+
+fn detect_arch(context: &Arc<CudaContext>) -> Result<&'static str> {
+    let capability = context
+        .compute_capability()
+        .map_err(|e| GpuDevice::driver_err("compute_capability", e))?;
+    arch_for_capability(capability).ok_or_else(|| PrismError::BackendUnsupported {
+        backend: "gpu".to_string(),
+        operation: format!(
+            "compute capability {}.{} is below the 6.0 floor the kernels target",
+            capability.0, capability.1
+        ),
+    })
 }
 
 #[cfg(test)]
@@ -202,5 +231,28 @@ mod tests {
             dev.stream().unwrap_err(),
             PrismError::BackendUnsupported { .. }
         ));
+    }
+
+    #[test]
+    fn arch_maps_exact_capabilities() {
+        assert_eq!(arch_for_capability((6, 1)), Some("compute_61"));
+        assert_eq!(arch_for_capability((8, 9)), Some("compute_89"));
+        assert_eq!(arch_for_capability((9, 0)), Some("compute_90"));
+    }
+
+    #[test]
+    fn arch_clamps_down_to_the_newest_entry_at_or_below() {
+        // Blackwell (10.0 / 12.0) and any gap inside the table take the newest
+        // entry below them, never the oldest.
+        assert_eq!(arch_for_capability((10, 0)), Some("compute_90"));
+        assert_eq!(arch_for_capability((12, 0)), Some("compute_90"));
+        assert_eq!(arch_for_capability((8, 8)), Some("compute_87"));
+        assert_eq!(arch_for_capability((7, 1)), Some("compute_70"));
+    }
+
+    #[test]
+    fn arch_rejects_capabilities_below_the_floor() {
+        assert_eq!(arch_for_capability((5, 2)), None);
+        assert_eq!(arch_for_capability((3, 5)), None);
     }
 }

--- a/src/gpu/kernels/bts.rs
+++ b/src/gpu/kernels/bts.rs
@@ -162,6 +162,12 @@ extern "C" __global__ void bts_popcount_rows(
 // Open-addressing insert-or-increment for a 3-state (empty / claiming / ready)
 // hash table. Spins on slots mid-claim, linear-probes on collision, and sets
 // `overflow` when a full sweep finds no usable slot.
+//
+// The mid-claim spin is bounded because pre-Volta SIMT gives the claiming lane
+// no forward-progress guarantee against a spinning lane of the same warp.
+// Exhausting the bound sets `overflow`, which sends counting back to the host.
+#define BTS_CLAIM_SPIN_LIMIT 4096U
+
 __device__ __forceinline__ void hash_insert_count(
     const unsigned long long *key,
     int m_words,
@@ -196,7 +202,12 @@ __device__ __forceinline__ void hash_insert_count(
             }
             continue;
         } else {
+            unsigned int spins = 0U;
             while ((state = load_state(slot_states + slot)) == 1U) {
+                if (++spins >= BTS_CLAIM_SPIN_LIMIT) {
+                    atomicExch(overflow, 1U);
+                    return;
+                }
             }
             if (state == 2U && keys_equal(slot_key, key, m_words)) {
                 atomicAdd(slot_counts + slot, 1ULL);
@@ -654,12 +665,11 @@ impl GpuBtsCache {
         chunk_shots: usize,
         chunk_s_words: usize,
     ) {
-        // Parallel path: for a large enough pool, seed one fresh xoshiro
-        // stream per worker from the master rng (matches the CPU BTS batched
-        // path in `src/sim/compiled/bts.rs`). Serial fallback keeps the
-        // existing single-stream sequence for small chunks or CPU-only
-        // builds so determinism is not accidentally coupled to the Rayon
-        // thread count.
+        // Parallel path: seed one fresh xoshiro stream per worker from the
+        // master rng, matching the CPU BTS batched path in
+        // `src/sim/compiled/bts.rs`. Partitioning by `current_num_threads()`
+        // means a seed reproduces only at a fixed thread count; the serial
+        // fallback below `MIN_PAR_DRAWS` reproduces outright.
         let required = chunk_s_words * rank;
         #[cfg(not(feature = "parallel"))]
         let _ = required;

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -297,12 +297,17 @@ pub struct GpuState {
 
 impl GpuState {
     /// Allocate a fresh |0…0⟩ state on the device bound to `context`.
+    ///
+    /// Rejects `num_qubits` at or above `usize::BITS - 4`, the bound
+    /// [`GpuContext::fits_statevector`] uses, where the 16 bytes per amplitude
+    /// overflow `usize`.
     pub fn new(context: Arc<GpuContext>, num_qubits: usize) -> Result<Self> {
-        let len = 2usize.checked_shl(num_qubits as u32).ok_or_else(|| {
-            crate::error::PrismError::InvalidParameter {
+        if num_qubits >= usize::BITS as usize - 4 {
+            return Err(crate::error::PrismError::InvalidParameter {
                 message: format!("num_qubits={num_qubits} overflows addressable memory"),
-            }
-        })?;
+            });
+        }
+        let len = 2usize << num_qubits;
         let buffer = GpuBuffer::<f64>::alloc_zeros(context.device(), len)?;
         let mut state = Self {
             context: context.clone(),
@@ -582,6 +587,18 @@ mod tests {
         // which no GPU has. The function clamps these to `Ok(false)` before
         // touching the device, so even the stub context returns cleanly.
         assert!(!ctx.fits_statevector(128).unwrap());
+    }
+
+    #[test]
+    fn state_new_rejects_overflowing_qubit_counts() {
+        let ctx = GpuContext::stub_for_tests();
+        // 63 is the silent case: `2 << 63` wraps to a zero-length buffer that
+        // allocates fine and is then written past. 62 already fails at
+        // allocation. The bound runs before allocation, so the stub reaches it.
+        assert!(matches!(
+            GpuState::new(ctx, 63).unwrap_err(),
+            PrismError::InvalidParameter { .. }
+        ));
     }
 
     #[test]

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1192,12 +1192,7 @@ fn run_expectation_values_with(
                     .map(|r| r.mean)
             })
             .collect(),
-        _ if kind.is_auto()
-            || matches!(
-                kind,
-                BackendKind::Stabilizer | BackendKind::FactoredStabilizer
-            ) =>
-        {
+        _ if kind.is_auto() || kind.is_stabilizer_family() => {
             if circuit.is_clifford_only() {
                 observables
                     .iter()

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -730,10 +730,10 @@ fn statevector_gpu_builder_matches_cpu_random() {
     assert_probs_close(&gpu_p, &cpu_p, 1e-10, "gpu/dispatch_random_14q");
 }
 
-// A mid-circuit measurement forces the per-shot slow path. With
-// `BackendKind::StatevectorGpu` at 14q each per-shot backend routes to the
-// device, and outcomes must match the host statevector shot-for-shot: both
-// backends draw the same RNG stream for the same shot seed.
+// A mid-circuit measurement forces the per-shot slow path. Shots match bit for
+// bit only because every measured probability here is exactly 0.5; see
+// `statevector_gpu_shot_frequencies_match_cpu_off_dyadic` for why that is a
+// special case rather than the contract.
 #[test]
 fn statevector_gpu_mid_measure_shots_match_cpu() {
     use prism_q::{BackendKind, Circuit};
@@ -763,6 +763,57 @@ fn statevector_gpu_mid_measure_shots_match_cpu() {
         .expect("gpu shots failed");
 
     assert_eq!(cpu.shots, gpu.shots);
+}
+
+// `sin^2(0.15)` is not a dyadic rational, so the device tree reduction and the
+// host sum can straddle a uniform draw and diverge from that shot onward. Equal
+// frequencies are what the two backends promise off dyadic probabilities.
+#[test]
+fn statevector_gpu_shot_frequencies_match_cpu_off_dyadic() {
+    use prism_q::{BackendKind, Circuit};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let shots = 2000;
+    let p_one = (0.3_f64 / 2.0).sin().powi(2);
+    let five_sigma = 5.0 * (p_one * (1.0 - p_one) / shots as f64).sqrt();
+
+    let mut circuit = Circuit::new(14, 2);
+    circuit.add_gate(Gate::Rx(0.3), &[0]);
+    for q in 0..13 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    circuit.add_measure(0, 0);
+    circuit.add_gate(Gate::H, &[1]);
+    circuit.add_measure(1, 1);
+
+    for seed in [42_u64, 43, 44] {
+        let cpu = prism_q::simulate(&circuit)
+            .backend(BackendKind::Statevector)
+            .seed(seed)
+            .shots(shots)
+            .expect("cpu shots failed");
+        let gpu = prism_q::simulate(&circuit)
+            .backend(BackendKind::StatevectorGpu {
+                context: f.ctx.clone(),
+            })
+            .seed(seed)
+            .shots(shots)
+            .expect("gpu shots failed");
+
+        let freq = |r: &prism_q::ShotsResult| {
+            r.shots.iter().filter(|s| s[0]).count() as f64 / shots as f64
+        };
+        let (cpu_f, gpu_f) = (freq(&cpu), freq(&gpu));
+        assert!(
+            (cpu_f - p_one).abs() < five_sigma,
+            "seed {seed}: cpu freq {cpu_f} off analytic {p_one}"
+        );
+        assert!(
+            (gpu_f - p_one).abs() < five_sigma,
+            "seed {seed}: gpu freq {gpu_f} off analytic {p_one}"
+        );
+    }
 }
 
 // ============================================================================
@@ -1662,6 +1713,49 @@ fn builder_stabilizer_gpu_shots_match_compiled_gpu_sampling() {
     assert_eq!(explicit.shots, compiled.shots);
 }
 
+// Observable propagation for a Clifford circuit is host side, so `StabilizerGpu`
+// answers exactly what `Stabilizer` answers rather than rejecting.
+#[test]
+fn stabilizer_gpu_expectation_values_match_cpu_stabilizer() {
+    use prism_q::{BackendKind, Circuit, PauliTerm, simulate};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let mut circuit = Circuit::new(4, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::Cx, &[1, 2]);
+    circuit.add_gate(Gate::S, &[3]);
+
+    let observables = vec![
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::z(0), PauliTerm::z(1)],
+        vec![PauliTerm::x(0), PauliTerm::x(1), PauliTerm::x(2)],
+        vec![PauliTerm::z(3)],
+    ];
+
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Stabilizer)
+        .seed(42)
+        .expectation_values(&observables)
+        .expect("cpu expectation values failed");
+    let gpu = simulate(&circuit)
+        .backend(BackendKind::StabilizerGpu {
+            context: f.ctx.clone(),
+        })
+        .seed(42)
+        .expectation_values(&observables)
+        .expect("gpu expectation values failed");
+
+    assert_eq!(gpu.len(), cpu.len());
+    for (i, (g, c)) in gpu.iter().zip(&cpu).enumerate() {
+        assert!(
+            (g - c).abs() < 1e-12,
+            "observable {i}: gpu {g}, stabilizer {c}"
+        );
+    }
+}
+
 // Reused GPU BTS scratch should not change the packed output stream for a
 // fixed sequence of batch requests.
 #[test]
@@ -1809,6 +1903,49 @@ fn sample_bulk_packed_device_counts_match_host_counts() {
     let host_counts = device.to_host().unwrap().counts();
 
     assert_eq!(device_counts, host_counts);
+}
+
+// Worst case for the device count table: a million shots over two outcomes, so
+// every thread contends for the same slot and the mid-claim spin in
+// `hash_insert_count` runs hot. Repeated because the failure mode is warp
+// scheduling. A hang is the bug; wrong totals would mean the spin dropped work.
+#[test]
+fn device_counts_survive_two_outcome_contention() {
+    use prism_q::{Circuit, compile_measurements};
+
+    let Some(f) = Fixture::try_new() else { return };
+
+    let n = 64;
+    let shots = 1_000_000;
+    let mut circuit = Circuit::new(n, n);
+    circuit.add_gate(Gate::H, &[0]);
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    circuit.measure_all();
+
+    let mut gpu = compile_measurements(&circuit, common::SEED)
+        .unwrap()
+        .with_gpu(f.ctx.clone());
+
+    for iteration in 0..50 {
+        let counts = gpu
+            .sample_bulk_packed_device(shots)
+            .unwrap()
+            .counts()
+            .unwrap();
+        assert_eq!(
+            counts.values().sum::<u64>(),
+            shots as u64,
+            "iteration {iteration}: counts lost shots"
+        );
+        assert_eq!(
+            counts.len(),
+            2,
+            "iteration {iteration}: GHZ parity gives two outcomes, got {}",
+            counts.len()
+        );
+    }
 }
 
 // Noisy GPU reductions draw from the same distribution as the CPU noisy


### PR DESCRIPTION
## Summary

Six GPU holes found by reading `main`, fixed together because they share a feature set,
a test file, and a device. Two were memory-safety or liveness bounds, two were contract
holes where the GPU path rejected or promised something its CPU sibling did not, one was
a portability fallback that fails on current toolkits, and one was a performance idea
that measurement killed. Five landed; the sixth is dropped with evidence below.

## Scope

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

The bounded spin in `hash_insert_count` is the only kernel edit here, so it carries the
row. Adjacent-binary A/B against `main` (37209ca), `--features "parallel gpu"`, 100
samples, i7-6700K, GTX 1080 Ti sm_61, rustc 1.97.0, bench profile `lto = "fat"` with
`codegen-units = 1`.

| Benchmark | Before | After | Change | Control (ref / new) | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- | --- |
| `gpu_bts_device_counts/n1024_r12/1000000` | 698.05 ms | 691.18 ms | -1.0% | +1.0% / +0.8% | yes |
| `gpu_bts_device_counts/n1024_r12/131072` | 103.85 ms | 100.51 ms | -3.2% | -0.6% / +1.2% | yes |
| `gpu_bts_device_counts/n512_r12/1000000` | 5.29 ms | 5.20 ms | -1.6% | -3.3% / +1.0% | yes |
| `gpu_bts_device_counts/n512_r12/131072` | 2.16 ms | 2.09 ms | -3.2% | -3.9% / +0.8% | yes |

Worst same-code control spread 3.9%. Two rows read faster than their own control, but a
counter increment inside a spin loop cannot make counting faster, so nothing is claimed
beyond no regression.

Regression verdict: PASS

### Dropped on measurement

Adding `__forceinline__` to `expand_2q` was expected to pay off, since plain `inline`
device helpers previously cost 5-28% on dense rows. It does nothing here. Compiling the
substituted kernel source both ways under nvcc 12.4 gives byte-identical output:

| Output | Plain `inline` | `__forceinline__` |
| --- | --- | --- |
| `-arch=compute_61 -ptx` | 65343 bytes | identical |
| `-arch=sm_61 -cubin` | 50080 bytes | identical |
| `cuobjdump -sass` diff | 0 lines | 0 lines |

`expand_2q` appears as a symbol nowhere in the PTX or SASS, and the module contains zero
`CAL` instructions, so every device helper is already inlined. The change was reverted
along with the CX-heavy 24q bench row added to gate it. No benchmark could have separated
the two binaries, because there is only one binary. This narrows the earlier 5-28%
result rather than overturning it: that was measured on helpers NVRTC declined to inline.

### Not reproduced

The unbounded intra-warp spin does not hang on sm_61. The stress shape (two outcomes,
1M shots, 50 iterations) passes against the pre-change kernel in 0.97 s, so the suite
passing today does rest on NVRTC branch ordering rather than on a guarantee. The bound
still landed on the pre-Volta forward-progress argument, and the bail path is verified
live rather than dead: forcing the spin limit to 1 pushes the same test onto the host
count fallback at 18.6 s with identical counts. Framing is bounded, not fixed.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally, 2041
      tests, with `PRISM_REQUIRE_GPU=1` so a missing device fails rather than skips
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes under `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on changed `pub` items add facts the signature does not carry
- [ ] New gate, backend, or fusion pass: N/A, none added
- [x] `golden_gpu` green, 67 tests

`--all-features` was not used: the diff reaches neither MPI code nor `Cargo.toml` feature
wiring, so the feature set above is the applicable gate.

New coverage:

| Test | Pins |
| --- | --- |
| `gpu::tests::state_new_rejects_overflowing_qubit_counts` | 63 qubits returns `Err`, before any allocation |
| `gpu::device::tests::arch_maps_exact_capabilities` | Table lookups |
| `gpu::device::tests::arch_clamps_down_to_the_newest_entry_at_or_below` | Capability above the table, and gaps inside it |
| `gpu::device::tests::arch_rejects_capabilities_below_the_floor` | Below 6.0 returns `None` |
| `stabilizer_gpu_expectation_values_match_cpu_stabilizer` | GPU expectations equal `Stabilizer`'s |
| `statevector_gpu_shot_frequencies_match_cpu_off_dyadic` | Frequency agreement across three seeds after `Rx(0.3)` |
| `device_counts_survive_two_outcome_contention` | Count-table liveness and totals under maximum slot contention |

The first four run without a device. The two reproductions that had a defect behind them
were confirmed failing before the fix: 63 qubits returned `BackendUnsupported` from the
allocator instead of rejecting, and `StabilizerGpu` expectation values returned
`BackendUnsupported { backend: "stabilizer", operation: "Pauli expectation values" }`.

## Hotspot notes

`hash_insert_count` is on the device count path, reached from `DevicePackedShots::counts`
for up to 8 packed measurement words. The added work is one register increment per
iteration of a spin that only runs when a thread finds a slot mid-claim. The row above
covers it. Nothing else in the diff is on a hot path: the qubit bound runs once per state
allocation, the arch lookup once per device construction, and the expectation arm is a
match on backend kind.

## Architecture or design changes

- [ ] `docs/architecture/` updated: N/A, no structural change
- [x] `docs/guides/gpu.md` gains a shot-reproducibility section

Reproducibility was pinned rather than only documented. A comment asserting a bitwise
CPU/GPU contract is what created this item, so a corrected comment would not hold the
line on its own. The docs section states both limits and names the test that pins each.

## Breaking changes

Three behavioral differences, all rejections that previously succeeded or silently
degraded:

- `GpuState::new` returns `InvalidParameter` at or above `usize::BITS - 4` qubits.
  Previously 63 allocated a zero-length buffer that the initial-state kernel wrote past,
  and 62 already failed at allocation, so no working call is affected.
- `GpuDevice::new` returns `BackendUnsupported` on a device below compute capability 6.0
  instead of compiling PTX for `compute_60`. Such a device could not have run these
  kernels; the failure moves earlier and names the capability.
- `GpuDevice::new` targets the newest arch at or below the device capability instead of
  `compute_60` for anything unrecognized. On hardware newer than the table this changes
  the generated PTX. The driver JITs forward, so the module still loads.

No public API signature changed.

## Risks and rollback

Blast radius is the `gpu` feature only; nothing here compiles without it.

The arch table is capped at 9.0 deliberately, not for lack of newer entries. Naming
`compute_100` or `compute_120` would fail compilation on a 12.x toolkit, which is a
combination that works today, so the ceiling tracks the pinned `cuda-12040` cudarc
binding and the constant documents raising them together. Clamping a Blackwell device to
`compute_90` is better than the previous `compute_60` in both instruction selection and
NVRTC 13.x compatibility.

The spin bound degrades to the pre-existing `overflow` host count path, which is the same
route table overflow already took, so exceeding it costs time and not correctness.

Rollback is a plain revert. No feature flag or dispatch guard gates any of it separately.

### Hardware coverage

Verified on a GTX 1080 Ti (sm_61, 11 GiB, driver 581.42, toolkit 12.4). That covers every
item except the Blackwell and NVRTC 13.x halves of the arch change, which rest on the
NVRTC support matrix rather than a measurement. No hardware newer than sm_61 is available
here, and VRAM caps the GPU statevector near 27 qubits.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green: not yet run, branch is local
