### PR TITLE
feat(sim): parameter-shift gradients on any observable backend

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -13,7 +13,7 @@ use prism_q::gates::Gate;
 use prism_q::sim;
 use prism_q::{
     BackendKind, ClassicalCondition, Instruction, MpsBackend, ParameterMap, PauliTerm,
-    run_expectation_gradient, run_expectation_values,
+    run_expectation_gradient, run_expectation_gradient_shift, run_expectation_values,
 };
 use rand::RngExt;
 use rand::SeedableRng;
@@ -1141,6 +1141,9 @@ fn bench_gradient(c: &mut Criterion) {
         });
         group.bench_with_input(BenchmarkId::new("finitediff", n), &circuit, |b, circ| {
             b.iter(|| black_box(finite_diff_gradient(circ, &ham, &params)));
+        });
+        group.bench_with_input(BenchmarkId::new("paramshift", n), &circuit, |b, circ| {
+            b.iter(|| black_box(run_expectation_gradient_shift(circ, &ham, &params, 42).unwrap()));
         });
     }
 

--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -32,7 +32,8 @@ Top-level re-exports from `src/lib.rs`. The full generated documentation is on
 `run_expectation_values`, `bitstring`
 
 **Gradients:**
-`run_expectation_gradient`, `ExpectationGradient`, `ParamLink`, `ParameterMap`
+`run_expectation_gradient`, `run_expectation_gradient_shift`, `ExpectationGradient`,
+`ParamLink`, `ParameterMap`
 
 **Compiled sampling:**
 `compile_measurements`, `compile_forward`, `compile_detector_sampler`, `compile_noisy`,

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -40,6 +40,7 @@ Orchestration layer in `src/sim/mod.rs`.
 | `simulate(circuit).backend(kind).seed(seed).marginals()` | Per-qubit marginal probabilities with backend selection |
 | `simulate(circuit).seed(seed).expectation_values(observables)` | `⟨P_k⟩` per Pauli string |
 | `simulate(circuit).seed(seed).expectation_gradient(hamiltonian, params)` | `⟨H⟩` and adjoint gradient |
+| `simulate(circuit).backend(kind).seed(seed).expectation_gradient_shift(hamiltonian, params)` | `⟨H⟩` and parameter-shift gradient |
 | `run_on(backend, circuit)` | Pre-constructed backend |
 | `run_qasm(qasm, seed)` | Parse + simulate |
 
@@ -79,7 +80,9 @@ same property that makes the density matrix the mixture oracle rather than a com
 participant in the branching families of `tests/conformance_matrix.rs`.
 
 `expectation_gradient` rejects a noise model on every backend, because the adjoint method
-backpropagates through a pure state.
+backpropagates through a pure state. `expectation_gradient_shift` rejects one too, though
+the obstacle there is only that the path is not wired: the shift rule holds under a
+parameter-independent channel, so the density matrix could serve it.
 
 ## Auto-dispatch decision tree
 
@@ -131,7 +134,14 @@ Block-level Rayon parallelism when all blocks are <14 qubits (avoids oversubscri
 
 For Clifford+T circuits: Clifford prefix runs on the Stabilizer backend, state is exported to Statevector for the non-Clifford tail. Saves exponential memory for circuits with a long Clifford preamble.
 
-## Expectation-value gradients (adjoint method)
+## Expectation-value gradients
+
+Two methods, chosen by the caller rather than by the engine: the adjoint method is the
+default and the reference, parameter shift is the fallback for what the adjoint declines.
+Selection is explicit because the two differ by a factor of `2 * links` in evaluation
+count, which is not a difference a caller should discover from a wall clock.
+
+### Adjoint method
 
 `run_expectation_gradient(circuit, hamiltonian, params, seed)` and
 `simulate(circuit).seed(seed).expectation_gradient(hamiltonian, params)` compute
@@ -164,8 +174,38 @@ inverse applications), and a trainable gate outside the Hamiltonian's inverse
 light cone has a provably zero gradient, so its sandwich is skipped.
 
 Memory is two statevectors, so the qubit ceiling is about one below a single
