### PR TITLE
perf(stabilizer): restrict the batch measure index to the stabilizer half

### DIFF
--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -849,14 +849,10 @@ impl StabilizerBackend {
         }
 
         let mut first_destab = vec![usize::MAX; num_meas];
-        let mut match_count = vec![0u16; num_meas];
-        let mut match_a = vec![0usize; num_meas];
-        let mut match_b = vec![0usize; num_meas];
 
+        // Only the stabilizer half can set `first_destab`, so the destabilizer
+        // rows carry no information this index reads.
         let build_index = |first_destab: &mut [usize],
-                           match_count: &mut [u16],
-                           match_a: &mut [usize],
-                           match_b: &mut [usize],
                            xz: &[u64],
                            qubit_to_meas: &[usize],
                            n: usize,
@@ -864,8 +860,7 @@ impl StabilizerBackend {
                            stride: usize,
                            num_meas: usize| {
             first_destab.fill(usize::MAX);
-            match_count.fill(0);
-            for r in 0..2 * n {
+            for r in n..2 * n {
                 let r_base = r * stride;
                 for w in 0..nw {
                     let x_word = xz[r_base + w];
@@ -878,20 +873,8 @@ impl StabilizerBackend {
                         let q = w * 64 + b;
                         if q < n {
                             let mi = qubit_to_meas[q];
-                            if mi < num_meas {
-                                if r >= n {
-                                    if first_destab[mi] == usize::MAX {
-                                        first_destab[mi] = r;
-                                    }
-                                } else {
-                                    let c = match_count[mi];
-                                    if c == 0 {
-                                        match_a[mi] = r;
-                                    } else if c == 1 {
-                                        match_b[mi] = r;
-                                    }
-                                    match_count[mi] = c.saturating_add(1);
-                                }
+                            if mi < num_meas && first_destab[mi] == usize::MAX {
+                                first_destab[mi] = r;
                             }
                         }
                         bits &= bits - 1;
@@ -902,9 +885,6 @@ impl StabilizerBackend {
 
         build_index(
             &mut first_destab,
-            &mut match_count,
-            &mut match_a,
-            &mut match_b,
             &self.xz,
             &qubit_to_meas,
             n,
@@ -922,9 +902,6 @@ impl StabilizerBackend {
                 random_x_support[mi] = support;
                 build_index(
                     &mut first_destab,
-                    &mut match_count,
-                    &mut match_a,
-                    &mut match_b,
                     &self.xz,
                     &qubit_to_meas,
                     n,


### PR DESCRIPTION
## Summary

`build_index` iterated all `2n` tableau rows, but only the `r >= n` arm writes
`first_destab`, the sole value any later code reads. The `r < n` arm filled
`match_count`, `match_a`, and `match_b`, which nothing reads anywhere in the crate.
Restricting the loop to `n..2*n` removes every bit iteration over destabilizer X bits,
which on a GHZ chain is almost the whole cost.

Output is unchanged by construction: the deleted arm could not reach `first_destab`.

## Scope

- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh --filter '^stabilizer/(measurement/ghz_measure_all/(1000|5000)|scaling/1000)$' --ref main`

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `stabilizer/measurement/ghz_measure_all/1000` | 4.08 ms | 2.59 ms | -36.4% | -0.7% / -0.9% | yes, improvement |
| `stabilizer/measurement/ghz_measure_all/5000` | 91.40 ms | 54.37 ms | -40.5% | +2.8% / +0.3% | yes, improvement |
| `stabilizer/scaling/1000` | 4.33 ms | 4.34 ms | +0.1% | +0.2% / +0.2% | yes, flat |

100 samples, i7-6700K, rustc 1.97.0. Every control under 3%, so both effects sit well
outside their own noise. `stabilizer/scaling/1000` is the control: gate-only, never
enters `build_index`, and it did not move.

This also settles an open question. The saving was in doubt because the closure inlines
at both call sites, and once inlined the dead stores are removable, so LLVM might have
deleted the arm already. It had not.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` (1888 tests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --doc --features parallel`

No new test: the change is provably output-preserving, and `ghz_measure_all` already
covers the batched measure path across the existing matrices.

## Hotspot notes

`build_index` in `src/backend/stabilizer/mod.rs`, called once before the measurement
loop and again after every random outcome.

## Breaking changes

None.

## Risks and rollback

Confined to the batched measurement index. Revert is one commit.
