### PR TITLE
fix(density-matrix): remap payload qubit indices onto the ket register

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -22,9 +22,11 @@
 //! reset, classically-conditioned gates, exact one-qubit Kraus channels
 //! (`apply_1q_kraus`), two-qubit depolarizing (`apply_2q_depolarizing`), and
 //! exact `Tr(rho P)` expectation (`expectation_pauli`, reachable through
-//! `pauli_expectations`). Fusion is disabled (`supports_fused_gates` returns
-//! `false`) so every instruction reaching the backend is a primitive whose
-//! qubits live in the instruction targets.
+//! `pauli_expectations`). Batched payload shapes (`QftBlock`, `BatchPhase`,
+//! `BatchRzz`, `DiagonalBatch`, `MultiFused`, `Multi2q`) carry qubit indices
+//! outside the instruction targets and are remapped onto the ket register
+//! before the left product; `sim` does not produce them here, since
+//! `supports_fused_gates` returns `false`, but a direct `Backend::apply` can.
 //!
 //! # When to prefer this backend
 //!
@@ -44,6 +46,8 @@
 //!   The mixture holds every branch at once, so per-shot feedback cannot be
 //!   replayed from it and the noisy terminals reject those shapes.
 
+use std::borrow::Cow;
+
 use num_complex::Complex64;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -54,7 +58,7 @@ use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
-use crate::gates::{Gate, McuData};
+use crate::gates::{DiagEntry, Gate, McuData};
 use crate::sim::i_pow;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -182,6 +186,64 @@ fn conjugate_gate(gate: &Gate) -> Option<Gate> {
     }
 }
 