-run. Only the statevector backend is supported; stabilizer/MPS/factored/GPU
-gradients are not implemented.
+run. Only the statevector backend is supported.
+
+### Parameter shift (fallback)
+
+`run_expectation_gradient_shift(circuit, hamiltonian, params, seed)` and
+`simulate(circuit).backend(kind).seed(seed).expectation_gradient_shift(hamiltonian,
+params)` evaluate `d⟨H⟩/dθ = (f(θ+π/2) - f(θ-π/2)) / 2` per trainable gate, exactly, from
+forward `expectation_values` calls alone. That is what makes it the fallback: it inherits
+whatever the selected backend can represent, so it serves Sparse, MPS, Factored,
+ProductState, DensityMatrix, and Distributed, widths past the statevector cap, and
+circuits containing `QftBlock`. A backend with no native observable path reports
+`BackendUnsupported` naming itself.
+
+The rule is exact because each differentiable gate is `exp(-iθG/2)` with `G` of
+eigenvalues `±1`, making `⟨H⟩` a degree-1 trigonometric polynomial in that angle. `P(θ)`
+is the apparent exception, its generator being the projector `|1⟩⟨1|` with eigenvalues
+`{0, 1}`, but `P(θ) = e^{iθ/2} Rz(θ)` and that scalar cancels against its conjugate in
+`⟨ψ|H|ψ⟩` wherever the gate sits, so the same shift applies.
+
+The differentiable gate set is unchanged: `Rx`, `Ry`, `Rz`, `Rzz`, and `P` are the only
+`Gate` variants carrying an angle inline, so parameter shift reaches no gate the adjoint
+rejects. Its reach is backends and circuit shapes, not gates.
+
+Gates sharing a parameter slot are shifted one at a time and their contributions summed.
+Shifting them together is a different quantity: two `Rx(θ)` on one qubit under `⟨Z⟩` give
+`cos 2θ`, whose joint ±π/2 shift is zero rather than `-2 sin 2θ`.
+
+Cost is `1 + 2 * links` circuit evaluations against the adjoint's one, and there is no
+light-cone pruning to recover any of it: a trainable gate with a provably zero gradient is
+still evaluated twice. Evaluations run in sequence, because each already drives a
+Rayon-parallel backend run and holding several in flight would multiply peak state memory
+by the parameter count, which is the resource this path exists to stay under.
 
 ## Backend dispatch variants
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,10 @@ pub use sim::compiled::{
     PauliExpectationAccumulator, ShotAccumulator, ShotLayout, compile_detector_sampler,
     compile_forward, compile_measurements, run_shots_compiled,
 };
-pub use sim::gradient::{ExpectationGradient, ParamLink, ParameterMap, run_expectation_gradient};
+pub use sim::gradient::{
+    ExpectationGradient, ParamLink, ParameterMap, run_expectation_gradient,
+    run_expectation_gradient_shift,
+};
 pub use sim::homological::{
     ErrorChainComplex, HomologicalSampler, noisy_marginals_analytical, run_shots_homological,
 };

--- a/src/sim/gradient.rs
+++ b/src/sim/gradient.rs
@@ -1,20 +1,18 @@
-//! Adjoint-method gradients of expectation values.
+//! Gradients of expectation values, by the adjoint method and by parameter
+//! shift.
 //!
-//! Computes the exact gradient of `⟨H⟩ = ⟨0|U†HU|0⟩` with respect to a vector
-//! of circuit parameters in a cost independent of the parameter count, by
-//! back-propagating two statevectors through the circuit. For `U = U_L…U_1`
-//! and a Hermitian Hamiltonian `H = Σ c_k P_k`:
+//! Both compute `⟨H⟩ = ⟨0|U†HU|0⟩` and `d⟨H⟩/dθ` for a Hermitian
+//! `H = Σ c_k P_k`. The adjoint method ([`run_expectation_gradient`]) is exact
+//! in one pair of statevectors and costs one circuit evaluation regardless of
+//! the parameter count, but runs only on the statevector backend. Parameter
+//! shift ([`run_expectation_gradient_shift`]) costs two evaluations per
+//! trainable gate and reaches any backend with a native observable path,
+//! including widths past the statevector cap.
 //!
