### PR TITLE
feat(sim): answer marginals from a backend's native observable path

### DIFF
--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -857,6 +857,48 @@ fn try_native_terminal_backend(
     Ok(Some(backend))
 }
 
+/// Build and run the backend for a marginal query when routing lands on a
+/// single backend that evaluates observables on its own representation.
+///
+/// Returns `None` when the route is not a direct single backend, or when that
+/// backend has no native observable path, leaving the dense probability route
+/// untouched. The capability is probed before `init`, so a backend without one
+/// costs an allocation and nothing else.
+///
+/// The product state is carried past subsystem decomposition for the reason
+/// [`try_native_terminal_backend`] carries it: it already holds one factor per
+/// qubit, and the decomposed route would build the `2^n` merged distribution to
+/// read marginals a per-qubit expectation answers directly. Every other backend
+/// keeps the block split, which has no single backend holding the joint state.
+fn try_native_marginal_backend(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    seed: u64,
+) -> Result<Option<Box<dyn Backend>>> {
+    if !kind.is_auto() {
+        validate_explicit_backend(kind, circuit)?;
+    }
+    let (decomposed, has_partial_independence) = match plan_probability_route(kind, circuit) {
+        ProbabilityRoute::Direct {
+            has_partial_independence,
+        } => (false, has_partial_independence),
+        ProbabilityRoute::Decomposed(_) => (true, false),
+        _ => return Ok(None),
+    };
+    let ExecutionPlan::Backend(plan) = resolve(kind, circuit, has_partial_independence) else {
+        return Ok(None);
+    };
+    if decomposed && !matches!(plan, BackendPlan::ProductState) {
+        return Ok(None);
+    }
+    let mut backend = plan.build(seed);
+    if !backend.supports_pauli_expectation() {
+        return Ok(None);
+    }
+    execute(&mut *backend, circuit, &SimOptions::classical_only())?;
+    Ok(Some(backend))
+}
+
 /// A source that answers every measurement in a circuit from a single state,
 /// in the precedence [`prepare_shot_source`] applies. Shots and counts both
 /// consume it, so the two cannot disagree about which shortcut applies.
@@ -1052,7 +1094,6 @@ fn run_marginals_with(kind: BackendKind, circuit: &Circuit, seed: u64) -> Result
 
 /// Per-qubit marginals from native single-qubit Z expectations, for a backend
 /// whose own representation answers them without a dense probability vector.
-#[cfg(feature = "distributed")]
 fn marginals_from_pauli_expectations(
     backend: &dyn Backend,
     num_qubits: usize,
@@ -1152,6 +1193,10 @@ fn run_marginals_result_with(
             );
         execute(&mut backend, circuit, &SimOptions::classical_only())?;
         return marginals_from_pauli_expectations(&backend, n);
+    }
+
+    if let Some(backend) = try_native_marginal_backend(&kind, circuit, seed)? {
+        return marginals_from_pauli_expectations(&*backend, n);
     }
 
     let result = run_with(kind, circuit, seed)?;

--- a/tests/backend_equivalence.rs
+++ b/tests/backend_equivalence.rs
@@ -1100,3 +1100,65 @@ fn factored_stabilizer_export_statevector_two_clusters_matches() {
         );
     }
 }
+
+// The native marginal route (per-qubit Z expectations off the backend's own
+// representation) against the dense route it replaces. The entangled fixture
+// keeps every explicit kind on direct resolution; the product fixture is the one
+// carried past subsystem decomposition.
+#[test]
+fn native_marginals_match_the_dense_route() {
+    let mut entangled = Circuit::new(4, 0);
+    entangled.add_gate(Gate::H, &[0]);
+    entangled.add_gate(Gate::T, &[1]);
+    entangled.add_gate(Gate::Cx, &[0, 1]);
+    entangled.add_gate(Gate::Ry(0.7), &[2]);
+    entangled.add_gate(Gate::Cx, &[1, 2]);
+    entangled.add_gate(Gate::Cx, &[2, 3]);
+    entangled.add_gate(Gate::Rz(0.4), &[3]);
+
+    let mut product = Circuit::new(4, 0);
+    product.add_gate(Gate::H, &[0]);
+    product.add_gate(Gate::Ry(0.7), &[1]);
+    product.add_gate(Gate::T, &[2]);
+    product.add_gate(Gate::Rx(1.1), &[3]);
+
+    let cases: [(prism_q::BackendKind, &Circuit, &str); 5] = [
+        (prism_q::BackendKind::Sparse, &entangled, "sparse"),
+        (
+            prism_q::BackendKind::Mps { max_bond_dim: 64 },
+            &entangled,
+            "mps",
+        ),
+        (prism_q::BackendKind::Factored, &entangled, "factored"),
+        (
+            prism_q::BackendKind::DensityMatrix,
+            &entangled,
+            "density_matrix",
+        ),
+        (prism_q::BackendKind::ProductState, &product, "product"),
+    ];
+
+    for (kind, circuit, label) in cases {
+        let dense = prism_q::simulate(circuit)
+            .backend(prism_q::BackendKind::Statevector)
+            .seed(SEED)
+            .run()
+            .unwrap()
+            .probabilities
+            .unwrap()
+            .marginals();
+        let native = prism_q::simulate(circuit)
+            .backend(kind)
+            .seed(SEED)
+            .marginals()
+            .unwrap()
+            .into_vec();
+        assert_eq!(native.len(), dense.len(), "{label}");
+        for (q, (got, want)) in native.iter().zip(&dense).enumerate() {
+            assert!(
+                (got.0 - want.0).abs() < EPS && (got.1 - want.1).abs() < EPS,
+                "{label} marginal[{q}]: got {got:?}, want {want:?}"
+            );
+        }
+    }
+}

