### PR TITLE
perf(sim): share one state traversal across a batch of observables

### DIFF
--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -663,12 +663,7 @@ fn expectation_values_from_initial_state(
 
     let evolved = backend.export_statevector()?;
     let norm = crate::backend::state_norm_sqr(&evolved);
-    Ok(masks
-        .iter()
-        .map(|&(xmask, zmask, num_y)| {
-            pauli_expectation_from_masks(&evolved, xmask, zmask, num_y, norm)
-        })
-        .collect())
+    Ok(pauli_expectations_from_masks(&evolved, &masks, norm))
 }
 
 fn require_unitary_circuit(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
@@ -1685,12 +1680,7 @@ fn expectation_values_statevector(
         backend.state_vector()
     };
     let norm = crate::backend::state_norm_sqr(state);
-    Ok(masks
-        .iter()
-        .map(|&(xmask, zmask, num_y)| {
-            pauli_expectation_from_masks(state, xmask, zmask, num_y, norm)
-        })
-        .collect())
+    Ok(pauli_expectations_from_masks(state, &masks, norm))
 }
 
 /// Reject out-of-range qubits and duplicate factors in a joint Pauli
@@ -1764,6 +1754,11 @@ pub(crate) fn pauli_masks(
 /// `P|j⟩ = i^{#Y}·(-1)^{popcount(j & Zmask)}·|j ⊕ Xmask⟩`. Returns the raw
 /// (unnormalized) complex value. The adjoint gradient engine uses this with
 /// distinct `λ` and `φ`; `pauli_expectation_from_masks` is the `λ = φ` case.
+///
+/// Inlined explicitly: this is the adjoint engine's inner reduction, called
+/// once per parameter, and leaving the decision to LTO ties it to how many
+/// other callers the function happens to have.
+#[inline]
 pub(crate) fn pauli_sandwich(
     lambda: &[Complex64],
     phi: &[Complex64],
@@ -1827,6 +1822,121 @@ pub(crate) fn pauli_expectation_from_masks(
         return 0.0;
     }
     pauli_sandwich(state, state, xmask, zmask, num_y).re / norm
+}
+
+/// Exact `⟨ψ|P_i|ψ⟩` for every mask triple in one traversal of `state`.
+///
+/// Same value as [`pauli_expectation_from_masks`] per entry, to within the
+/// association of the sum. A Z-only observable has `xmask == 0` and therefore
+/// no Y factor, so its contribution is `±|amp|^2` and needs neither the partner
+/// load nor complex arithmetic; the two families are accumulated separately for
+/// that reason.
+pub(crate) fn pauli_expectations_from_masks(
+    state: &[Complex64],
+    masks: &[(usize, usize, u32)],
+    norm: f64,
+) -> Vec<f64> {
+    if norm == 0.0 {
+        return vec![0.0; masks.len()];
+    }
+    if masks.len() < 2 {
+        return masks
+            .iter()
+            .map(|&(xmask, zmask, num_y)| {
+                pauli_expectation_from_masks(state, xmask, zmask, num_y, norm)
+            })
+            .collect();
+    }
+
+    let z_only: Vec<usize> = masks
+        .iter()
+        .filter(|&&(xmask, _, _)| xmask == 0)
+        .map(|&(_, zmask, _)| zmask)
+        .collect();
+    let general: Vec<(usize, usize)> = masks
+        .iter()
+        .filter(|&&(xmask, _, _)| xmask != 0)
+        .map(|&(xmask, zmask, _)| (xmask, zmask))
+        .collect();
+
+    let accumulate = |z_acc: &mut [f64], g_acc: &mut [Complex64], base: usize, len: usize| {
+        for j in base..base + len {
+            let amp = state[j];
+            let n2 = amp.norm_sqr();
+            for (slot, &zmask) in z_acc.iter_mut().zip(z_only.iter()) {
+                *slot += if (j & zmask).count_ones() & 1 == 1 {
+                    -n2
+                } else {
+                    n2
+                };
+            }
+            for (slot, &(xmask, zmask)) in g_acc.iter_mut().zip(general.iter()) {
+                let partner = state[j ^ xmask];
+                let sign = if (j & zmask).count_ones() & 1 == 1 {
+                    -1.0
+                } else {
+                    1.0
+                };
+                *slot += partner.conj() * amp * sign;
+            }
+        }
+    };
+
+    let zeros = || {
+        (
+            vec![0.0f64; z_only.len()],
+            vec![Complex64::new(0.0, 0.0); general.len()],
+        )
+    };
+    let (mut z_sum, mut g_sum) = zeros();
+
+    #[cfg(feature = "parallel")]
+    if state.len() >= crate::backend::MIN_PAR_REDUCE_ELEMS {
+        use rayon::prelude::*;
+        let chunk = crate::backend::MIN_PAR_ELEMS;
+        let (z, g) = state
+            .par_chunks(chunk)
+            .enumerate()
+            .fold(zeros, |mut acc, (c, block)| {
+                accumulate(&mut acc.0, &mut acc.1, c * chunk, block.len());
+                acc
+            })
+            .reduce(zeros, |mut a, b| {
+                for (slot, v) in a.0.iter_mut().zip(b.0) {
+                    *slot += v;
+                }
+                for (slot, v) in a.1.iter_mut().zip(b.1) {
+                    *slot += v;
+                }
+                a
+            });
+        return finish_expectations(masks, &z, &g, norm);
+    }
+
+    accumulate(&mut z_sum, &mut g_sum, 0, state.len());
+    finish_expectations(masks, &z_sum, &g_sum, norm)
+}
+
+/// Interleave the two accumulator families back into observable order.
+fn finish_expectations(
+    masks: &[(usize, usize, u32)],
+    z_sum: &[f64],
+    g_sum: &[Complex64],
+    norm: f64,
+) -> Vec<f64> {
+    let (mut zi, mut gi) = (0, 0);
+    masks
+        .iter()
+        .map(|&(xmask, _, num_y)| {
+            if xmask == 0 {
+                zi += 1;
+                z_sum[zi - 1] / norm
+            } else {
+                gi += 1;
+                (g_sum[gi - 1] * i_pow(num_y)).re / norm
+            }
+        })
+        .collect()
 }
 
 /// Multi-shot execution for the distributed statevector backend.

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -430,3 +430,34 @@ fn statevector_route_matches_scalar_reference_above_the_parallel_norm_threshold(
         assert_close(&got, &[expect_zz / norm, expect_x / norm], TOL);
     }
 }