-//! 1. Forward: apply `U` unfused, keep `|φ⟩ = U|0⟩`.
-//! 2. Build `|λ⟩ = H|φ⟩`; the value `⟨H⟩ = Re⟨φ|λ⟩`.
-//! 3. Backward `i = L…1`: for each trainable gate with generator `G_i`,
-//!    accumulate the gradient from `⟨λ|G_i|φ⟩` (with `|φ⟩` on the output side
-//!    of gate `i`), then step both states back through `U_i†`.
-//!
-//! Only the statevector backend is supported. The differentiated circuit must
-//! be unitary (no measurement, reset, or conditional). Differentiable gates are
-//! `Rx`, `Ry`, `Rz`, `Rzz`, and `P`; a trainable link on any other gate is an
-//! error.
+//! The differentiated circuit must be unitary (no measurement, reset, or
+//! conditional) on both paths. Differentiable gates are `Rx`, `Ry`, `Rz`,
+//! `Rzz`, and `P` for both: those are the only `Gate` variants carrying an
+//! angle inline, so the shift rule reaches no gate the adjoint rejects.
 
 use num_complex::Complex64;
 
@@ -25,7 +23,7 @@ use crate::error::{PrismError, Result};
 use crate::gates::{Gate, GeneratorKind};
 
 use super::unified_pauli::PauliTerm;
-use super::{i_pow, pauli_masks, pauli_sandwich};
+use super::{BackendKind, i_pow, pauli_masks, pauli_sandwich};
 
 /// Binds one trainable gate instruction to a slot in the parameter vector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,6 +377,114 @@ fn gradient_contribution(
             }
             -2.0 * acc.im
         }
+    }
+}
+
+/// Compute `⟨H⟩` and its gradient by the parameter-shift rule, routing every
+/// evaluation through automatic backend selection.
+///
+/// Unlike [`run_expectation_gradient`] this places no ceiling on the qubit
+/// count of its own: it holds one backend state at a time and inherits whatever
+/// the selected backend can represent. It also accepts `QftBlock`. The price is
+/// `1 + 2 * params.links().len()` circuit evaluations against the adjoint's
+/// one, so prefer the adjoint wherever it applies. Select an explicit backend
+/// with [`crate::simulate`] and `expectation_gradient_shift`.
+///
+/// # Examples
+///
+/// ```
+/// use prism_q::{Circuit, Gate, ParameterMap, PauliTerm, run_expectation_gradient_shift};
+///
+/// let theta = 0.5_f64;
+/// let mut circuit = Circuit::new(2, 0);
+/// circuit.add_gate(Gate::Rx(theta), &[0]);
+///
+/// let hamiltonian = vec![(1.0, vec![PauliTerm::z(0)])];
+/// let params = ParameterMap::all_rotations(&circuit);
+/// let g = run_expectation_gradient_shift(&circuit, &hamiltonian, &params, 42)?;
+/// assert!((g.gradient[0] + theta.sin()).abs() < 1e-9);
+/// # Ok::<(), prism_q::PrismError>(())
+/// ```
+pub fn run_expectation_gradient_shift(
+    circuit: &Circuit,
+    hamiltonian: &[(f64, Vec<PauliTerm>)],
+    params: &ParameterMap,
+    seed: u64,
+) -> Result<ExpectationGradient> {
+    shift_gradient(&BackendKind::Auto, circuit, hamiltonian, params, None, seed)
+}
+
+/// Parameter-shift gradient on the backend `kind` selects, optionally from a
+/// start state.
+///
+/// Every differentiable gate is `exp(-iθG/2)` with `G` of eigenvalues `±1`, so
+/// `⟨H⟩` is a degree-1 trigonometric polynomial in each angle and
+/// `d⟨H⟩/dθ = (f(θ+π/2) - f(θ-π/2)) / 2` is exact. `P(θ) = diag(1, e^{iθ})` has
+/// the projector `|1⟩⟨1|` for a generator, eigenvalues `{0, 1}` rather than
+/// `{-1, +1}`, but `P(θ) = e^{iθ/2} Rz(θ)`: the θ-dependent factor is a scalar
+/// wherever the gate sits, so it cancels against its conjugate in `⟨ψ|H|ψ⟩` and
+/// the same shift applies unchanged.
+///
+/// Gates sharing a parameter slot are shifted one at a time and summed. Shifting
+/// them together is a different quantity: two `Rx(θ)` on one qubit under `⟨Z⟩`
+/// give `cos 2θ`, whose joint ±π/2 shift is zero rather than `-2 sin 2θ`.
+pub(crate) fn shift_gradient(
+    kind: &BackendKind,
+    circuit: &Circuit,
+    hamiltonian: &[(f64, Vec<PauliTerm>)],
+    params: &ParameterMap,
+    initial_state: Option<&[Complex64]>,
+    seed: u64,
+) -> Result<ExpectationGradient> {
+    params.validate(circuit)?;
+    if initial_state.is_some() {
+        super::require_unitary_circuit(kind, circuit)?;
+    }
+
+    let observables: Vec<Vec<PauliTerm>> =
+        hamiltonian.iter().map(|(_, terms)| terms.clone()).collect();
+    let evaluate = |c: &Circuit| -> Result<f64> {
+        let per_term = match initial_state {
+            Some(state) => {
+                super::expectation_values_from_initial_state(kind, c, state, &observables, seed)?
+            }
+            None => super::run_expectation_values_with(kind.clone(), c, &observables, seed)?,
+        };
+        Ok(hamiltonian
+            .iter()
+            .zip(per_term)
+            .map(|((coeff, _), v)| coeff * v)
+            .sum())
+    };
+
+    let value = evaluate(circuit)?;
+    let mut gradient = vec![0.0; params.num_params()];
+    if params.is_empty() {
+        return Ok(ExpectationGradient { value, gradient });
+    }
+
+    let shift = std::f64::consts::FRAC_PI_2;
+    let mut shifted = circuit.clone();
+    for link in params.links() {
+        let base = *angle_mut(&mut shifted.instructions[link.instruction]);
+        *angle_mut(&mut shifted.instructions[link.instruction]) = base + shift;
+        let plus = evaluate(&shifted)?;
+        *angle_mut(&mut shifted.instructions[link.instruction]) = base - shift;
+        let minus = evaluate(&shifted)?;
+        *angle_mut(&mut shifted.instructions[link.instruction]) = base;
+        gradient[link.param] += 0.5 * (plus - minus);
+    }
+
+    Ok(ExpectationGradient { value, gradient })
+}
+
+fn angle_mut(instruction: &mut Instruction) -> &mut f64 {
+    match instruction {
+        Instruction::Gate {
+            gate: Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::Rzz(t) | Gate::P(t),
+            ..
+        } => t,
+        _ => unreachable!("trainable instruction validated as differentiable"),
     }
 }
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -413,6 +413,42 @@ impl<'c> Simulate<'c, Seeded> {
         }
         gradient::run_expectation_gradient(self.circuit, hamiltonian, params, seed)
     }
