### PR TITLE
feat(distributed): answer shots, observables, and marginals per rank

### DIFF
--- a/docs/architecture/samplers.md
+++ b/docs/architecture/samplers.md
@@ -57,7 +57,10 @@ draws outcomes from its own representation, and `sample_basis_states(num_shots,
 seed)` returns packed per-qubit outcomes as `BasisSamples`
 (`ceil(n / 64)` words per shot). Seeding is from the argument, not the backend's
 RNG, so a shot request replays exactly, and the call does not collapse the
-state. `supports_pauli_expectation` and `pauli_expectations(observables)` are
+state. It takes `&mut self` because a backend may first have to reorganize its
+own storage: the distributed backend restores its qubit map, a collective, so
+that each rank owns a contiguous slice in circuit order.
+`supports_pauli_expectation` and `pauli_expectations(observables)` are
 the observable-side pair, normalization independent so a truncated MPS is
 divided by `⟨ψ|ψ⟩` rather than assumed unit.
 
@@ -67,6 +70,7 @@ divided by `⟨ψ|ψ⟩` rather than assumed unit.
 | Factored | `O(Σ 2^kᵢ)` once, `O(B log)` per shot | One draw per sub-state, concatenated; `B` blocks |
 | MPS | `O(n·χ³)` once, `O(n·χ²)` per shot | Sequential conditional sampling against precomputed right environments |
 | Product State | `O(n)` once, `O(n)` per shot | One Bernoulli draw per qubit against that qubit's own weight on `1` |
+| Distributed | `O(2^(n-p))` once, `O(log)` per shot | CDF over the rank-local slice; one scalar gathered per rank picks the owner |
 | Everything else | dense | Unchanged: `probabilities()` then CDF |
 
 `run_shots_with` picks the native path through `try_native_terminal_backend`,

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -76,6 +76,7 @@ bounded only by their own representation.
 | MPS | Native, sequential conditional sampling | Native, one chain contraction per observable |
 | Factored | Native, one draw per sub-state | Native, product over the blocks |
 | Product State | Native, one Bernoulli draw per qubit | Native, one closed-form factor per qubit |
+| Distributed Statevector | Native, rank-local CDF plus one scalar per rank | Native, rank-local sandwich plus one `Allreduce` |
 | Statevector | Dense (streams from amplitudes, no probability vector) | Dense |
 | Stabilizer, Factored Stabilizer | Compiled Clifford sampler | Sparse Pauli Dynamics, exact |
 | Stochastic / Deterministic Pauli | Not applicable | Native Pauli propagation |
@@ -89,6 +90,12 @@ distributions agree.
 Backends without an observable path return `BackendUnsupported` naming
 themselves, so a rejected request says which engine could not serve it rather
 than blaming the route that selected it.
+
+`simulate(...).marginals()` is dense everywhere except the distributed backend,
+where it is per-qubit Z expectations and therefore also uncapped.
+`simulate(...).run()` is the one terminal that needs the whole distribution, so
+on the distributed backend it rejects a register past the dense cap up front
+rather than running first and answering with no distribution.
 
 ## Not yet supported
 

--- a/scripts/test-mpi.ps1
+++ b/scripts/test-mpi.ps1
@@ -3,8 +3,10 @@
 # Usage:   powershell -ExecutionPolicy Bypass -File scripts\test-mpi.ps1 [-Ranks 4]
 #
 # Sets up the MPI build environment, builds the lib tests and the mpiexec check