+/// The gate with every qubit index stored inside its payload shifted onto the
+/// ket register. Offsetting the instruction targets is not enough for the
+/// batched shapes, whose application indices live in the payload, nor for
+/// `QftBlock`, whose whole range lives in the variant. Borrows the gate when it
+/// carries no such index.
+fn ket_register_gate(gate: &Gate, n: usize) -> Cow<'_, Gate> {
+    match gate {
+        Gate::BatchPhase(data) => {
+            let mut data = data.clone();
+            for entry in &mut data.phases {
+                entry.0 += n;
+            }
+            Cow::Owned(Gate::BatchPhase(data))
+        }
+        Gate::BatchRzz(data) => {
+            let mut data = data.clone();
+            for entry in &mut data.edges {
+                entry.0 += n;
+                entry.1 += n;
+            }
+            Cow::Owned(Gate::BatchRzz(data))
+        }
+        Gate::DiagonalBatch(data) => {
+            let mut data = data.clone();
+            for entry in &mut data.entries {
+                match entry {
+                    DiagEntry::Phase1q { qubit, .. } => *qubit += n,
+                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                        *q0 += n;
+                        *q1 += n;
+                    }
+                }
+            }
+            Cow::Owned(Gate::DiagonalBatch(data))
+        }
+        Gate::MultiFused(data) => {
+            let mut data = data.clone();
+            for entry in &mut data.gates {
+                entry.0 += n;
+            }
+            Cow::Owned(Gate::MultiFused(data))
+        }
+        Gate::Multi2q(data) => {
+            let mut data = data.clone();
+            for entry in &mut data.gates {
+                entry.0 += n;
+                entry.1 += n;
+            }
+            Cow::Owned(Gate::Multi2q(data))
+        }
+        Gate::QftBlock { start, num } => Cow::Owned(Gate::QftBlock {
+            start: start + n as u8,
+            num: *num,
+        }),
+        _ => Cow::Borrowed(gate),
+    }
+}
+
 /// Exact density-matrix simulator. See the module docs for the state layout.
 pub struct DensityMatrixBackend {
     num_qubits: usize,
@@ -242,11 +304,12 @@ impl DensityMatrixBackend {
 
     /// Evolve `rho -> U rho U^dagger` for the unitary `gate` on `targets`.
     ///
-    /// `U` applies to the ket register (targets offset by `n`) for the left
-    /// product `U rho`, and `conj(U)` to the bra register (original targets) for
-    /// the right product `rho U^dagger`. Variants with no native conjugate form
-    /// fall back to conjugating the whole buffer around the gate, which costs
-    /// two extra passes.
+    /// `U` applies to the ket register (targets and payload indices offset by
+    /// `n`, see [`ket_register_gate`]) for the left product `U rho`, and
+    /// `conj(U)` to the bra register (indices unchanged) for the right product
+    /// `rho U^dagger`. Variants with no native conjugate form fall back to
+    /// conjugating the whole buffer around the gate, which costs two extra
+    /// passes.
     ///
     /// A one-qubit gate can instead compile to a block superoperator and sweep
     /// the buffer once, which wins once the buffer stops fitting in cache. Below
@@ -268,7 +331,7 @@ impl DensityMatrixBackend {
 
         let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
         self.sv.apply(&Instruction::Gate {
-            gate: gate.clone(),
+            gate: ket_register_gate(gate, n).into_owned(),
             targets: ket_targets,
         })?;
 

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -110,9 +110,9 @@ pub enum BackendKind {
     /// Explicit-dispatch only: [`BackendKind::Auto`] never selects it. Stores
     /// `4^n` `Complex64` amplitudes, so the qubit ceiling is roughly half the
     /// statevector cap (14 on a 16 GiB host); `PRISM_MAX_DM_QUBITS` moves it
-    /// within that bound. Fusion is skipped for this backend because batched
-    /// and fused gate variants carry qubit indices in their payload that the
-    /// ket-register offset cannot relocate.
+    /// within that bound. Fusion is skipped for this backend: the sandwich
+    /// applies a fused payload as one ket pass plus three bra passes, which no
+    /// benchmark row covers today.
     ///
     /// Under an attached noise model this is the exact route: the mixture is
     /// evolved once and every terminal reads it, so shot counts carry sampling

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1011,3 +1011,98 @@ fn dm_purity_matches_analytic_above_parallel_reduce_threshold() {
         backend.purity()
     );
 }
+
+fn assert_rdm_close(a: &DensityMatrixBackend, b: &StatevectorBackend, n: usize, label: &str) {
+    for q in 0..n {
+        let x = a.reduced_density_matrix_1q(q).unwrap();
+        let y = b.reduced_density_matrix_1q(q).unwrap();
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (x[i][j] - y[i][j]).norm() < DM_EPS,
+                    "{label}: rdm[{q}][{i}][{j}] dm={} sv={}",
+                    x[i][j],
+                    y[i][j]
+                );
+            }
+        }
+    }
+}
+
+// `QftBlock` holds its qubit range in the variant, so the ket-register offset
+// the sandwich applies to `targets` has to reach `start` too. The QFT of a basis
+// state is uniform over the register under either bit-order convention, which an
+// identity-acting block cannot produce.
+#[test]
+fn dm_qft_block_through_apply_evolves_the_state() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::QftBlock { start: 0, num: 2 }, &[0, 1]);
+
+    let mut dm = DensityMatrixBackend::new(SEED);
+    dm.init(2, 0).unwrap();
+    dm.apply_instructions(&circuit.instructions).unwrap();
+
+    assert_probs_close(
+        &dm.probabilities().unwrap(),
+        &[0.25; 4],
+        DM_EPS,
+        "qft block of a basis state",
+    );
+    assert!(
+        (dm.purity() - 1.0).abs() < DM_EPS,
+        "qft block keeps the state pure, purity {}",
+        dm.purity()
+    );
+
+    let mut sv = StatevectorBackend::new(SEED);
+    sim::run_on(&mut sv, &circuit).unwrap();
+    assert_rdm_close(&dm, &sv, 2, "qft block");
+}
+
+// `BatchPhase` keeps its control in `targets[0]` and its targets in the payload,
+// so only the control picks up the ket-register offset. On the uniform two-qubit
+// superposition a cphase(pi/2) from q0 to q1 sends the amplitude 1/2 at index 3
+// to i/2. The result is symmetric in the pair, so both reduced states are
+// [[1/2, (1-i)/4], [(1+i)/4, 1/2]].
+#[test]
+fn dm_batch_phase_through_apply_matches_the_unfused_cphase() {
+    let phase = c(0.0, 1.0);
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::H, &[1]);
+
+    let mut dm = DensityMatrixBackend::new(SEED);
+    dm.init(2, 0).unwrap();
+    dm.apply_instructions(&circuit.instructions).unwrap();
+    dm.apply(&prism_q::circuit::Instruction::Gate {
+        gate: Gate::BatchPhase(Box::new(prism_q::gates::BatchPhaseData {
+            phases: [(1usize, phase)].into_iter().collect(),
+        })),
+        targets: [0usize].into_iter().collect(),
+    })
+    .unwrap();
+
+    let expected = [[c(0.5, 0.0), c(0.25, -0.25)], [c(0.25, 0.25), c(0.5, 0.0)]];
+    for q in 0..2 {
+        let rdm = dm.reduced_density_matrix_1q(q).unwrap();
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (rdm[i][j] - expected[i][j]).norm() < DM_EPS,
+                    "batch phase: rdm[{q}][{i}][{j}] expected {} got {}",
+                    expected[i][j],
+                    rdm[i][j]
+                );
+            }
+        }
+    }
+
+    circuit.add_gate(
+        Gate::cu([[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), phase]]),
+        &[0, 1],
+    );
+    let mut sv = StatevectorBackend::new(SEED);
+    sim::run_on(&mut sv, &circuit).unwrap();
+    assert_rdm_close(&dm, &sv, 2, "batch phase");
+}