+
+    /// Compute `⟨H⟩` and its gradient by the parameter-shift rule on the
+    /// selected backend.
+    ///
+    /// Serves the cases [`Simulate::expectation_gradient`] declines: any
+    /// backend with a native observable path, circuits containing `QftBlock`,
+    /// and widths past the statevector cap. It differentiates the same gate set
+    /// (`Rx`, `Ry`, `Rz`, `Rzz`, `P`) at `1 + 2 * links` circuit evaluations
+    /// against the adjoint's one, so the adjoint stays the better choice where
+    /// it applies. A backend with no native observable path reports
+    /// `BackendUnsupported` naming itself. See
+    /// [`gradient::run_expectation_gradient_shift`].
+    #[inline]
+    pub fn expectation_gradient_shift(
+        self,
+        hamiltonian: &[(f64, Vec<PauliTerm>)],
+        params: &gradient::ParameterMap,
+    ) -> Result<gradient::ExpectationGradient> {
+        let seed = self.seed_value();
+        if self.noise_model.is_some() {
+            return Err(PrismError::IncompatibleBackend {
+                backend: format!("{:?}", self.kind),
+                reason: "noisy parameter-shift gradients are not wired; drop the noise model, or \
+                         differentiate noisy `expectation_values` numerically"
+                    .into(),
+            });
+        }
+        gradient::shift_gradient(
+            &self.kind,
+            self.circuit,
+            hamiltonian,
+            params,
+            self.initial_state,
+            seed,
+        )
+    }
 }
 
 /// Start a query-aware simulation request for `circuit`.

--- a/tests/expectation_gradient.rs
+++ b/tests/expectation_gradient.rs
@@ -1,14 +1,15 @@
-//! Adjoint-gradient correctness: `run_expectation_gradient` and
-//! `Simulate::expectation_gradient` validated against central finite
-//! differences and the parameter-shift rule, at the fixed test seed.
+//! Gradient correctness: the adjoint entry points validated against central
+//! finite differences and a hand-rolled parameter-shift rule, and the shipped
+//! parameter-shift path validated against the adjoint, at the fixed test seed.
 
 mod common;
 
 use common::SEED;