-# binary, then launches it across N ranks. Rank 0 asserts the gathered result
-# matches the one process statevector reference and exits nonzero on mismatch.
+# binary, then launches it across N ranks under three configurations (default,
+# tiled exchange, relabeling off). Rank 0 asserts the gathered result matches
+# the one process statevector reference and exits nonzero on mismatch. A final
+# three rank run asserts the power of two requirement is rejected.
 
 param(
     [int[]] $RankCounts = @(1, 2, 4)
@@ -31,38 +33,61 @@ $exe = Join-Path $scriptDir '..\target\debug\examples\dist_mpi_check.exe'
 $mpiexec = "C:\Program Files\Microsoft MPI\Bin\mpiexec.exe"
 if (-not (Test-Path $mpiexec)) { $mpiexec = "mpiexec" }
 
-# The check circuit is small, so relax the local qubit floor to let it
-# distribute across ranks on a single host.
+# Each configuration is run at every rank count. Results must not depend on
+# either axis: tiling only splits a transfer into more messages, and relabeling
+# only changes which amplitudes move. The check circuit is small, so the local
+# qubit floor is relaxed everywhere to let it distribute on a single host.
+$configs = @(
+    @{ Name = 'default'; Env = @{} },
+    @{ Name = 'tiled-exchange'; Env = @{ 'PRISM_DIST_EXCHANGE_CHUNK' = '4096' } },
+    @{ Name = 'no-relabel'; Env = @{ 'PRISM_DIST_RELABEL' = '0' } }
+)
+
 $measSigs = @{}
 $shotSigs = @{}
 foreach ($n in $RankCounts) {
-    Write-Host "`n== mpiexec -n $n dist_mpi_check =="
-    $out = & $mpiexec -n $n -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe
-    if ($LASTEXITCODE -ne 0) { throw "rank check failed at -n $n" }
-    $out | ForEach-Object { Write-Host $_ }
-    # Capture the measurement signature to confirm it matches across rank counts.
-    $match = $out | Select-String -Pattern 'outcome_sig=(\S+)' | Select-Object -First 1
-    if (-not $match) {
-        throw "measurement signature missing at -n $n"
+    foreach ($cfg in $configs) {
+        $label = "$n/$($cfg.Name)"
+        $envArgs = @('-env', 'PRISM_DIST_MIN_LOCAL_QUBITS', '1')
+        foreach ($key in $cfg.Env.Keys) {
+            $envArgs += @('-env', $key, $cfg.Env[$key])
+        }
+        Write-Host "`n== mpiexec -n $n dist_mpi_check [$($cfg.Name)] =="
+        $out = & $mpiexec -n $n @envArgs $exe
+        if ($LASTEXITCODE -ne 0) { throw "rank check failed at $label" }
+        $out | ForEach-Object { Write-Host $_ }
+        $match = $out | Select-String -Pattern 'outcome_sig=(\S+)' | Select-Object -First 1
+        if (-not $match) {
+            throw "measurement signature missing at $label"
+        }
+        $measSigs[$label] = $match.Matches[0].Groups[1].Value
+        $match = $out | Select-String -Pattern 'shots_sig=(\S+)' | Select-Object -First 1
+        if (-not $match) {
+            throw "shots signature missing at $label"
+        }
+        $shotSigs[$label] = $match.Matches[0].Groups[1].Value
     }
-    $measSigs[$n] = $match.Matches[0].Groups[1].Value
-    $match = $out | Select-String -Pattern 'shots_sig=(\S+)' | Select-Object -First 1
-    if (-not $match) {
-        throw "shots signature missing at -n $n"
-    }
-    $shotSigs[$n] = $match.Matches[0].Groups[1].Value
 }
 
 $unique = $measSigs.Values | Select-Object -Unique
 if ($unique.Count -gt 1) {
-    throw "measurement outcomes differ across rank counts: $($measSigs | Out-String)"
+    throw "measurement outcomes differ across configurations: $($measSigs | Out-String)"
 }
-Write-Host "`nMeasurement determinism: signature $($unique) identical across ranks."
+Write-Host "`nMeasurement determinism: signature $($unique) identical across ranks and configurations."
 
 $uniqueShots = $shotSigs.Values | Select-Object -Unique
 if ($uniqueShots.Count -gt 1) {
-    throw "shot outcomes differ across rank counts: $($shotSigs | Out-String)"
+    throw "shot outcomes differ across configurations: $($shotSigs | Out-String)"
 }
-Write-Host "Shot sampling determinism: signature $($uniqueShots) identical across ranks."
+Write-Host "Shot sampling determinism: signature $($uniqueShots) identical across ranks and configurations."
+
+# The backend requires a power of two rank count. Three ranks must fail loudly
+# under a real launcher, not hang or produce a partial result.
+Write-Host "`n== mpiexec -n 3 dist_mpi_check (expected to fail) =="
+& $mpiexec -n 3 -env PRISM_DIST_MIN_LOCAL_QUBITS 1 $exe | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -eq 0) {
+    throw "a rank count that is not a power of two must fail"
+}
+Write-Host "Rejected as expected (exit $LASTEXITCODE)."
 
 Write-Host "`nAll distributed MPI checks passed."

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -29,9 +29,15 @@
 //!
 //! Measurement, reset, and classical conditionals are supported. Measurement
 //! probabilities are summed with `Allreduce`. Each rank uses the same seeded RNG,
-//! so ranks agree without exchanging the draw. Reset follows the statevector
-//! convention: project onto `|0>`, renormalize, and reinitialize to `|0...0>`
-//! when the zero branch is empty.
+//! so ranks agree without exchanging the draw. Reset runs one trajectory of the
+//! reset channel, as [`Backend::reset`] specifies: sample the outcome, collapse
+//! onto it, and apply X when it is 1.
+//!
+//! Per-qubit probabilities and Pauli expectation values answer from rank-local
+//! sums plus one `Allreduce`, at any register width. `probabilities` and
+//! `export_statevector` are the only queries that gather, so they carry the
+//! dense output cap; `Simulate::run` rejects a beyond-cap register before the
+//! run rather than returning no distribution after it.
 //!
 //! # When to prefer this backend
 //!
@@ -97,9 +103,9 @@
 //! Circuits whose measurements are terminal sample shots without gathering the
 //! dense state or probability vector on any rank; communication scales with
 //! the rank count and shot count, never with the state size. See
-//! [`DistributedStatevectorBackend::sample_state_indices`] for the algorithm.
-//! Circuits with mid-circuit measurements fall back to one lockstep run per
-//! shot.
+//! [`DistributedStatevectorBackend::sample_state_indices`] for the algorithm,
+//! which [`Backend::sample_basis_states`] exposes at the trait level. Circuits
+//! with mid-circuit measurements fall back to one lockstep run per shot.
 //!
 //! Not implemented yet: lookahead epoch planning that batches several relabels
 //! into one exchange.
@@ -116,11 +122,14 @@ use rand_chacha::ChaCha8Rng;
 
 use crate::backend::simd;
 use crate::backend::statevector::StatevectorBackend;
-use crate::backend::{Backend, dense_probability_len, dense_statevector_len, measurement_inv_norm};
+use crate::backend::{
+    Backend, BasisSamples, dense_probability_len, dense_statevector_len, measurement_inv_norm,
+};
 use crate::circuit::{Instruction, SmallVec, smallvec};
 use crate::distributed::DistributedContext;
 use crate::error::{PrismError, Result};
 use crate::gates::{DiagEntry, Gate, is_diagonal_2x2};
+use crate::sim::unified_pauli::PauliTerm;
 
 const BACKEND_NAME: &str = "distributed_statevector";
 
@@ -300,7 +309,9 @@ impl DistributedStatevectorBackend {
     /// Number of `sendrecv` messages this rank has issued since `init`.
     ///
     /// Cost proxy for this backend. One host cannot measure real network
-    /// latency, so routing changes are evaluated against this count.
+    /// latency, so routing changes are evaluated against this count. Counts
+    /// gate and relabel exchanges; the query paths take `&self` and cannot
+    /// record theirs.
     pub fn exchange_messages(&self) -> u64 {
         self.exchange_messages
     }
@@ -582,6 +593,59 @@ impl DistributedStatevectorBackend {
         let mut all = true;
         for_each_gate_qubit(gate, targets, |q| all &= q < local);
         all
+    }
+
+    /// Fingerprint of every setting the collective sequence assumes is shared.
+    /// Rank id and rank count are excluded; they legitimately differ. Folded to
+    /// 53 bits so it survives the `f64` collectives exactly.
+    fn config_fingerprint(&self, num_qubits: usize, num_classical_bits: usize) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::hash::DefaultHasher::new();
+        (
+            self.seed,
+            self.exchange_chunk,
+            self.relabel,
+            crate::distributed::min_local_qubits(),
+            num_qubits,
+            num_classical_bits,
+        )
+            .hash(&mut hasher);
+        hasher.finish() >> 11
+    }
+
+    /// Reject a run whose ranks disagree about anything the collective sequence
+    /// depends on.
+    ///
+    /// Without this the mismatch surfaces as a hang (a diverging collective
+    /// order) or as silently wrong amplitudes (measurement branches drawn from
+    /// different seeds), both far from the setting that caused them.
+    fn check_config_agreement(&self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        let local = self.config_fingerprint(num_qubits, num_classical_bits) as f64;
+        let all = self.context.comm().allgather_f64(&[local]);
+        match all.iter().position(|&other| other != local) {
+            None => Ok(()),
+            Some(other) => Err(PrismError::BackendUnsupported {
+                backend: BACKEND_NAME.to_string(),
+                operation: format!(
+                    "configuration on rank {} differs from rank {other}: seed, relabel mode, \
+                     exchange chunk, local qubit floor, and register shape must be identical \
+                     on every rank",
+                    self.context.rank()
+                ),
+            }),
+        }
+    }
+
+    /// Translate a circuit-qubit bit mask into physical positions.
+    fn to_physical_mask(&self, mask: usize) -> usize {
+        if self.map_identity {
+            return mask;
+        }
+        let mut out = 0usize;
+        for (q, &pos) in self.qubit_map.iter().enumerate() {
+            out |= ((mask >> q) & 1) << pos;
+        }
+        out
     }
 
     /// Reorder a gathered dense vector from physical to circuit qubit order.
@@ -1210,7 +1274,9 @@ impl DistributedStatevectorBackend {
         self.restore_identity_map();
         debug_assert!(self.map_identity);
 
-        let mut local_cdf = self.inner.probabilities()?;
+        // The rank-local CDF is a working buffer half the size of the slice
+        // this rank already holds, so the dense output cap does not gate it.
+        let mut local_cdf = self.inner.host_probability_vector();
         let mut acc = 0.0f64;
         for p in &mut local_cdf {
             acc += *p;
@@ -1369,6 +1435,12 @@ impl Backend for DistributedStatevectorBackend {
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
         let size = self.context.size();
+        // Before the local validations: those read `num_qubits`, so ranks given
+        // different circuits could disagree about whether to reject and leave
+        // one side alone at the next collective.
+        if size > 1 {
+            self.check_config_agreement(num_qubits, num_classical_bits)?;
+        }
         if !size.is_power_of_two() {
             return Err(PrismError::BackendUnsupported {
                 backend: BACKEND_NAME.to_string(),
@@ -1412,8 +1484,11 @@ impl Backend for DistributedStatevectorBackend {
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         match instruction {
             // Measurement routes through the distributed path even at a single
-            // rank, so `meas_rng` is the sole measurement RNG and outcomes
-            // match across every rank count for a given seed.
+            // rank, so `meas_rng` is the sole measurement RNG and one seed
+            // draws one outcome stream. Outcomes then agree across rank counts
+            // except where the `Allreduce` association order moves a summed
+            // probability across the drawn value, the caveat
+            // `sample_state_indices` documents for the same reason.
             Instruction::Measure {
                 qubit,
                 classical_bit,
@@ -1468,6 +1543,87 @@ impl Backend for DistributedStatevectorBackend {
 
     fn qubit_probability(&self, qubit: usize) -> Result<f64> {
         Ok(self.prob_one_global(self.physical_qubit(qubit)))
+    }
+
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Trait-level entry to [`DistributedStatevectorBackend::sample_state_indices`],
+    /// so a caller holding a `dyn Backend` gets the same rank-local draw the
+    /// shot route takes instead of falling back to the dense vector.
+    ///
+    /// Collective: every rank must call it with identical `num_shots` and
+    /// `seed`.
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let indices = self.sample_state_indices(num_shots, seed)?;
+        let mut samples = BasisSamples::new(num_shots, self.num_qubits);
+        for (shot, &index) in indices.iter().enumerate() {
+            samples.set_index(shot, index as usize);
+        }
+        Ok(samples)
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// Evaluate each observable on the sharded state with no dense gather.
+    ///
+    /// A Z factor on a rank bit is a constant sign for the whole slice, so an
+    /// observable whose X and Y factors are all local costs one `Allreduce` and
+    /// no transfer. X and Y factors on rank bits displace the bra by the same
+    /// rank offset for every amplitude, so however many there are they name one
+    /// partner rank, and one slice exchange covers them. That is the direct
+    /// route rather than a relabel because relabeling mutates the state, which
+    /// a `&self` query cannot do.
+    ///
+    /// Collective: every rank must call it with identical observables.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let comm = self.context.comm();
+        let norm = comm.allreduce_sum_f64(crate::backend::state_norm_sqr(&self.inner.state));
+        let local_qubits = self.local_qubits();
+        let local_mask = (1usize << local_qubits) - 1;
+        let mut recv: Vec<Complex64> = Vec::new();
+
+        let mut values = Vec::with_capacity(observables.len());
+        for observable in observables {
+            let (xmask, zmask, num_y) = crate::sim::pauli_masks(observable, self.num_qubits)?;
+            let xphys = self.to_physical_mask(xmask);
+            let zphys = self.to_physical_mask(zmask);
+            let partner_bits = xphys >> local_qubits;
+            if partner_bits != 0 {
+                recv.resize(self.inner.state.len(), Complex64::new(0.0, 0.0));
+                comm.sendrecv_c64(
+                    self.context.rank() ^ partner_bits,
+                    &self.inner.state,
+                    &mut recv,
+                );
+            }
+            let bra: &[Complex64] = if partner_bits == 0 {
+                &self.inner.state
+            } else {
+                &recv
+            };
+            let sandwich = crate::sim::pauli_sandwich(
+                bra,
+                &self.inner.state,
+                xphys & local_mask,
+                zphys & local_mask,
+                num_y,
+            );
+            let rank_parity = (self.context.rank() & (zphys >> local_qubits)).count_ones() & 1;
+            let signed = if rank_parity == 1 {
+                -sandwich.re
+            } else {
+                sandwich.re
+            };
+            // The total is real, so summing the per-rank real parts loses
+            // nothing even where a rank's own term is not.
+            let total = comm.allreduce_sum_f64(signed);
+            values.push(if norm == 0.0 { 0.0 } else { total / norm });
+        }
+        Ok(values)
     }
 
     fn reset(&mut self, qubit: usize) -> Result<()> {

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -3,208 +3,30 @@ use crate::backend::Backend;
 use crate::backend::statevector::StatevectorBackend;
 use crate::circuit::Circuit;
 use crate::circuit::builder::CircuitBuilder;
-use crate::distributed::{DistributedContext, RankComm};
+use crate::distributed::DistributedContext;
+use crate::distributed::loopback::{run_ranks, run_ranks_max_gather};
 use crate::sim::run_on;
+use crate::sim::unified_pauli::PauliTerm;
 use num_complex::Complex64;
-use std::collections::VecDeque;
-use std::sync::{Arc, Condvar, Mutex};
 
 const SEED: u64 = 42;
 const TOL: f64 = 1e-10;
 
-/// Test transport that simulates ranks with threads.
-///
-/// This covers global gate exchange without an MPI launcher. Each rank runs the
-/// same circuit and reaches collectives in the same order.
-struct LoopbackShared {
-    size: usize,
-    state: Mutex<LoopbackState>,
-    cv: Condvar,
-}
-
-struct LoopbackState {
-    generation: u64,
-    arrived: usize,
-    cslots: Vec<Vec<Complex64>>,
-    fslots: Vec<f64>,
-    reduce: Vec<f64>,
-    // Largest block sent by a rank to allgather. Shot sampling tests
-    // assert this stays at one element, proving no dense gather happened.
-    max_gather_block: usize,
-    // Mailboxes indexed by `sender * size + receiver`. FIFO order matches MPI
-    // sendrecv order and stays separate from collective barriers.
-    mailbox: Vec<VecDeque<Vec<Complex64>>>,
-}
-
-impl LoopbackShared {
-    fn new(size: usize) -> Arc<Self> {
-        Arc::new(Self {
-            size,
-            state: Mutex::new(LoopbackState {
-                generation: 0,
-                arrived: 0,
-                cslots: vec![Vec::new(); size],
-                fslots: vec![0.0; size],
-                reduce: Vec::new(),
-                max_gather_block: 0,
-                mailbox: (0..size * size).map(|_| VecDeque::new()).collect(),
-            }),
-            cv: Condvar::new(),
-        })
-    }
-
-    fn barrier(&self) {
-        let mut st = self.state.lock().unwrap();
-        let arrival_generation = st.generation;
-        st.arrived += 1;
-        if st.arrived == self.size {
-            st.arrived = 0;
-            st.generation = st.generation.wrapping_add(1);
-            self.cv.notify_all();
-        } else {
-            while st.generation == arrival_generation {
-                st = self.cv.wait(st).unwrap();
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
-struct LoopbackComm {
-    shared: Arc<LoopbackShared>,
-    rank: usize,
-}
-
-impl std::fmt::Debug for LoopbackComm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LoopbackComm")
-            .field("rank", &self.rank)
-            .field("size", &self.shared.size)
-            .finish()
-    }
-}
-
-impl RankComm for LoopbackComm {
-    fn rank(&self) -> usize {
-        self.rank
-    }
-
-    fn size(&self) -> usize {
-        self.shared.size
-    }
-
-    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
-        {
-            let mut st = self.shared.state.lock().unwrap();
-            st.max_gather_block = st.max_gather_block.max(local.len());
-            st.cslots[self.rank] = local.to_vec();
-        }
-        self.shared.barrier();
-        let out = {
-            let st = self.shared.state.lock().unwrap();
-            st.cslots.iter().flat_map(|s| s.iter().copied()).collect()
-        };
-        self.shared.barrier();
-        out
-    }
-
-    fn allgather_f64(&self, local: &[f64]) -> Vec<f64> {
-        let as_c: Vec<Complex64> = local.iter().map(|&v| Complex64::new(v, 0.0)).collect();
-        self.allgather_c64(&as_c).iter().map(|c| c.re).collect()
-    }
-
-    fn allreduce_sum_f64(&self, value: f64) -> f64 {
-        {
-            let mut st = self.shared.state.lock().unwrap();
-            st.fslots[self.rank] = value;
-        }
-        self.shared.barrier();
-        let sum = {
-            let st = self.shared.state.lock().unwrap();
-            st.fslots.iter().sum()
-        };
-        self.shared.barrier();
-        sum
-    }
-
-    fn allreduce_sum_f64_slice(&self, values: &mut [f64]) {
-        {
-            let mut st = self.shared.state.lock().unwrap();
-            if st.reduce.len() != values.len() {
-                st.reduce = vec![0.0; values.len()];
-            }
-            for (acc, &v) in st.reduce.iter_mut().zip(values.iter()) {
-                *acc += v;
-            }
-        }
-        self.shared.barrier();
-        {
-            let st = self.shared.state.lock().unwrap();
-            values.copy_from_slice(&st.reduce);
-        }
-        self.shared.barrier();
-        if self.rank == 0 {
-            let mut st = self.shared.state.lock().unwrap();
-            st.reduce.clear();
-        }
-        self.shared.barrier();
-    }
-
-    fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
-        debug_assert_eq!(send.len(), recv.len());
-        let size = self.shared.size;
-        let mut st = self.shared.state.lock().unwrap();
-        // Send to partner, then wait for partner to send back. Ranks that skip
-        // an exchange do not block because their partner skips it too.
-        st.mailbox[self.rank * size + partner].push_back(send.to_vec());
-        self.shared.cv.notify_all();
-        let inbox = partner * size + self.rank;
-        loop {
-            if let Some(msg) = st.mailbox[inbox].pop_front() {
-                recv.copy_from_slice(&msg);
-                return;
-            }
-            st = self.shared.cv.wait(st).unwrap();
-        }
-    }
-
-    fn barrier(&self) {
-        self.shared.barrier();
-    }
-}
-
 /// Run `circuit` across simulated ranks with the given backend configuration
 /// and return rank 0's probabilities.
 fn loopback_probs_with(circuit: &Circuit, size: usize, chunk: usize, relabel: bool) -> Vec<f64> {
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                    backend.set_exchange_chunk(chunk);
-                    backend.set_relabel(relabel);
-                    run_on(&mut backend, &circuit)
-                        .expect("distributed run")
-                        .probabilities
-                        .expect("probabilities")
-                        .to_vec()
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let mut results: Vec<Vec<f64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
     // Every rank holds the same gathered vector.
-    let first = results.swap_remove(0);
-    results.clear();
-    first
+    run_ranks(size, |ctx| {
+        let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+        backend.set_exchange_chunk(chunk);
+        backend.set_relabel(relabel);
+        run_on(&mut backend, circuit)
+            .expect("distributed run")
+            .probabilities
+            .expect("probabilities")
+            .to_vec()
+    })
+    .swap_remove(0)
 }
 
 fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
@@ -230,32 +52,14 @@ fn assert_loopback_matches(circuit: &Circuit, sizes: &[usize]) {
 /// Run `circuit` across simulated ranks and return rank 0's probabilities and
 /// classical bits.
 fn loopback_run_with(circuit: &Circuit, size: usize, relabel: bool) -> (Vec<f64>, Vec<bool>) {
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                    backend.set_relabel(relabel);
-                    let out = run_on(&mut backend, &circuit).expect("distributed run");
-                    let probs = out.probabilities.expect("probabilities").to_vec();
-                    (probs, out.classical_bits)
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let mut results: Vec<(Vec<f64>, Vec<bool>)> =
-        handles.into_iter().map(|h| h.join().unwrap()).collect();
-    let first = results.swap_remove(0);
-    results.clear();
-    first
+    run_ranks(size, |ctx| {
+        let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+        backend.set_relabel(relabel);
+        let out = run_on(&mut backend, circuit).expect("distributed run");
+        let probs = out.probabilities.expect("probabilities").to_vec();
+        (probs, out.classical_bits)
+    })
+    .swap_remove(0)
 }
 
 fn loopback_run(circuit: &Circuit, size: usize) -> (Vec<f64>, Vec<bool>) {
@@ -508,30 +312,14 @@ fn loopback_export_statevector_after_swap() {
     sv.apply_instructions(&circuit.instructions).unwrap();
     let expected = sv.export_statevector().unwrap();
 
-    let size = 4;
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                    backend
-                        .init(circuit.num_qubits, circuit.num_classical_bits)
-                        .unwrap();
-                    backend.apply_instructions(&circuit.instructions).unwrap();
-                    backend.export_statevector().unwrap()
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let results: Vec<Vec<Complex64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let results = run_ranks(4, |ctx| {
+        let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+        backend
+            .init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        backend.apply_instructions(&circuit.instructions).unwrap();
+        backend.export_statevector().unwrap()
+    });
     for actual in &results {
         assert_eq!(expected.len(), actual.len());
         for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
@@ -663,6 +451,75 @@ fn loopback_mixed_circuit_qft_like() {
 // in `circuit::fusion`. The reference statevector fuses identically, so a
 // match confirms the distributed backend decomposes each fused or batched
 // variant correctly.
+
+// Eight ranks put three qubits in the rank id, so the four-rank group
+// `apply_2q_two_global` gathers is a strict subset of the world for the first
+// time, and a gate can name more rank bits than that group holds.
+
+#[test]
+fn loopback_eight_ranks_fused_2q_on_two_rank_bits() {
+    relax_min_local_qubits();
+    let n = 12;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    b.ry(0.6, n - 2)
+        .rz(0.3, n - 1)
+        .cx(n - 2, n - 1)
+        .ry(-0.4, n - 1);
+    assert_loopback_matches(&b.build(), &[8]);
+}
+
+#[test]
+fn loopback_eight_ranks_mcu_spans_three_rank_bits() {
+    relax_min_local_qubits();
+    let x = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let n = 6;
+    let mut b = CircuitBuilder::new(n);
+    for q in 0..n {
+        b.h(q);
+    }
+    b.rx(0.4, n - 1).mcu(x, &[n - 3, n - 2], n - 1);
+    assert_loopback_matches(&b.build(), &[8]);
+}
+
+#[test]
+fn serial_measured_circuit_matches_statevector_bit_for_bit() {
+    // One rank shares the dense backend's measurement stream, so the outcomes
+    // must agree exactly, not just in distribution.
+    let n = 5;
+    let mut b = CircuitBuilder::new_with_classical(n, n);
+    b.h(0).ry(0.7, 1).h(2).rx(1.1, 3).h(4);
+    for q in 0..n - 1 {
+        b.cx(q, q + 1);
+    }
+    for q in 0..n {
+        b.measure(q, q);
+    }
+    let mut circuit = b.build();
+    circuit.add_reset(2);
+
+    let mut sv = StatevectorBackend::new(SEED);
+    let expected = run_on(&mut sv, &circuit).expect("statevector run");
+
+    let mut dist = DistributedStatevectorBackend::new(DistributedContext::serial(), SEED);
+    let actual = run_on(&mut dist, &circuit).expect("distributed run");
+
+    assert_eq!(
+        expected.classical_bits, actual.classical_bits,
+        "single rank must reproduce the dense measurement outcomes"
+    );
+    let expected = expected.probabilities.expect("probabilities").to_vec();
+    let actual = actual.probabilities.expect("probabilities").to_vec();
+    assert_eq!(expected.len(), actual.len());
+    for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+        assert!((e - a).abs() < 1e-12, "prob[{i}] expected {e}, got {a}");
+    }
+}
 
 #[test]
 fn loopback_fused_multifused_and_2q() {
@@ -944,14 +801,13 @@ fn loopback_tiled_exchange_matches_full() {
 fn exchange_counters_track_communication() {
     relax_min_local_qubits();
     // A single rank keeps every qubit local, so no gate exchanges.
-    let ctx = DistributedContext::from_comm(Arc::new(LoopbackComm {
-        shared: LoopbackShared::new(1),
-        rank: 0,
-    }));
-    let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
-    dist.init(4, 0).unwrap();
-    dist.apply(&inst_h(3)).unwrap();
-    assert_eq!(dist.exchange_messages(), 0, "single rank never exchanges");
+    let messages = run_ranks(1, |ctx| {
+        let mut dist = DistributedStatevectorBackend::new(ctx, SEED);
+        dist.init(4, 0).unwrap();
+        dist.apply(&inst_h(3)).unwrap();
+        dist.exchange_messages()
+    });
+    assert_eq!(messages[0], 0, "single rank never exchanges");
 
     // At 2 ranks qubit 3 is global and the local slice is 8 amplitudes. The
     // diagonal Z and Rz are free. Direct mode exchanges the full slice per H.
@@ -1064,34 +920,17 @@ fn loopback_exchange_stats(
     chunk: usize,
     relabel: bool,
 ) -> (u64, u64) {
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                    backend.set_exchange_chunk(chunk);
-                    backend.set_relabel(relabel);
-                    backend
-                        .init(circuit.num_qubits, circuit.num_classical_bits)
-                        .unwrap();
-                    backend.apply_instructions(&circuit.instructions).unwrap();
-                    (backend.exchange_messages(), backend.exchange_amplitudes())
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let mut results: Vec<(u64, u64)> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-    let first = results.swap_remove(0);
-    results.clear();
-    first
+    run_ranks(size, |ctx| {
+        let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+        backend.set_exchange_chunk(chunk);
+        backend.set_relabel(relabel);
+        backend
+            .init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        backend.apply_instructions(&circuit.instructions).unwrap();
+        (backend.exchange_messages(), backend.exchange_amplitudes())
+    })
+    .swap_remove(0)
 }
 
 #[test]
@@ -1110,29 +949,12 @@ fn loopback_shots(
     size: usize,
     num_shots: usize,
 ) -> (Vec<Vec<Vec<bool>>>, usize) {
-    let shared = LoopbackShared::new(size);
-    let handles: Vec<_> = (0..size)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::Builder::new()
-                .stack_size(64 * 1024 * 1024)
-                .spawn(move || {
-                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                    let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
-                    crate::sim::run_shots_with(kind, &circuit, num_shots, SEED)
-                        .expect("distributed shots")
-                        .shots
-                })
-                .expect("spawn rank thread")
-        })
-        .collect();
-    let results: Vec<Vec<Vec<bool>>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-    let max_gather = shared.state.lock().unwrap().max_gather_block;
-    (results, max_gather)
+    run_ranks_max_gather(size, |ctx| {
+        let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
+        crate::sim::run_shots_with(kind, circuit, num_shots, SEED)
+            .expect("distributed shots")
+            .shots
+    })
 }
 
 /// Sample shots through the production dense sampler, so the comparison
@@ -1285,29 +1107,210 @@ fn noisy_shots_rejected_on_distributed_kind() {
 fn shots_without_measurements_still_validate_configuration() {
     relax_min_local_qubits();
     // Three ranks is not a power of two; the error must surface even though a
-    // circuit without measurements needs no execution to produce all false shots.
-    // The init failure happens before any collective, so ranks do not block.
+    // circuit without measurements needs no execution to produce all false
+    // shots. Every rank reaches the same rejection, so none blocks.
     let circuit = Circuit::new(4, 0);
-    let shared = LoopbackShared::new(3);
-    let handles: Vec<_> = (0..3)
-        .map(|rank| {
-            let comm = LoopbackComm {
-                shared: shared.clone(),
-                rank,
-            };
-            let circuit = circuit.clone();
-            std::thread::spawn(move || {
-                let ctx = DistributedContext::from_comm(Arc::new(comm));
-                let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
-                crate::sim::run_shots_with(kind, &circuit, 8, SEED).is_err()
-            })
-        })
-        .collect();
-    for handle in handles {
+    let failed = run_ranks(3, |ctx| {
+        let kind = crate::sim::BackendKind::StatevectorDistributed { context: ctx };
+        crate::sim::run_shots_with(kind, &circuit, 8, SEED).is_err()
+    });
+    assert!(
+        failed.iter().all(|&f| f),
+        "non power of two rank count must error"
+    );
+}
+
+// A caller holding a `dyn Backend` must reach the rank-local sampler. Before
+// the override it saw `supports_native_sampling() == false` and fell back to
+// the dense probability vector.
+#[test]
+fn trait_sampling_draws_natively_across_rank_counts() {
+    relax_min_local_qubits();
+    let n = 4;
+    let shots = 32;
+    let mut circuit = Circuit::new(n, n);
+    for q in 0..n {
+        circuit.add_gate(crate::gates::Gate::H, &[q]);
+    }
+    circuit.add_gate(crate::gates::Gate::Cx, &[0, n - 1]);
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    let stripped = circuit.without_measurements();
+    let expected = dense_reference_shots(&circuit, shots);
+
+    for size in [1usize, 2, 4] {
+        let (per_rank, max_gather) = run_ranks_max_gather(size, |ctx| {
+            let mut backend: Box<dyn Backend> =
+                Box::new(DistributedStatevectorBackend::new(ctx, SEED));
+            assert!(
+                backend.supports_native_sampling(),
+                "the trait must advertise the native sampler"
+            );
+            backend
+                .init(stripped.num_qubits, stripped.num_classical_bits)
+                .expect("init");
+            backend
+                .apply_instructions(&stripped.instructions)
+                .expect("apply");
+            let samples = backend
+                .sample_basis_states(shots, SEED)
+                .expect("native sampling");
+            (0..shots)
+                .map(|shot| (0..n).map(|q| samples.bit(shot, q)).collect::<Vec<bool>>())
+                .collect::<Vec<Vec<bool>>>()
+        });
+        for shots in &per_rank {
+            assert_eq!(shots, &expected, "size {size}");
+        }
         assert!(
-            handle.join().unwrap(),
-            "non power of two rank count must error"
+            max_gather <= 1,
+            "size {size}: the trait sampler must not gather a dense block"
         );
+    }
+}
+
+// Observables that put X or Y on a rank bit are the case needing an exchange;
+// Z on a rank bit is a per-rank sign. The SWAP leaves the qubit map permuted,
+// so the masks must be read through it.
+#[test]
+fn pauli_expectations_match_the_dense_route_across_rank_counts() {
+    relax_min_local_qubits();
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    b.h(0).ry(0.7, 1).rx(1.1, 2).h(3).ry(-0.5, 4);
+    b.cx(0, 4).cz(1, 3).swap(2, 4).cx(3, 2);
+    b.rz(0.3, 4).ry(0.9, 0);
+    let circuit = b.build();
+
+    let observables = vec![
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::z(n - 1)],
+        vec![PauliTerm::z(0), PauliTerm::z(n - 1)],
+        vec![PauliTerm::x(n - 1)],
+        vec![PauliTerm::y(n - 1)],
+        vec![PauliTerm::x(n - 2), PauliTerm::y(n - 1)],
+        vec![PauliTerm::x(0), PauliTerm::y(2), PauliTerm::z(n - 1)],
+        vec![PauliTerm::y(1), PauliTerm::x(n - 1)],
+    ];
+    let expected =
+        crate::sim::run_expectation_values(&circuit, &observables, SEED).expect("dense reference");
+
+    for &relabel in &[true, false] {
+        for size in [1usize, 2, 4] {
+            let (per_rank, max_gather) = run_ranks_max_gather(size, |ctx| {
+                let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                backend.set_relabel(relabel);
+                backend
+                    .init(circuit.num_qubits, circuit.num_classical_bits)
+                    .expect("init");
+                backend
+                    .apply_instructions(&circuit.instructions)
+                    .expect("apply");
+                backend
+                    .pauli_expectations(&observables)
+                    .expect("distributed expectations")
+            });
+            for values in &per_rank {
+                assert_eq!(values.len(), expected.len());
+                for (i, (e, a)) in expected.iter().zip(values.iter()).enumerate() {
+                    assert!(
+                        (e - a).abs() < 1e-12,
+                        "size {size} relabel {relabel}: observable {i} expected {e}, got {a}"
+                    );
+                }
+            }
+            assert!(
+                max_gather <= 1,
+                "size {size} relabel {relabel}: expectations must not gather a dense block"
+            );
+        }
+    }
+
+    // The public terminal rejected this backend outright before the override.
+    for values in run_ranks(4, |ctx| {
+        crate::simulate(&circuit)
+            .distributed(ctx)
+            .seed(SEED)
+            .expectation_values(&observables)
+            .expect("distributed expectation values")
+    }) {
+        for (i, (e, a)) in expected.iter().zip(values.iter()).enumerate() {
+            assert!(
+                (e - a).abs() < 1e-12,
+                "observable {i} expected {e}, got {a}"
+            );
+        }
+    }
+}
+
+// Marginals come from per-qubit Z expectations, so no rank builds the 2^n
+// vector the dense route allgathers.
+#[test]
+fn loopback_marginals_match_the_dense_route_without_gathering() {
+    relax_min_local_qubits();
+    let n = 5;
+    let mut b = CircuitBuilder::new(n);
+    b.h(0).ry(0.4, 1).rx(0.9, 2).h(3).ry(1.3, 4);
+    b.cx(0, 1).cz(2, 4).swap(1, 4).cx(3, 0);
+    let circuit = b.build();
+
+    let expected = crate::sim::Probabilities::Dense(reference_probs(&circuit)).marginals();
+
+    for size in [1usize, 2, 4] {
+        let (per_rank, max_gather) = run_ranks_max_gather(size, |ctx| {
+            crate::simulate(&circuit)
+                .distributed(ctx)
+                .seed(SEED)
+                .marginals()
+                .expect("distributed marginals")
+                .into_vec()
+        });
+        for actual in &per_rank {
+            assert_eq!(actual.len(), expected.len());
+            for (q, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
+                assert!(
+                    (e.0 - a.0).abs() < 1e-12 && (e.1 - a.1).abs() < 1e-12,
+                    "size {size}: qubit {q} expected {e:?}, got {a:?}"
+                );
+            }
+        }
+        assert!(
+            max_gather <= 1,
+            "size {size}: marginals must not gather a dense block"
+        );
+    }
+}
+
+// A rank whose configuration differs from the others desynchronizes the
+// collective sequence, which surfaces as a hang or as diverging measurement
+// branches. `init` has to name the mismatch instead.
+#[test]
+fn mismatched_rank_configuration_is_rejected_at_init() {
+    relax_min_local_qubits();
+    let mut b = CircuitBuilder::new_with_classical(4, 1);
+    b.h(0).cx(0, 3).measure(3, 0);
+    let circuit = b.build();
+
+    let odd_seed = run_ranks(2, |ctx| {
+        let seed = if ctx.rank() == 1 { SEED + 1 } else { SEED };
+        let mut backend = DistributedStatevectorBackend::new(ctx, seed);
+        run_on(&mut backend, &circuit).map(|_| ()).unwrap_err()
+    });
+    let odd_relabel = run_ranks(2, |ctx| {
+        let mut backend = DistributedStatevectorBackend::new(ctx.clone(), SEED);
+        backend.set_relabel(ctx.rank() != 1);
+        run_on(&mut backend, &circuit).map(|_| ()).unwrap_err()
+    });
+
+    for err in odd_seed.iter().chain(odd_relabel.iter()) {
+        match err {
+            crate::error::PrismError::BackendUnsupported { operation, .. } => assert!(
+                operation.contains("must be identical on every rank"),
+                "expected a configuration mismatch, got {operation}"
+            ),
+            other => panic!("expected a configuration mismatch, got {other:?}"),
+        }
     }
 }
 
@@ -1347,30 +1350,16 @@ fn loopback_apply_1q_matrix_all_qubit_splits() {
 
             for &relabel in &[true, false] {
                 for &size in &[1usize, 2, 4] {
-                    let shared = LoopbackShared::new(size);
-                    let handles: Vec<_> = (0..size)
-                        .map(|rank| {
-                            let comm = LoopbackComm {
-                                shared: shared.clone(),
-                                rank,
-                            };
-                            let prep = prep.clone();
-                            std::thread::Builder::new()
-                                .stack_size(64 * 1024 * 1024)
-                                .spawn(move || {
-                                    let ctx = DistributedContext::from_comm(Arc::new(comm));
-                                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
-                                    backend.set_relabel(relabel);
-                                    backend.init(n, 0).unwrap();
-                                    backend.apply_instructions(&prep.instructions).unwrap();
-                                    backend.apply_1q_matrix(target, &matrix).unwrap();
-                                    backend.export_statevector().unwrap()
-                                })
-                                .expect("spawn rank thread")
-                        })
-                        .collect();
+                    let results = run_ranks(size, |ctx| {
+                        let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                        backend.set_relabel(relabel);
+                        backend.init(n, 0).unwrap();
+                        backend.apply_instructions(&prep.instructions).unwrap();
+                        backend.apply_1q_matrix(target, &matrix).unwrap();
+                        backend.export_statevector().unwrap()
+                    });
 
-                    for actual in handles.into_iter().map(|h| h.join().unwrap()) {
+                    for actual in results {
                         assert_eq!(expected.len(), actual.len());
                         for (i, (e, a)) in expected.iter().zip(actual.iter()).enumerate() {
                             assert!(

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -793,7 +793,7 @@ impl Backend for FactoredBackend {
     ///
     /// Blocks are visited in slot order and each consumes one draw per shot,
     /// which is the order and the count the dense factored sampler uses.
-    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
         let blocks: Vec<(Vec<f64>, &[usize])> = self
             .substates
             .iter()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -407,7 +407,12 @@ pub trait Backend {
     /// Seeded from `seed` alone rather than from the backend's own RNG, so a
     /// shot request replays exactly. Does not collapse the state. The default
     /// reports that the backend has no native sampler.
-    fn sample_basis_states(&self, _num_shots: usize, _seed: u64) -> Result<BasisSamples> {
+    ///
+    /// Takes `&mut self` because a backend may have to reorganize its own
+    /// storage before it can draw: the distributed backend restores its qubit
+    /// map, which is a collective. The represented state is unchanged either
+    /// way.
+    fn sample_basis_states(&mut self, _num_shots: usize, _seed: u64) -> Result<BasisSamples> {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
             operation: "native basis-state sampling".to_string(),

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -2034,7 +2034,7 @@ impl Backend for MpsBackend {
     /// Sites are visited left to right and each bit is recorded against the
     /// logical qubit currently hosted there, so a layout permuted by SWAP
     /// routing needs no canonicalization pass.
-    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
         let n = self.num_qubits;
         let mut samples = BasisSamples::new(num_shots, n);
         if n == 0 {

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -255,7 +255,7 @@ impl Backend for ProductStateBackend {
     /// Qubits are independent, so a shot is `n` Bernoulli draws on the
     /// per-qubit `|β|²` rather than one draw from a `2^n` CDF: `O(shots·n)`
     /// with the probabilities computed once up front.
-    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
         let prob_one: Vec<f64> = self
             .qubits
             .iter()

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -541,7 +541,7 @@ impl Backend for SparseBackend {
     /// Entries are ordered by basis index, which is the order the dense route
     /// accumulates its CDF in, so the same seed draws the same basis states
     /// the dense path would have drawn.
-    fn sample_basis_states(&self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
         let mut indices: Vec<usize> = self.state.keys().copied().collect();
         indices.sort_unstable();
         let probs: Vec<f64> = indices

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -476,6 +476,41 @@ impl StatevectorBackend {
         self.pending_norm * self.pending_norm
     }
 
+    /// Probabilities of the host state, skipping the dense-output cap.
+    ///
+    /// For a caller whose vector is a working buffer sized by a state it
+    /// already holds, where the output cap does not apply: the distributed
+    /// backend builds its rank-local sampling CDF from its own slice. Anything
+    /// handing the vector back to a user goes through
+    /// [`probabilities`](crate::backend::Backend::probabilities).
+    pub(crate) fn host_probability_vector(&self) -> Vec<f64> {
+        let norm_sq = self.probability_scale();
+        let mut probs = vec![0.0_f64; self.state.len()];
+
+        #[cfg(feature = "parallel")]
+        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            let src_chunks = self.state.par_chunks(MIN_PAR_ELEMS);
+            let dst_chunks = probs.par_chunks_mut(MIN_PAR_ELEMS);
+            if norm_sq == 1.0 {
+                src_chunks.zip(dst_chunks).for_each(|(s, d)| {
+                    simd::norm_sqr_to_slice(s, d);
+                });
+            } else {
+                src_chunks.zip(dst_chunks).for_each(|(s, d)| {
+                    simd::norm_sqr_to_slice_scaled(s, d, norm_sq);
+                });
+            }
+            return probs;
+        }
+
+        if norm_sq == 1.0 {
+            simd::norm_sqr_to_slice(&self.state, &mut probs);
+        } else {
+            simd::norm_sqr_to_slice_scaled(&self.state, &mut probs, norm_sq);
+        }
+        probs
+    }
+
     /// Whether the amplitudes live in device memory. When true, the host
     /// `state_vector()` slice is empty; read the state through
     /// [`probabilities`](crate::backend::Backend::probabilities) or
@@ -714,32 +749,8 @@ impl Backend for StatevectorBackend {
         if let Some(gpu) = self.gpu_state.as_ref() {
             return gpu.probabilities();
         }
-        let dim = dense_probability_len(self.name(), self.num_qubits)?;
-        let norm_sq = self.pending_norm * self.pending_norm;
-        let mut probs = vec![0.0_f64; dim];
-
-        #[cfg(feature = "parallel")]
-        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
-            let src_chunks = self.state.par_chunks(MIN_PAR_ELEMS);
-            let dst_chunks = probs.par_chunks_mut(MIN_PAR_ELEMS);
-            if norm_sq == 1.0 {
-                src_chunks.zip(dst_chunks).for_each(|(s, d)| {
-                    simd::norm_sqr_to_slice(s, d);
-                });
-            } else {
-                src_chunks.zip(dst_chunks).for_each(|(s, d)| {
-                    simd::norm_sqr_to_slice_scaled(s, d, norm_sq);
-                });
-            }
-            return Ok(probs);
-        }
-
-        if norm_sq == 1.0 {
-            simd::norm_sqr_to_slice(&self.state, &mut probs);
-        } else {
-            simd::norm_sqr_to_slice_scaled(&self.state, &mut probs, norm_sq);
-        }
-        Ok(probs)
+        dense_probability_len(self.name(), self.num_qubits)?;
+        Ok(self.host_probability_vector())
     }
 
     fn num_qubits(&self) -> usize {

--- a/src/distributed/loopback.rs
+++ b/src/distributed/loopback.rs
@@ -1,0 +1,217 @@
+//! Thread-backed [`RankComm`] for driving multi-rank code without an MPI
+//! launcher. Available to tests and, behind `bench-internal`, to benchmarks.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
+
+use num_complex::Complex64;
+
+use super::{DistributedContext, RankComm};
+
+/// Debug SIMD kernels overflow the default thread stack at the widths the
+/// loopback suite runs.
+const RANK_STACK_BYTES: usize = 64 * 1024 * 1024;
+
+struct LoopbackShared {
+    size: usize,
+    state: Mutex<LoopbackState>,
+    cv: Condvar,
+}
+
+struct LoopbackState {
+    generation: u64,
+    arrived: usize,
+    cslots: Vec<Vec<Complex64>>,
+    fslots: Vec<f64>,
+    reduce: Vec<f64>,
+    /// Largest block one rank passed to an allgather. Shot sampling tests
+    /// assert this stays at one element, proving no dense gather happened.
+    max_gather_block: usize,
+    /// Mailboxes indexed by `sender * size + receiver`. FIFO order matches MPI
+    /// sendrecv order and stays separate from collective barriers.
+    mailbox: Vec<VecDeque<Vec<Complex64>>>,
+}
+
+impl LoopbackShared {
+    fn new(size: usize) -> Arc<Self> {
+        Arc::new(Self {
+            size,
+            state: Mutex::new(LoopbackState {
+                generation: 0,
+                arrived: 0,
+                cslots: vec![Vec::new(); size],
+                fslots: vec![0.0; size],
+                reduce: Vec::new(),
+                max_gather_block: 0,
+                mailbox: (0..size * size).map(|_| VecDeque::new()).collect(),
+            }),
+            cv: Condvar::new(),
+        })
+    }
+
+    fn barrier(&self) {
+        let mut st = self.state.lock().unwrap();
+        let arrival_generation = st.generation;
+        st.arrived += 1;
+        if st.arrived == self.size {
+            st.arrived = 0;
+            st.generation = st.generation.wrapping_add(1);
+            self.cv.notify_all();
+        } else {
+            while st.generation == arrival_generation {
+                st = self.cv.wait(st).unwrap();
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LoopbackComm {
+    shared: Arc<LoopbackShared>,
+    rank: usize,
+}
+
+impl std::fmt::Debug for LoopbackComm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoopbackComm")
+            .field("rank", &self.rank)
+            .field("size", &self.shared.size)
+            .finish()
+    }
+}
+
+impl RankComm for LoopbackComm {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn size(&self) -> usize {
+        self.shared.size
+    }
+
+    fn allgather_c64(&self, local: &[Complex64]) -> Vec<Complex64> {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            st.max_gather_block = st.max_gather_block.max(local.len());
+            st.cslots[self.rank] = local.to_vec();
+        }
+        self.shared.barrier();
+        let out = {
+            let st = self.shared.state.lock().unwrap();
+            st.cslots.iter().flat_map(|s| s.iter().copied()).collect()
+        };
+        self.shared.barrier();
+        out
+    }
+
+    fn allgather_f64(&self, local: &[f64]) -> Vec<f64> {
+        let as_c: Vec<Complex64> = local.iter().map(|&v| Complex64::new(v, 0.0)).collect();
+        self.allgather_c64(&as_c).iter().map(|c| c.re).collect()
+    }
+
+    fn allreduce_sum_f64(&self, value: f64) -> f64 {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            st.fslots[self.rank] = value;
+        }
+        self.shared.barrier();
+        let sum = {
+            let st = self.shared.state.lock().unwrap();
+            st.fslots.iter().sum()
+        };
+        self.shared.barrier();
+        sum
+    }
+
+    fn allreduce_sum_f64_slice(&self, values: &mut [f64]) {
+        {
+            let mut st = self.shared.state.lock().unwrap();
+            if st.reduce.len() != values.len() {
+                st.reduce = vec![0.0; values.len()];
+            }
+            for (acc, &v) in st.reduce.iter_mut().zip(values.iter()) {
+                *acc += v;
+            }
+        }
+        self.shared.barrier();
+        {
+            let st = self.shared.state.lock().unwrap();
+            values.copy_from_slice(&st.reduce);
+        }
+        self.shared.barrier();
+        if self.rank == 0 {
+            let mut st = self.shared.state.lock().unwrap();
+            st.reduce.clear();
+        }
+        self.shared.barrier();
+    }
+
+    fn sendrecv_c64(&self, partner: usize, send: &[Complex64], recv: &mut [Complex64]) {
+        debug_assert_eq!(send.len(), recv.len());
+        let size = self.shared.size;
+        let mut st = self.shared.state.lock().unwrap();
+        // Send to partner, then wait for partner to send back. Ranks that skip
+        // an exchange do not block because their partner skips it too.
+        st.mailbox[self.rank * size + partner].push_back(send.to_vec());
+        self.shared.cv.notify_all();
+        let inbox = partner * size + self.rank;
+        loop {
+            if let Some(msg) = st.mailbox[inbox].pop_front() {
+                recv.copy_from_slice(&msg);
+                return;
+            }
+            st = self.shared.cv.wait(st).unwrap();
+        }
+    }
+
+    fn barrier(&self) {
+        self.shared.barrier();
+    }
+}
+
+/// Run `f` once per simulated rank on its own thread and collect the results in
+/// rank order.
+///
+/// `f` receives a context whose transport reaches every other rank, so it may
+/// issue the same collectives real ranks do. Every rank must call the same
+/// sequence, as under MPI.
+pub fn run_ranks<T, F>(size: usize, f: F) -> Vec<T>
+where
+    F: Fn(Arc<DistributedContext>) -> T + Sync,
+    T: Send,
+{
+    run_ranks_max_gather(size, f).0
+}
+
+/// [`run_ranks`] plus the largest block any rank passed to an allgather, which
+/// distinguishes a dense gather from a scalar reduction.
+pub fn run_ranks_max_gather<T, F>(size: usize, f: F) -> (Vec<T>, usize)
+where
+    F: Fn(Arc<DistributedContext>) -> T + Sync,
+    T: Send,
+{
+    let shared = LoopbackShared::new(size);
+    let results = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..size)
+            .map(|rank| {
+                let comm = LoopbackComm {
+                    shared: shared.clone(),
+                    rank,
+                };
+                let f = &f;
+                std::thread::Builder::new()
+                    .stack_size(RANK_STACK_BYTES)
+                    .spawn_scoped(scope, move || {
+                        f(DistributedContext::from_comm(Arc::new(comm)))
+                    })
+                    .expect("spawn rank thread")
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("rank thread panicked"))
+            .collect()
+    });
+    let max_gather = shared.state.lock().unwrap().max_gather_block;
+    (results, max_gather)
+}

--- a/src/distributed/mod.rs
+++ b/src/distributed/mod.rs
@@ -11,6 +11,8 @@
 //! Tuning thresholds are cached after the first environment variable read.
 
 pub mod comm;
+#[cfg(any(test, feature = "bench-internal"))]
+pub mod loopback;
 
 use std::sync::Arc;
 
@@ -25,10 +27,19 @@ pub use comm::MpiComm;
 pub const MIN_LOCAL_QUBITS_DEFAULT: usize = 10;
 
 /// Minimum local qubits per rank, tunable via `PRISM_DIST_MIN_LOCAL_QUBITS`.
+///
+/// An unparseable or out-of-range value warns on stderr and uses the default.
 pub fn min_local_qubits() -> usize {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
-    *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_MIN_LOCAL_QUBITS", MIN_LOCAL_QUBITS_DEFAULT, 1))
+    *CACHED.get_or_init(|| {
+        parse_usize_knob(
+            "PRISM_DIST_MIN_LOCAL_QUBITS",
+            std::env::var("PRISM_DIST_MIN_LOCAL_QUBITS").ok(),
+            MIN_LOCAL_QUBITS_DEFAULT,
+            1,
+        )
+    })
 }
 
 /// Maximum number of amplitudes exchanged per message for a global one qubit
@@ -39,10 +50,19 @@ pub fn min_local_qubits() -> usize {
 pub const EXCHANGE_CHUNK_DEFAULT: usize = usize::MAX;
 
 /// Chunk size in amplitudes for tiled global one qubit exchange.
+///
+/// An unparseable or out-of-range value warns on stderr and uses the default.
 pub fn exchange_chunk() -> usize {
     use std::sync::OnceLock;
     static CACHED: OnceLock<usize> = OnceLock::new();
-    *CACHED.get_or_init(|| env_usize_or("PRISM_DIST_EXCHANGE_CHUNK", EXCHANGE_CHUNK_DEFAULT, 1))
+    *CACHED.get_or_init(|| {
+        parse_usize_knob(
+            "PRISM_DIST_EXCHANGE_CHUNK",
+            std::env::var("PRISM_DIST_EXCHANGE_CHUNK").ok(),
+            EXCHANGE_CHUNK_DEFAULT,
+            1,
+        )
+    })
 }
 
 /// Whether the distributed backend relabels qubits to keep busy qubits local.
@@ -51,23 +71,59 @@ pub fn exchange_chunk() -> usize {
 /// updates and moves global qubits into local positions with a half-slice
 /// exchange before non-diagonal gates touch them. Set `PRISM_DIST_RELABEL=0`
 /// to disable and force direct per-gate exchange.
+///
+/// Accepts `0`/`false` and `1`/`true`; anything else warns on stderr and uses
+/// the default.
 pub fn relabel_enabled() -> bool {
     use std::sync::OnceLock;
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
-        std::env::var("PRISM_DIST_RELABEL")
-            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-            .unwrap_or(true)
+        parse_bool_knob(
+            "PRISM_DIST_RELABEL",
+            std::env::var("PRISM_DIST_RELABEL").ok(),
+            true,
+        )
     })
 }
 
-#[inline]
-fn env_usize_or(var: &str, default: usize, min: usize) -> usize {
-    std::env::var(var)
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .map(|n| n.max(min))
-        .unwrap_or(default)
+/// Read a count knob, warning on stderr and falling back to `default` when the
+/// value does not parse or falls below `min`.
+///
+/// Warning rather than erroring is the knob contract: every reader is a cached
+/// initializer on an infallible path, so an invalid value must not take down a
+/// run that would otherwise be correct with the default.
+fn parse_usize_knob(var: &str, raw: Option<String>, default: usize, min: usize) -> usize {
+    let Some(raw) = raw else {
+        return default;
+    };
+    match raw.trim().parse::<usize>() {
+        Ok(n) if n >= min => n,
+        Ok(n) => {
+            eprintln!("warning: {var}={n} is below the minimum of {min}; using {default}.");
+            default
+        }
+        Err(_) => {
+            eprintln!("warning: {var}={raw:?} is not a count; using {default}.");
+            default
+        }
+    }
+}
+
+/// Read a flag knob. See [`parse_usize_knob`] for why an invalid value warns.
+fn parse_bool_knob(var: &str, raw: Option<String>, default: bool) -> bool {
+    let Some(raw) = raw else {
+        return default;
+    };
+    match raw.trim() {
+        "0" => false,
+        "1" => true,
+        other if other.eq_ignore_ascii_case("false") => false,
+        other if other.eq_ignore_ascii_case("true") => true,
+        other => {
+            eprintln!("warning: {var}={other:?} is not a flag; using {default}.");
+            default
+        }
+    }
 }
 
 /// Shared handle to a rank transport for distributed simulation.
@@ -115,5 +171,52 @@ impl DistributedContext {
 
     pub(crate) fn comm(&self) -> &Arc<dyn RankComm> {
         &self.comm
+    }
+}
+
+#[cfg(test)]
+mod knob_tests {
+    use super::*;
+
+    // One case per parse site. The knob functions cache per process, so the
+    // parsers are exercised directly rather than through the environment.
+    #[test]
+    fn min_local_qubits_knob_rejects_invalid_values() {
+        let d = MIN_LOCAL_QUBITS_DEFAULT;
+        let parse =
+            |raw: &str| parse_usize_knob("PRISM_DIST_MIN_LOCAL_QUBITS", Some(raw.into()), d, 1);
+        assert_eq!(parse("4"), 4);
+        assert_eq!(parse(" 4 "), 4);
+        assert_eq!(parse("abc"), d, "unparseable falls back");
+        assert_eq!(parse("-1"), d, "negative falls back");
+        assert_eq!(parse("0"), d, "below the minimum falls back");
+        assert_eq!(
+            parse_usize_knob("PRISM_DIST_MIN_LOCAL_QUBITS", None, d, 1),
+            d
+        );
+    }
+
+    #[test]
+    fn exchange_chunk_knob_rejects_invalid_values() {
+        let d = EXCHANGE_CHUNK_DEFAULT;
+        let parse =
+            |raw: &str| parse_usize_knob("PRISM_DIST_EXCHANGE_CHUNK", Some(raw.into()), d, 1);
+        assert_eq!(parse("4096"), 4096);
+        assert_eq!(parse("4k"), d, "unparseable falls back");
+        assert_eq!(parse("0"), d, "below the minimum falls back");
+        assert_eq!(parse_usize_knob("PRISM_DIST_EXCHANGE_CHUNK", None, d, 1), d);
+    }
+
+    #[test]
+    fn relabel_knob_rejects_invalid_values() {
+        let parse = |raw: &str| parse_bool_knob("PRISM_DIST_RELABEL", Some(raw.into()), true);
+        assert!(!parse("0"));
+        assert!(!parse("false"));
+        assert!(!parse("FALSE"));
+        assert!(parse("1"));
+        assert!(parse("true"));
+        assert!(parse("yes"), "unrecognized falls back to the default");
+        assert!(parse(""), "empty falls back to the default");
+        assert!(parse_bool_knob("PRISM_DIST_RELABEL", None, true));
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1052,6 +1052,7 @@ fn run_marginals_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result
 
 /// Per-qubit marginals from native single-qubit Z expectations, for a backend
 /// whose own representation answers them without a dense probability vector.
+#[cfg(feature = "distributed")]
 fn marginals_from_pauli_expectations(
     backend: &dyn Backend,
     num_qubits: usize,

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -520,6 +520,13 @@ fn run_with_internal(
     #[cfg(feature = "distributed")]
     if matches!(kind, BackendKind::StatevectorDistributed { .. }) {
         let mut backend = resolve_backend(&kind, circuit, false).build(seed);
+        if opts.probabilities {
+            // The gather cap follows from the register width alone, so a
+            // register past it is rejected here rather than after the run has
+            // been paid for. Same check `probabilities()` applies, so the
+            // message does not depend on where it surfaced.
+            crate::backend::dense_probability_len(backend.name(), circuit.num_qubits)?;
+        }
         return execute(&mut *backend, circuit, &opts);
     }
     match plan_probability_route(&kind, circuit) {
@@ -1008,7 +1015,10 @@ pub(crate) fn run_counts_with(
                 ))
             }
         }
-        ShotSource::Native { backend, meas_map } => {
+        ShotSource::Native {
+            mut backend,
+            meas_map,
+        } => {
             let samples = backend.sample_basis_states(num_shots, seed)?;
             Ok(counts_of(
                 shots_from_basis_samples(&samples, &meas_map, bits),
@@ -1038,6 +1048,19 @@ fn run_marginals(circuit: &Circuit, seed: u64) -> Result<Vec<(f64, f64)>> {
 #[cfg(test)]
 fn run_marginals_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result<Vec<(f64, f64)>> {
     run_marginals_result_with(kind, circuit, seed).map(MarginalsResult::into_vec)
+}
+
+/// Per-qubit marginals from native single-qubit Z expectations, for a backend
+/// whose own representation answers them without a dense probability vector.
+fn marginals_from_pauli_expectations(
+    backend: &dyn Backend,
+    num_qubits: usize,
+) -> Result<MarginalsResult> {
+    let observables: Vec<Vec<PauliTerm>> = (0..num_qubits).map(|q| vec![PauliTerm::z(q)]).collect();
+    let expectations = backend.pauli_expectations(&observables)?;
+    Ok(MarginalsResult {
+        marginals: expectations_to_marginals(&expectations),
+    })
 }
 
 pub(crate) fn expectations_to_marginals(expectations: &[f64]) -> Vec<(f64, f64)> {
@@ -1115,6 +1138,19 @@ fn run_marginals_result_with(
         return Ok(MarginalsResult {
             marginals: expectations_to_marginals(&spd.expectations),
         });
+    }
+
+    // The distributed backend answers a marginal from rank-local sums plus one
+    // `Allreduce`, so it never needs the 2^n gather the fallback below takes.
+    #[cfg(feature = "distributed")]
+    if let BackendKind::StatevectorDistributed { context } = &kind {
+        let mut backend =
+            crate::backend::distributed_statevector::DistributedStatevectorBackend::new(
+                context.clone(),
+                seed,
+            );
+        execute(&mut backend, circuit, &SimOptions::classical_only())?;
+        return marginals_from_pauli_expectations(&backend, n);
     }
 
     let result = run_with(kind, circuit, seed)?;
@@ -1472,18 +1508,11 @@ fn run_shots_distributed(
         let stripped = circuit.without_measurements();
         let mut backend = DistributedStatevectorBackend::new(context, seed);
         execute(&mut backend, &stripped, &SimOptions::classical_only())?;
-        let indices = backend.sample_state_indices(num_shots, seed)?;
-        let shots = indices
-            .iter()
-            .map(|&idx| {
-                let mut shot = vec![false; circuit.num_classical_bits];
-                for &(qubit, cbit) in &meas_map {
-                    shot[cbit] = (idx >> qubit) & 1 == 1;
-                }
-                shot
-            })
-            .collect();
-        return Ok(ShotsResult::from_shots(shots, circuit.num_classical_bits));
+        let samples = backend.sample_basis_states(num_shots, seed)?;
+        return Ok(ShotsResult::from_shots(
+            shots_from_basis_samples(&samples, &meas_map, circuit.num_classical_bits),
+            circuit.num_classical_bits,
+        ));
     }
 
     let probe = DistributedStatevectorBackend::new(context.clone(), seed);
@@ -1548,7 +1577,10 @@ pub(crate) fn run_shots_with(
             };
             Ok(ShotsResult::from_shots(shots, bits))
         }
-        ShotSource::Native { backend, meas_map } => {
+        ShotSource::Native {
+            mut backend,
+            meas_map,
+        } => {
             let samples = backend.sample_basis_states(num_shots, seed)?;
             Ok(ShotsResult::from_shots(
                 shots_from_basis_samples(&samples, &meas_map, bits),

--- a/tests/distributed_output_cap.rs
+++ b/tests/distributed_output_cap.rs
@@ -1,0 +1,92 @@
+//! Distributed queries either need the dense gather or they do not. Isolated in
+//! its own test binary: it overrides `PRISM_MAX_PROB_QUBITS`, which the cap
+//! helper caches per process.
+#![cfg(feature = "distributed")]
+
+use std::sync::Once;
+
+use prism_q::distributed::DistributedContext;
+use prism_q::gates::Gate;
+use prism_q::{Circuit, PrismError, simulate};
+
+const SEED: u64 = 42;
+const PROB_CAP: usize = 4;
+const N: usize = PROB_CAP + 2;
+
+fn small_prob_cap() {
+    static SET: Once = Once::new();
+    SET.call_once(|| {
+        // SAFETY: set exactly once, and every reader in this binary is gated
+        // behind this `Once`, so no thread queries the cap while it is written.
+        unsafe { std::env::set_var("PRISM_MAX_PROB_QUBITS", "4") };
+    });
+}
+
+/// Qubit 0 held at |1>, the rest in an even superposition, so every marginal is
+/// known without a reference run (the reference would hit the same cap).
+fn known_marginals_circuit(num_classical_bits: usize) -> Circuit {
+    let mut circuit = Circuit::new(N, num_classical_bits);
+    circuit.add_gate(Gate::X, &[0]);
+    for q in 1..N {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    circuit
+}
+
+#[test]
+fn run_rejects_a_register_past_the_dense_cap_before_executing() {
+    small_prob_cap();
+    let err = simulate(&known_marginals_circuit(0))
+        .distributed(DistributedContext::serial())
+        .seed(SEED)
+        .run()
+        .unwrap_err();
+    match err {
+        PrismError::BackendUnsupported { backend, operation } => {
+            assert_eq!(backend, "distributed_statevector");
+            assert!(
+                operation.contains("probabilities")
+                    && operation.contains(&format!("max {PROB_CAP}")),
+                "expected the dense probability cap, got {operation}"
+            );
+        }
+        other => panic!("expected a cap rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn shots_answer_past_the_dense_cap() {
+    small_prob_cap();
+    let mut circuit = known_marginals_circuit(N);
+    for q in 0..N {
+        circuit.add_measure(q, q);
+    }
+    let result = simulate(&circuit)
+        .distributed(DistributedContext::serial())
+        .seed(SEED)
+        .shots(16)
+        .expect("shots do not need the dense gather");
+    assert_eq!(result.shots.len(), 16);
+    for shot in &result.shots {
+        assert!(shot[0], "qubit 0 is held at |1> in every shot");
+    }
+}
+
+#[test]
+fn marginals_answer_past_the_dense_cap() {
+    small_prob_cap();
+    let marginals = simulate(&known_marginals_circuit(0))
+        .distributed(DistributedContext::serial())
+        .seed(SEED)
+        .marginals()
+        .expect("marginals come from per-qubit expectations, not the dense vector")
+        .into_vec();
+    assert_eq!(marginals.len(), N);
+    assert!(marginals[0].0.abs() < 1e-12 && (marginals[0].1 - 1.0).abs() < 1e-12);
+    for (q, m) in marginals.iter().enumerate().skip(1) {
+        assert!(
+            (m.0 - 0.5).abs() < 1e-12 && (m.1 - 0.5).abs() < 1e-12,
+            "qubit {q}: expected an even split, got {m:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The distributed statevector backend declined `sample_basis_states` and
`pauli_expectations` and had no marginal route, so a trait-level caller fell back
to the dense probability vector, expectation values were rejected outright, and
marginals allgathered `2^n` on every rank. All three now answer from the
rank-local slice at any register width. The same batch closes three contract
holes on that backend: ranks never cross-checked the settings their collective
sequence assumes are shared, `run()` paid for a whole distributed run before
discovering its output was unavailable, and the `PRISM_DIST_*` knobs silently
accepted invalid values.

## Scope

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks (required for any change that touches a hot path)

N/A, no hot-path changes.

Nothing on a gate-application path changed. The one refactor,
`StatevectorBackend::probabilities` split into a cap check plus
`host_probability_vector`, is a code move with identical arithmetic and the same
parallel and SIMD structure. The new query paths run once per call, not per gate.

No benchmark row exists to run either: there is no distributed bench binary, and
the only multi-rank transport was the thread loopback inside the backend's test
module, which Criterion cannot reach. This PR moves that transport to
`src/distributed/loopback.rs` behind `bench-internal` and exposes `run_ranks`, so
a future bench binary can drive N ranks. No bench rows are added here.

Regression verdict: PASS

## Correctness

- [x] `cargo test --all-features` passes locally (`cargo nextest run
      --all-features`, 2065 tests, plus `cargo test --doc`, under the MPI
      environment with `PRISM_REQUIRE_GPU=1`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with
      `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry, and stay concise; none restate the signature
- [ ] New gate, backend, or fusion pass has golden tests against the statevector
      backend (N/A, none added; the new query paths are compared against the
      dense route instead)
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
      (not GPU-affecting, but `golden_gpu` ran as part of the suite above)

Every item has a test that fails against the code without its fix, verified by
reverting each fix in place and re-running:

- `trait_sampling_draws_natively_across_rank_counts`
- `pauli_expectations_match_the_dense_route_across_rank_counts` (eight
  observables including X and Y on rank bits and a permuted qubit map, both
  relabel modes, agreement to 1e-12)
- `loopback_marginals_match_the_dense_route_without_gathering`
- `mismatched_rank_configuration_is_rejected_at_init`
- `tests/distributed_output_cap.rs`, in its own binary because the cap helper
  caches per process: the plan-time rejection, plus shots and marginals still
  answering above the cap
- `loopback_eight_ranks_fused_2q_on_two_rank_bits` and
  `loopback_eight_ranks_mcu_spans_three_rank_bits`, the first cases where three
  rank bits make the four-rank exchange group a strict subset of the world
- `serial_measured_circuit_matches_statevector_bit_for_bit`
- Three knob parser cases, one per parse site

`scripts/test-mpi.ps1` was run on real MPI ranks and passed. It now sweeps
default, tiled exchange, and relabel-off at every rank count and asserts a three
rank launch is rejected. The tiled configuration reports 4 messages against 2 for
the same amplitude volume at 4 ranks, so the tiled path executes rather than
being configured and skipped.

Coverage limit worth stating: every rank count in the automated suite is
simulated in process, and the size-8 suite is eight threads on one eight-thread
host, not eight nodes. The MPI harness runs real ranks, still on a single host.
Nothing here validates multi-host behavior.

## Hotspot notes

N/A. `pauli_expectations` allocates one receive buffer per call, reused across
observables, and only when an observable puts X or Y on a rank bit. The `init`
fingerprint costs one allgather of a single scalar per run. Expectation-path
exchanges are not recorded by the exchange counters, since the query takes
`&self` and cannot increment them; the counter docstring now says so.

## Architecture or design changes

- [x] `docs/architecture/` updated: `samplers.md` gains the distributed sampling
      row and the reason `sample_basis_states` takes `&mut self`.
      `docs/guides/capabilities.md` gains the distributed row in the shots and
      observables table and a note on which terminals are uncapped.
- [ ] Design or research notes added where required for new subsystems (N/A, no
      new subsystem)

The backend module header was also corrected: it described reset as
project-and-renormalize, which neither backend implements and the backend's own
test contradicts, and claimed measurement outcomes match across every rank count,
which cannot hold bitwise. Both now match the code.

## Breaking changes

1. `Backend::sample_basis_states` takes `&mut self` instead of `&self`. Any
   external implementor or caller of the trait needs the signature updated. The
   distributed backend restores its qubit map before drawing, which is a
   collective mutation. The four in-tree implementors needed the signature change
   and no body change.
2. `simulate(..).distributed(..).run()` on a register past the dense probability
   cap now returns `BackendUnsupported` before executing. It previously ran the
   whole circuit and returned `Ok` with `probabilities: None` and the classical
   bits intact. `shots`, `marginals`, and `expectation_values` request classical
   output only and are unaffected; `run_on` keeps the old degrade, since a caller
   driving the backend directly gets the check inside `probabilities()`.
3. `PRISM_DIST_EXCHANGE_CHUNK=0` previously clamped to 1 and now falls back to
   the default with a warning on stderr. Invalid values for the other two
   `PRISM_DIST_*` knobs behave the same way.

One fix is user-visible in the other direction: the shot sampler built its
rank-local CDF through `StatevectorBackend::probabilities`, so lowering
`PRISM_MAX_PROB_QUBITS`, which is what that knob is for, disabled distributed
shot sampling. The CDF is a working buffer half the size of the slice the rank
already holds, so it no longer consults the dense output cap.

## Risks and rollback

Most of the change is behind the `distributed` feature and reachable only through
`BackendKind::StatevectorDistributed`, so the blast radius outside that backend
is small. Two pieces are unconditional: the `sample_basis_states` signature,
which touches four other backends and any external implementor, and the
`StatevectorBackend::probabilities` split, which is a pure code move.

There is no dispatch guard or flag that disables the new query paths
independently; rollback is reverting the commit. The `init` fingerprint is the
one addition that can reject a run that previously started, and it only fires
when ranks genuinely disagree, in which case the previous behavior was a hang or
silently wrong amplitudes.

The distributed suite is thread loopback plus a single-host MPI harness, so a
transport-level regression that only appears across hosts would not be caught
here.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed as an issue or noted above
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale (none added)
- [ ] CI is green
