### PR TITLE
bench(tn): add a rising-treewidth row at the parallel crossover

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -59,6 +59,7 @@ worth the disk.
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
 | `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
+| `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 
 The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs
@@ -151,6 +152,40 @@ quiet. `density_matrix/neutrality/22` has read a control spread of -15.9% to
 +37.0% under this method with the editor consuming about half the CPU, so read the
 control column on every run rather than assuming any row is stable. When the
 controls are wide, the answer is "not measurable right now", not a number.
+
+### What the reference worktree cannot resolve
+
+The reference binary is built in a separate worktree, so the two binaries differ in
+embedded paths and therefore in code layout. The control columns compare each binary
+against itself, so neither can see that difference. For a change to a hot loop's
+arithmetic this does not matter. For a change that adds or removes linked code it can
+invert the result.
+
+Adding a faer matmul call to `tensornetwork.rs` measured -10.3% to -13.2% on the four
+`tn/scalar_hea_l2` rows under this script. Rebuilt with both commits compiled from one
+directory, the same rows read +11.3% to +13.2%: the change costs 13% there, and the
+script had reported it as a 13% gain. A build with the crossover raised past every
+reachable size, so the new code is linked but never called, carries the same +13%, which
+is what identifies layout rather than execution as the cause.
+
+So: when a change adds a dependency call, instantiates a large generic, or deletes a
+sizeable function, compare two binaries built from the same directory before trusting
+this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
+the difference; both were tried and both left it intact.
+
+Building both binaries from one directory narrows the difference but does not remove it.
+To remove it, put both implementations in the same binary behind a switch read once at
+startup, and run that one binary twice:
+
+```rust
+static SCATTER: OnceLock<bool> = OnceLock::new();
+if *SCATTER.get_or_init(|| std::env::var("PRISM_TRANSPOSE_SCATTER").is_ok()) { .. }
+```
+
+Code, layout and embedded paths are then identical by construction, so the layout term
+cancels exactly rather than approximately, and the branch is paid on both sides. It costs
+one build rather than two. Use it whenever the change itself adds or removes linked code,
+which is the case this section's caveat exists for.
 
 The two binaries are never byte identical even from identical sources, because
 `[profile.bench] debug = "line-tables-only"` records the package path and the two