+use num_complex::Complex64;
 use prism_q::circuits;
 use prism_q::{
-    Circuit, Gate, Instruction, ParameterMap, PauliTerm, run_expectation_gradient,
-    run_expectation_values, simulate,
+    BackendKind, Circuit, Gate, Instruction, ParameterMap, PauliTerm, run_expectation_gradient,
+    run_expectation_gradient_shift, run_expectation_values, simulate,
 };
 
 type Hamiltonian = Vec<(f64, Vec<PauliTerm>)>;
@@ -252,6 +253,148 @@ fn nontrainable_prefix_is_skipped_correctly() {
             g.gradient[slot]
         );
     }
+}
+
+#[test]
+fn shift_matches_adjoint_on_statevector() {
+    let c = circuits::hardware_efficient_ansatz(4, 2, SEED);
+    let params = ParameterMap::all_rotations(&c);
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (0.7, vec![PauliTerm::x(0)]),
+        (0.5, vec![PauliTerm::y(2)]),
+        (-0.3, vec![PauliTerm::z(3)]),
+    ];
+
+    let adjoint = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    let shift = simulate(&c)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_gradient_shift(&obs, &params)
+        .unwrap();
+
+    assert!((shift.value - adjoint.value).abs() < 1e-12);
+    assert_eq!(shift.gradient.len(), params.num_params());
+    for slot in 0..params.num_params() {
+        assert!(
+            (shift.gradient[slot] - adjoint.gradient[slot]).abs() < 1e-9,
+            "slot {slot}: shift {} vs adjoint {}",
+            shift.gradient[slot],
+            adjoint.gradient[slot]
+        );
+    }
+}
+
+#[test]
+fn shift_matches_adjoint_on_phase_and_rzz() {
+    // P(theta) = e^{i theta/2} Rz(theta) and the scalar cancels in <H>, so P
+    // takes the same pi/2 shift as the rotations despite its {0, 1} generator
+    // eigenvalues.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::P(0.9), &[0]);
+    c.add_gate(Gate::Rzz(0.4), &[0, 1]);
+    let mut params = ParameterMap::new();
+    params.push(2, 0);
+    params.push(3, 1);
+
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::x(0)]),
+        (0.6, vec![PauliTerm::y(0), PauliTerm::x(1)]),
+    ];
+    let adjoint = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    let shift = run_expectation_gradient_shift(&c, &obs, &params, SEED).unwrap();
+    for slot in 0..2 {
+        assert!(
+            (shift.gradient[slot] - adjoint.gradient[slot]).abs() < 1e-9,
+            "slot {slot}: shift {} vs adjoint {}",
+            shift.gradient[slot],
+            adjoint.gradient[slot]
+        );
+    }
+}
+
+#[test]
+fn shift_accumulates_a_shared_slot() {
+    // Two Rx on one qubit bound to a single slot: <Z> = cos(2 theta), so the
+    // shared gradient is -2 sin(2 theta). Each bound gate must be shifted on
+    // its own; shifting both at once gives zero here.
+    let theta = 0.35;
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::Rx(theta), &[0]);
+    c.add_gate(Gate::Rx(theta), &[0]);
+    let mut params = ParameterMap::new();
+    params.push(0, 0);
+    params.push(1, 0);
+
+    let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(0)])];
+    let shift = run_expectation_gradient_shift(&c, &obs, &params, SEED).unwrap();
+    assert_eq!(shift.gradient.len(), 1);
+    assert!((shift.gradient[0] - (-2.0 * (2.0 * theta).sin())).abs() < 1e-9);
+
+    let adjoint = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    assert!((shift.gradient[0] - adjoint.gradient[0]).abs() < 1e-12);
+}
+
+#[test]
+fn shift_differentiates_a_circuit_holding_a_qft_block() {
+    // The adjoint rejects QftBlock outright; parameter shift differentiates
+    // through it because it only ever calls the forward observable path.
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::Rx(0.4), &[0]);
+    c.add_gate(Gate::QftBlock { start: 0, num: 3 }, &[0, 1, 2]);
+    let mut params = ParameterMap::new();
+    params.push(0, 0);
+
+    let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(2)])];
+    assert!(run_expectation_gradient(&c, &obs, &params, SEED).is_err());
+
+    let shift = run_expectation_gradient_shift(&c, &obs, &params, SEED).unwrap();
+    assert!((shift.gradient[0] - finite_diff(&c, &obs, &params, 0)).abs() < 1e-6);
+}
+
+#[test]
+fn shift_differentiates_from_a_start_state() {
+    // The adjoint declines a start state: its backward pass inverts the circuit
+    // back to |0...0>. Parameter shift only ever runs forward. Starting from
+    // |1> on q0, Rx(theta) gives <Z0> = -cos(theta), so the gradient is
+    // sin(theta).
+    let theta = 0.8;
+    let mut c = Circuit::new(1, 0);
+    c.add_gate(Gate::Rx(theta), &[0]);
+    let mut params = ParameterMap::new();
+    params.push(0, 0);
+
+    let start = [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)];
+    let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(0)])];
+    let g = simulate(&c)
+        .initial_state(&start)
+        .seed(SEED)
+        .expectation_gradient_shift(&obs, &params)
+        .unwrap();
+
+    assert!((g.value - (-theta.cos())).abs() < 1e-12);
+    assert!((g.gradient[0] - theta.sin()).abs() < 1e-9);
+}
+
+#[test]
+fn shift_on_a_backend_without_an_observable_path_names_it() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::Rx(0.3), &[0]);
+    let mut params = ParameterMap::new();
+    params.push(2, 0);
+
+    let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(0)])];
+    let err = simulate(&c)
+        .backend(BackendKind::TensorNetwork)
+        .seed(SEED)
+        .expectation_gradient_shift(&obs, &params)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("tensornetwork"), "{err}");
 }
 
 #[test]