--- a/tests/marginal_output_cap.rs
+++ b/tests/marginal_output_cap.rs
@@ -1,0 +1,77 @@
+//! Marginals either need the dense gather or they do not. Isolated in its own
+//! test binary: it overrides `PRISM_MAX_PROB_QUBITS`, which the cap helper
+//! caches per process.
+
+use std::sync::Once;
+
+use prism_q::gates::Gate;
+use prism_q::{BackendKind, Circuit, simulate};
+
+const SEED: u64 = 42;
+const PROB_CAP: usize = 4;
+const N: usize = PROB_CAP + 2;
+const EPS: f64 = 1e-12;
+
+fn small_prob_cap() {
+    static SET: Once = Once::new();
+    SET.call_once(|| {
+        // SAFETY: set exactly once, and every reader in this binary is gated
+        // behind this `Once`, so no thread queries the cap while it is written.
+        unsafe { std::env::set_var("PRISM_MAX_PROB_QUBITS", "4") };
+    });
+}
+
+fn assert_marginals(kind: BackendKind, circuit: &Circuit, want: &[(f64, f64)], label: &str) {
+    let got = simulate(circuit)
+        .backend(kind)
+        .seed(SEED)
+        .marginals()
+        .expect("marginals come from per-qubit expectations, not the dense vector")
+        .into_vec();
+    assert_eq!(got.len(), want.len(), "{label}");
+    for (q, (g, w)) in got.iter().zip(want).enumerate() {
+        assert!(
+            (g.0 - w.0).abs() < EPS && (g.1 - w.1).abs() < EPS,
+            "{label} marginal[{q}]: got {g:?}, want {w:?}"
+        );
+    }
+}
+
+// GHZ keeps the whole register in one component, so the route is direct
+// resolution onto a single backend. Every qubit is an even mixture of |0> and
+// |1>, which needs no reference run (the reference would hit the same cap).
+#[test]
+fn direct_route_marginals_answer_past_the_dense_cap() {
+    small_prob_cap();
+    let mut circuit = Circuit::new(N, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    for q in 1..N {
+        circuit.add_gate(Gate::Cx, &[q - 1, q]);
+    }
+
+    let want = vec![(0.5, 0.5); N];
+    assert_marginals(BackendKind::Sparse, &circuit, &want, "sparse");
+    assert_marginals(
+        BackendKind::Mps { max_bond_dim: 64 },
+        &circuit,
+        &want,
+        "mps",
+    );
+}
+
+// No entangling gate, so the route is subsystem decomposition, whose merge
+// builds the 2^n distribution the cap rejects. The product state is the one
+// backend carried past that split.
+#[test]
+fn product_state_marginals_answer_past_the_dense_cap() {
+    small_prob_cap();
+    let mut circuit = Circuit::new(N, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    for q in 1..N {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+
+    let mut want = vec![(0.5, 0.5); N];
+    want[0] = (0.0, 1.0);
+    assert_marginals(BackendKind::ProductState, &circuit, &want, "product");
+}


### PR DESCRIPTION
## Description

A per-qubit marginal is `expectations_to_marginals` of single-qubit Z
expectations, which Sparse, MPS, Factored, ProductState, and DensityMatrix all
evaluate on their own representation. `run_marginals_result_with` nonetheless
fell through to `run_with` and read `probs.marginals()` off the dense `2^n`
vector, so those backends paid a gather they did not need and returned
`BackendUnsupported` past the dense output cap, which is exactly the regime where
their native path matters most.

`try_native_marginal_backend` resolves the route, probes
`supports_pauli_expectation` on the built backend before `init`, and executes the
circuit once with probabilities off when the probe succeeds. Placement is forced
by the route: only the direct route yields a single backend holding the joint
state, and the Pauli-propagation routes return probabilities with no backend at
all, so the probe cannot sit inside `run_with`. A backend without the capability
costs one allocation and falls through unchanged. This mirrors
`try_native_terminal_backend`, which makes the same decision for native shot
sampling.

The product state is carried past subsystem decomposition for the reason that
function carries it: it already holds one factor per qubit, so the decomposed
route would build the merged `2^n` distribution to read what a per-qubit
expectation answers directly. Every other backend keeps the block split, so a
Factored circuit that decomposes into blocks still takes the dense merge, which
is correct because no single backend holds the joint state there.

Noisy marginals are untouched. With a noise model attached `Simulate::marginals`
routes to `exact_noisy_probabilities` before reaching this decision point.

The `cfg(feature = "distributed")` comes off `marginals_from_pauli_expectations`,
which now has callers in every feature set.

## Benchmark summary

N/A. This changes a query path that runs once per `marginals()` call, not per
gate, and the circuit still executes exactly once on either route. No benchmark
row covers marginal extraction.

## Regression verdict

PASS. No hot-path change.

## Tests

`tests/marginal_output_cap.rs` is a new binary, isolated because it overrides
`PRISM_MAX_PROB_QUBITS`, which the cap helper caches per process. It covers both
arms: a GHZ register on Sparse and MPS for the direct route, and a product
circuit on ProductState for the decomposition carve-out, each with marginals
known in closed form since a reference run would hit the same cap. Both cases
fail against the unfixed route with `BackendUnsupported` naming "marginals for 6
qubits without backend probability output", confirmed by reverting the route in
place.

`native_marginals_match_the_dense_route` in `tests/backend_equivalence.rs` holds
all five backends to the dense route at four qubits. It guards the answer rather
than the route, since it passes either way by construction; the cap binary is
what proves the native path is taken.

## Documentation

Docstring on the new resolver covering what it declines and why, and the
cross-reference to the sampler that shares its shape.