### PR TITLE
perf: factored observable norm and high-target 1q traversal

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1225,6 +1225,41 @@ fn bench_expectation(c: &mut Criterion) {
     group.finish();
 }
 
+/// `expectation/pauli_sum` runs `Auto` and resolves to the statevector family,
+/// so it never reaches the factored observable path. `hardware_efficient_ansatz`
+/// is one connected component, so the factored state is a single sub-state
+/// spanning every qubit.
+fn bench_expectation_factored(c: &mut Criterion) {
+    let mut group = c.benchmark_group("expectation/pauli_sum_factored");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, SEED);
+        let observables: Vec<Vec<PauliTerm>> = (0..n - 1)
+            .map(|q| vec![PauliTerm::z(q), PauliTerm::z(q + 1)])
+            .collect();
+
+        for &(name, ref kind) in &[
+            ("factored", BackendKind::Factored),
+            ("statevector", BackendKind::Statevector),
+        ] {
+            group.bench_with_input(BenchmarkId::new(name, n), &circuit, |b, circ| {
+                b.iter(|| {
+                    black_box(
+                        sim::simulate(circ)
+                            .backend(kind.clone())
+                            .seed(42)
+                            .expectation_values(&observables)
+                            .unwrap(),
+                    )
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
 // ---- Factored backend benchmarks ----
 
 fn bench_factored_random(c: &mut Criterion) {
@@ -2027,6 +2062,7 @@ criterion_group! {
     bench_gradient_prefix,
     // Forward Pauli-sum expectation (parallel-sandwich neutrality)
     bench_expectation,
+    bench_expectation_factored,
     // Factored backend
     bench_factored_random,
     bench_factored_independent,

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -864,6 +864,15 @@ impl Backend for FactoredBackend {
     /// the product of the per-block expectations. Blocks the observable does
     /// not touch contribute one and are skipped.
     fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let norms: Vec<f64> = self
+            .substates
+            .iter()
+            .map(|slot| {
+                slot.as_ref()
+                    .map_or(0.0, |sub| crate::backend::state_norm_sqr(&sub.state))
+            })
+            .collect();
+
         observables
             .iter()
             .map(|observable| {
@@ -875,9 +884,8 @@ impl Backend for FactoredBackend {
                     if xmask == 0 && zmask == 0 {
                         continue;
                     }
-                    let norm: f64 = sub.state.iter().map(|amp| amp.norm_sqr()).sum();
                     product *= crate::sim::pauli_expectation_from_masks(
-                        &sub.state, xmask, zmask, num_y, norm,
+                        &sub.state, xmask, zmask, num_y, norms[ss],
                     );
                 }
                 Ok(product)

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -37,6 +37,11 @@ const MULTI_GATE_L2_TILE: usize = 16_384;
 const MULTI_GATE_L3_TILE: usize = 131_072;
 const MULTI_GATE_MAX_L2_TARGET: usize = max_target_for_tile(MULTI_GATE_L2_TILE);
 const MULTI_GATE_MAX_L3_TARGET: usize = max_target_for_tile(MULTI_GATE_L3_TILE);
+/// Targets folded into one shared high-target traversal. `lanes * tile_len` is
+/// fixed at the L2 budget, so each lane's run shrinks as `2^-k` while the
+/// stream count grows; past three the tiles are too short to prefetch.
+#[cfg(feature = "parallel")]
+const MAX_SHARED_1Q_TARGETS: usize = 3;
 
 #[inline(always)]
 fn adjacent_2q_indices(offset: usize, stride: usize, q0_is_lo: bool) -> [usize; 4] {
@@ -2825,12 +2830,92 @@ impl StatevectorBackend {
         self.pending_norm *= inv_norm;
     }
 
+    /// Apply gates on `k` distinct targets in one traversal instead of `k`.
+    ///
+    /// Gates on disjoint qubits commute, so the stages run in target order.
+    /// For targets above the L3 tier only: below it the tiered passes keep a
+    /// tile cache resident across gates, which this shape cannot.
+    #[cfg(feature = "parallel")]
+    fn apply_multi_1q_shared(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
+        let mut sorted: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = gates.into();
+        sorted.sort_unstable_by_key(|&(target, _)| target);
+        let k = sorted.len();
+        let lanes = 1usize << k;
+        let low_target = sorted[0].0;
+
+        let prepared: SmallVec<[simd::PreparedGate1q; 4]> = sorted
+            .iter()
+            .map(|(_, mat)| simd::PreparedGate1q::new(mat))
+            .collect();
+
+        let mut offsets: SmallVec<[usize; 16]> = SmallVec::with_capacity(lanes);
+        for j in 0..lanes {
+            let mut offset = 0usize;
+            for (axis, &(target, _)) in sorted.iter().enumerate() {
+                if (j >> axis) & 1 == 1 {
+                    offset |= 1usize << target;
+                }
+            }
+            offsets.push(offset);
+        }
+
+        let run = 1usize << low_target;
+        let tile_len = (MULTI_GATE_L2_TILE / lanes).max(1);
+        let tiles_per_run = run / tile_len;
+        let blocks = (self.state.len() >> k) >> low_target;
+
+        let base_of = |block: usize| {
+            let mut base = block << low_target;
+            for &(target, _) in sorted.iter() {
+                base = insert_zero_bit(base, target);
+            }
+            base
+        };
+
+        let start_of =
+            |unit: usize| base_of(unit / tiles_per_run) + (unit % tiles_per_run) * tile_len;
+        let units = blocks * tiles_per_run;
+
+        #[cfg(feature = "parallel")]
+        {
+            let ptr = SendPtr(self.state.as_mut_ptr());
+            (0..units).into_par_iter().for_each(|unit| {
+                let start = start_of(unit);
+                for (axis, prep) in prepared.iter().enumerate() {
+                    let stride = 1usize << axis;
+                    for j in 0..lanes {
+                        if j & stride != 0 {
+                            continue;
+                        }
+                        // SAFETY: the target weights are super-increasing, so
+                        // the target bits and tile index partition the buffer
+                        // into disjoint `tile_len` runs; no two lanes or units
+                        // alias.
+                        unsafe {
+                            let base = ptr.as_complex_ptr();
+                            let lo = std::slice::from_raw_parts_mut(
+                                base.add(start + offsets[j]),
+                                tile_len,
+                            );
+                            let hi = std::slice::from_raw_parts_mut(
+                                base.add(start + offsets[j | stride]),
+                                tile_len,
+                            );
+                            prep.apply(lo, hi);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
     /// Apply multiple single-qubit gates in a multi-tier tiled pass.
     ///
     /// Three tiers based on gate target qubit:
     /// - **L2 tier** (target 0..13): 256KB tiles, all applied per tile in L2 cache
     /// - **L3 tier** (target 14..16): 2MB tiles, applied per tile in L3 cache
-    /// - **Individual** (target 17+): separate full-state passes
+    /// - **Individual** (target 17+): one shared traversal, or a single
+    ///   full-state pass when only one gate lands there
     #[inline(always)]
     pub(super) fn apply_multi_1q(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
         if gates.is_empty() {
@@ -2929,8 +3014,12 @@ impl StatevectorBackend {
                 });
         }
 
-        for (target, mat) in large_gates {
-            self.apply_single_gate(target, mat);
+        for chunk in large_gates.chunks(MAX_SHARED_1Q_TARGETS) {
+            if chunk.len() > 1 {
+                self.apply_multi_1q_shared(chunk);
+            } else {
+                self.apply_single_gate(chunk[0].0, chunk[0].1);
+            }
         }
     }
 

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -190,6 +190,11 @@ impl SendPtr {
     pub(crate) fn as_f64_ptr(self) -> *mut f64 {
         self.0 as *mut f64
     }
+
+    #[inline(always)]
+    pub(crate) fn as_complex_ptr(self) -> *mut Complex64 {
+        self.0
+    }
 }
 
 /// Full state-vector backend.

--- a/tests/fusion_correctness.rs
+++ b/tests/fusion_correctness.rs
@@ -1186,3 +1186,18 @@ fn fusion_batch_phase_folds_duplicate_pair() {
         }
     }
 }
+
+// qaoa puts three targets past the L3 tier at 20q (17, 18, 19) and two at 19q,
+// so both the k=3 and k=2 shapes run; 18q leaves one gate on the single-gate
+// path. Compared at amplitude level because the tail carries phases.
+#[test]
+fn fusion_multi_1q_high_targets_match_unfused() {
+    for n in [18usize, 19, 20] {
+        let circuit = circuits::qaoa_circuit(n, 3, 42);
+        assert_state_close(
+            &run_fused_state(&circuit),
+            &run_unfused_state(&circuit),
+            EPS,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
`FactoredBackend::pauli_expectations` recomputed each block's norm once per observable,
as a serial scalar sweep, although it depends on the sub-state alone. Taken once per
block now, through the SIMD helper.

Above the L3 tier no tile holds both halves of a butterfly, so each gate in a
`MultiFused` took its own full-state pass. Those gates commute, so up to three share a
traversal at a third of the traffic. The cap is deliberate: `lanes * tile_len` is fixed
at the L2 budget, so each lane's run shrinks as `2^-k` while the stream count grows.

## Scope

- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh`, 30 samples, adjacent binaries. The factored rows do not exist on
`main`, so the reference carries the bench row and not the fix.
Intel i7-6700K, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `expectation/pauli_sum_factored/factored/16` | 5.08 ms | 3.76 ms | -26.0% | -0.3% / +0.2% | yes, faster |
| `expectation/pauli_sum_factored/factored/20` | 87.42 ms | 64.15 ms | -26.6% | +5.2% / +0.1% | yes, faster |
| `expectation/pauli_sum_factored/statevector/16` | 1.60 ms | 1.60 ms | -0.0% | +6.0% / +2.0% | unmeasured |
| `expectation/pauli_sum_factored/statevector/20` | 32.30 ms | 31.51 ms | -2.4% | +5.9% / +0.9% | unmeasured |
| `statevector/qaoa_l3/20` | 40.45 ms | 32.83 ms | -18.8% | +11.6% / -3.7% | yes, faster |
| `statevector/hea_l5/20` | 61.88 ms | 64.57 ms | +4.3% | +0.8% / +0.1% | yes, under gate |
| `statevector/qaoa_l3/16` | 1.90 ms | 1.91 ms | +0.4% | +6.5% / +3.6% | unmeasured |
| `statevector/qft_textbook/20` | 27.86 ms | 26.82 ms | -3.7% | +8.8% / +1.0% | unmeasured |

`statevector/hea_l5/20` is a real move rather than noise: +4.3% against a +/-0.8% control.
It is under the gate and an earlier A/B of the same statevector change measured the row
flat, but it does take the shared path, so it is reported rather than rounded away.
`qaoa_l3/16` is the control for that half: no target clears the tier at 16 qubits, so the
path never fires.

Regression verdict: PASS

## Breaking changes

None.

## Risks and rollback

The two halves are separate commits and revert independently. The shared traversal is
capped at three targets and falls back to the per-gate pass beyond that and on
`--no-default-features`, so the widths and configurations it does not cover keep their
previous behaviour.