--- a/tests/expectation_gradient_oversize.rs
+++ b/tests/expectation_gradient_oversize.rs
@@ -1,0 +1,86 @@
+//! Parameter-shift gradients above the statevector cap. Isolated in its own
+//! test binary: it overrides `PRISM_MAX_SV_QUBITS`, which is cached per
+//! process. The adjoint cannot run at this width, so the reference is closed
+//! form rather than a statevector comparison.
+
+use prism_q::gates::Gate;
+use prism_q::{BackendKind, Circuit, ParameterMap, PauliTerm, run_expectation_gradient, simulate};
+
+const SEED: u64 = 42;
+const TOL: f64 = 1e-9;
+
+struct Fixture {
+    circuit: Circuit,
+    params: ParameterMap,
+    hamiltonian: Vec<(f64, Vec<PauliTerm>)>,
+    want: Vec<f64>,
+}
+
+// Rx(theta_q) on every qubit, then CX(0->1) and CX(2->3). Under the Heisenberg
+// conjugation of CX(0->1), Z0 is unchanged and Z0*Z1 becomes Z1, so
+// <H> = cos(theta_0) + 0.5 cos(theta_1) for H = Z0 + 0.5 Z0 Z1. Slots 0 and 1
+// therefore carry -sin(theta_0) and -0.5 sin(theta_1); every other slot is
+// exactly zero.
+fn fixture(n: usize) -> Fixture {
+    let mut circuit = Circuit::new(n, 0);
+    let angles: Vec<f64> = (0..n).map(|q| 0.2 + 0.1 * q as f64).collect();
+    for (q, &theta) in angles.iter().enumerate() {
+        circuit.add_gate(Gate::Rx(theta), &[q]);
+    }
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::Cx, &[2, 3]);
+
+    let params = ParameterMap::all_rotations(&circuit);
+    let hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0)]),
+        (0.5, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+    ];
+    let mut want = vec![0.0; n];
+    want[0] = -angles[0].sin();
+    want[1] = -0.5 * angles[1].sin();
+    Fixture {
+        circuit,
+        params,
+        hamiltonian,
+        want,
+    }
+}
+
+fn assert_gradient(label: &str, gradient: &[f64], want: &[f64]) {
+    assert_eq!(gradient.len(), want.len());
+    for (slot, (&got, &expected)) in gradient.iter().zip(want).enumerate() {
+        assert!(
+            (got - expected).abs() < TOL,
+            "{label} slot {slot}: got {got}, want {expected}"
+        );
+    }
+}
+
+#[test]
+fn shift_gradient_above_the_cap_on_mps_and_factored() {
+    // SAFETY: single test in this binary; the variable is set before any cap
+    // query and no other thread is running.
+    unsafe { std::env::set_var("PRISM_MAX_SV_QUBITS", "4") };
+
+    let f = fixture(8);
+
+    // The adjoint declines at this width: it holds two statevectors.
+    assert!(run_expectation_gradient(&f.circuit, &f.hamiltonian, &f.params, SEED).is_err());
+
+    for kind in [BackendKind::Mps { max_bond_dim: 16 }, BackendKind::Factored] {
+        let label = format!("{kind:?}");
+        let g = simulate(&f.circuit)
+            .backend(kind)
+            .seed(SEED)
+            .expectation_gradient_shift(&f.hamiltonian, &f.params)
+            .unwrap();
+        assert_gradient(&label, &g.gradient, &f.want);
+    }
+
+    // Auto routes past the cap to a native observable path of its own.
+    let g = simulate(&f.circuit)
+        .seed(SEED)
+        .expectation_gradient_shift(&f.hamiltonian, &f.params)
+        .unwrap();
+    assert_gradient("auto", &g.gradient, &f.want);
+}