--- a/benches/README.md
+++ b/benches/README.md
@@ -58,9 +58,10 @@ worth the disk.
 | `stabilizer_rank/shots_terminal` | Clifford+T shot sampling with terminal measurements, including 1000q chi2 |
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
+| `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
 
-`tn/scalar_hea_l2` is compiled out unless `bench-internal` is enabled, and
-`bench_ab.sh` defaults to `--features parallel`, so a gating run over it needs
+The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
+`bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs
 `--features "parallel bench-internal"` or it silently reports zero rows. Cargo
 fingerprints feature sets separately, so the first such run pays a cold build in
 both the working tree and the reference worktree.

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -850,6 +850,30 @@ fn bench_tn_scalar_expectation(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_depth(_c: &mut Criterion) {}
+
+/// Rising-treewidth rows: 20 qubits, layer count swept, so the intermediates
+/// grow instead of staying flat as they do in `tn/scalar_hea_l2`. 4 layers is
+/// where the largest first clears `MIN_PAR_ELEMS`, below which the parallel arms
+/// of `contract` and `transpose` never run.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_depth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_depth_20q");
+    configure_group(&mut group);
+
+    let observable = [PauliTerm::z(0), PauliTerm::z(10)];
+    for &layers in &[4, 5, 6, 7] {
+        let circuit = circuits::hardware_efficient_ansatz(20, layers, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(layers), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2068,6 +2092,7 @@ criterion_group! {
     bench_tn_scaling,
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
+    bench_tn_scalar_depth,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -874,6 +874,35 @@ fn bench_tn_scalar_depth(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
+
+/// Wide and deep together, the only rows where width drives the faer arm.
+///
+/// `tn/scalar_hea_l2` sweeps the same widths two layers deep, where the largest
+/// intermediate holds 256 elements and no contraction reaches
+/// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
+/// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
+/// so a change to the crossover shows up here as a function of width. Seven
+/// layers would be the natural next row and is left out: its peak intermediate
+/// jumps to 16.8M elements and an iteration costs 3.3 s.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l6");
+    configure_group(&mut group);
+
+    for &n in &[20, 30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 6, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2093,6 +2122,7 @@ criterion_group! {
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
     bench_tn_scalar_depth,
+    bench_tn_scalar_wide_deep,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -78,8 +78,18 @@ use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 use rayon::prelude::*;
 
 type LegId = usize;
+
 #[cfg(feature = "parallel")]
 use crate::backend::MIN_PAR_ELEMS;
+
+/// `m*k*n` at or above which a contraction goes to faer instead of the scalar
+/// loop below.
+///
+/// A 64-cubed complex product. Routing everything to faer instead costs 23% on
+/// `tn/scalar_depth_20q/4`, where the operands are too small to cover its
+/// packing.
+#[cfg(feature = "parallel")]
+const MIN_FAER_GEMM_WORK: usize = 1 << 18;
 
 /// Dense multidimensional tensor with named legs for contraction.
 ///
@@ -105,13 +115,9 @@ impl Tensor {
 /// Fill `out` with transposed elements, `out[0]` being output index `start`.
 ///
 /// The output index is walked as an odometer over the permuted axes, so the
-/// source offset advances by addition. Only the initial `start` decomposition
-/// divides, which is once per call rather than once per axis per element. The
-/// odometer carries a fixed setup cost, so this is worth calling only for
-/// chunks large enough to amortize it, which is what the parallel path does.
+/// source offset advances by addition and only a nonzero `start` needs division.
 ///
 /// `steps[a]` is the source stride of the axis that output axis `a` came from.
-#[cfg(feature = "parallel")]
 fn transpose_range(
     out: &mut [Complex64],
     src: &[Complex64],
@@ -180,7 +186,6 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
-    #[cfg(feature = "parallel")]
     let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
 
     #[cfg(feature = "parallel")]
@@ -207,29 +212,32 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         };
     }
 
-    let perm_strides: SmallVec<[usize; 6]> = (0..rank)
-        .map(|old_ax| {
-            let new_ax = perm.iter().position(|&p| p == old_ax).unwrap();
-            new_strides[new_ax]
-        })
-        .collect();
-
-    for (old_linear, &amp) in t.data.iter().enumerate() {
-        let mut new_linear = 0usize;
-        let mut rem = old_linear;
-        for i in 0..rank {
-            let idx = rem / old_strides[i];
-            rem %= old_strides[i];
-            new_linear += idx * perm_strides[i];
-        }
-        new_data[new_linear] = amp;
-    }
+    transpose_range(&mut new_data, &t.data, 0, &new_shape, &new_strides, &steps);
 
     Tensor {
         data: new_data,
         shape: new_shape,
         legs: new_legs,
     }
+}
+
+/// Multiply the row-major `m` by `k` and `k` by `n` operands into `c`.
+///
+/// A row-major array is its own transpose read column-major, so `C = A*B` is
+/// issued as `C^T = B^T * A^T` over the same buffers with no repacking.
+#[cfg(feature = "parallel")]
+fn faer_gemm(a: &[Complex64], b: &[Complex64], c: &mut [Complex64], m: usize, k: usize, n: usize) {
+    use faer::linalg::matmul::matmul;
+    use faer::{Accum, MatMut, MatRef, Par};
+
+    matmul(
+        MatMut::from_column_major_slice_mut(c, n, m),
+        Accum::Replace,
+        MatRef::from_column_major_slice(b, n, k),
+        MatRef::from_column_major_slice(a, k, m),
+        Complex64::new(1.0, 0.0),
+        Par::rayon(0),
+    );
 }
 
 /// Contract two tensors over shared legs (matching LegId).
@@ -283,7 +291,9 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     let mut c_data = vec![zero; m * n];
 
     #[cfg(feature = "parallel")]
-    if m * n >= MIN_PAR_ELEMS {
+    if m * k * n >= MIN_FAER_GEMM_WORK {
+        faer_gemm(&a_t.data, &b_t.data, &mut c_data, m, k, n);
+    } else if m * n >= MIN_PAR_ELEMS {
         let a_data = &a_t.data;
         let b_data = &b_t.data;
         c_data.par_chunks_mut(n).enumerate().for_each(|(i, c_row)| {


### PR DESCRIPTION
## Summary

Adds `tn/scalar_depth_20q`, 20 qubits with the layer count swept 4 to 7. Every other
`tn/` row holds intermediates at 64 to 256 elements, so the rayon arms in `contract` and
`transpose` never execute and no change to either could be measured. 4 layers is where
the largest intermediate first clears `MIN_PAR_ELEMS = 4096`.

Stacked on #146.

## Scope

- [x] Performance improvement (benchmark coverage only, no code change on the hot path)

## Benchmarks

N/A, no hot-path changes. The rows are new. `bench-fast` triage, which is triage and not
a measurement, reads 3.77 / 5.90 / 23.1 / 157 ms across the four layer counts.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2094)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (12)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

## Risks and rollback

`bench-internal` only, so the default build and the CI gate are unaffected.
