### PR TITLE
perf(mps): share prefix contractions across the dense expansion

### DIFF
--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -52,9 +52,41 @@ const DEFAULT_SVD_EPSILON: f64 = 1e-12;
 const MAX_SVD_SWEEPS: usize = 100;
 const SVD_CONVERGENCE: f64 = 1e-14;
 #[cfg(feature = "parallel")]
-const MIN_DIM_FOR_PAR: usize = 1 << 14;
-#[cfg(feature = "parallel")]
 const MIN_BOND_FOR_PAR: usize = 32;
+/// Leaves per Rayon task in the dense expansion, as a bit count. The split
+/// depth is chosen to leave at least `2^6` amplitudes under each prefix, so
+/// the gate is per-task work rather than total element count: each element
+/// here costs a site contraction, not the few flops a statevector sweep pays.
+#[cfg(feature = "parallel")]
+const MIN_LEAVES_PER_TASK_BITS: usize = 6;
+/// Cap on the split depth, bounding the serial prefix walk and the number of
+/// scratch stacks allocated.
+#[cfg(feature = "parallel")]
+const MAX_SPLIT_BITS: usize = 6;
+
+/// Raw output pointer for the dense expansion's Rayon split.
+#[cfg(feature = "parallel")]
+#[derive(Copy, Clone)]
+struct DenseOutPtr<T>(*mut T);
+
+#[cfg(feature = "parallel")]
+// SAFETY: the expansion partitions basis indices by their top-site bits before
+// entering Rayon, so each task writes a disjoint set of elements.
+unsafe impl<T: Send> Send for DenseOutPtr<T> {}
+#[cfg(feature = "parallel")]
+// SAFETY: same partition as Send; sharing the wrapper grants no overlap.
+unsafe impl<T: Send> Sync for DenseOutPtr<T> {}
+
+#[cfg(feature = "parallel")]
+impl<T> DenseOutPtr<T> {
+    #[inline(always)]
+    unsafe fn store(self, idx: usize, val: T) {
+        // SAFETY: same contract as the enclosing unsafe fn.
+        unsafe {
+            *self.0.add(idx) = val;
+        }
+    }
+}
 
 #[derive(Clone)]
 struct SiteTensor {
@@ -1839,26 +1871,133 @@ impl MpsBackend {
         prob
     }
 
-    fn chain_amplitude(&self, basis: usize) -> Complex64 {
-        let n = self.num_qubits;
-        let mut vec_data = vec![ONE];
-        for site in 0..n {
-            let logical = self.logical_for_site(site);
-            let bit = (basis >> logical) & 1;
-            let t = &self.sites[site];
-            let br = t.bond_right;
-            let new_vec: Vec<Complex64> = (0..br)
-                .map(|beta| {
-                    vec_data
-                        .iter()
-                        .enumerate()
-                        .map(|(alpha, &v)| v * t.data[t.idx(alpha, bit, beta)])
-                        .sum()
-                })
-                .collect();
-            vec_data = new_vec;
+    /// Contract site `site` against the right-side vector `src`, selecting
+    /// physical index `bit`, into `dst` of length `bond_left`.
+    #[inline(always)]
+    fn contract_site_right(
+        &self,
+        site: usize,
+        bit: usize,
+        src: &[Complex64],
+        dst: &mut [Complex64],
+    ) {
+        let t = &self.sites[site];
+        debug_assert_eq!(src.len(), t.bond_right);
+        debug_assert_eq!(dst.len(), t.bond_left);
+        for (alpha, slot) in dst.iter_mut().enumerate() {
+            let mut acc = ZERO;
+            for (beta, &v) in src.iter().enumerate() {
+                acc += t.data[t.idx(alpha, bit, beta)] * v;
+            }
+            *slot = acc;
         }
-        vec_data[0]
+    }
+
+    /// Depth-first expansion of the subtree below `depth`, writing one
+    /// amplitude per leaf through `store`.
+    ///
+    /// Sites are consumed right to left, so `scratch[d]` holds the vector on
+    /// the left bond of site `n - d` and the deepest level decides site 0.
+    /// With an unpermuted layout that makes consecutive leaves differ in the
+    /// lowest basis bit, so leaf writes run in address order.
+    fn expand_subtree(
+        &self,
+        depth: usize,
+        basis: usize,
+        scratch: &mut [Vec<Complex64>],
+        store: &mut impl FnMut(usize, Complex64),
+    ) {
+        let n = self.num_qubits;
+        if depth == n {
+            store(basis, scratch[n][0]);
+            return;
+        }
+        let site = n - 1 - depth;
+        let logical = self.site_to_logical[site];
+        for bit in 0..2 {
+            let (lo, hi) = scratch.split_at_mut(depth + 1);
+            self.contract_site_right(site, bit, &lo[depth], &mut hi[0]);
+            self.expand_subtree(depth + 1, basis | (bit << logical), scratch, store);
+        }
+    }
+
+    /// Scratch stack for [`MpsBackend::expand_subtree`], one buffer per depth.
+    fn expansion_scratch(&self) -> Vec<Vec<Complex64>> {
+        let n = self.num_qubits;
+        let mut scratch = Vec::with_capacity(n + 1);
+        scratch.push(vec![ONE]);
+        for depth in 1..=n {
+            scratch.push(vec![ZERO; self.sites[n - depth].bond_left]);
+        }
+        scratch
+    }
+
+    /// Every `(basis prefix, left-bond vector)` pair at `depth`, in DFS order.
+    #[cfg(feature = "parallel")]
+    fn expansion_prefixes(&self, depth: usize) -> Vec<(usize, Vec<Complex64>)> {
+        let mut scratch = self.expansion_scratch();
+        let mut out = Vec::with_capacity(1 << depth);
+        self.collect_prefixes(0, depth, 0, &mut scratch, &mut out);
+        out
+    }
+
+    #[cfg(feature = "parallel")]
+    fn collect_prefixes(
+        &self,
+        depth: usize,
+        stop: usize,
+        basis: usize,
+        scratch: &mut [Vec<Complex64>],
+        out: &mut Vec<(usize, Vec<Complex64>)>,
+    ) {
+        if depth == stop {
+            out.push((basis, scratch[depth].clone()));
+            return;
+        }
+        let site = self.num_qubits - 1 - depth;
+        let logical = self.site_to_logical[site];
+        for bit in 0..2 {
+            let (lo, hi) = scratch.split_at_mut(depth + 1);
+            self.contract_site_right(site, bit, &lo[depth], &mut hi[0]);
+            self.collect_prefixes(depth + 1, stop, basis | (bit << logical), scratch, out);
+        }
+    }
+
+    /// Fill `out` with `convert(amplitude)` per basis index, sharing every
+    /// prefix contraction across the `2^(n-k)` basis states below it.
+    ///
+    /// [`MpsBackend::chain_amplitude`] recomputes that prefix per amplitude and
+    /// allocates once per site, so a dense fill costs `2^n * sum_k bl_k*br_k`
+    /// against `sum_k 2^(k+1)*bl_k*br_k` here. The parallel split fixes the top
+    /// `m` sites, whose basis-bit sets are disjoint across prefixes.
+    fn expand_dense<T: Copy + Send>(&self, out: &mut [T], convert: impl Fn(Complex64) -> T + Sync) {
+        #[cfg(feature = "parallel")]
+        {
+            let split = self
+                .num_qubits
+                .saturating_sub(MIN_LEAVES_PER_TASK_BITS)
+                .min(MAX_SPLIT_BITS);
+            if split > 0 {
+                let ptr = DenseOutPtr(out.as_mut_ptr());
+                self.expansion_prefixes(split)
+                    .into_par_iter()
+                    .for_each(|(basis, vector)| {
+                        let mut scratch = self.expansion_scratch();
+                        scratch[split].copy_from_slice(&vector);
+                        self.expand_subtree(split, basis, &mut scratch, &mut |idx, amp| {
+                            // SAFETY: this task owns every basis index whose top
+                            // `split` site bits match its prefix, and those sets
+                            // partition the output, so no two tasks reach the
+                            // same element.
+                            unsafe { ptr.store(idx, convert(amp)) }
+                        });
+                    });
+                return;
+            }
+        }
+
+        let mut scratch = self.expansion_scratch();
+        self.expand_subtree(0, 0, &mut scratch, &mut |idx, amp| out[idx] = convert(amp));
     }
 
     fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
@@ -2005,18 +2144,7 @@ impl Backend for MpsBackend {
         let mut probs = Vec::new();
         reserve_dense_output(&mut probs, dim, self.name(), "probabilities")?;
         probs.resize(dim, 0.0);
-
-        #[cfg(feature = "parallel")]
-        if dim >= MIN_DIM_FOR_PAR {
-            probs.par_iter_mut().enumerate().for_each(|(basis, prob)| {
-                *prob = self.chain_amplitude(basis).norm_sqr();
-            });
-            return Ok(probs);
-        }
-
-        for (basis, prob) in probs.iter_mut().enumerate() {
-            *prob = self.chain_amplitude(basis).norm_sqr();
-        }
+        self.expand_dense(&mut probs, |amp| amp.norm_sqr());
         Ok(probs)
     }
 
@@ -2115,18 +2243,7 @@ impl Backend for MpsBackend {
         let mut state = Vec::new();
         reserve_dense_output(&mut state, dim, self.name(), "statevector export")?;
         state.resize(dim, ZERO);
-
-        #[cfg(feature = "parallel")]
-        if dim >= MIN_DIM_FOR_PAR {
-            state.par_iter_mut().enumerate().for_each(|(basis, amp)| {
-                *amp = self.chain_amplitude(basis);
-            });
-            return Ok(state);
-        }
-
-        for (basis, amp) in state.iter_mut().enumerate() {
-            *amp = self.chain_amplitude(basis);
-        }
+        self.expand_dense(&mut state, |amp| amp);
         Ok(state)
     }
 }

--- a/tests/mps_correctness.rs
+++ b/tests/mps_correctness.rs
@@ -171,3 +171,52 @@ fn mps_cz_chain_12q_fused() {
         &circuits::cz_chain_circuit(12, 3, SEED),
     );
 }
+
+// ===== dense expansion =====
+
+// The dense expansion splits the top sites across Rayon tasks once the chain
+// is deeper than the per-task leaf floor, so 6 qubits take the serial walk and
+// 7 and up take the split. Both must agree with the statevector.
+#[test]
+fn mps_dense_expansion_across_the_parallel_split() {
+    for n in [6usize, 7, 8, 13] {
+        check_sv_cross(
+            &format!("dense expansion {n}q"),
+            &circuits::random_circuit(n, 4, SEED),
+        );
+    }
+}
+
+// SWAP routing permutes the site layout, so the basis bit a site decides is no
+// longer the site's own index. Long-range CX force that permutation, and
+// export_statevector orders amplitudes by logical qubit, not by site.
+#[test]
+fn mps_dense_expansion_survives_swap_routing() {
+    use prism_q::backend::Backend;
+    use prism_q::gates::Gate;
+
+    let n = 8;
+    let mut circuit = Circuit::new(n, 0);
+    for q in 0..n {
+        circuit.add_gate(Gate::Ry(0.3 + 0.2 * q as f64), &[q]);
+    }
+    for (control, target) in [(0usize, 7usize), (1, 6), (2, 5), (0, 4)] {
+        circuit.add_gate(Gate::Cx, &[control, target]);
+    }
+    circuit.add_gate(Gate::T, &[3]);
+
+    let mut backend = MpsBackend::new(SEED, bond_dim_for(n));
+    assert_backend_matches_sv(&mut backend, &circuit, MPS_EPS, "swap-routed expansion");
+
+    let amplitudes = backend.export_statevector().unwrap();
+    let probs = backend.probabilities().unwrap();
+    assert_eq!(amplitudes.len(), probs.len());
+    for (basis, amp) in amplitudes.iter().enumerate() {
+        assert!(
+            (amp.norm_sqr() - probs[basis]).abs() < MPS_EPS,
+            "basis {basis}: |amp|^2 {} vs probability {}",
+            amp.norm_sqr(),
+            probs[basis]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`probabilities` and `export_statevector` filled their `2^n` buffer by walking the whole
chain once per basis index, so every amplitude recomputed the prefix contraction its
`2^(n-k)` siblings share and allocated once per site. A depth-first walk carries the
partial vector down a reused buffer per depth instead, turning `2^n * sum_k bl_k*br_k`
into `sum_k 2^(k+1)*bl_k*br_k`.

Sites are consumed right to left, so the deepest level decides the lowest basis bit and
leaf writes run in address order. Rayon splits on the top sites, whose basis-bit sets
partition the output.

The element-count gate on the parallel arm went with it. Per element the work here is a
site contraction, not the few flops a statevector sweep pays, so the split comes from
per-task leaf count instead. That brings the 7 to 13 qubit band into the parallel arm for
the first time.

## Scope

- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh`, 30 samples, adjacent binaries against `main` (c1068c2).
Intel i7-6700K, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `compare/general_d10/mps_64/16` | 17.24 ms | 509.27 us | -97.0% | +0.1% / +1.9% | yes, faster |
| `compare/general_d10/mps_64/20` | 17.28 ms | 539.96 us | -96.9% | +0.9% / +0.2% | yes, faster |
| `mps/random_d10/12` | 3.85 ms | 217.27 us | -94.4% | -5.3% / -6.2% | yes, faster |
| `mps/random_d10/16` | 18.57 ms | 531.15 us | -97.1% | -0.4% / +5.4% | yes, faster |
| `mps/random_d10/20` | 19.48 ms | 586.59 us | -97.0% | +3.8% / -5.7% | yes, faster |
| `mps/hotspots/adjacent_cp_r4/32` | 110.88 us | 109.43 us | -1.3% | -1.9% / +1.2% | yes, flat |
| `mps/hotspots/long_range_cp_r4/32` | 462.54 us | 473.51 us | +2.4% | -2.2% / +6.1% | yes, flat |
| `mps/linear_chain_d10/64` | 1.80 ms | 1.77 ms | -1.4% | +20.3% / +15.4% | unmeasured |

Every effect is one to two orders of magnitude above its own control. The controls held:
both `hotspots` rows run through `run_mps_apply_only`, which never calls `probabilities`,
and `linear_chain_d10/64` is above the dense cap so the terminal returns `Ok(None)`. That
last row carries a 20.3% same-code spread here and is reported as unmeasured, though its
point estimate is flat and it is a control rather than a target.

Sizing came first, with no code change: capping the terminal off with
`PRISM_MAX_PROB_QUBITS=12` cut `mps/random_d10/16` from 20.53 ms to 192 us and `/20` from
20.61 ms to 190 us, so the dense expansion was 99.1% of both rows before this change.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (1895 tests)
- [x] `cargo test --doc --features parallel` passes (12 doctests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo check --no-default-features` passes, warning free

`mps_dense_expansion_across_the_parallel_split` covers 6, 7, 8, and 13 qubits, straddling
the depth at which the Rayon split engages, against the statevector.
`mps_dense_expansion_survives_swap_routing` forces a permuted site layout with long-range
CX, since the walk decides basis bits through `site_to_logical` rather than the site
index, and also checks `export_statevector` against `probabilities` element by element.

`contract_site_right` carries `debug_assert_eq!` on both bond dimensions, matching
`compute_left_env` and `compute_right_env`. Without them a malformed chain would sum over
a short slice and return silently wrong amplitudes rather than failing. `[profile.test]`
sets `debug-assertions = true`, so the suite exercises them.

## Hotspot notes

The removed `chain_amplitude` walked all n sites per basis index and collected a fresh
`Vec` at each, so a `2^20` expansion allocated about 21 million times.

## Breaking changes

None.

## Risks and rollback

Confined to the two dense-output terminals on the MPS backend. Values are unchanged;
only the order of the contractions producing them differs. `DenseOutPtr` carries
`// SAFETY:` on both unsafe impls naming the partition that makes the parallel writes
disjoint: each task owns the basis indices whose top-`split` site bits match its prefix,
and those sets partition the output.