### PR DESCRIPTION
## Summary

Gradients ran on the statevector backend alone: the adjoint method holds two state vectors,
so it stops about a qubit below a single run's ceiling and declines every other backend
along with `QftBlock`. Parameter shift needs only two forward `expectation_values`
evaluations per trainable gate, so it reaches every backend with a native observable path,
any width those backends represent, and circuits carrying a `QftBlock`. Additive API: the
adjoint path is unchanged, stays the default, and stays the reference the new path is
checked against.

## Scope

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Benchmarks

`scripts/bench_ab.sh --ref main` (18ce57b), features `parallel`, Intel i7-6700K,
Windows 10, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`. Both script control columns
kept.

Run 1, `--filter '^gradient/.*/adjoint/'`, 20 samples:

| Benchmark | Before | After | Change | Control (ref) | Control (new) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `gradient/hea_l2/adjoint/14` | 10.15 ms | 10.41 ms | +2.6% | -0.4% | +1.8% | yes |
| `gradient/hea_l2/adjoint/18` | 66.44 ms | 66.92 ms | +0.7% | -27.6% | +39.9% | unresolvable |
| `gradient/hea_l2/adjoint/20` | 556.89 ms | 650.73 ms | +16.9% | -3.4% | +2.8% | no |
| `gradient/hea_l2/adjoint/22` | 2.801 s | 2.850 s | +1.7% | -0.3% | -0.2% | yes |
| `gradient/prefix_local/adjoint/16` | 5.64 ms | 5.90 ms | +4.7% | -1.2% | -11.5% | unresolvable |
| `gradient/prefix_local/adjoint/18` | 25.65 ms | 20.72 ms | -19.2% | -47.3% | -20.4% | unresolvable |
| `gradient/prefix_local/adjoint/20` | 274.98 ms | 285.21 ms | +3.7% | -12.4% | -20.5% | unresolvable |
| `gradient/qaoa_l1/adjoint/14` | 4.13 ms | 4.25 ms | +2.8% | +1.9% | -10.1% | unresolvable |
| `gradient/qaoa_l1/adjoint/18` | 31.42 ms | 36.94 ms | +17.6% | -1.7% | -26.3% | unresolvable |
| `gradient/qaoa_l1/adjoint/20` | 256.61 ms | 276.90 ms | +7.9% | -0.5% | -17.6% | unresolvable |

Run 2, recheck, `--filter '^gradient/hea_l2/adjoint/(14|18|20)$'`, 50 samples:

| Benchmark | Before | After | Change | Control (ref) | Control (new) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `gradient/hea_l2/adjoint/14` | 10.77 ms | 10.81 ms | +0.4% | +1.4% | -5.0% | yes |
| `gradient/hea_l2/adjoint/18` | 84.00 ms | 87.04 ms | +3.6% | -19.0% | +31.6% | unresolvable |
| `gradient/hea_l2/adjoint/20` | 672.75 ms | 682.94 ms | +1.5% | -7.9% | +6.3% | unresolvable |

Regression verdict: FAIL on run 1, not reproduced on run 2. Not a PASS.

The +16.9% row had tight within-run controls, so it did not dismiss as noise on its own,
and the recheck read +1.5%. The decisive figure is the reference column: identical `main`
code moved 556.89 ms to 672.75 ms between runs, +20.8%, which is a same-code control at
four times the gate that the within-run columns cannot see. The row is unmeasured on this
host, not passing, and seven of ten rows in run 1 already exceeded the gate on control
spread alone (worst 47.3%). No mechanism supports a real regression:
`run_expectation_gradient` is textually unchanged and shares no function with the new path.
The ask is a re-gate of `gradient/hea_l2/adjoint/20` on a quiet runner, not a waiver.

A `paramshift` variant was added to `gradient/hea_l2` to gate the next change to this path.
It gets no A/B verdict here, because the harness builds its row list from the reference
pass and drops a row absent from `main`. One pass at 10 samples, same binary:

| n | adjoint | finitediff | paramshift |
| ---: | ---: | ---: | ---: |
| 14 | 10.4 ms | 98.6 ms | 103.8 ms |
| 18 | 73.1 ms | 1296.7 ms | 1453.6 ms |
| 20 | 744.2 ms | 7455.2 ms | 7608.4 ms |

Parameter shift tracks finite differences, as expected at `1 + 2 * links` against
`2 * links` evaluations. The residual spread has no trend and is not claimed as a result.
Both are 10x to 20x the adjoint, which is why the adjoint stays the default.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes (2083 tests,
      0 skipped, `PRISM_REQUIRE_GPU=1`); `cargo test --doc` on the same set passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes, and also at `--features parallel` and
      `--no-default-features`, so no helper is left dead in a set CI builds
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes under
      `RUSTDOCFLAGS="-D warnings"`
- [x] Docstrings on new `pub` items carry the exactness argument, the `P(theta)` phase
      cancellation, the weight-sharing rule, and the evaluation count
- [ ] New gate, backend, or fusion pass has golden tests: N/A, none added
- [x] GPU: not GPU-affecting, but `golden_gpu` ran in the suite above

`--all-features` was not used: it pulls MPI and needs the MSVC environment, and this diff
touches neither the MPI surface nor feature wiring.

Six tests in `tests/expectation_gradient.rs` cover agreement with the adjoint to 1e-9
(including `P` and `Rzz`), weight sharing, `QftBlock`, a start state, and the rejection
naming the backend that could not serve it. `tests/expectation_gradient_oversize.rs` is a
separate binary because `PRISM_MAX_SV_QUBITS` caches per process; it asserts the adjoint
declines at that width, then pins closed-form values on MPS, Factored, and Auto from hand
algebra rather than a second simulator, since no statevector run exists under the same cap.

Every new assertion was confirmed to fail against reverted code, in place: shifting bound
gates together fails the shared-slot test and nothing else, a pi/4 shift constant fails all
four value tests including the oversize binary, and pointing the rejection test at a
backend that does have an observable path makes the call succeed.

## Hotspot notes

N/A for the adjoint path, which is unchanged. The new path's cost is `1 + 2 * links` full
backend runs; per-shift work outside those is one circuit clone plus one `f64` write, with
angles mutated in place and restored exactly rather than rebuilding a circuit per shift.
There is no light-cone equivalent, so a trainable gate with a provably zero gradient is
still evaluated twice, which is a real cost difference on the `gradient/prefix_local` shape.

## Architecture or design changes

- [x] `docs/architecture/engine.md`: gradient section now covers both methods, why
      selection is explicit, the exactness and `P(theta)` arguments, the cost, and the
      sequential-evaluation rationale. `docs/architecture/api-surface.md` lists the entry
      point.
- [ ] Design or research note: N/A, no new subsystem.

One correction worth reviewer attention: the motivating item claimed parameter shift covers
gates the adjoint rejects. It does not, and no coverage was invented for it. `Rx`, `Ry`,
`Rz`, `Rzz`, and `P` are the only `Gate` variants carrying an angle inline, so both methods
gate on the same `Gate::pauli_generator` and the differentiable set is identical. The real
reach is backends, widths past the cap, and `QftBlock`.

## Breaking changes

None. Two additive entry points plus one re-export; no existing signature, default, or
dispatch decision changed, and no caller is routed to the new path automatically.

## Risks and rollback

Small blast radius: nothing dispatches to the new code unless a caller names it, and the
adjoint entry points are untouched. Rollback is deleting the two entry points and their
helper; no feature flag or dispatch guard is needed because there is no automatic route to
guard. The one behaviour to confirm rather than assume is weight sharing, since shifting
bound gates together is the natural implementation and is wrong; it is pinned by a test
that fails on that variant.

Noisy gradients stay rejected on both methods. For parameter shift the obstacle is wiring
rather than mathematics, so it is filed as its own backlog item with its own acceptance
instead of being enabled here. The Python bindings do not expose the new entry point.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed as backlog items, not code stubs
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green (pending; the benchmark ask is a re-gate of one row on a quiet runner,
      not a code change)
