### PR TITLE
perf(factored): return per-block probabilities instead of merging to 2^n

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1322,6 +1322,29 @@ fn bench_factored_dynamic(c: &mut Criterion) {
     group.finish();
 }
 
+/// The factored backend's multi-block probability terminal, which
+/// `dynamic_advantage` does not reach: that group decomposes at the sim layer,
+/// which returns per-block probabilities without merging. Here the largest
+/// component is `n - 2`, so `should_decompose` declines and the whole circuit
+/// runs on one backend while the factored state stays in two sub-states. The
+/// statevector row is the reference for the same terminal cost.
+fn bench_factored_partial_independence(c: &mut Criterion) {
+    let mut group = c.benchmark_group("factored/partial_independence");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let circuit = circuits::partially_independent_circuit(n, 5, SEED);
+        group.bench_with_input(BenchmarkId::new("statevector", n), &circuit, |b, circ| {
+            b.iter(|| run_with(BackendKind::Statevector, circ, 42).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("factored", n), &circuit, |b, circ| {
+            b.iter(|| run_with(BackendKind::Factored, circ, 42).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
 /// Non-Pauli trajectory noise on the factored backend, the only path that reaches
 /// `Backend::apply_1q_matrix`. Pauli noise routes to gate application instead, so
 /// `noisy_sampling` does not cover this at all.
@@ -2008,6 +2031,7 @@ criterion_group! {
     bench_factored_independent,
     bench_factored_sim_only,
     bench_factored_dynamic,
+    bench_factored_partial_independence,
     bench_factored_dense,
     bench_factored_noise_kraus,
     // Clifford+T (SPD/SPP)

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -781,6 +781,40 @@ impl Backend for FactoredBackend {
         Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
     }
 
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        // `FactoredBlock::mask` is a u64 and `Probabilities::len` is
+        // `1 << total_qubits`, so a wider register has no representable lazy
+        // form either; the dense terminal declines it.
+        if self.num_qubits > 64 {
+            return None;
+        }
+
+        let active: SmallVec<[&SubState; 16]> = self
+            .substates
+            .iter()
+            .filter_map(|opt| opt.as_ref())
+            .collect();
+
+        if active.len() < 2 {
+            return None;
+        }
+
+        let blocks = active
+            .iter()
+            .map(|sub| {
+                let mut probs = vec![0.0_f64; sub.state.len()];
+                simd::norm_sqr_to_slice(&sub.state, &mut probs);
+                let mask = sub.qubits.iter().fold(0u64, |m, &q| m | 1 << q);
+                crate::sim::FactoredBlock { probs, mask }
+            })
+            .collect();
+
+        Some(crate::sim::Probabilities::Factored {
+            blocks,
+            total_qubits: self.num_qubits,
+        })
+    }
+
     fn num_qubits(&self) -> usize {
         self.num_qubits
     }

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -901,6 +901,32 @@ impl Backend for FactoredStabilizerBackend {
         Ok(crate::sim::merge_probabilities(&blocks, self.num_qubits))
     }
 
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        // `FactoredBlock::mask` is a u64 and `Probabilities::len` is
+        // `1 << total_qubits`, so a wider register has no representable lazy
+        // form either; the dense terminal declines it.
+        if self.num_qubits > 64 {
+            return None;
+        }
+
+        let active: Vec<&SubTableau> = self.subs.iter().filter_map(|s| s.as_ref()).collect();
+        if active.len() < 2 {
+            return None;
+        }
+
+        let mut blocks = Vec::with_capacity(active.len());
+        for sub in active {
+            let probs = sub.compute_probabilities().ok()?;
+            let mask = sub.qubits.iter().fold(0u64, |m, &q| m | 1 << q);
+            blocks.push(crate::sim::FactoredBlock { probs, mask });
+        }
+
+        Some(crate::sim::Probabilities::Factored {
+            blocks,
+            total_qubits: self.num_qubits,
+        })
+    }
+
     fn num_qubits(&self) -> usize {
         self.num_qubits
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -358,6 +358,18 @@ pub trait Backend {
     /// provide this efficiently, they may return `Err(BackendUnsupported)`.
     fn probabilities(&self) -> Result<Vec<f64>>;
 
+    /// Per-block probabilities for a backend holding a product of independent
+    /// sub-states, skipping the `2^n` Kronecker expansion
+    /// [`Backend::probabilities`] would materialize.
+    ///
+    /// `None` means the caller takes [`Backend::probabilities`] instead, which
+    /// is the right answer for a single block or a monolithic state. Each
+    /// block's `probs` is indexed by its own qubits in ascending global order,
+    /// matching the `mask` convention of [`crate::sim::FactoredBlock`].
+    fn block_probabilities(&self) -> Option<crate::sim::Probabilities> {
+        None
+    }
+
     /// Number of qubits the backend is currently configured for.
     fn num_qubits(&self) -> usize;
 

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -127,6 +127,50 @@ pub fn independent_bell_pairs(n_pairs: usize) -> Circuit {
     c
 }
 
+/// One connected block spanning `n - 2` qubits plus one independent pair.
+///
+/// Sized so the decomposition heuristic declines: it needs the largest
+/// component to be at least three qubits smaller than the register, which
+/// `n - 2` fails. The circuit is therefore partially independent but runs whole
+/// on one backend, which is the shape that reaches the factored backend's
+/// multi-block probability terminal.
+pub fn partially_independent_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    assert!(
+        n >= 4,
+        "partially_independent_circuit needs at least 4 qubits"
+    );
+    let big = n - 2;
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    let singles = [Gate::H, Gate::X, Gate::Y, Gate::Z, Gate::S, Gate::T];
+
+    for layer in 0..depth {
+        for q in 0..big {
+            c.add_gate(singles[rng.random_range(0..singles.len())].clone(), &[q]);
+        }
+        for q in (layer % 2..big - 1).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    // The chain runs unconditionally so the large block is one component at
+    // every seed; group count must not be a seed property.
+    for q in 0..big - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+
+    for layer in 0..depth {
+        c.add_gate(singles[rng.random_range(0..singles.len())].clone(), &[big]);
+        c.add_gate(
+            singles[rng.random_range(0..singles.len())].clone(),
+            &[big + 1],
+        );
+        if layer == 0 {
+            c.add_gate(Gate::Cx, &[big, big + 1]);
+        }
+    }
+    c
+}
+
 /// K independent random sub-circuits of `block_size` qubits each.
 ///
 /// Total qubits = `num_blocks * block_size`. Each block has its own

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -739,6 +739,9 @@ fn probs_only_result(probs: Vec<f64>) -> RunOutcome {
 }
 
 fn try_backend_probabilities(backend: &dyn Backend) -> Result<Option<Probabilities>> {
+    if let Some(factored) = backend.block_probabilities() {
+        return Ok(Some(factored));
+    }
     match backend.probabilities() {
         Ok(probs) => Ok(Some(Probabilities::Dense(probs))),
         Err(PrismError::BackendUnsupported { .. }) => Ok(None),

--- a/src/sim/probability.rs
+++ b/src/sim/probability.rs
@@ -173,24 +173,6 @@ impl Probabilities {
     }
 }
 
-impl std::ops::Index<usize> for Probabilities {
-    type Output = f64;
-
-    /// Index into a dense probability vector.
-    ///
-    /// Only works for `Dense`. Panics on `Factored` because `Index` must
-    /// return `&f64` and factored values are computed, not stored.
-    /// Use [`Probabilities::get`] or [`Probabilities::iter`] instead.
-    fn index(&self, index: usize) -> &f64 {
-        match self {
-            Probabilities::Dense(v) => &v[index],
-            Probabilities::Factored { .. } => {
-                panic!("cannot index Factored probabilities; use .get(i) or .to_vec()")
-            }
-        }
-    }
-}
-
 /// Concrete iterator for [`Probabilities::iter`].
 pub struct ProbabilitiesIter<'a> {
     inner: ProbabilitiesIterInner<'a>,
@@ -291,7 +273,7 @@ mod tests {
         assert_eq!(p.len(), 4);
         assert!(!p.is_empty());
         assert_eq!(p.get(2), 0.3);
-        assert_eq!(p[3], 0.4);
+        assert_eq!(p.get(3), 0.4);
         assert_eq!(p.to_vec(), vec![0.1, 0.2, 0.3, 0.4]);
         let collected: Vec<f64> = p.iter().collect();
         assert_eq!(collected, vec![0.1, 0.2, 0.3, 0.4]);
@@ -340,13 +322,6 @@ mod tests {
         let p = Probabilities::Dense(vec![0.5, 0.5]);
         let it = p.iter();
         assert_eq!(it.size_hint(), (2, Some(2)));
-    }
-
-    #[test]
-    #[should_panic(expected = "cannot index Factored")]
-    fn factored_index_panics() {
-        let p = factored_2x3();
-        let _ = p[0];
     }
 
     #[test]

--- a/tests/factored_correctness.rs
+++ b/tests/factored_correctness.rs
@@ -396,3 +396,56 @@ fn factored_oversize_probabilities_decline_instead_of_panicking() {
         "a 100 qubit factored register cannot serve a dense probability vector"
     );
 }
+
+// The multi-block probability terminal now returns per-block marginals instead
+// of the merged 2^n vector. Expanding that lazy form must reproduce the merge
+// exactly, which pins the block bit-order convention: each block's probs are
+// indexed by its own qubits in ascending global order, and `mask` records which
+// global positions those are.
+#[test]
+fn factored_block_probabilities_expand_to_the_merged_vector() {
+    use prism_q::backend::Backend;
+    use prism_q::sim::{BackendKind, Probabilities};
+
+    for n in [10usize, 14, 16] {
+        let circuit = circuits::partially_independent_circuit(n, 4, SEED);
+        assert!(
+            circuit.independent_subsystems().len() > 1,
+            "{n}q: circuit must stay partially independent for this to test anything"
+        );
+
+        let mut backend = FactoredBackend::new(SEED);
+        prism_q::sim::run_on(&mut backend, &circuit).unwrap();
+
+        let lazy = backend
+            .block_probabilities()
+            .expect("multi-block state must offer per-block probabilities");
+        match &lazy {
+            Probabilities::Factored { blocks, .. } => {
+                assert!(blocks.len() > 1, "{n}q: expected more than one block")
+            }
+            Probabilities::Dense(_) => panic!("{n}q: expected the factored variant"),
+        }
+
+        let merged = backend.probabilities().unwrap();
+        let expanded = lazy.to_vec();
+        assert_eq!(expanded.len(), merged.len(), "{n}q: length mismatch");
+        for (i, (a, b)) in expanded.iter().zip(&merged).enumerate() {
+            assert!(
+                (a - b).abs() < FACTORED_EPS,
+                "{n}q: state {i}: lazy {a} vs merged {b}"
+            );
+        }
+
+        // The public run must now carry the lazy form end to end.
+        let out = prism_q::sim::simulate(&circuit)
+            .backend(BackendKind::Factored)
+            .seed(SEED)
+            .run()
+            .unwrap();
+        assert!(matches!(
+            out.probabilities,
+            Some(Probabilities::Factored { .. })
+        ));
+    }
+}

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -73,7 +73,10 @@ fn qiskit_style_conditional_x_after_measure() {
     let mut backend = StatevectorBackend::new(42);
     let result = sim::run_on(&mut backend, &circuit).expect("run");
     let probs = result.probabilities.expect("probs");
-    assert!(probs[0] > 0.999, "expected |0> after teleport-style reset");
+    assert!(
+        probs.get(0) > 0.999,
+        "expected |0> after teleport-style reset"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The factored backend's multi-block probability terminal ran `merge_probabilities`, which
holds three `2^n` allocations plus a serial Kronecker expansion and permutation build, to
produce a dense vector the caller usually only samples from. `Probabilities` already
carries a lazy factored form and the decomposed sim route emits it; the backends now do
too. `factored_stabilizer` has the identical terminal and gets the same treatment.

Three commits: the bench row that reaches the code, the change, and removal of an
`Index` impl that could not serve the lazy variant.

## Scope

- [x] Performance improvement
- [x] Refactor or cleanup

## Benchmarks

`scripts/bench_ab.sh --filter '^factored/(partial_independence|dense)/(statevector|factored)/(12|16|20)$' --ref 1673717`

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `factored/partial_independence/factored/20` | 25.47 ms | 15.60 ms | -38.8% | +1.0% / -0.9% | yes, improvement |
| `factored/partial_independence/factored/16` | 1.38 ms | 1.05 ms | -23.9% | -3.5% / -1.7% | yes, improvement |
| `factored/partial_independence/statevector/20` | 49.78 ms | 50.14 ms | +0.7% | +0.7% / +0.7% | yes, flat |
| `factored/partial_independence/statevector/16` | 1.97 ms | 1.98 ms | +0.7% | -1.9% / -1.1% | yes, flat |
| `factored/dense/factored/{12,16,20}` | | | +0.1% to -0.8% | | yes, flat |
| `factored/dense/statevector/{12,16,20}` | | | -1.1% to -2.9% | | yes, flat |

100 samples, i7-6700K, rustc 1.97.0. `factored/dense/statevector/16` carries an 18.5%
control and is unreadable; it is a control row and its change is within the others.

The `factored/dense/*` rows are the controls that matter: one sub-state spans every
qubit there, so the single-block path is taken and must not move. It did not. The
`statevector` rows on the same circuits are flat because that backend takes the `None`
default.

The bench row is new because the group the original proposal named cannot reach this
code. On `factored/dynamic_advantage`, `independent_subsystems` returns 7 to 10
components, `should_decompose` passes, and the sim answers per block without ever
calling `merge_probabilities`. `partially_independent_circuit` sizes the largest
component at `n - 2`, which `should_decompose` declines, so the whole circuit runs on one
backend with the state still in two sub-states.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` (1889 tests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --features "parallel distributed"` under `-D warnings`

`factored_block_probabilities_expand_to_the_merged_vector` expands the lazy form and
compares it to the merged vector at 10, 14, and 16 qubits, which pins the block bit-order
convention. It fails if the mask ordering is permuted.

## Breaking changes

Two.

1. An explicit `BackendKind::Factored` run on a partially independent circuit now returns
   `Probabilities::Factored` where it returned `Dense`. The decomposed route already
   exposed that variant from the same entry point, so this widens an existing shape
   rather than introducing one.
2. `Index` on `Probabilities` is removed. `probs[i]` no longer compiles; use
   `probs.get(i)`. `Index` must return a reference and the lazy variant computes its
   values, so the impl panicked on half its domain, which the compiler could not catch.
   One in-tree caller migrated.

## Risks and rollback

A caller relying on `Dense` from an explicit `Factored` run gets a different variant,
which `get`, `iter`, and `to_vec` all serve. Rollback is the three commits; the bench row
can stay.
