### PR TITLE
perf(tn): queue contraction candidates through a leg index

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -58,9 +58,11 @@ worth the disk.
 | `stabilizer_rank/shots_terminal` | Clifford+T shot sampling with terminal measurements, including 1000q chi2 |
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
+| `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
+| `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 
-`tn/scalar_hea_l2` is compiled out unless `bench-internal` is enabled, and
-`bench_ab.sh` defaults to `--features parallel`, so a gating run over it needs
+The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
+`bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs
 `--features "parallel bench-internal"` or it silently reports zero rows. Cargo
 fingerprints feature sets separately, so the first such run pays a cold build in
 both the working tree and the reference worktree.
@@ -150,6 +152,40 @@ quiet. `density_matrix/neutrality/22` has read a control spread of -15.9% to
 +37.0% under this method with the editor consuming about half the CPU, so read the
 control column on every run rather than assuming any row is stable. When the
 controls are wide, the answer is "not measurable right now", not a number.
+
+### What the reference worktree cannot resolve
+
+The reference binary is built in a separate worktree, so the two binaries differ in
+embedded paths and therefore in code layout. The control columns compare each binary
+against itself, so neither can see that difference. For a change to a hot loop's
+arithmetic this does not matter. For a change that adds or removes linked code it can
+invert the result.
+
+Adding a faer matmul call to `tensornetwork.rs` measured -10.3% to -13.2% on the four
+`tn/scalar_hea_l2` rows under this script. Rebuilt with both commits compiled from one
+directory, the same rows read +11.3% to +13.2%: the change costs 13% there, and the
+script had reported it as a 13% gain. A build with the crossover raised past every
+reachable size, so the new code is linked but never called, carries the same +13%, which
+is what identifies layout rather than execution as the cause.
+
+So: when a change adds a dependency call, instantiates a large generic, or deletes a
+sizeable function, compare two binaries built from the same directory before trusting
+this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
+the difference; both were tried and both left it intact.
+
+Building both binaries from one directory narrows the difference but does not remove it.
+To remove it, put both implementations in the same binary behind a switch read once at
+startup, and run that one binary twice:
+
+```rust
+static SCATTER: OnceLock<bool> = OnceLock::new();
+if *SCATTER.get_or_init(|| std::env::var("PRISM_TRANSPOSE_SCATTER").is_ok()) { .. }
+```
+
+Code, layout and embedded paths are then identical by construction, so the layout term
+cancels exactly rather than approximately, and the branch is paid on both sides. It costs
+one build rather than two. Use it whenever the change itself adds or removes linked code,
+which is the case this section's caveat exists for.
 
 The two binaries are never byte identical even from identical sources, because
 `[profile.bench] debug = "line-tables-only"` records the package path and the two

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -850,6 +850,59 @@ fn bench_tn_scalar_expectation(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_depth(_c: &mut Criterion) {}
+
+/// Rising-treewidth rows: 20 qubits, layer count swept, so the intermediates
+/// grow instead of staying flat as they do in `tn/scalar_hea_l2`. 4 layers is
+/// where the largest first clears `MIN_PAR_ELEMS`, below which the parallel arms
+/// of `contract` and `transpose` never run.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_depth_20q");
+    configure_group(&mut group);
+
+    let observable = [PauliTerm::z(0), PauliTerm::z(10)];
+    for &layers in &[4, 5, 6, 7] {
+        let circuit = circuits::hardware_efficient_ansatz(20, layers, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(layers), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
+
+/// Wide and deep together, the only rows where width drives the faer arm.
+///
+/// `tn/scalar_hea_l2` sweeps the same widths two layers deep, where the largest
+/// intermediate holds 256 elements and no contraction reaches
+/// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
+/// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
+/// so a change to the crossover shows up here as a function of width. Seven
+/// layers would be the natural next row and is left out: its peak intermediate
+/// jumps to 16.8M elements and an iteration costs 3.3 s.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l6");
+    configure_group(&mut group);
+
+    for &n in &[20, 30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 6, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2068,6 +2121,8 @@ criterion_group! {
     bench_tn_scaling,
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
+    bench_tn_scalar_depth,
+    bench_tn_scalar_wide_deep,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -78,8 +78,18 @@ use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 use rayon::prelude::*;
 
 type LegId = usize;
+
 #[cfg(feature = "parallel")]
 use crate::backend::MIN_PAR_ELEMS;
+
+/// `m*k*n` at or above which a contraction goes to faer instead of the scalar
+/// loop below.
+///
+/// A 64-cubed complex product. Routing everything to faer instead costs 23% on
+/// `tn/scalar_depth_20q/4`, where the operands are too small to cover its
+/// packing.
+#[cfg(feature = "parallel")]
+const MIN_FAER_GEMM_WORK: usize = 1 << 18;
 
 /// Dense multidimensional tensor with named legs for contraction.
 ///
@@ -105,13 +115,9 @@ impl Tensor {
 /// Fill `out` with transposed elements, `out[0]` being output index `start`.
 ///
 /// The output index is walked as an odometer over the permuted axes, so the
-/// source offset advances by addition. Only the initial `start` decomposition
-/// divides, which is once per call rather than once per axis per element. The
-/// odometer carries a fixed setup cost, so this is worth calling only for
-/// chunks large enough to amortize it, which is what the parallel path does.
+/// source offset advances by addition and only a nonzero `start` needs division.
 ///
 /// `steps[a]` is the source stride of the axis that output axis `a` came from.
-#[cfg(feature = "parallel")]
 fn transpose_range(
     out: &mut [Complex64],
     src: &[Complex64],
@@ -180,7 +186,6 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
-    #[cfg(feature = "parallel")]
     let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
 
     #[cfg(feature = "parallel")]
@@ -207,29 +212,32 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         };
     }
 
-    let perm_strides: SmallVec<[usize; 6]> = (0..rank)
-        .map(|old_ax| {
-            let new_ax = perm.iter().position(|&p| p == old_ax).unwrap();
-            new_strides[new_ax]
-        })
-        .collect();
-
-    for (old_linear, &amp) in t.data.iter().enumerate() {
-        let mut new_linear = 0usize;
-        let mut rem = old_linear;
-        for i in 0..rank {
-            let idx = rem / old_strides[i];
-            rem %= old_strides[i];
-            new_linear += idx * perm_strides[i];
-        }
-        new_data[new_linear] = amp;
-    }
+    transpose_range(&mut new_data, &t.data, 0, &new_shape, &new_strides, &steps);
 
     Tensor {
         data: new_data,
         shape: new_shape,
         legs: new_legs,
     }
+}
+
+/// Multiply the row-major `m` by `k` and `k` by `n` operands into `c`.
+///
+/// A row-major array is its own transpose read column-major, so `C = A*B` is
+/// issued as `C^T = B^T * A^T` over the same buffers with no repacking.
+#[cfg(feature = "parallel")]
+fn faer_gemm(a: &[Complex64], b: &[Complex64], c: &mut [Complex64], m: usize, k: usize, n: usize) {
+    use faer::linalg::matmul::matmul;
+    use faer::{Accum, MatMut, MatRef, Par};
+
+    matmul(
+        MatMut::from_column_major_slice_mut(c, n, m),
+        Accum::Replace,
+        MatRef::from_column_major_slice(b, n, k),
+        MatRef::from_column_major_slice(a, k, m),
+        Complex64::new(1.0, 0.0),
+        Par::rayon(0),
+    );
 }
 
 /// Contract two tensors over shared legs (matching LegId).
@@ -283,7 +291,9 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     let mut c_data = vec![zero; m * n];
 
     #[cfg(feature = "parallel")]
-    if m * n >= MIN_PAR_ELEMS {
+    if m * k * n >= MIN_FAER_GEMM_WORK {
+        faer_gemm(&a_t.data, &b_t.data, &mut c_data, m, k, n);
+    } else if m * n >= MIN_PAR_ELEMS {
         let a_data = &a_t.data;
         let b_data = &b_t.data;
         c_data.par_chunks_mut(n).enumerate().for_each(|(i, c_row)| {

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -33,7 +33,8 @@
 //! # Contraction strategy
 //!
 //! Greedy min-size heuristic: repeatedly contract the pair of tensors whose
-//! result has the smallest total element count. O(T²) where T = tensor count.
+//! result has the smallest total element count, preferring pairs sharing a leg.
+//! O(T·r·log T) for T tensors of rank at most r.
 //!
 //! # Shot and observable queries stay on the dense route
 //!
@@ -59,6 +60,8 @@
 //! only. Revisit if Auto starts routing wide low-treewidth circuits here.
 
 use std::borrow::Cow;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 
 use num_complex::Complex64;
 use rand::SeedableRng;
@@ -348,18 +351,6 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     }
 }
 
-fn shared_leg_count(a: &Tensor, b: &Tensor) -> usize {
-    let mut count = 0;
-    for &a_leg in &a.legs {
-        for &b_leg in &b.legs {
-            if a_leg == b_leg {
-                count += 1;
-            }
-        }
-    }
-    count
-}
-
 fn contraction_result_size(a: &Tensor, b: &Tensor) -> usize {
     let mut a_free_size = 1usize;
     let mut b_free_size = 1usize;
@@ -378,76 +369,109 @@ fn contraction_result_size(a: &Tensor, b: &Tensor) -> usize {
     a_free_size * b_free_size
 }
 
-/// Contract an entire tensor network using a greedy min-size heuristic.
+/// Contraction candidates ordered by result element count, then by the higher
+/// slot id descending, then the lower.
 ///
-/// Repeatedly finds the pair with the smallest contraction result and
-/// contracts them, until a single tensor remains.
+/// Newest-first on ties keeps the contraction on its frontier instead of letting
+/// fresh tensors accumulate legs. Reversing the tie-break raises peak
+/// intermediates 16x on `hardware_efficient_ansatz(50, 3)`.
+type PairQueue = BinaryHeap<Reverse<(usize, Reverse<usize>, Reverse<usize>)>>;
+
+/// Record `slot` against each of its legs and queue it against every live tensor
+/// already sharing one, pruning contracted slots off the holder lists it walks.
+///
+/// A tensor carrying one leg twice would otherwise queue against itself; no
+/// valid circuit produces one.
+fn queue_slot_pairs(
+    slots: &[Option<Tensor>],
+    slot: usize,
+    leg_holders: &mut Vec<SmallVec<[usize; 2]>>,
+    queue: &mut PairQueue,
+) {
+    let tensor = slots[slot].as_ref().expect("slot just filled");
+    for &leg in &tensor.legs {
+        if leg >= leg_holders.len() {
+            leg_holders.resize(leg + 1, SmallVec::new());
+        }
+        leg_holders[leg].retain(|held| slots[*held].is_some());
+        for &other in leg_holders[leg].iter().filter(|&&held| held != slot) {
+            let cost = contraction_result_size(
+                tensor,
+                slots[other].as_ref().expect("holder list pruned above"),
+            );
+            queue.push(Reverse((
+                cost,
+                Reverse(other.max(slot)),
+                Reverse(other.min(slot)),
+            )));
+        }
+        leg_holders[leg].push(slot);
+    }
+}
+
+/// Pop the cheapest queued pair whose members are both still live.
+///
+/// Returns `None` once no two live tensors share a leg.
+fn pop_live_pair(queue: &mut PairQueue, slots: &[Option<Tensor>]) -> Option<(usize, usize)> {
+    while let Some(Reverse((_, Reverse(j), Reverse(i)))) = queue.pop() {
+        if slots[i].is_some() && slots[j].is_some() {
+            return Some((i, j));
+        }
+    }
+    None
+}
+
+/// Multiply out the tensors left once no pair shares a leg, smallest first.
+///
+/// Reached when every connected component has collapsed to a single tensor, and
+/// stable from there: merging two tensors that share no leg with anything cannot
+/// create a shared leg. For disjoint operands the greedy cost reduces to the
+/// product of their element counts, so smallest-first is the same choice a scan
+/// over every pair would make, without the scan.
+fn join_disjoint(mut slots: Vec<Option<Tensor>>) -> Tensor {
+    let mut by_size: BinaryHeap<Reverse<(usize, usize)>> = slots
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, held)| held.as_ref().map(|t| Reverse((t.num_elements(), idx))))
+        .collect();
+
+    while by_size.len() > 1 {
+        let Reverse((_, i)) = by_size.pop().expect("two or more queued");
+        let Reverse((_, j)) = by_size.pop().expect("two or more queued");
+        let a_tensor = slots[i].take().expect("queued slots are live");
+        let b_tensor = slots[j].take().expect("queued slots are live");
+        let merged = contract(&a_tensor, &b_tensor);
+        by_size.push(Reverse((merged.num_elements(), slots.len())));
+        slots.push(Some(merged));
+    }
+
+    let Reverse((_, last)) = by_size.pop().expect("the network is never empty");
+    slots[last].take().expect("queued slots are live")
+}
+
+/// Contract an entire tensor network with the greedy min-size heuristic.
+///
+/// Only pairs involving the tensor a contraction produced change cost, so
+/// candidates come off a leg-indexed queue.
 fn greedy_contract(tensors: &mut Vec<Tensor>) -> Tensor {
     debug_assert!(!tensors.is_empty());
 
-    while tensors.len() > 1 {
-        let len = tensors.len();
+    let mut slots: Vec<Option<Tensor>> = std::mem::take(tensors).into_iter().map(Some).collect();
+    let mut leg_holders: Vec<SmallVec<[usize; 2]>> = Vec::new();
+    let mut queue: PairQueue = BinaryHeap::new();
 
-        #[cfg(feature = "parallel")]
-        let (best_i, best_j) = if len >= 50 {
-            let t_ref: &[Tensor] = tensors;
-            let (_, bi, bj) = (0..len)
-                .into_par_iter()
-                .flat_map_iter(|i| {
-                    (i + 1..len).map(move |j| {
-                        let shared = shared_leg_count(&t_ref[i], &t_ref[j]);
-                        let cost = contraction_result_size(&t_ref[i], &t_ref[j]);
-                        let priority = if shared > 0 { 0usize } else { 1 };
-                        ((priority, cost), i, j)
-                    })
-                })
-                .min_by_key(|&(key, _, _)| key)
-                .unwrap();
-            (bi, bj)
-        } else {
-            find_best_pair(tensors, len)
-        };
-
-        #[cfg(not(feature = "parallel"))]
-        let (best_i, best_j) = find_best_pair(tensors, len);
-
-        let b_tensor = tensors.swap_remove(best_j);
-        let a_tensor = tensors.swap_remove(best_i);
-        let result = contract(&a_tensor, &b_tensor);
-        tensors.push(result);
+    for slot in 0..slots.len() {
+        queue_slot_pairs(&slots, slot, &mut leg_holders, &mut queue);
     }
 
-    tensors.pop().unwrap()
-}
-
-fn find_best_pair(tensors: &[Tensor], len: usize) -> (usize, usize) {
-    let mut best_i = 0;
-    let mut best_j = 1;
-    let mut best_cost = usize::MAX;
-    let mut found_shared = false;
-
-    for i in 0..len {
-        for j in (i + 1)..len {
-            let shared = shared_leg_count(&tensors[i], &tensors[j]);
-            if shared > 0 {
-                let cost = contraction_result_size(&tensors[i], &tensors[j]);
-                if !found_shared || cost < best_cost {
-                    best_i = i;
-                    best_j = j;
-                    best_cost = cost;
-                    found_shared = true;
-                }
-            } else if !found_shared {
-                let cost = contraction_result_size(&tensors[i], &tensors[j]);
-                if cost < best_cost {
-                    best_i = i;
-                    best_j = j;
-                    best_cost = cost;
-                }
-            }
-        }
+    while let Some((i, j)) = pop_live_pair(&mut queue, &slots) {
+        let a_tensor = slots[i].take().expect("popped pair is live");
+        let b_tensor = slots[j].take().expect("popped pair is live");
+        slots.push(Some(contract(&a_tensor, &b_tensor)));
+        queue_slot_pairs(&slots, slots.len() - 1, &mut leg_holders, &mut queue);
     }
-    (best_i, best_j)
+
+    join_disjoint(slots)
 }
 
 struct ScalarExpectationNetwork {
@@ -1525,6 +1549,43 @@ mod tests {
     fn test_scalar_expectation_matches_statevector() {
         let circuit = crate::circuits::hardware_efficient_ansatz(8, 2, 42);
         let terms = [PauliTerm::z(1), PauliTerm::x(5)];
+
+        let expected =
+            crate::sim::run_expectation_values(&circuit, &[terms.to_vec()], 42).unwrap()[0];
+        let actual = expectation_zero_state(&circuit, &terms).unwrap();
+        assert!((actual - expected).abs() < EPS, "{actual} vs {expected}");
+    }
+
+    // Idle qubits leave one disconnected component each, which is what
+    // join_disjoint exists for.
+    #[test]
+    fn test_scalar_expectation_with_idle_qubits() {
+        let mut circuit = Circuit::new(9, 0);
+        circuit.add_gate(Gate::H, &[2]);
+        circuit.add_gate(Gate::Cx, &[2, 3]);
+        circuit.add_gate(Gate::Ry(0.7), &[6]);
+        let terms = [PauliTerm::z(2), PauliTerm::z(3), PauliTerm::x(6)];
+
+        let expected =
+            crate::sim::run_expectation_values(&circuit, &[terms.to_vec()], 42).unwrap()[0];
+        let actual = expectation_zero_state(&circuit, &terms).unwrap();
+        assert!((actual - expected).abs() < EPS, "{actual} vs {expected}");
+    }
+
+    // Two entangled components of unequal size, so join_disjoint merges tensors
+    // rather than bare scalars and its smallest-first order is observable.
+    #[test]
+    fn test_scalar_expectation_unequal_disjoint_components() {
+        let mut circuit = Circuit::new(10, 0);
+        for &q in &[0usize, 1, 2, 3, 4] {
+            circuit.add_gate(Gate::Ry(0.3 + q as f64 * 0.1), &[q]);
+        }
+        for &(a, b) in &[(0usize, 1usize), (1, 2), (2, 3), (3, 4)] {
+            circuit.add_gate(Gate::Cx, &[a, b]);
+        }
+        circuit.add_gate(Gate::H, &[7]);
+        circuit.add_gate(Gate::Cx, &[7, 8]);
+        let terms = [PauliTerm::z(0), PauliTerm::x(4), PauliTerm::z(7)];
 
         let expected =
             crate::sim::run_expectation_values(&circuit, &[terms.to_vec()], 42).unwrap()[0];


### PR DESCRIPTION
## Summary

The greedy contraction ordering rescanned every pair of live tensors on every step to
find the cheapest one, which is cubic in tensor count. Candidates now come off a
leg-indexed heap, since only pairs involving the tensor a contraction just produced can
change cost. Leg-disjoint components merge smallest first instead of through another
rescan.

Paired timers put the ordering search at 97.3% to 99.3% of the row before this change,
so the wide rows were spending nearly all their time deciding what to contract rather
than contracting.

Stacked on #145.

## Scope

- [x] Performance improvement

## Benchmarks

All ten `tn/` rows faster, -30.0% to -99.7%, reproduced across two independent A/B runs
that agree to one decimal on the four `scalar_hea_l2` rows. Run 1's worst control is
3.1%, so it is gate-precise; run 2's worst is 8.8% with seven rows flagged unresolvable.
Full tables for both runs are below.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `tn/scalar_hea_l2/20` | 12.79 ms | 372.9 us | -97.1% | +0.2% | PASS |
| `tn/scalar_hea_l2/30` | 42.62 ms | 565.9 us | -98.7% | -2.3% | PASS |
| `tn/scalar_hea_l2/40` | 100.4 ms | 757.4 us | -99.2% | -0.4% | PASS |
| `tn/scalar_hea_l2/50` | 196.6 ms | 944.3 us | -99.5% | +2.5% | PASS |
| `tn/random_d10/4` | 74.0 us | 51.8 us | -30.0% | +4.9% | PASS |
| `tn/random_d10/8` | 215.6 us | 150.9 us | -30.0% | -1.4% | PASS |
| `tn/random_d10/12` | 419.0 us | 293.3 us | -30.0% | -1.0% | PASS |

Full Criterion tier, not `bench-fast`.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2094)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (12)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

## Hotspot notes

Two findings the benchmark table does not carry.

Peak intermediates fall on every family measured, and that came from the tie-break rather
than from the index. Resolving equal costs to the oldest slot benchmarked the same but
took `hea_l3` peaks from 2048 to 16384 elements, which is worse than the code being
replaced. Newest-first keeps the contraction on its frontier instead of letting fresh
tensors accumulate legs. The `PairQueue` docstring records the 16x so a later refactor
does not quietly reverse it.

The disjoint fallback as first written was still cubic in component count: 8.1x per
doubling, 317.88 ms at 800 idle qubits. That is not a regression against `main`, but it
would have made this PR's own claim false in that shape. Smallest-first merging takes it
to 1.75 ms, and `join_disjoint` explains why smallest-first is the same choice a full
scan would make.

The rayon arm in `greedy_contract` is gone, so these rows no longer vary with thread
count.

## Risks and rollback

Contained to `greedy_contract` and its two helpers; no public API and no other backend
touches them. Reverting the commit restores the previous ordering exactly.