### PR DESCRIPTION
## Description

The density matrix evolves `rho -> U rho U^dagger` by embedding the state as a
`2n`-qubit statevector and applying `U` to the ket register (targets offset by
`n`) and `conj(U)` to the bra register. That offset reached the instruction
targets only. Six gate shapes carry qubit indices the targets do not name:
`BatchPhase`, `BatchRzz`, `DiagonalBatch`, `MultiFused`, and `Multi2q` store
application indices inside the payload, and `QftBlock` stores its whole range in
the variant.

The consequence differed by shape. The five payload shapes applied the ket pass
to offset targets with unoffset payload indices, straddling both registers.
`QftBlock` was worse: its targets are not the qubits at all, so the ket pass
landed entirely on the bra register, and because the QFT matrix is symmetric the
two passes composed to `rho Q^T Q^dagger = rho`. The gate acted as exact
identity while trace and purity stayed 1, which is why nothing caught it.

`ket_register_gate` now shifts those indices alongside the targets, borrowing the
gate when it carries none. It applies to the ket pass only, so the
`conjugate_buffer` fallback that handles the bra side does not remap twice, and
it sits below the `matrix_1q` early return that one-qubit gates take.

This is unreachable through `sim`, which expands `QftBlock` and skips fusion for
this backend, and reachable for any direct `Backend::apply` or `run_on` caller,
which is public API. The remap lands directly rather than the interim
`BackendUnsupported` that was previously proposed, since a decline would have had
to be deprecated a commit later.

`supports_fused_gates` stays `false` and is deliberately not part of this change.
Flipping it routes every density-matrix circuit through the fusion pass, and no
benchmark row reaches that path today: `density_matrix/unitary_layers` calls
`apply_instructions` on the backend directly, and `density_matrix/noisy_shots`
evolves instruction by instruction because the noise model is indexed by
instruction position. That flip needs a bench row of its own.

## Benchmark summary

N/A, no hot-path change. The remap adds one enum discriminant match per
multi-qubit gate, below the one-qubit early return, against a `4^n` buffer sweep,
and only on gate shapes `sim` never produces for this backend. Every benched
density-matrix row calls `apply_instructions`, `apply_1q_kraus`, or
`apply_2q_depolarizing` directly, or evolves under a noise model, so none of them
constructs a payload-carrying gate.

## Regression verdict

PASS. No benchmark-affecting change.

## Tests

Two cases in `tests/density_matrix_correctness.rs`, both confirmed failing
against the unfixed code before the fix was written. The `QftBlock` case is
anchored by hand on the QFT of a basis state being uniform over the register
under either bit-order convention, which an identity-acting block cannot produce;
the unfixed code returned `prob[0] = 0`. The `BatchPhase` case is anchored on a
hand-computed reduced density matrix after a cphase between two qubits in the
uniform superposition, checked on both qubits since the state is symmetric in the
pair, then cross-checked against the same circuit run unfused.

## Documentation

Module docstring and the `apply_unitary` contract updated to state that payload
shapes are remapped. The `BackendKind::DensityMatrix` docstring no longer gives
the index remap as the reason fusion is skipped, since that reason is gone.