### PR TITLE
bench(config): lower the default sample count from 100 to 30

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -12,7 +12,7 @@ Criterion.rs. Two benchmark binaries:
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `PRISM_BENCH_PLOTS` | unset | Set to render the Criterion HTML report. Off by default: on the reference host a five-row group took 335s with plots and 47s without, so roughly 58s per row goes to rendering against 9s of measurement. Gating reads stdout and `target/criterion/**/estimates.json`, which the plots do not feed. |
-| `PRISM_BENCH_SAMPLES` | 100 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the same five-row group took 47s at 10 samples and 48s at 100. Lower it only for opt-in rows whose single iteration is slow enough that the sample count, not the time budget, sets the cost. Values below 10 are clamped. |
+| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
 
 Sample count controls the precision of one run's mean. It does not remove
 drift between runs: on the reference host, back-to-back runs of identical code
@@ -266,7 +266,7 @@ independent pairs.
 ## Reproducibility checklist
 
 - [ ] Fixed RNG seed (`0xDEAD_BEEF` for circuit generation, `42` for simulation)
-- [ ] Criterion defaults: 5s warm-up, 5s measurement, 100 samples
+- [ ] Criterion settings: 5s warm-up, 5s measurement, 30 samples (`PRISM_BENCH_SAMPLES`)
 - [ ] Gating comparisons run through `scripts/bench_ab.sh`, with the control column reported
 - [ ] Document CPU model, OS, Rust version, RUSTFLAGS (`bench_ab.sh` records these in its table)
 - [ ] Disable CPU frequency scaling if possible (`performance` governor on Linux)

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -56,19 +56,24 @@ pub fn criterion_config() -> criterion::Criterion {
 /// Samples per row outside the `bench-fast` tier.
 ///
 /// Criterion splits `measurement_time` across the sample count rather than
-/// multiplying by it, so for every row recorded so far (the slowest is 75ms per
-/// iteration) raising this from 10 costs almost nothing: the same five-row group
-/// took 47s at 10 samples and 48s at 100, while the standard error of the mean
-/// falls by roughly three.
+/// multiplying by it, so the count is free while one iteration still fits in
+/// `measurement_time / samples`. Past that the count sets the cost outright, and
+/// the corpus now holds rows well past it: `density_matrix/unitary_layers/12`
+/// runs 3.87s per iteration, where 100 samples cost 39 minutes across the six
+/// passes of an adjacent A/B against 4 minutes at 10.
 ///
-/// `PRISM_BENCH_SAMPLES` overrides it for opt-in rows whose single iteration is
-/// slow enough that the sample count, not the time budget, sets the cost.
-/// Criterion rejects fewer than 10.
+/// 30 is the compromise. Standard error falls as `1/sqrt(n)`, so dropping from
+/// 100 widens it by about 1.8x while cutting slow-row wall time by 3.3x, and a
+/// 2026-08-05 A/B at 30 held every control row on the stabilizer and factored
+/// groups under 3%.
+///
+/// `PRISM_BENCH_SAMPLES` raises it for a row that needs a tighter interval, or
+/// lowers it for triage. Criterion rejects fewer than 10.
 pub fn sample_size() -> usize {
     std::env::var("PRISM_BENCH_SAMPLES")
         .ok()
         .and_then(|value| value.parse().ok())
-        .unwrap_or(100)
+        .unwrap_or(30)
         .max(10)
 }
 

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -342,7 +342,7 @@ set +e
     echo "| Reference | \`$REF\` ($REF_SHA) |"
     echo "| Features | \`$FEATURES\` |"
     echo "| Pass order | ref, new discarded, then ref, new, new, ref (adjacent, no rebuild) |"
-    echo "| Samples | ${PRISM_BENCH_SAMPLES:-100} |"
+    echo "| Samples | ${PRISM_BENCH_SAMPLES:-30} |"
     echo "| High-qubit rows | $HIGH_QUBITS_STATE |"
     echo "| CPU | $(host_cpu) |"
     echo "| OS | $(uname -srm) |"


### PR DESCRIPTION
## Summary

The 100-sample default rested on every row fitting one iteration inside
`measurement_time / samples`, where Criterion makes the count nearly free. The corpus
outgrew that: `density_matrix/unitary_layers/12` runs 3.87s per iteration, so 100 samples
cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10.

30 widens the interval about 1.8x, since standard error falls as `1/sqrt(n)`, while
cutting slow-row wall time 3.3x.
