### PR TITLE
perf(density-matrix): compose a 1q gate with the channel that follows it

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -58,7 +58,7 @@ use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
-use crate::gates::{DiagEntry, Gate, McuData};
+use crate::gates::{DiagEntry, Gate, McuData, mat_mul_4x4};
 use crate::sim::i_pow;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -472,6 +472,31 @@ impl DensityMatrixBackend {
     pub fn apply_1q_kraus(&mut self, qubit: usize, kraus: &[[[Complex64; 2]; 2]]) {
         let s = block_superoperator(kraus);
         self.apply_block_superoperator(qubit, &s);
+    }
+
+    /// Apply `gate` and then every Kraus set in `channels`, all one-qubit maps
+    /// on `qubit`, in one buffer sweep instead of one per map.
+    ///
+    /// Returns false with the buffer untouched when `gate` has no one-qubit
+    /// matrix. Each block superoperator acts on the same `(row-bit, col-bit)`
+    /// 4-vector of `qubit`, so the composition is their matrix product in
+    /// application order and costs 64 complex multiplies per factor, once per
+    /// instruction rather than once per amplitude.
+    pub(crate) fn try_apply_fused_1q_channels(
+        &mut self,
+        gate: &Gate,
+        qubit: usize,
+        channels: &[Vec<[[Complex64; 2]; 2]>],
+    ) -> bool {
+        let Some(mat) = matrix_1q(gate) else {
+            return false;
+        };
+        let mut s = block_superoperator(&[mat]);
+        for kraus in channels {
+            s = mat_mul_4x4(&block_superoperator(kraus), &s);
+        }
+        self.apply_block_superoperator(qubit, &s);
+        true
     }
 
     /// Apply symmetric two-qubit depolarizing on `(q0, q1)`:

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -2507,14 +2507,33 @@ fn evolve_density_matrix(
         None => dm.init(circuit.num_qubits, circuit.num_classical_bits)?,
     }
     for (i, inst) in circuit.instructions.iter().enumerate() {
+        let events: &[NoiseEvent] = match noise {
+            Some(noise) => &noise.after_gate[i],
+            None => &[],
+        };
+
+        if let Instruction::Gate { gate, targets } = inst {
+            if targets.len() == 1
+                && !events.is_empty()
+                && events.iter().all(|event| {
+                    !matches!(event.channel, NoiseChannel::TwoQubitDepolarizing { .. })
+                        && event.qubits[0] == targets[0]
+                })
+            {
+                let channels: Vec<Vec<[[Complex64; 2]; 2]>> =
+                    events.iter().map(|e| kraus_1q(&e.channel)).collect();
+                if dm.try_apply_fused_1q_channels(gate, targets[0], &channels) {
+                    continue;
+                }
+            }
+        }
+
         match inst {
             Instruction::Measure { .. } => {}
             other => dm.apply(other)?,
         }
-        if let Some(noise) = noise {
-            for event in &noise.after_gate[i] {
-                apply_noise_event_dm(&mut dm, event);
-            }
+        for event in events {
+            apply_noise_event_dm(&mut dm, event);
         }
     }
     Ok(dm)

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1106,3 +1106,80 @@ fn dm_batch_phase_through_apply_matches_the_unfused_cphase() {
     sim::run_on(&mut sv, &circuit).unwrap();
     assert_rdm_close(&dm, &sv, 2, "batch phase");
 }
+
+// A 1q gate and the 1q channel that follows it compose into one superoperator
+// sweep on the noisy density-matrix route. The composed map is order sensitive,
+// so comparing every 1q Pauli expectation against sequential application pins
+// the order as well as the value: the three expectations fix each reduced
+// density matrix completely.
+#[test]
+fn fused_gate_and_channel_matches_sequential_application() {
+    use prism_q::sim::noise::{NoiseModel, density_matrix_expectation_values};
+    use prism_q::sim::unified_pauli::PauliTerm;
+
+    let gamma = 0.17;
+    let n = 4;
+    let mut circuit = Circuit::new(n, 0);
+    for q in 0..n {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::T, &[q]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::Ry(0.63 + q as f64), &[q]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::S, &[q]);
+    }
+
+    let noise = NoiseModel::with_amplitude_damping(&circuit, gamma);
+    let observables: Vec<Vec<PauliTerm>> = (0..n)
+        .flat_map(|q| {
+            [
+                vec![PauliTerm::x(q)],
+                vec![PauliTerm::y(q)],
+                vec![PauliTerm::z(q)],
+            ]
+        })
+        .collect();
+    let fused =
+        density_matrix_expectation_values(&circuit, &observables, Some(&noise), SEED).unwrap();
+
+    // Sequential reference: gate, then the channel, as two separate sweeps.
+    let damping = [
+        [c(1.0, 0.0), c(0.0, 0.0)],
+        [c(0.0, 0.0), c((1.0 - gamma).sqrt(), 0.0)],
+    ];
+    let jump = [
+        [c(0.0, 0.0), c(gamma.sqrt(), 0.0)],
+        [c(0.0, 0.0), c(0.0, 0.0)],
+    ];
+    let mut reference = DensityMatrixBackend::new(SEED);
+    reference.init(n, 0).unwrap();
+    for instr in &circuit.instructions {
+        reference.apply(instr).unwrap();
+        if let prism_q::circuit::Instruction::Gate { targets, .. } = instr {
+            for &q in targets.iter() {
+                reference.apply_1q_kraus(q, &[damping, jump]);
+            }
+        }
+    }
+
+    for q in 0..n {
+        let rdm = reference.reduced_density_matrix_1q(q).unwrap();
+        let expected = [
+            (rdm[0][1] + rdm[1][0]).re,
+            (Complex64::new(0.0, 1.0) * (rdm[0][1] - rdm[1][0])).re,
+            (rdm[0][0] - rdm[1][1]).re,
+        ];
+        for (k, label) in ["X", "Y", "Z"].iter().enumerate() {
+            let got = fused[3 * q + k];
+            assert!(
+                (got - expected[k]).abs() < DM_EPS,
+                "qubit {q} <{label}>: fused {got} vs sequential {}",
+                expected[k]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

On the exact noisy density-matrix route a one-qubit gate and the one-qubit channels
after it were independent full-buffer sweeps of identical shape, all ending in the same
block superoperator on the same (row-bit, col-bit) pair. They are linear maps on the same
4-vector, so their product is one 4x4 built once per instruction and the buffer is swept
once instead of once per map. `random_circuit` emits one gate per qubit per layer and each
draws one Pauli event, so this removes roughly a third of the sweeps on the noisy rows.

Sequential application stays the fallback for every shape that does not compose: a
multi-qubit gate, a channel on another qubit, two-qubit depolarizing, or a gate with no
one-qubit matrix.

## Scope

- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh`, 30 samples, adjacent binaries against `main` (5831fad).
Intel i7-6700K, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `density_matrix/noisy_shots/10` | 148.69 ms | 90.80 ms | -38.9% | +17.2% / +9.6% | yes, faster |
| `density_matrix/noisy_shots/8` | 5.48 ms | 4.58 ms | -16.4% | +8.4% / -33.6% | unmeasured |
| `density_matrix/noisy_channels/kraus_amp_damp/10` | 1.29 ms | 1.24 ms | -3.9% | -14.0% / -10.9% | unmeasured |
| `density_matrix/unitary_layers/10` | 175.10 ms | 160.33 ms | -8.4% | +0.3% / +3.8% | yes, faster |

Only `noisy_shots/10` clears its own noise floor, at 2.3x the worst same-code control on
that row. `noisy_shots/8` is not claimable at a -33.6% control and is reported as
unmeasured rather than rounded into the headline. `unitary_layers` calls
`apply_instructions` directly (`benches/circuits.rs:1816`) and never enters
`evolve_density_matrix`, so its move cannot come from this diff's logic; it is binary
layout, and it goes the harmless way.

A no-code pre-check supports the mechanism: `kraus_amp_damp/10` times exactly one block
superoperator sweep at n=10 and reads 1.35 ms, against 1.47 ms predicted from the pass
model this change is built on.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (1892 tests)
- [x] `cargo test --doc --features parallel` passes (12 doctests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

`fused_gate_and_channel_matches_sequential_application` in
`tests/density_matrix_correctness.rs` compares every one-qubit Pauli expectation against
sequential application. The composed map is order sensitive, and the three expectations
fix each reduced density matrix completely, so the test pins the order as well as the
value. It runs at n=4, below the block-superoperator threshold, covering the width where
the sequential path would not have used a block superoperator at all.

## Hotspot notes

`evolve_density_matrix` (`src/sim/noise.rs`) issues the gate and its noise events back to
back, and both end in `apply_block_superoperator`, which sweeps the whole `4^n` buffer.

## Breaking changes

None.

## Risks and rollback

Confined to the exact noisy density-matrix route. The fused path is opt-in per
instruction: `try_apply_fused_1q_channels` returns false and leaves the buffer untouched
for any shape it does not handle, and the caller falls through to the sequential path.
Reverting the guard in `evolve_density_matrix` restores the old behaviour without
touching the backend.
