### PR TITLE
ci(bench): gate on an adjacent-binary A/B against the PR base

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,9 +24,8 @@ builds both bench binaries first and runs them adjacent, which is the only metho
 reads correctly on a development host: separate `cargo bench` invocations minutes apart
 have moved a byte-identical control group by as much as +98%. See `benches/README.md`.
 
-Include at least one control row the diff cannot reach. A control that moves is the
-signal that the change altered a shared callee's inlining or the binary layout, which no
-target row will show on its own.
+Include at least one control row the diff cannot reach. When a control moves, the change
+altered a shared callee's inlining or the binary layout, which no target row will show.
 
 If this PR only changes documentation or non-performance code, write "N/A, no hot-path
 changes" and skip the table.
@@ -38,17 +37,15 @@ changes" and skip the table.
 Keep the control column. A change no larger than its row's same-code control spread is
 noise, not a result; say so rather than rounding it into a win.
 
-Name the tier if the numbers are not gate-precise. A `bench-fast` or reduced-sample run
-is triage and should say so rather than be quoted as a measurement.
+Name the tier. A `bench-fast` or reduced-sample run is triage, not a measurement.
 
 Regression verdict: PASS / FAIL / WAIVER
 
 If WAIVER, explain why the regression is acceptable and what future work will recover it.
 
-If the CI gate fails, check the failing row's control column before treating it as a
-regression: a row the diff cannot reach, or one whose control moved as far as its mean,
-is the runner and not the change. Say which, and paste the local A/B on the same two
-commits. Do not merge through a red gate without that.
+If the CI gate fails, read the failing row's control column first. A row the diff cannot
+reach, or one whose control moved as far as its mean, is the runner. Say which, and paste
+a local A/B on the same two commits before merging through it.
 
 ## Correctness
 
