### PR TITLE
fix(factored): decline oversize probabilities instead of shifting past a word

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1322,6 +1322,29 @@ fn bench_factored_dynamic(c: &mut Criterion) {
     group.finish();
 }
 
+/// The factored backend's multi-block probability terminal, which
+/// `dynamic_advantage` does not reach: that group decomposes at the sim layer,
+/// which returns per-block probabilities without merging. Here the largest
+/// component is `n - 2`, so `should_decompose` declines and the whole circuit
+/// runs on one backend while the factored state stays in two sub-states. The
+/// statevector row is the reference for the same terminal cost.
+fn bench_factored_partial_independence(c: &mut Criterion) {
+    let mut group = c.benchmark_group("factored/partial_independence");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let circuit = circuits::partially_independent_circuit(n, 5, SEED);
+        group.bench_with_input(BenchmarkId::new("statevector", n), &circuit, |b, circ| {
+            b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("factored", n), &circuit, |b, circ| {
+            b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
 /// Non-Pauli trajectory noise on the factored backend, the only path that reaches
 /// `Backend::apply_1q_matrix`. Pauli noise routes to gate application instead, so
 /// `noisy_sampling` does not cover this at all.
@@ -2008,6 +2031,7 @@ criterion_group! {
     bench_factored_independent,
     bench_factored_sim_only,
     bench_factored_dynamic,
+    bench_factored_partial_independence,
     bench_factored_dense,
     bench_factored_noise_kraus,
     // Clifford+T (SPD/SPP)

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -781,6 +781,40 @@ impl Backend for FactoredBackend {
         Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
     }
 
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        // `FactoredBlock::mask` is a u64 and `Probabilities::len` is
+        // `1 << total_qubits`, so a wider register has no representable lazy
+        // form either; the dense terminal declines it.
+        if self.num_qubits > 64 {
+            return None;
+        }
+
+        let active: SmallVec<[&SubState; 16]> = self
+            .substates
+            .iter()
+            .filter_map(|opt| opt.as_ref())
+            .collect();
+
+        if active.len() < 2 {
+            return None;
+        }
+
+        let blocks = active
+            .iter()
+            .map(|sub| {
+                let mut probs = vec![0.0_f64; sub.state.len()];
+                simd::norm_sqr_to_slice(&sub.state, &mut probs);
+                let mask = sub.qubits.iter().fold(0u64, |m, &q| m | 1 << q);
+                crate::sim::FactoredBlock { probs, mask }
+            })
+            .collect();
+
+        Some(crate::sim::Probabilities::Factored {
+            blocks,
+            total_qubits: self.num_qubits,
+        })
+    }
+
     fn num_qubits(&self) -> usize {
         self.num_qubits
     }

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -39,7 +39,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use smallvec::{SmallVec, smallvec};
 
-use crate::backend::memory::dense_statevector_len;
+use crate::backend::memory::{dense_probability_len, dense_statevector_len};
 use crate::backend::simd;
 use crate::backend::statevector::insert_zero_bit;
 use crate::backend::{
@@ -745,6 +745,7 @@ impl Backend for FactoredBackend {
     }
 
     fn probabilities(&self) -> Result<Vec<f64>> {
+        dense_probability_len(self.name(), self.num_qubits)?;
         let active: SmallVec<[&SubState; 16]> = self
             .substates
             .iter()

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -901,6 +901,32 @@ impl Backend for FactoredStabilizerBackend {
         Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
     }
 
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        // `FactoredBlock::mask` is a u64 and `Probabilities::len` is
+        // `1 << total_qubits`, so a wider register has no representable lazy
+        // form either; the dense terminal declines it.
+        if self.num_qubits > 64 {
+            return None;
+        }
+
+        let active: Vec<&SubTableau> = self.subs.iter().filter_map(|s| s.as_ref()).collect();
+        if active.len() < 2 {
+            return None;
+        }
+
+        let mut blocks = Vec::with_capacity(active.len());
+        for sub in active {
+            let probs = sub.compute_probabilities().ok()?;
+            let mask = sub.qubits.iter().fold(0u64, |m, &q| m | 1 << q);
+            blocks.push(crate::sim::FactoredBlock { probs, mask });
+        }
+
+        Some(crate::sim::Probabilities::Factored {
+            blocks,
+            total_qubits: self.num_qubits,
+        })
+    }
+
     fn num_qubits(&self) -> usize {
         self.num_qubits
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -358,6 +358,18 @@ pub trait Backend {
     /// provide this efficiently, they may return `Err(BackendUnsupported)`.
     fn probabilities(&self) -> Result<Vec<f64>>;
 
+    /// Per-block probabilities for a backend holding a product of independent
+    /// sub-states, skipping the `2^n` Kronecker expansion
+    /// [`Backend::probabilities`] would materialize.
+    ///
+    /// `None` means the caller takes [`Backend::probabilities`] instead, which
+    /// is the right answer for a single block or a monolithic state. Each
+    /// block's `probs` is indexed by its own qubits in ascending global order,
+    /// matching the `mask` convention of [`crate::sim::FactoredBlock`].
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        None
+    }
+
     /// Number of qubits the backend is currently configured for.
     fn num_qubits(&self) -> usize;
 

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -127,6 +127,50 @@ pub fn independent_bell_pairs(n_pairs: usize) -> Circuit {
     c
 }
 
+/// One connected block spanning `n - 2` qubits plus one independent pair.
+///
+/// Sized so the decomposition heuristic declines: it needs the largest
+/// component to be at least three qubits smaller than the register, which
+/// `n - 2` fails. The circuit is therefore partially independent but runs whole
+/// on one backend, which is the shape that reaches the factored backend's
+/// multi-block probability terminal.
+pub fn partially_independent_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    assert!(
+        n >= 4,
+        "partially_independent_circuit needs at least 4 qubits"
+    );
+    let big = n - 2;
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let singles = [Gate::H, Gate::X, Gate::Y, Gate::Z, Gate::S, Gate::T];
+
+    for layer in 0..depth {
+        for q in 0..big {
+            c.add_gate(singles[rng.random_range(0..singles.len())].clone(), &[q]);
+        }
+        for q in (layer % 2..big - 1).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    // The chain runs unconditionally so the large block is one component at
+    // every seed; group count must not be a seed property.
+    for q in 0..big - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+
+    for layer in 0..depth {
+        c.add_gate(singles[rng.random_range(0..singles.len())].clone(), &[big]);
+        c.add_gate(
+            singles[rng.random_range(0..singles.len())].clone(),
+            &[big + 1],
+        );
+        if layer == 0 {
+            c.add_gate(Gate::Cx, &[big, big + 1]);
+        }
+    }
+    c
+}
+
 /// K independent random sub-circuits of `block_size` qubits each.
 ///
 /// Total qubits = `num_blocks * block_size`. Each block has its own

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -739,6 +739,9 @@ fn probs_only_result(probs: Vec<f64>) -> RunOutcome {
 }
 
 fn try_backend_probabilities(backend: &dyn Backend) -> Result<Option<Probabilities>> {
+    if let Some(factored) = backend.block_probabilities() {
+        return Ok(Some(factored));
+    }
     match backend.probabilities() {
         Ok(probs) => Ok(Some(Probabilities::Dense(probs))),
         Err(PrismError::BackendUnsupported { .. }) => Ok(None),

--- a/src/sim/probability.rs
+++ b/src/sim/probability.rs
@@ -173,24 +173,6 @@ impl Probabilities {
     }
 }
 
-impl std::ops::Index<usize> for Probabilities {
-    type Output = f64;
-
-    /// Index into a dense probability vector.
-    ///
-    /// Only works for `Dense`. Panics on `Factored` because `Index` must
-    /// return `&f64` and factored values are computed, not stored.
-    /// Use [`Probabilities::get`] or [`Probabilities::iter`] instead.
-    fn index(&self, index: usize) -> &f64 {
-        match self {
-            Probabilities::Dense(v) => &v[index],
-            Probabilities::Factored { .. } => {
-                panic!("cannot index Factored probabilities; use .get(i) or .to_vec()")
-            }
-        }
-    }
-}
-
 /// Concrete iterator for [`Probabilities::iter`].
 pub struct ProbabilitiesIter<'a> {
     inner: ProbabilitiesIterInner<'a>,
@@ -291,7 +273,7 @@ mod tests {
         assert_eq!(p.len(), 4);
         assert!(!p.is_empty());
         assert_eq!(p.get(2), 0.3);
-        assert_eq!(p[3], 0.4);
+        assert_eq!(p.get(3), 0.4);
         assert_eq!(p.to_vec(), vec![0.1, 0.2, 0.3, 0.4]);
         let collected: Vec<f64> = p.iter().collect();
         assert_eq!(collected, vec![0.1, 0.2, 0.3, 0.4]);
@@ -340,13 +322,6 @@ mod tests {
         let p = Probabilities::Dense(vec![0.5, 0.5]);
         let it = p.iter();
         assert_eq!(it.size_hint(), (2, Some(2)));
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot index Factored")]
-    fn factored_index_panics() {
-        let p = factored_2x3();
-        let _ = p[0];
     }
 
     #[test]

--- a/tests/factored_correctness.rs
+++ b/tests/factored_correctness.rs
@@ -396,3 +396,56 @@ fn factored_oversize_probabilities_decline_instead_of_panicking() {
         "a 100 qubit factored register cannot serve a dense probability vector"
     );
 }
+
+// The multi-block probability terminal now returns per-block marginals instead
+// of the merged 2^n vector. Expanding that lazy form must reproduce the merge
+// exactly, which pins the block bit-order convention: each block's probs are
+// indexed by its own qubits in ascending global order, and `mask` records which
+// global positions those are.
+#[test]
+fn factored_block_probabilities_expand_to_the_merged_vector() {
+    use prism_q::backend::Backend;
+    use prism_q::sim::{BackendKind, Probabilities};
+
+    for n in [10usize, 14, 16] {
+        let circuit = circuits::partially_independent_circuit(n, 4, SEED);
+        assert!(
+            circuit.independent_subsystems().len() > 1,
+            "{n}q: circuit must stay partially independent for this to test anything"
+        );
+
+        let mut backend = FactoredBackend::new(SEED);
+        prism_q::sim::run_on(&mut backend, &circuit).unwrap();
+
+        let lazy = backend
+            .block_probabilities()
+            .expect("multi-block state must offer per-block probabilities");
+        match &lazy {
+            Probabilities::Factored { blocks, .. } => {
+                assert!(blocks.len() > 1, "{n}q: expected more than one block")
+            }
+            Probabilities::Dense(_) => panic!("{n}q: expected the factored variant"),
+        }
+
+        let merged = backend.probabilities().unwrap();
+        let expanded = lazy.to_vec();
+        assert_eq!(expanded.len(), merged.len(), "{n}q: length mismatch");
+        for (i, (a, b)) in expanded.iter().zip(&merged).enumerate() {
+            assert!(
+                (a - b).abs() < FACTORED_EPS,
+                "{n}q: state {i}: lazy {a} vs merged {b}"
+            );
+        }
+
+        // The public run must now carry the lazy form end to end.
+        let out = prism_q::sim::simulate(&circuit)
+            .backend(BackendKind::Factored)
+            .seed(SEED)
+            .run()
+            .unwrap();
+        assert!(matches!(
+            out.probabilities,
+            Some(Probabilities::Factored { .. })
+        ));
+    }
+}

--- a/tests/factored_correctness.rs
+++ b/tests/factored_correctness.rs
@@ -357,3 +357,42 @@ fn factored_phase_estimation_8q_sv() {
 fn factored_phase_estimation_12q_fused() {
     check_fused_vs_unfused("qpe 12q fused", &circuits::phase_estimation_circuit(12));
 }
+
+// A factored register past 64 qubits has no dense probability vector and no
+// representable lazy one either: the block mask is a u64 and Probabilities::len
+// is 1 << total_qubits. The terminal must decline rather than shift past the
+// word. Self-inverse bridges keep static analysis at one component so the sim
+// runs the whole circuit on one backend instead of decomposing it.
+#[test]
+fn factored_oversize_probabilities_decline_instead_of_panicking() {
+    use prism_q::sim::BackendKind;
+
+    let n = 100;
+    let block = 5;
+    let mut circuit = Circuit::new(n, 0);
+    for base in (0..n).step_by(block) {
+        circuit.add_gate(Gate::H, &[base]);
+        for q in base..(base + block - 1).min(n - 1) {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    for base in (block..n).step_by(block) {
+        circuit.add_gate(Gate::Cx, &[0, base]);
+        circuit.add_gate(Gate::Cx, &[0, base]);
+    }
+    assert_eq!(
+        circuit.independent_subsystems().len(),
+        1,
+        "bridges must leave one static component or the sim decomposes instead"
+    );
+
+    let out = prism_q::sim::simulate(&circuit)
+        .backend(BackendKind::Factored)
+        .seed(SEED)
+        .run()
+        .expect("an oversize register must not fail the run");
+    assert!(
+        out.probabilities.is_none(),
+        "a 100 qubit factored register cannot serve a dense probability vector"
+    );
+}

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -73,7 +73,10 @@ fn qiskit_style_conditional_x_after_measure() {
     let mut backend = StatevectorBackend::new(42);
     let result = sim::run_on(&mut backend, &circuit).expect("run");
     let probs = result.probabilities.expect("probs");
-    assert!(probs[0] > 0.999, "expected |0> after teleport-style reset");
+    assert!(
+        probs.get(0) > 0.999,
+        "expected |0> after teleport-style reset"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`FactoredBackend::probabilities` had no dense-output guard, so a register past 64 qubits
reached `merge_probabilities` and panicked on a shift overflow while building the bit
permutation. `factored_stabilizer` already guards the identical terminal with
`dense_probability_len`; factored now does the same and returns `BackendUnsupported`,
which the sim reports as probabilities unavailable.

Found while reviewing an adjacent change, not introduced by one.

## Scope

- [x] Bug fix

## Benchmarks

N/A, no hot-path changes. The guard is one length check per terminal call.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` (1889 tests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings`
- [x] `cargo fmt --check`

`factored_oversize_probabilities_decline_instead_of_panicking` panics without the guard.
Reaching the path needs a circuit whose static analysis finds one component, since a
decomposable one is answered per block instead; self-inverse CX bridges do that, because
the union-find sees them and fusion cancels them.

## Breaking changes

None. A 100-qubit factored run previously aborted; it now returns no probabilities.

## Risks and rollback

Revert is one commit.