+
+// A batch of observables shares one traversal of the amplitude buffer, while a
+// batch of one keeps the single-observable reduction. The two must agree, and
+// the batch must return values in request order: the shared pass splits the
+// list into a Z-only family and a family carrying an X or Y factor, then
+// interleaves them back. Sizes straddle the parallel threshold at 2^16, and the
+// observable order alternates between the two families so a mismatched
+// interleave cannot pass.
+#[test]
+fn batched_observables_match_one_at_a_time() {
+    use prism_q::circuits;
+
+    for n in [12usize, 16, 17] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, 42);
+        let observables: Vec<Vec<PauliTerm>> = vec![
+            vec![PauliTerm::x(0), PauliTerm::y(1)],
+            vec![PauliTerm::z(2), PauliTerm::z(n - 1)],
+            vec![PauliTerm::y(n / 2)],
+            vec![PauliTerm::z(n - 2)],
+            vec![],
+        ];
+
+        let batched = run_expectation_values(&circuit, &observables, 42).unwrap();
+        let one_at_a_time: Vec<f64> = observables
+            .iter()
+            .map(|obs| run_expectation_values(&circuit, std::slice::from_ref(obs), 42).unwrap()[0])
+            .collect();
+
+        assert_close(&batched, &one_at_a_time, TOL);
+    }
+}


### PR DESCRIPTION
## Summary

The dense statevector route mapped each observable to its own
`pauli_expectation_from_masks` call, so a k-observable query made k full reductions over
the amplitude buffer, each parallel and bandwidth-bound from 16 qubits up. One pass now
carries k accumulators. The marginal route builds one single-Z observable per qubit, so
it is the widest consumer of this shape.

A Z-only observable has no X or Y factor, so its contribution is the amplitude norm with
a parity sign and needs neither the partner load nor complex arithmetic. The two families
accumulate separately and interleave back into request order. A batch of one keeps the
old single-observable reduction untouched.

## Scope

- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh`, 30 samples, adjacent binaries against `main` (89a0350).
Intel i7-6700K, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `expectation/pauli_sum/14` | 891.63 us | 782.21 us | -12.3% | -1.5% / -8.1% | yes, faster |
| `expectation/pauli_sum/16` | 2.61 ms | 1.65 ms | -36.7% | +11.1% / +7.1% | yes, faster |
| `expectation/pauli_sum/18` | 7.07 ms | 5.33 ms | -24.6% | +2.0% / +0.6% | yes, faster |
| `expectation/pauli_sum/20` | 37.80 ms | 31.65 ms | -16.3% | +0.1% / +0.2% | yes, faster |
| `gradient/prefix_local/adjoint/18` | 18.81 ms | 19.71 ms | +4.8% | +2.0% / +11.2% | unmeasured |
| `gradient/prefix_local/adjoint/20` | 283.82 ms | 273.99 ms | -3.5% | +0.4% / +0.1% | yes |

The `adjoint` rows are the control: a single-term observable on the untouched adjoint
route. `/18` sits inside its own same-code control and is reported as unmeasured rather
than rounded either way.

That control row is why this PR also touches `pauli_sandwich`. Without the `#[inline]`,
`/18` measured +13.8% against a +/-3% control, reproduced across two runs. The adjoint
engine (`src/sim/gradient.rs`) calls `pauli_sandwich` once per parameter, so it is that
row's inner kernel; this change removes its hot caller here, and with the decision left
to LTO its inlining followed a caller count that no longer represents how it is used.
Pinning it returns the row to its noise floor and moves `/20` from +2.5% to -3.5% on
+/-0.4% controls.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (1893 tests)
- [x] `cargo test --doc --features parallel` passes (12 doctests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo check --no-default-features` passes

`batched_observables_match_one_at_a_time` in `tests/expectation_values.rs` compares a
batch against the same observables requested one at a time, which is the untouched
single-observable reduction. The list alternates between the Z-only and general families
so a mismatched interleave cannot pass, and includes a Y factor and an empty (identity)
observable. Sizes 12, 16, and 17 straddle the parallel threshold.

`statevector_route_matches_scalar_reference_above_the_parallel_norm_threshold` already
pinned these values against a hand-written scalar sweep and still passes.

## Hotspot notes

`expectation_values_statevector` into `pauli_sandwich`, whose reduction goes parallel from
2^16 elements up and is bandwidth-bound there. At 20 qubits with 19 observables the old
shape streamed the 16 MiB buffer 19 times against an 8 MiB L3.

## Breaking changes

None. Values are unchanged to within the association of the sum.

## Risks and rollback

Confined to the dense statevector observable route. A batch of one delegates to the
previous code path, so single-observable callers are bit-identical. The `#[inline]` is
independent and can be kept or dropped on its own.