@@ -63,10 +60,9 @@ commits. Do not merge through a red gate without that.
 - [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
 - [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
 
-`--all-features` pulls `distributed-mpi`, whose `mpi-sys` build script needs an MPI
-toolkit, which is why CI enumerates features instead. Use it only when the diff touches
-the MPI surface or the `Cargo.toml` feature wiring, and run it from an environment where
-`bindgen` finds libclang and the MSVC headers (`scripts/mpi-env.ps1`).
+`--all-features` pulls `distributed-mpi`, whose build script needs an MPI toolkit, so CI
+enumerates features instead. Reach for it only when the diff touches the MPI surface or
+the `Cargo.toml` feature wiring, from a shell set up by `scripts/mpi-env.ps1`.
 
 ## Hotspot notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,10 @@ builds both bench binaries first and runs them adjacent, which is the only metho
 reads correctly on a development host: separate `cargo bench` invocations minutes apart
 have moved a byte-identical control group by as much as +98%. See `benches/README.md`.
 
+Include at least one control row the diff cannot reach. A control that moves is the
+signal that the change altered a shared callee's inlining or the binary layout, which no
+target row will show on its own.
+
 If this PR only changes documentation or non-performance code, write "N/A, no hot-path
 changes" and skip the table.
 
@@ -34,14 +38,23 @@ changes" and skip the table.
 Keep the control column. A change no larger than its row's same-code control spread is
 noise, not a result; say so rather than rounding it into a win.
 
+Name the tier if the numbers are not gate-precise. A `bench-fast` or reduced-sample run
+is triage and should say so rather than be quoted as a measurement.
+
 Regression verdict: PASS / FAIL / WAIVER
 
 If WAIVER, explain why the regression is acceptable and what future work will recover it.
 
+If the CI gate fails, check the failing row's control column before treating it as a
+regression: a row the diff cannot reach, or one whose control moved as far as its mean,
+is the runner and not the change. Say which, and paste the local A/B on the same two
+commits. Do not merge through a red gate without that.
+
 ## Correctness
 
-- [ ] `cargo test --all-features` passes locally
-- [ ] `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
+- [ ] `cargo nextest run --features "parallel gpu distributed"` passes locally
+- [ ] `cargo test --doc --features "parallel gpu distributed"` passes
+- [ ] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
 - [ ] `cargo fmt --check` passes
 - [ ] `cargo doc --no-deps --features "parallel gpu distributed"` passes (CI denies
       rustdoc warnings)
@@ -49,6 +62,11 @@ If WAIVER, explain why the regression is acceptable and what future work will re
       signature do not carry, and stay concise; none restate the signature
 - [ ] New gate, backend, or fusion pass has golden tests against the statevector backend
 - [ ] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`
+
+`--all-features` pulls `distributed-mpi`, whose `mpi-sys` build script needs an MPI
+toolkit, which is why CI enumerates features instead. Use it only when the diff touches
+the MPI surface or the `Cargo.toml` feature wiring, and run it from an environment where
+`bindgen` finds libclang and the MSVC headers (`scripts/mpi-env.ps1`).
 
 ## Hotspot notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo clippy --all-targets --features "$CI_FEATURES" -- -D warnings -D clippy::undocumented_unsafe_blocks
 
       # The bindings are not a default workspace member, so the line above stops
-      # at the root crate. This is the configuration every published wheel ships.
+      # at the root crate. This is the configuration every wheel ships.
       - name: Clippy Python bindings
         run: cargo clippy -p prism-q-py --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ env:
   # docs build on a bare runner. distributed-mpi stays out: mpi-sys fails in its build
   # script when no MPI library is installed.
   CI_DOC_FEATURES: parallel,gpu,distributed
-  CI_BENCH_FEATURES: parallel,bench-fast
+  # Not `bench-fast`: that tier also cuts warmup to 200ms and measurement to 1s,
+  # which the cheaper gate rows have the budget for. The sample count is pinned
+  # separately in scripts/bench_ci.sh, where the reasoning lives.
+  CI_BENCH_FEATURES: parallel
   REGRESSION_THRESHOLD: ${{ vars.REGRESSION_THRESHOLD || '5.0' }}
 
 jobs:
@@ -145,22 +148,30 @@ jobs:
       - name: Verify the conventional-commit mapping and the pre-1.0 clamp
         run: bash scripts/release_bump_level_test.sh
 
+  # Adjacent-binary A/B against the PR base. Both bench binaries are built first,
+  # then run with no build in between, so the compile no longer sits between the
+  # two measurements and every row reports its own same-code control spread. The
+  # gate fires only when a row exceeds both the threshold and that spread.
+  #
+  # The reference worktree lives beside the checkout rather than inside it: the
+  # A/B fingerprints the working tree before and after the reference build, and
+  # `/target/` in .gitignore is anchored to the repository root, so a nested
+  # worktree's build output would read as an untracked change and abort the run.
   benchmark-regression:
     name: Benchmark Regression
     runs-on: ubuntu-latest
     needs: check
     if: github.event_name == 'pull_request'
-    timeout-minutes: 45
+    # Six passes where the old gate ran two, at Criterion's default measurement
+    # window rather than the `bench-fast` one, so the measured stretch grows by
+    # roughly ten minutes on top of two reference builds.
+    timeout-minutes: 60
     permissions:
       contents: read
+    env:
+      PRISM_BENCH_REF: ${{ github.event.pull_request.base.sha }}
+      PRISM_BENCH_REF_DIR: ${{ github.workspace }}/bench-ref
     steps:
-      - name: Checkout base
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: base
-          fetch-depth: 1
-
       - name: Checkout head
         uses: actions/checkout@v7
         with:
@@ -169,74 +180,68 @@ jobs:
           path: head
           fetch-depth: 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # A fork's origin does not carry the base commit, and the A/B needs the
+      # object locally to build the reference from it.
+      - name: Fetch the base commit
+        working-directory: head
+        run: |
+          git remote add upstream "https://github.com/${{ github.repository }}"
+          git fetch --no-tags --depth=1 upstream "$PRISM_BENCH_REF"
 
+      # There is no job-level paths filter, and a separate workflow file would
+      # duplicate the setup, so the scope check runs in-job. It reports a result
+      # either way, which keeps the job safe to promote to a required check.
+      - name: Decide whether anything benchmarked changed
+        id: scope
+        working-directory: head
+        run: |
+          changed="$(git diff --name-only "$PRISM_BENCH_REF" HEAD)"
+          if grep -Eq '^(src/|benches/|Cargo\.(toml|lock)$)' <<< "$changed"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No change under src/, benches/, or the manifests. Nothing to measure." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Prepare the reference worktree
+        if: steps.scope.outputs.run == 'true'
+        working-directory: head
+        run: git worktree add --detach "$PRISM_BENCH_REF_DIR" "$PRISM_BENCH_REF"
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.scope.outputs.run == 'true'
+
+      # Keyed per directory, so the reference build stays warm across PRs that
+      # share a base.
       - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true'
         with:
           cache-bin: false
           workspaces: |
-            base -> target
             head -> target
+            bench-ref -> target
 
-      - name: Install benchmark tools
-        run: sudo apt-get update && sudo apt-get install -y bc jq
-
-      - name: Benchmark base
-        working-directory: base
-        run: bash ../head/scripts/bench_ci.sh
-        env:
-          PRISM_BENCH_PROJECT_DIR: ${{ github.workspace }}/base
-
-      - name: Save base baseline
-        working-directory: base
-        run: bash scripts/bench_check.sh save --name ci-base
-
-      - name: Copy base baseline
-        run: |
-          mkdir -p head/bench_results/baselines
-          cp base/bench_results/baselines/ci-base.json head/bench_results/baselines/ci-base.json
-
-      - name: Benchmark head
-        working-directory: head
-        run: bash scripts/bench_ci.sh
-
-      - name: Compare benchmark results
+      - name: Benchmark regression gate
+        if: steps.scope.outputs.run == 'true'
         working-directory: head
         run: |
           set +e
-          bash scripts/bench_check.sh table --baseline ci-base | tee ../benchmark-summary.md
-          table_status=${PIPESTATUS[0]}
-          bash scripts/bench_check.sh compare --baseline ci-base | tee ../benchmark-compare.txt
-          compare_status=${PIPESTATUS[0]}
-
+          bash scripts/bench_ci.sh
+          status=$?
           {
             echo "## Benchmark Regression Gate"
             echo ""
-            cat ../benchmark-summary.md
-            echo ""
-            echo '```text'
-            cat ../benchmark-compare.txt
-            echo '```'
+            cat bench_results/ci-ab.md
           } >> "$GITHUB_STEP_SUMMARY"
-
-          if [[ "$table_status" -ne 0 ]]; then
-            exit "$table_status"
-          fi
-          exit "$compare_status"
+          exit "$status"
 
       - name: Upload benchmark artifacts
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-regression
           if-no-files-found: ignore
-          path: |
-            benchmark-summary.md
-            benchmark-compare.txt
-            base/bench_results/baselines/ci-base.json
-            head/bench_results/baselines/ci-base.json
-            head/target/criterion/**/benchmark.json
-            head/target/criterion/**/new/estimates.json
+          path: head/bench_results/ci-ab.md
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,9 @@ jobs:
     name: Benchmark Regression
     runs-on: ubuntu-latest
     needs: check
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-bench')
+    if: >-
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-bench')
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,6 @@ env:
   # docs build on a bare runner. distributed-mpi stays out: mpi-sys fails in its build
   # script when no MPI library is installed.
   CI_DOC_FEATURES: parallel,gpu,distributed
-  # `bench-fast` pins samples to 10 and shortens the warmup and measurement
-  # windows. The gate's confidence comes from the four-pass structure and the
-  # per-row control column, not from a wider window, and the expensive rows run
-  # seconds per iteration where the sample count sets the cost outright.
   CI_BENCH_FEATURES: parallel,bench-fast
   REGRESSION_THRESHOLD: ${{ vars.REGRESSION_THRESHOLD || '5.0' }}
 
@@ -149,15 +145,10 @@ jobs:
       - name: Verify the conventional-commit mapping and the pre-1.0 clamp
         run: bash scripts/release_bump_level_test.sh
 
-  # Adjacent-binary A/B against the PR base. Both bench binaries are built first,
-  # then run with no build in between, so the compile no longer sits between the
-  # two measurements and every row reports its own same-code control spread. The
-  # gate fires only when a row exceeds both the threshold and that spread.
-  #
-  # The reference worktree lives beside the checkout rather than inside it: the
-  # A/B fingerprints the working tree before and after the reference build, and
-  # `/target/` in .gitignore is anchored to the repository root, so a nested
-  # worktree's build output would read as an untracked change and abort the run.
+  # Adjacent-binary A/B against the PR base; see scripts/bench_ci.sh. The
+  # reference worktree sits beside the checkout, not inside it: `/target/` in
+  # .gitignore is anchored to the repository root, so a nested worktree's build
+  # output would read as an untracked change and abort the A/B.
   benchmark-regression:
     name: Benchmark Regression
     runs-on: ubuntu-latest
@@ -178,21 +169,15 @@ jobs:
           path: head
           fetch-depth: 1
 
-      # A fork's origin does not carry the base commit, and the A/B needs the
-      # object locally to build the reference from it.
+      # A fork's origin does not carry the base commit.
       - name: Fetch the base commit
         working-directory: head
         run: |
           git remote add upstream "https://github.com/${{ github.repository }}"
           git fetch --no-tags --depth=1 upstream "$PRISM_BENCH_REF"
 
-      # There is no job-level paths filter, and a separate workflow file would
-      # duplicate the setup, so the scope check runs in-job. It reports a result
-      # either way, which keeps the job safe to promote to a required check.
-      #
-      # Compiled sources only. A docs, workflow, or tooling change cannot move a
-      # kernel, and benches/README.md sits next to the bench sources without
-      # being one of them.
+      # In-job rather than a paths filter, so a skip still reports a result and
+      # the job stays safe to promote to a required check.
       - name: Decide whether anything benchmarked changed
         id: scope
         working-directory: head
@@ -213,8 +198,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.scope.outputs.run == 'true'
 
-      # Keyed per directory, so the reference build stays warm across PRs that
-      # share a base.
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ env:
   # docs build on a bare runner. distributed-mpi stays out: mpi-sys fails in its build
   # script when no MPI library is installed.
   CI_DOC_FEATURES: parallel,gpu,distributed
-  # Not `bench-fast`: that tier also cuts warmup to 200ms and measurement to 1s,
-  # which the cheaper gate rows have the budget for. The sample count is pinned
-  # separately in scripts/bench_ci.sh, where the reasoning lives.
-  CI_BENCH_FEATURES: parallel
+  # `bench-fast` pins samples to 10 and shortens the warmup and measurement
+  # windows. The gate's confidence comes from the four-pass structure and the
+  # per-row control column, not from a wider window, and the expensive rows run
+  # seconds per iteration where the sample count sets the cost outright.
+  CI_BENCH_FEATURES: parallel,bench-fast
   REGRESSION_THRESHOLD: ${{ vars.REGRESSION_THRESHOLD || '5.0' }}
 
 jobs:
@@ -161,11 +162,8 @@ jobs:
     name: Benchmark Regression
     runs-on: ubuntu-latest
     needs: check
-    if: github.event_name == 'pull_request'
-    # Six passes where the old gate ran two, at Criterion's default measurement
-    # window rather than the `bench-fast` one, so the measured stretch grows by
-    # roughly ten minutes on top of two reference builds.
-    timeout-minutes: 60
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-bench')
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
@@ -191,16 +189,20 @@ jobs:
       # There is no job-level paths filter, and a separate workflow file would
       # duplicate the setup, so the scope check runs in-job. It reports a result
       # either way, which keeps the job safe to promote to a required check.
+      #
+      # Compiled sources only. A docs, workflow, or tooling change cannot move a
+      # kernel, and benches/README.md sits next to the bench sources without
+      # being one of them.
       - name: Decide whether anything benchmarked changed
         id: scope
         working-directory: head
         run: |
           changed="$(git diff --name-only "$PRISM_BENCH_REF" HEAD)"
-          if grep -Eq '^(src/|benches/|Cargo\.(toml|lock)$)' <<< "$changed"; then
+          if grep -Eq '^(src/.*\.rs$|benches/.*\.rs$|Cargo\.(toml|lock)$)' <<< "$changed"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No change under src/, benches/, or the manifests. Nothing to measure." >> "$GITHUB_STEP_SUMMARY"
+            echo "No Rust source or manifest change. Nothing to measure." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Prepare the reference worktree

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,7 +12,7 @@ Criterion.rs. Two benchmark binaries:
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `PRISM_BENCH_PLOTS` | unset | Set to render the Criterion HTML report. Off by default: on the reference host a five-row group took 335s with plots and 47s without, so roughly 58s per row goes to rendering against 9s of measurement. Gating reads stdout and `target/criterion/**/estimates.json`, which the plots do not feed. |
-| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. `statevector/qpe_t_gate/22q` is the same shape at 2.94s per iteration, which is why the CI gate runs the `bench-fast` tier. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
+| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. Raise it for a row needing a tighter interval, lower it for triage; the CI gate runs the `bench-fast` tier for the same reason. Values below 10 are clamped. |
 
 Sample count controls the precision of one run's mean. It does not remove
 drift between runs: on the reference host, back-to-back runs of identical code
@@ -160,8 +160,7 @@ directory.
 
 Point-in-time snapshots for tracking a number across weeks. Not a gating
 mechanism: one job on one runner does not make two measurements comparable when
-a build sits between them, which is why the CI gate now runs the A/B above
-rather than a stored baseline.
+a build sits between them, which is why the CI gate runs the A/B above.
 
 ```bash
 # Save (Unix)
@@ -192,33 +191,25 @@ base commit as the reference, so the gate reports a same-code control column per
 row and fires only when a row exceeds both the threshold and its own control
 spread.
 
-The gate previously ran the two sides as separate `cargo bench` invocations with
-the head build between them, which is the pattern the A/B exists to replace, on a
-shared runner. Rows a hosted runner cannot resolve now say so instead of reading
-as a result.
+Until 2026-08, the two sides ran as separate `cargo bench` invocations with the
+head build between them, on a shared runner. A row a hosted runner cannot resolve
+now says so instead of reading as a result.
 
 The subset runs at `CI_BENCH_FEATURES=parallel,bench-fast` and covers larger
-CPU-only parameter points that are already present on the base branch. That tier
-pins samples to Criterion's floor of 10 and shortens the warmup and measurement
-windows, which is what keeps the four passes affordable: the expensive rows run
-seconds per iteration, where the sample count rather than the time budget sets
-the cost, and six passes over `statevector/qpe_t_gate/22q` alone would cost half
-an hour at 100 samples. The four-pass structure and the per-row control column,
-not a wider measurement window, are what make the gate trustworthy. The filters
-are intentionally narrow so hosted runner noise from tiny parameter sweeps does
-not dominate the gate. A row must exist on the reference commit as well as on
-head, or it drops out of the comparison and the row-count guard fails the run. It
-is a regression gate, not a replacement for the full local benchmark suite
-required for performance sensitive changes.
+CPU-only parameter points already present on the base branch. That tier pins
+samples to 10 and shortens the measurement windows, which is what keeps four
+passes affordable: at 100 samples, `statevector/qpe_t_gate/22q` alone would cost
+half an hour. The filters stay narrow so noise from tiny parameter sweeps does
+not dominate. A row missing from either side drops out of the comparison and the
+row-count guard fails the run. This is a regression gate, not a replacement for
+the local suite a performance change needs.
 
-The job measures only when a pull request changes a `.rs` file under `src/` or
-`benches/`, or a manifest. Documentation, workflow, and tooling changes cannot
-move a kernel and skip it, as does any pull request carrying a `skip-bench`
-label. It reports a result either way, so it stays safe to promote to a required
-check. The reference worktree sits beside the checkout rather than inside it:
-`/target/` in `.gitignore` is anchored to the repository root, so a nested
-worktree's build output would read as an untracked working-tree change and abort
-the A/B.
+It measures only when a pull request changes a `.rs` file under `src/` or
+`benches/`, or a manifest; a `skip-bench` label opts out. Either way it reports a
+result, so it stays safe to promote to a required check. The reference worktree
+sits beside the checkout rather than inside it: `/target/` in `.gitignore` is
+anchored to the repository root, so a nested worktree's build output would read
+as an untracked change and abort the A/B.
 
 Representative CI workloads:
 
@@ -242,9 +233,8 @@ PRISM_BENCH_REF=main ./scripts/bench_ci.sh
 PRISM_BENCH_REF=main PRISM_BENCH_REF_DIR=/tmp/prism-q-ref ./scripts/bench_ci.sh
 ```
 
-Pointing `PRISM_BENCH_REF` at `HEAD` on a clean tree builds both binaries from
-the same code, so every row is a control row and the report is the host's
-same-code noise floor with no change under test.
+`PRISM_BENCH_REF=HEAD` on a clean tree builds both binaries from the same code,
+so every row is a control row and the report is this host's noise floor.
 
 ## Regression detection
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,7 +12,7 @@ Criterion.rs. Two benchmark binaries:
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `PRISM_BENCH_PLOTS` | unset | Set to render the Criterion HTML report. Off by default: on the reference host a five-row group took 335s with plots and 47s without, so roughly 58s per row goes to rendering against 9s of measurement. Gating reads stdout and `target/criterion/**/estimates.json`, which the plots do not feed. |
-| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. `statevector/qpe_t_gate/22q` is the same shape at 2.94s per iteration, which is why the CI gate pins the count to 10. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
+| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. `statevector/qpe_t_gate/22q` is the same shape at 2.94s per iteration, which is why the CI gate runs the `bench-fast` tier. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
 
 Sample count controls the precision of one run's mean. It does not remove
 drift between runs: on the reference host, back-to-back runs of identical code
@@ -197,27 +197,28 @@ the head build between them, which is the pattern the A/B exists to replace, on 
 shared runner. Rows a hosted runner cannot resolve now say so instead of reading
 as a result.
 
-The subset uses `CI_BENCH_FEATURES=parallel` with `PRISM_BENCH_SAMPLES=10`, and
-covers larger CPU-only parameter points that are already present on the base
-branch. Warmup and measurement time stay at Criterion's defaults, which the
-`bench-fast` tier cuts and the cheaper rows have the budget for. The sample
-count is pinned because the expensive rows run seconds per iteration, where the
-count rather than the time budget sets the cost: six passes over
-`statevector/qpe_t_gate/22q` alone would cost half an hour at 100 samples. The
-four-pass structure and the per-row control column, not the sample count, are
-what make the gate trustworthy. The filters are
-intentionally narrow so hosted runner noise from tiny parameter sweeps does not
-dominate the gate. A row must exist on the reference commit as well as on head,
-or it drops out of the comparison and the row-count guard fails the run. It is a
-regression gate, not a replacement for the full local benchmark suite required
-for performance sensitive changes.
+The subset runs at `CI_BENCH_FEATURES=parallel,bench-fast` and covers larger
+CPU-only parameter points that are already present on the base branch. That tier
+pins samples to Criterion's floor of 10 and shortens the warmup and measurement
+windows, which is what keeps the four passes affordable: the expensive rows run
+seconds per iteration, where the sample count rather than the time budget sets
+the cost, and six passes over `statevector/qpe_t_gate/22q` alone would cost half
+an hour at 100 samples. The four-pass structure and the per-row control column,
+not a wider measurement window, are what make the gate trustworthy. The filters
+are intentionally narrow so hosted runner noise from tiny parameter sweeps does
+not dominate the gate. A row must exist on the reference commit as well as on
+head, or it drops out of the comparison and the row-count guard fails the run. It
+is a regression gate, not a replacement for the full local benchmark suite
+required for performance sensitive changes.
 
-The job skips the measurement when a pull request touches nothing under `src/`,
-`benches/`, or the manifests. It reports a result either way, so it stays safe to
-promote to a required check. The reference worktree sits beside the checkout
-rather than inside it: `/target/` in `.gitignore` is anchored to the repository
-root, so a nested worktree's build output would read as an untracked
-working-tree change and abort the A/B.
+The job measures only when a pull request changes a `.rs` file under `src/` or
+`benches/`, or a manifest. Documentation, workflow, and tooling changes cannot
+move a kernel and skip it, as does any pull request carrying a `skip-bench`
+label. It reports a result either way, so it stays safe to promote to a required
+check. The reference worktree sits beside the checkout rather than inside it:
+`/target/` in `.gitignore` is anchored to the repository root, so a nested
+worktree's build output would read as an untracked working-tree change and abort
+the A/B.
 
 Representative CI workloads:
 
@@ -229,8 +230,6 @@ Representative CI workloads:
 | `statevector/qaoa_l3/20` | QAOA workload with ZZ rotations and mixer layers |
 | `stabilizer/scaling/1000` | Large Clifford stabilizer backend path |
 | `stabilizer/measurement/ghz_measure_all/1000` | Large GHZ preparation plus terminal measurements |
-| `auto/qft_textbook/22` | Auto dispatch on a structured dense circuit |
-| `auto/qpe_t_gate/22q` | Auto dispatch on a non-Clifford phase estimation circuit |
 | `compiled_sampler/noiseless/noiseless_1000q_10k` | Compiled shot sampling path |
 | `compiled_sampler/noisy/noisy_1000q_10k` | Compiled Pauli-noise shot sampling path |
 
@@ -255,8 +254,9 @@ Default threshold: **5%** per benchmark (configurable via `REGRESSION_THRESHOLD`
 it exceeds both the threshold and that row's own control spread. `bench_check.*`
 reads Criterion JSON from `target/criterion/`, compares matching benchmark means,
 and exits with code 1 when a benchmark exceeds the threshold and its confidence
-interval clears the baseline's. The older `bench_compare.*` wrappers still parse
-Criterion console output for quick baseline checks.
+interval clears the baseline's, in both the shell and PowerShell forms. The older
+`bench_compare.*` wrappers still parse Criterion console output for quick
+baseline checks.
 
 ### Rows this host cannot resolve
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -12,7 +12,7 @@ Criterion.rs. Two benchmark binaries:
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `PRISM_BENCH_PLOTS` | unset | Set to render the Criterion HTML report. Off by default: on the reference host a five-row group took 335s with plots and 47s without, so roughly 58s per row goes to rendering against 9s of measurement. Gating reads stdout and `target/criterion/**/estimates.json`, which the plots do not feed. |
-| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
+| `PRISM_BENCH_SAMPLES` | 30 | Samples per row outside the `bench-fast` tier. Criterion divides `measurement_time` across the sample count rather than multiplying by it, so the count is free while one iteration still fits in `measurement_time / samples`. Past that it sets the cost outright: `density_matrix/unitary_layers/12` runs 3.87s per iteration, where 100 samples cost 39 minutes across the six passes of an adjacent A/B against 4 minutes at 10. `statevector/qpe_t_gate/22q` is the same shape at 2.94s per iteration, which is why the CI gate pins the count to 10. Raise it for a row needing a tighter interval, lower it for triage. Values below 10 are clamped. |
 
 Sample count controls the precision of one run's mean. It does not remove
 drift between runs: on the reference host, back-to-back runs of identical code
@@ -158,9 +158,10 @@ directory.
 
 ## Stored baselines
 
-Point-in-time snapshots for tracking a number across weeks, and the mechanism the
-CI gate uses (where both sides run in one job on one runner, so the drift the
-method above defends against does not apply). Not a substitute for it locally.
+Point-in-time snapshots for tracking a number across weeks. Not a gating
+mechanism: one job on one runner does not make two measurements comparable when
+a build sits between them, which is why the CI gate now runs the A/B above
+rather than a stored baseline.
 
 ```bash
 # Save (Unix)
@@ -185,18 +186,38 @@ and `bc`, so it runs in CI but not on the Windows reference host.
 
 ## CI regression gate
 
-Pull requests run a focused benchmark gate after lint and tests pass. The job
-checks out the base commit and PR head on the same runner, runs
-`scripts/bench_ci.sh` in both worktrees, saves the base results with
-`scripts/bench_check.sh`, then fails if any matching benchmark regresses beyond
-the configured threshold.
+Pull requests run a focused benchmark gate after lint and tests pass.
+`scripts/bench_ci.sh` delegates to the adjacent-binary A/B above, with the PR
+base commit as the reference, so the gate reports a same-code control column per
+row and fires only when a row exceeds both the threshold and its own control
+spread.
 
-The CI subset uses `CI_BENCH_FEATURES=parallel,bench-fast` and covers larger
-CPU-only parameter points that are already present on the base branch. The
-filters are intentionally narrow so GitHub hosted runner noise from tiny
-parameter sweeps does not dominate the gate. It is a regression gate, not a
-replacement for the full local benchmark suite required for performance
-sensitive changes.
+The gate previously ran the two sides as separate `cargo bench` invocations with
+the head build between them, which is the pattern the A/B exists to replace, on a
+shared runner. Rows a hosted runner cannot resolve now say so instead of reading
+as a result.
+
+The subset uses `CI_BENCH_FEATURES=parallel` with `PRISM_BENCH_SAMPLES=10`, and
+covers larger CPU-only parameter points that are already present on the base
+branch. Warmup and measurement time stay at Criterion's defaults, which the
+`bench-fast` tier cuts and the cheaper rows have the budget for. The sample
+count is pinned because the expensive rows run seconds per iteration, where the
+count rather than the time budget sets the cost: six passes over
+`statevector/qpe_t_gate/22q` alone would cost half an hour at 100 samples. The
+four-pass structure and the per-row control column, not the sample count, are
+what make the gate trustworthy. The filters are
+intentionally narrow so hosted runner noise from tiny parameter sweeps does not
+dominate the gate. A row must exist on the reference commit as well as on head,
+or it drops out of the comparison and the row-count guard fails the run. It is a
+regression gate, not a replacement for the full local benchmark suite required
+for performance sensitive changes.
+
+The job skips the measurement when a pull request touches nothing under `src/`,
+`benches/`, or the manifests. It reports a result either way, so it stays safe to
+promote to a required check. The reference worktree sits beside the checkout
+rather than inside it: `/target/` in `.gitignore` is anchored to the repository
+root, so a nested worktree's build output would read as an untracked
+working-tree change and abort the A/B.
 
 Representative CI workloads:
 
@@ -213,21 +234,18 @@ Representative CI workloads:
 | `compiled_sampler/noiseless/noiseless_1000q_10k` | Compiled shot sampling path |
 | `compiled_sampler/noisy/noisy_1000q_10k` | Compiled Pauli-noise shot sampling path |
 
-The script builds the `circuits` benchmark binary once with
-`cargo bench --no-run`, then runs the compiled executable directly with
-Criterion filters. This keeps Cargo setup out of the timed regression subset.
-
-Local reproduction:
+Local reproduction, against `main` as the reference:
 
 ```bash
-CI_BENCH_FEATURES=parallel,bench-fast ./scripts/bench_ci.sh
-./scripts/bench_check.sh save --name ci-base
+PRISM_BENCH_REF=main ./scripts/bench_ci.sh
 
-# After applying changes:
-CI_BENCH_FEATURES=parallel,bench-fast ./scripts/bench_ci.sh
-./scripts/bench_check.sh table --baseline ci-base
-./scripts/bench_check.sh compare --baseline ci-base
+# Cache the reference build between runs:
+PRISM_BENCH_REF=main PRISM_BENCH_REF_DIR=/tmp/prism-q-ref ./scripts/bench_ci.sh
 ```
+
+Pointing `PRISM_BENCH_REF` at `HEAD` on a clean tree builds both binaries from
+the same code, so every row is a control row and the report is the host's
+same-code noise floor with no change under test.
 
 ## Regression detection
 
@@ -236,9 +254,9 @@ Default threshold: **5%** per benchmark (configurable via `REGRESSION_THRESHOLD`
 `bench_ab.sh` applies the threshold per row and only calls a row a regression when
 it exceeds both the threshold and that row's own control spread. `bench_check.*`
 reads Criterion JSON from `target/criterion/`, compares matching benchmark means,
-and exits with code 1 when any benchmark exceeds the threshold. The older
-`bench_compare.*` wrappers still parse Criterion console output for quick baseline
-checks.
+and exits with code 1 when a benchmark exceeds the threshold and its confidence
+interval clears the baseline's. The older `bench_compare.*` wrappers still parse
+Criterion console output for quick baseline checks.
 
 ### Rows this host cannot resolve
 

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -34,6 +34,9 @@
 #   --ref-dir       reference worktree path. Persists between runs, so the
 #                   reference build is cached. Default: a temporary directory
 #                   removed on exit.
+#   --min-rows      fail when fewer than this many rows appear in all four
+#                   passes. Catches a filter that silently stopped matching a
+#                   renamed benchmark id. Default: 1.
 #   --out           markdown output path (default: bench_results/ab-<stamp>.md)
 #
 # Environment:
@@ -60,6 +63,7 @@ BENCH="circuits"
 FEATURES="parallel"
 REF_DIR=""
 OUT=""
+MIN_ROWS=1
 THRESHOLD="${REGRESSION_THRESHOLD:-5.0}"
 
 while [[ $# -gt 0 ]]; do
@@ -69,6 +73,7 @@ while [[ $# -gt 0 ]]; do
         --bench|-b)    BENCH="$2"; shift 2 ;;
         --features)    FEATURES="$2"; shift 2 ;;
         --ref-dir)     REF_DIR="$2"; shift 2 ;;
+        --min-rows)    MIN_ROWS="$2"; shift 2 ;;
         --out)         OUT="$2"; shift 2 ;;
         --threshold|-t) THRESHOLD="$2"; shift 2 ;;
         -h|--help)     awk 'NR > 1 && !/^#/ { exit } NR > 1' "${BASH_SOURCE[0]}"; exit 0 ;;
@@ -323,9 +328,9 @@ for idx in 1 2 3 4; do
 done
 
 if [[ -z "$OUT" ]]; then
-    mkdir -p "$PROJECT_DIR/bench_results"
     OUT="$PROJECT_DIR/bench_results/ab-$(date +%Y-%m-%d_%H%M%S).md"
 fi
+mkdir -p "$(dirname "$OUT")"
 
 HIGH_QUBITS_STATE="off"
 if [[ -n "${PRISM_BENCH_HIGH_QUBITS:-}" ]]; then
@@ -351,7 +356,7 @@ set +e
     echo "| Threshold | ${THRESHOLD}% |"
     echo ""
 
-    awk -v threshold="$THRESHOLD" '
+    awk -v threshold="$THRESHOLD" -v min_rows="$MIN_ROWS" '
         BEGIN { FS = "\t"; SEP = "\x1f" }
 
         {
@@ -414,6 +419,12 @@ set +e
 
             if (compared == 0) {
                 print "**Regression verdict**: NO DATA. No row appeared in all four passes."
+                exit 1
+            }
+
+            if (compared < min_rows) {
+                printf "**Regression verdict**: NO DATA. %d row(s) appeared in all four passes, expected at least %d. The filter no longer matches every benchmark id it names.\n",
+                    compared, min_rows
                 exit 1
             }
 

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -35,8 +35,8 @@
 #                   reference build is cached. Default: a temporary directory
 #                   removed on exit.
 #   --min-rows      fail when fewer than this many rows appear in all four
-#                   passes. Catches a filter that silently stopped matching a
-#                   renamed benchmark id. Default: 1.
+#                   passes, catching a filter that stopped matching a renamed
+#                   benchmark id. Default: 1.
 #   --out           markdown output path (default: bench_results/ab-<stamp>.md)
 #
 # Environment:

--- a/scripts/bench_check.ps1
+++ b/scripts/bench_check.ps1
@@ -173,9 +173,8 @@ function Compare-BenchBaseline {
         $cMean = $currBench.mean_ns
         $pctChange = (($cMean - $bMean) / $bMean) * 100.0
 
-        # A baseline written before the interval fields existed collapses to a
-        # zero-width interval, which reduces the separation test below to the
-        # mean comparison it replaces.
+        # A pre-interval baseline falls back to a zero-width interval, which
+        # reduces the test below to the mean comparison it replaces.
         $bLo = if ($null -ne $baseBench.ci_lo_ns) { $baseBench.ci_lo_ns } else { $bMean }
         $bHi = if ($null -ne $baseBench.ci_hi_ns) { $baseBench.ci_hi_ns } else { $bMean }
         $cLo = if ($null -ne $currBench.ci_lo_ns) { $currBench.ci_lo_ns } else { $cMean }
@@ -196,9 +195,6 @@ function Compare-BenchBaseline {
         return
     }
 
-    # Both sides of a verdict: past the threshold, and the two confidence
-    # intervals do not overlap. A mean that moved further than the gate while the
-    # intervals still overlap is host noise.
     $regressions = @($rows | Where-Object { $_.Slower })
     $improvements = @($rows | Where-Object { $_.Faster })
 

--- a/scripts/bench_check.ps1
+++ b/scripts/bench_check.ps1
@@ -173,11 +173,21 @@ function Compare-BenchBaseline {
         $cMean = $currBench.mean_ns
         $pctChange = (($cMean - $bMean) / $bMean) * 100.0
 
+        # A baseline written before the interval fields existed collapses to a
+        # zero-width interval, which reduces the separation test below to the
+        # mean comparison it replaces.
+        $bLo = if ($null -ne $baseBench.ci_lo_ns) { $baseBench.ci_lo_ns } else { $bMean }
+        $bHi = if ($null -ne $baseBench.ci_hi_ns) { $baseBench.ci_hi_ns } else { $bMean }
+        $cLo = if ($null -ne $currBench.ci_lo_ns) { $currBench.ci_lo_ns } else { $cMean }
+        $cHi = if ($null -ne $currBench.ci_hi_ns) { $currBench.ci_hi_ns } else { $cMean }
+
         $rows += [PSCustomObject]@{
             Name       = $name
             BeforeNs   = $bMean
             AfterNs    = $cMean
             PctChange  = $pctChange
+            Slower     = ($pctChange -gt $Threshold) -and ($cLo -gt $bHi)
+            Faster     = ($pctChange -lt (-$Threshold)) -and ($cHi -lt $bLo)
         }
     }
 
@@ -186,8 +196,11 @@ function Compare-BenchBaseline {
         return
     }
 
-    $regressions = @($rows | Where-Object { $_.PctChange -gt $Threshold })
-    $improvements = @($rows | Where-Object { $_.PctChange -lt (-$Threshold) })
+    # Both sides of a verdict: past the threshold, and the two confidence
+    # intervals do not overlap. A mean that moved further than the gate while the
+    # intervals still overlap is host noise.
+    $regressions = @($rows | Where-Object { $_.Slower })
+    $improvements = @($rows | Where-Object { $_.Faster })
 
     if ($Markdown) {
         Write-Output ''
@@ -195,8 +208,8 @@ function Compare-BenchBaseline {
         Write-Output '|-----------|--------|-------|--------|'
         foreach ($r in $rows) {
             $flag = ''
-            if ($r.PctChange -gt $Threshold) { $flag = ' :x:' }
-            elseif ($r.PctChange -lt (-$Threshold)) { $flag = ' :white_check_mark:' }
+            if ($r.Slower) { $flag = ' :x:' }
+            elseif ($r.Faster) { $flag = ' :white_check_mark:' }
             $sign = if ($r.PctChange -ge 0) { '+' } else { '' }
             $before = Format-Duration $r.BeforeNs
             $after = Format-Duration $r.AfterNs
@@ -205,7 +218,7 @@ function Compare-BenchBaseline {
         }
         Write-Output ''
         $verdict = if ($regressions.Count -gt 0) { 'FAIL' } else { 'PASS' }
-        Write-Output ('**Regression verdict**: {0} (threshold: {1}%)' -f $verdict, $Threshold)
+        Write-Output ('**Regression verdict**: {0} (threshold: {1}%, confidence intervals must not overlap)' -f $verdict, $Threshold)
         return
     }
 
@@ -229,8 +242,8 @@ function Compare-BenchBaseline {
         $changeStr = "{0}{1:F1}%" -f $sign, $r.PctChange
 
         $color = "Gray"
-        if ($r.PctChange -gt $Threshold) { $color = "Red" }
-        elseif ($r.PctChange -lt (-$Threshold)) { $color = "Green" }
+        if ($r.Slower) { $color = "Red" }
+        elseif ($r.Faster) { $color = "Green" }
 
         $truncName = $r.Name
         if ($truncName.Length -gt $nameWidth) {
@@ -245,6 +258,7 @@ function Compare-BenchBaseline {
     Write-Host ("  {0} benchmarks | {1} regressions | {2} improvements | {3} unchanged" -f `
         $rows.Count, $regressions.Count, $improvements.Count, `
         ($rows.Count - $regressions.Count - $improvements.Count))
+    Write-Host "  A verdict needs both a move past ${Threshold}% and non-overlapping confidence intervals."
 
     if ($regressions.Count -gt 0) {
         Write-Host ""

--- a/scripts/bench_check.sh
+++ b/scripts/bench_check.sh
@@ -179,11 +179,13 @@ cmd_compare() {
     local base_date
     base_date="$(jq -r '.date' "$base_file")"
 
-    # Collect current estimates into an associative array
-    declare -A curr_mean
+    # Collect current estimates into associative arrays
+    declare -A curr_mean curr_ci_lo curr_ci_hi
     while IFS='|' read -r id mean ci_lo ci_hi stddev; do
         [[ -z "$id" ]] && continue
         curr_mean["$id"]="$mean"
+        curr_ci_lo["$id"]="${ci_lo:-$mean}"
+        curr_ci_hi["$id"]="${ci_hi:-$mean}"
     done < <(get_criterion_estimates "$SOURCE")
 
     if (( ${#curr_mean[@]} == 0 )); then
@@ -208,6 +210,13 @@ cmd_compare() {
         local cur="${curr_mean[$id]:-}"
         [[ -z "$cur" ]] && continue
 
+        # A baseline written before the interval fields existed collapses to a
+        # zero-width interval, which reduces the separation test below to the
+        # mean comparison it replaces.
+        local base_ci_lo base_ci_hi
+        base_ci_lo="$(jq -r ".benchmarks.\"$id\".ci_lo_ns // .benchmarks.\"$id\".mean_ns" "$base_file")"
+        base_ci_hi="$(jq -r ".benchmarks.\"$id\".ci_hi_ns // .benchmarks.\"$id\".mean_ns" "$base_file")"
+
         local pct
         pct="$(echo "scale=1; ($cur - $base_mean) * 100 / $base_mean" | bc -l)"
 
@@ -217,9 +226,17 @@ cmd_compare() {
         rows+=("$id|$base_mean|$cur|$sign$pct%")
         total=$((total + 1))
 
-        if (( $(echo "$pct > $THRESHOLD" | bc -l) )); then
+        # Both sides of a verdict: past the threshold, and the two confidence
+        # intervals do not overlap. A mean that moved further than the gate while
+        # the intervals still overlap is host noise, which is the majority of
+        # what a shared runner produces.
+        local slower_separated faster_separated
+        slower_separated="$(echo "${curr_ci_lo[$id]} > $base_ci_hi" | bc -l)"
+        faster_separated="$(echo "${curr_ci_hi[$id]} < $base_ci_lo" | bc -l)"
+
+        if (( $(echo "$pct > $THRESHOLD" | bc -l) )) && (( slower_separated )); then
             reg_count=$((reg_count + 1))
-        elif (( $(echo "$pct < -$THRESHOLD" | bc -l) )); then
+        elif (( $(echo "$pct < -$THRESHOLD" | bc -l) )) && (( faster_separated )); then
             imp_count=$((imp_count + 1))
         fi
     done < <(jq -r '.benchmarks | keys[]' "$base_file" | sort)
@@ -240,7 +257,7 @@ cmd_compare() {
         echo ""
         local verdict="PASS"
         if (( reg_count > 0 )); then verdict="FAIL"; fi
-        echo "**Regression verdict**: $verdict (threshold: ${THRESHOLD}%)"
+        echo "**Regression verdict**: $verdict (threshold: ${THRESHOLD}%, confidence intervals must not overlap)"
         return
     fi
 
@@ -269,6 +286,7 @@ cmd_compare() {
 
     echo ""
     echo "  $total benchmarks | $reg_count regressions | $imp_count improvements | $((total - reg_count - imp_count)) unchanged"
+    echo "  A verdict needs both a move past ${THRESHOLD}% and non-overlapping confidence intervals."
 
     if (( reg_count > 0 )); then
         echo ""

--- a/scripts/bench_check.sh
+++ b/scripts/bench_check.sh
@@ -179,7 +179,6 @@ cmd_compare() {
     local base_date
     base_date="$(jq -r '.date' "$base_file")"
 
-    # Collect current estimates into associative arrays
     declare -A curr_mean curr_ci_lo curr_ci_hi
     while IFS='|' read -r id mean ci_lo ci_hi stddev; do
         [[ -z "$id" ]] && continue
@@ -210,9 +209,8 @@ cmd_compare() {
         local cur="${curr_mean[$id]:-}"
         [[ -z "$cur" ]] && continue
 
-        # A baseline written before the interval fields existed collapses to a
-        # zero-width interval, which reduces the separation test below to the
-        # mean comparison it replaces.
+        # A pre-interval baseline falls back to a zero-width interval, which
+        # reduces the test below to the mean comparison it replaces.
         local base_ci_lo base_ci_hi
         base_ci_lo="$(jq -r ".benchmarks.\"$id\".ci_lo_ns // .benchmarks.\"$id\".mean_ns" "$base_file")"
         base_ci_hi="$(jq -r ".benchmarks.\"$id\".ci_hi_ns // .benchmarks.\"$id\".mean_ns" "$base_file")"
@@ -226,10 +224,6 @@ cmd_compare() {
         rows+=("$id|$base_mean|$cur|$sign$pct%")
         total=$((total + 1))
 
-        # Both sides of a verdict: past the threshold, and the two confidence
-        # intervals do not overlap. A mean that moved further than the gate while
-        # the intervals still overlap is host noise, which is the majority of
-        # what a shared runner produces.
         local slower_separated faster_separated
         slower_separated="$(echo "${curr_ci_lo[$id]} > $base_ci_hi" | bc -l)"
         faster_separated="$(echo "${curr_ci_hi[$id]} < $base_ci_lo" | bc -l)"

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -1,92 +1,62 @@
 #!/usr/bin/env bash
 # Run the benchmark subset used by the CI regression gate.
 #
-# This intentionally covers representative hot paths without running the full
-# Criterion suite. Use `CI_BENCH_FEATURES` to override the default feature set.
+# Delegates to the adjacent-binary A/B. Measuring the base branch, building the
+# head branch, then measuring head is not a valid comparison: the build sits
+# between the two measurements and drifts them by more than the gate on its own
+# (see scripts/bench_ab.sh). The A/B builds both binaries first, then runs them
+# adjacent in ref, new, new, ref order, so linear drift cancels and every row
+# carries a same-code control column.
+#
+# The filter covers representative hot paths rather than the full Criterion
+# suite. A row must exist on the reference commit as well as on the working
+# tree, or it drops out of the comparison and the row-count guard fails the run.
+#
+# Sample count is pinned to Criterion's floor. These rows are large on purpose,
+# and Criterion only divides `measurement_time` across the samples while one
+# iteration still fits the budget: at 100 samples `statevector/qpe_t_gate/22q`
+# reported 293.8s per pass and `statevector/qft_textbook/22` 77.8s, against six
+# passes. The A/B's four passes give two independent measurements per binary and
+# a control column per row, which is what the gate reads, so a tighter
+# single-pass mean on top of that is not worth the wall time.
+#
+# Environment:
+#   PRISM_BENCH_REF       git ref for the reference build (required)
+#   PRISM_BENCH_REF_DIR   reference worktree path, cached between CI runs
+#   CI_BENCH_FEATURES     cargo feature list (default: parallel)
+#   PRISM_BENCH_SAMPLES   samples per row (default: 10)
+#   REGRESSION_THRESHOLD  regression gate in percent (default: 5.0)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="${PRISM_BENCH_PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
-FEATURES="${CI_BENCH_FEATURES:-parallel,bench-fast}"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+FEATURES="${CI_BENCH_FEATURES:-parallel}"
+export PRISM_BENCH_SAMPLES="${PRISM_BENCH_SAMPLES:-10}"
 
-cd "$PROJECT_DIR"
+if [[ -z "${PRISM_BENCH_REF:-}" ]]; then
+    echo "Error: PRISM_BENCH_REF must name the reference commit." >&2
+    exit 1
+fi
 
-echo "=== PRISM-Q CI benchmark subset ==="
-echo "Features: $FEATURES"
-echo ""
-
-rm -rf "$PROJECT_DIR/target/criterion"
-
-echo ">>> cargo bench --bench circuits --features $FEATURES --no-run"
-cargo bench --bench circuits --features "$FEATURES" --no-run
-echo ""
-
-count_estimates() {
-    if [[ ! -d "$PROJECT_DIR/target/criterion" ]]; then
-        echo 0
-        return
-    fi
-
-    find "$PROJECT_DIR/target/criterion" -path "*/new/estimates.json" | wc -l | tr -d ' '
-}
-
-bench_executable() {
-    local bench="$1"
-    local deps_dir="$PROJECT_DIR/target/release/deps"
-    local candidate
-    local newest=""
-    local newest_mtime=0
-    local mtime
-
-    shopt -s nullglob
-    for candidate in "$deps_dir"/"$bench"-* "$deps_dir"/"$bench"-*.exe; do
-        [[ -f "$candidate" && -x "$candidate" ]] || continue
-        mtime="$(stat -c "%Y" "$candidate" 2>/dev/null || stat -f "%m" "$candidate")"
-        if (( mtime > newest_mtime )); then
-            newest="$candidate"
-            newest_mtime="$mtime"
-        fi
-    done
-    shopt -u nullglob
-
-    if [[ -z "$newest" ]]; then
-        echo "Error: benchmark executable not found for $bench in $deps_dir" >&2
-        exit 1
-    fi
-
-    echo "$newest"
-}
-
-run_bench() {
-    local bench="$1"
-    local filter="$2"
-    local expected_count="$3"
-    local exe
-    local before_count
-    local after_count
-    local added_count
-
-    exe="$(bench_executable "$bench")"
-    before_count="$(count_estimates)"
-
-    echo ">>> $exe --bench $filter"
-    "$exe" --bench "$filter"
-    after_count="$(count_estimates)"
-    added_count=$((after_count - before_count))
-    if (( added_count < expected_count )); then
-        echo "Error: benchmark filter produced $added_count Criterion estimates, expected at least $expected_count:" >&2
-        echo "  $bench $filter" >&2
-        exit 1
-    fi
-    echo ""
-}
-
-# Keep CI filters on benchmark IDs that exist on the base branch. Prefer larger
-# rows while keeping hosted runner cost bounded.
 CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q|qaoa_l3/20)"
 CIRCUITS_FILTER+="|stabilizer/(scaling/1000|measurement/ghz_measure_all/1000)"
 CIRCUITS_FILTER+="|auto/(qft_textbook/22|qpe_t_gate/22q)"
 CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_1000q_10k|noisy/noisy_1000q_10k))$"
 
-run_bench "circuits" "$CIRCUITS_FILTER" 10
+CIRCUITS_ROWS=10
+
+args=(
+    --bench circuits
+    --filter "$CIRCUITS_FILTER"
+    --min-rows "$CIRCUITS_ROWS"
+    --ref "$PRISM_BENCH_REF"
+    --features "$FEATURES"
+    --out "$PROJECT_DIR/bench_results/ci-ab.md"
+)
+
+if [[ -n "${PRISM_BENCH_REF_DIR:-}" ]]; then
+    args+=(--ref-dir "$PRISM_BENCH_REF_DIR")
+fi
+
+exec bash "$SCRIPT_DIR/bench_ab.sh" "${args[@]}"

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -1,25 +1,13 @@
 #!/usr/bin/env bash
 # Run the benchmark subset used by the CI regression gate.
 #
-# Delegates to the adjacent-binary A/B. Measuring the base branch, building the
-# head branch, then measuring head is not a valid comparison: the build sits
-# between the two measurements and drifts them by more than the gate on its own
-# (see scripts/bench_ab.sh). The A/B builds both binaries first, then runs them
-# adjacent in ref, new, new, ref order, so linear drift cancels and every row
-# carries a same-code control column.
+# Delegates to the adjacent-binary A/B in scripts/bench_ab.sh, which explains why
+# measuring the base, building head, then measuring head is not a comparison.
 #
 # The filter covers representative hot paths rather than the full Criterion
-# suite. A row must exist on the reference commit as well as on the working
-# tree, or it drops out of the comparison and the row-count guard fails the run.
-#
-# The `bench-fast` tier holds the wall time down: it pins samples to Criterion's
-# floor of 10 and shortens the warmup and measurement windows. These rows are
-# large on purpose, and Criterion only divides `measurement_time` across the
-# samples while one iteration still fits the budget, so at 100 samples
-# `statevector/qpe_t_gate/22q` alone reports 293.8s per pass against six passes.
-# The A/B's four passes give two independent measurements per binary and a
-# control column per row, which is what the gate reads; a tighter single-pass
-# mean on top of that is not worth the wall time.
+# suite, and `--min-rows` fails the run if one stops matching. `bench-fast` keeps
+# the four passes affordable: the 22q rows run seconds per iteration, where the
+# sample count sets the cost outright.
 #
 # Environment:
 #   PRISM_BENCH_REF       git ref for the reference build (required)
@@ -38,10 +26,8 @@ if [[ -z "${PRISM_BENCH_REF:-}" ]]; then
     exit 1
 fi
 
-# The `auto/` twins of the two 22q rows are deliberately absent. They run the
-# same circuits through dispatch, which resolves to the statevector backend
-# already covered above, so they doubled the most expensive pair in the set
-# without covering a distinct kernel.
+# The `auto/` twins of the 22q rows are absent on purpose: dispatch resolves them
+# to the statevector rows above, doubling the most expensive pair for nothing.
 CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q|qaoa_l3/20)"
 CIRCUITS_FILTER+="|stabilizer/(scaling/1000|measurement/ghz_measure_all/1000)"
 CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_1000q_10k|noisy/noisy_1000q_10k))$"

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -12,39 +12,41 @@
 # suite. A row must exist on the reference commit as well as on the working
 # tree, or it drops out of the comparison and the row-count guard fails the run.
 #
-# Sample count is pinned to Criterion's floor. These rows are large on purpose,
-# and Criterion only divides `measurement_time` across the samples while one
-# iteration still fits the budget: at 100 samples `statevector/qpe_t_gate/22q`
-# reported 293.8s per pass and `statevector/qft_textbook/22` 77.8s, against six
-# passes. The A/B's four passes give two independent measurements per binary and
-# a control column per row, which is what the gate reads, so a tighter
-# single-pass mean on top of that is not worth the wall time.
+# The `bench-fast` tier holds the wall time down: it pins samples to Criterion's
+# floor of 10 and shortens the warmup and measurement windows. These rows are
+# large on purpose, and Criterion only divides `measurement_time` across the
+# samples while one iteration still fits the budget, so at 100 samples
+# `statevector/qpe_t_gate/22q` alone reports 293.8s per pass against six passes.
+# The A/B's four passes give two independent measurements per binary and a
+# control column per row, which is what the gate reads; a tighter single-pass
+# mean on top of that is not worth the wall time.
 #
 # Environment:
 #   PRISM_BENCH_REF       git ref for the reference build (required)
 #   PRISM_BENCH_REF_DIR   reference worktree path, cached between CI runs
-#   CI_BENCH_FEATURES     cargo feature list (default: parallel)
-#   PRISM_BENCH_SAMPLES   samples per row (default: 10)
+#   CI_BENCH_FEATURES     cargo feature list (default: parallel,bench-fast)
 #   REGRESSION_THRESHOLD  regression gate in percent (default: 5.0)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-FEATURES="${CI_BENCH_FEATURES:-parallel}"
-export PRISM_BENCH_SAMPLES="${PRISM_BENCH_SAMPLES:-10}"
+FEATURES="${CI_BENCH_FEATURES:-parallel,bench-fast}"
 
 if [[ -z "${PRISM_BENCH_REF:-}" ]]; then
     echo "Error: PRISM_BENCH_REF must name the reference commit." >&2
     exit 1
 fi
 
+# The `auto/` twins of the two 22q rows are deliberately absent. They run the
+# same circuits through dispatch, which resolves to the statevector backend
+# already covered above, so they doubled the most expensive pair in the set
+# without covering a distinct kernel.
 CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q|qaoa_l3/20)"
 CIRCUITS_FILTER+="|stabilizer/(scaling/1000|measurement/ghz_measure_all/1000)"
-CIRCUITS_FILTER+="|auto/(qft_textbook/22|qpe_t_gate/22q)"
 CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_1000q_10k|noisy/noisy_1000q_10k))$"
 
-CIRCUITS_ROWS=10
+CIRCUITS_ROWS=8
 
 args=(
     --bench circuits


### PR DESCRIPTION
## Summary

The benchmark gate measured the base commit, built head, then measured head, so a
fat-LTO compile sat between the two measurements on a shared runner. It has failed three
of the last four PRs, on a different row each time, and twice on rows the diff could not
reach. `statevector/qaoa_l3/20` alone has read -19.9%, -12.5%, +0.3%, +13.3%, and +2.7%
across runs. Both times a failure was checked against a local `bench_ab.sh` run on the
same two commits, the local run contradicted CI.

`scripts/bench_ci.sh` now delegates to that A/B with the PR base as the reference. Both
binaries are built before either runs, the pass order is ref, new, new, ref, and every
row carries a same-code control column, so a row this runner cannot resolve says so
instead of reading as a result.

The PR template picks up what the last four benchmark PRs each worked out by hand, and
drops an `--all-features` checklist nobody without an MPI toolkit can run.

## Scope

- [x] Build, CI, or tooling
- [x] Documentation

## Benchmarks

N/A, no hot-path changes. Nothing under `src/` is touched, so this PR skips its own gate
by the same scope rule it adds.

Both A/B paths were exercised locally against `HEAD` on a clean tree, which builds two
binaries from identical code:

| Check | Result |
| --- | --- |
| Same-code row, `--min-rows 1` | `stabilizer/scaling/1000` read -0.8% against controls of -0.7% and -1.3%, verdict noise, exit 0 |
| Filter short of its row count, `--min-rows 5` | `NO DATA. 1 row(s) appeared in all four passes, expected at least 5`, exit 1 |
| `bench_check.ps1` on fabricated Criterion data | Two rows both +20%; only the one whose confidence interval separated from the baseline's was called a regression |

Regression verdict: PASS

## Correctness

Wall time is the constraint this had to satisfy, and the first draft failed it: six
passes at Criterion's default measurement window would have put roughly ten minutes of
benching on every pull request.

- `bench-fast` stays. It pins samples to Criterion's floor of 10 and shortens the warmup
  and measurement windows. The four-pass structure and the per-row control column are
  what make the gate trustworthy, not a wider window.
- The `auto/qft_textbook/22` and `auto/qpe_t_gate/22q` rows are gone. They ran the same
  circuits through dispatch onto the statevector backend already covered above, so they
  duplicated the most expensive pair in the set.
- The scope check requires a changed `.rs` file under `src/` or `benches/`, or a
  manifest. A `skip-bench` label opts a pull request out.

The job timeout stays at 45 minutes.

## Breaking changes

None to the library. Two behavioral changes to tooling:

- `scripts/bench_ci.sh` requires `PRISM_BENCH_REF` and delegates to the A/B. Its old
  `PRISM_BENCH_PROJECT_DIR` knob is gone, as is the `bc` and `jq` install step CI needed
  for the stored-baseline path.
- `bench_check.sh compare` and `bench_check.ps1 compare` call a regression only when the
  confidence intervals separate as well as the mean moving past the threshold. Both
  already collected the intervals and compared only the means. The PowerShell form is the
  one that runs on the Windows reference host, so the two had to move together.

## Risks and rollback

The gate can fail for a reason it could not before: `--min-rows` fails the run when a
filtered row is missing from either binary, which catches a renamed benchmark id that
would previously have dropped out of the comparison silently.

The wall-time figures above are estimates from Criterion's per-iteration costs, not
measurements. Because this PR skips its own gate, the first real timing comes from the
next change that touches `src/`.

Rollback is reverting the commits. The gate is not a required check.
