### PR TITLE
feat(factored-stabilizer): export a statevector across clusters

### DIFF
--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -918,17 +918,41 @@ impl Backend for FactoredStabilizerBackend {
         Ok(())
     }
 
+    /// Tensor the live sub-tableaux back into a joint amplitude vector.
+    ///
+    /// Clusters are mutually unentangled, so the joint amplitude at a global
+    /// index is the product of each cluster's amplitude at the index restricted
+    /// to that cluster's qubits. `init` gives every qubit a cluster and the
+    /// merge and split passes preserve the partition, so the product covers the
+    /// whole register.
     fn export_statevector(&self) -> Result<Vec<Complex64>> {
+        let dim = dense_statevector_len(self.name(), "statevector", self.num_qubits)?;
         let active: Vec<&SubTableau> = self.subs.iter().filter_map(|s| s.as_ref()).collect();
 
         if active.len() == 1 && active[0].n == self.num_qubits {
             return active[0].compute_statevector();
         }
 
-        Err(PrismError::BackendUnsupported {
-            backend: self.name().to_string(),
-            operation: "statevector export for multiple sub-tableaux".to_string(),
-        })
+        let blocks: Vec<(Vec<Complex64>, &[usize])> = active
+            .iter()
+            .map(|sub| Ok((sub.compute_statevector()?, sub.qubits.as_slice())))
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut joint = Vec::new();
+        reserve_dense_output(&mut joint, dim, self.name(), "statevector")?;
+        joint.resize(dim, Complex64::new(0.0, 0.0));
+        for (index, amp) in joint.iter_mut().enumerate() {
+            let mut product = Complex64::new(1.0, 0.0);
+            for (state, qubits) in &blocks {
+                let mut local = 0usize;
+                for (bit, &q) in qubits.iter().enumerate() {
+                    local |= ((index >> q) & 1) << bit;
+                }
+                product *= state[local];
+            }
+            *amp = product;
+        }
+        Ok(joint)
     }
 }
 

--- a/tests/backend_equivalence.rs
+++ b/tests/backend_equivalence.rs
@@ -1073,3 +1073,30 @@ fn factored_conditional_gate() {
     let fp = fac.probabilities().unwrap();
     assert_probs(&fp, &sv);
 }
+
+// Two clusters that are mutually unentangled and interleaved in register order
+// (`{0, 3}` and `{1, 2}`), so the export cannot assume a cluster owns a
+// contiguous bit range. Amplitudes, not probabilities: `S` on q2 puts an `i` on
+// one branch that only the amplitude check sees.
+#[test]
+fn factored_stabilizer_export_statevector_two_clusters_matches() {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 3]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::S, &[2]);
+
+    let sv_ref = run_and_state(&c);
+
+    let mut fs = prism_q::backend::factored_stabilizer::FactoredStabilizerBackend::new(SEED);
+    sim::run_on(&mut fs, &c).unwrap();
+    let sv = fs.export_statevector().unwrap();
+    assert_eq!(sv.len(), sv_ref.len());
+    for (i, (a, e)) in sv.iter().zip(sv_ref.iter()).enumerate() {
+        assert!(
+            (a - e).norm() < EPS,
+            "factored-stabilizer export[{i}]: expected {e}, got {a}"
+        );
+    }
+}


### PR DESCRIPTION
## Description

`export_statevector` expanded only when a single active sub-tableau covered every
qubit, and otherwise returned `BackendUnsupported` naming "statevector export for
multiple sub-tableaux". That decline described the tableau rather than the state.
Clusters are mutually unentangled by construction, which is the invariant the
merge-on-cross-cluster-gate policy exists to maintain, so the joint state is the
tensor product of the per-cluster expansions and the export is liftable without
new theory.

The joint amplitude at a global index is the product of each cluster's amplitude
at that index restricted to the cluster's qubits. That gathers the permutation
into the index arithmetic instead of building one, and it is the same shape
`FactoredBackend::export_statevector` already uses for its sub-states, so the two
factored backends now answer the same way.

Two details are worth naming for review. The dense cap is now checked once on the
full register before any cluster expands, rather than per cluster after the fact,
so an oversize register is rejected before the work is paid for; the
single-cluster path applies the identical check it always did, so its behavior is
unchanged. And the product provably covers the whole register: `init` gives every
qubit its own sub-tableau, and the merge and split passes only repartition, so no
qubit belongs to no active cluster.

## Benchmark summary

N/A. `export_statevector` is a terminal query that runs once per call, on a path
that previously returned an error for this case. No benchmark row exercises it.

## Regression verdict

PASS. No hot-path change.

## Tests

`factored_stabilizer_export_statevector_two_clusters_matches` in
`tests/backend_equivalence.rs` builds two clusters that are interleaved in
register order (`{0, 3}` and `{1, 2}`) so a wrong permutation cannot pass, and
puts an `S` on one cluster so a branch carries a factor of `i`. It compares
amplitudes rather than probabilities, which is what sees that phase. The test
fails against the unfixed code with the backend's own `BackendUnsupported`.

The per-cluster expansion picks its own global phase, so the comparison against
the statevector was written expecting a phase mismatch. There is none: the
product of the per-cluster phases matched the statevector exactly, so the test
asserts plain amplitude equality at 1e-12.

## Documentation

Docstring on `export_statevector` giving the product rule and the partition
invariant that makes it total. Module docs updated: the export is no longer
restricted to a single joint tableau.