### PR TITLE
perf(tn): route large contractions through faer

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -152,6 +152,26 @@ quiet. `density_matrix/neutrality/22` has read a control spread of -15.9% to
 control column on every run rather than assuming any row is stable. When the
 controls are wide, the answer is "not measurable right now", not a number.
 
+### What the reference worktree cannot resolve
+
+The reference binary is built in a separate worktree, so the two binaries differ in
+embedded paths and therefore in code layout. The control columns compare each binary
+against itself, so neither can see that difference. For a change to a hot loop's
+arithmetic this does not matter. For a change that adds or removes linked code it can
+invert the result.
+
+Adding a faer matmul call to `tensornetwork.rs` measured -10.3% to -13.2% on the four
+`tn/scalar_hea_l2` rows under this script. Rebuilt with both commits compiled from one
+directory, the same rows read +11.3% to +13.2%: the change costs 13% there, and the
+script had reported it as a 13% gain. A build with the crossover raised past every
+reachable size, so the new code is linked but never called, carries the same +13%, which
+is what identifies layout rather than execution as the cause.
+
+So: when a change adds a dependency call, instantiates a large generic, or deletes a
+sizeable function, compare two binaries built from the same directory before trusting
+this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
+the difference; both were tried and both left it intact.
+
 The two binaries are never byte identical even from identical sources, because
 `[profile.bench] debug = "line-tables-only"` records the package path and the two
 worktrees differ. The script decides "same code" from git, not from `cmp`.

--- a/benches/README.md
+++ b/benches/README.md
@@ -59,6 +59,7 @@ worth the disk.
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
 | `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
+| `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 
 The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs
@@ -171,6 +172,20 @@ So: when a change adds a dependency call, instantiates a large generic, or delet
 sizeable function, compare two binaries built from the same directory before trusting
 this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
 the difference; both were tried and both left it intact.
+
+Building both binaries from one directory narrows the difference but does not remove it.
+To remove it, put both implementations in the same binary behind a switch read once at
+startup, and run that one binary twice:
+
+```rust
+static SCATTER: OnceLock<bool> = OnceLock::new();
+if *SCATTER.get_or_init(|| std::env::var("PRISM_TRANSPOSE_SCATTER").is_ok()) { .. }
+```
+
+Code, layout and embedded paths are then identical by construction, so the layout term
+cancels exactly rather than approximately, and the branch is paid on both sides. It costs
+one build rather than two. Use it whenever the change itself adds or removes linked code,
+which is the case this section's caveat exists for.
 
 The two binaries are never byte identical even from identical sources, because
 `[profile.bench] debug = "line-tables-only"` records the package path and the two

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -874,6 +874,35 @@ fn bench_tn_scalar_depth(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
+
+/// Wide and deep together, the only rows where width drives the faer arm.
+///
+/// `tn/scalar_hea_l2` sweeps the same widths two layers deep, where the largest
+/// intermediate holds 256 elements and no contraction reaches
+/// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
+/// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
+/// so a change to the crossover shows up here as a function of width. Seven
+/// layers would be the natural next row and is left out: its peak intermediate
+/// jumps to 16.8M elements and an iteration costs 3.3 s.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l6");
+    configure_group(&mut group);
+
+    for &n in &[20, 30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 6, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2093,6 +2122,7 @@ criterion_group! {
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
     bench_tn_scalar_depth,
+    bench_tn_scalar_wide_deep,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -78,8 +78,18 @@ use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 use rayon::prelude::*;
 
 type LegId = usize;
+
 #[cfg(feature = "parallel")]
 use crate::backend::MIN_PAR_ELEMS;
+
+/// `m*k*n` at or above which a contraction goes to faer instead of the scalar
+/// loop below.
+///
+/// A 64-cubed complex product. Routing everything to faer instead costs 23% on
+/// `tn/scalar_depth_20q/4`, where the operands are too small to cover its
+/// packing.
+#[cfg(feature = "parallel")]
+const MIN_FAER_GEMM_WORK: usize = 1 << 18;
 
 /// Dense multidimensional tensor with named legs for contraction.
 ///
@@ -232,6 +242,25 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
     }
 }
 
+/// Multiply the row-major `m` by `k` and `k` by `n` operands into `c`.
+///
+/// A row-major array is its own transpose read column-major, so `C = A*B` is
+/// issued as `C^T = B^T * A^T` over the same buffers with no repacking.
+#[cfg(feature = "parallel")]
+fn faer_gemm(a: &[Complex64], b: &[Complex64], c: &mut [Complex64], m: usize, k: usize, n: usize) {
+    use faer::linalg::matmul::matmul;
+    use faer::{Accum, MatMut, MatRef, Par};
+
+    matmul(
+        MatMut::from_column_major_slice_mut(c, n, m),
+        Accum::Replace,
+        MatRef::from_column_major_slice(b, n, k),
+        MatRef::from_column_major_slice(a, k, m),
+        Complex64::new(1.0, 0.0),
+        Par::rayon(0),
+    );
+}
+
 /// Contract two tensors over shared legs (matching LegId).
 ///
 /// Standard tensordot: find shared legs, reshape both to 2D matrices,
@@ -283,7 +312,9 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     let mut c_data = vec![zero; m * n];
 
     #[cfg(feature = "parallel")]
-    if m * n >= MIN_PAR_ELEMS {
+    if m * k * n >= MIN_FAER_GEMM_WORK {
+        faer_gemm(&a_t.data, &b_t.data, &mut c_data, m, k, n);
+    } else if m * n >= MIN_PAR_ELEMS {
         let a_data = &a_t.data;
         let b_data = &b_t.data;
         c_data.par_chunks_mut(n).enumerate().for_each(|(i, c_row)| {

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -115,13 +115,9 @@ impl Tensor {
 /// Fill `out` with transposed elements, `out[0]` being output index `start`.
 ///
 /// The output index is walked as an odometer over the permuted axes, so the
-/// source offset advances by addition. Only the initial `start` decomposition
-/// divides, which is once per call rather than once per axis per element. The
-/// odometer carries a fixed setup cost, so this is worth calling only for
-/// chunks large enough to amortize it, which is what the parallel path does.
+/// source offset advances by addition and only a nonzero `start` needs division.
 ///
 /// `steps[a]` is the source stride of the axis that output axis `a` came from.
-#[cfg(feature = "parallel")]
 fn transpose_range(
     out: &mut [Complex64],
     src: &[Complex64],
@@ -190,7 +186,6 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
-    #[cfg(feature = "parallel")]
     let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
 
     #[cfg(feature = "parallel")]
@@ -217,23 +212,7 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         };
     }
 
-    let perm_strides: SmallVec<[usize; 6]> = (0..rank)
-        .map(|old_ax| {
-            let new_ax = perm.iter().position(|&p| p == old_ax).unwrap();
-            new_strides[new_ax]
-        })
-        .collect();
-
-    for (old_linear, &amp) in t.data.iter().enumerate() {
-        let mut new_linear = 0usize;
-        let mut rem = old_linear;
-        for i in 0..rank {
-            let idx = rem / old_strides[i];
-            rem %= old_strides[i];
-            new_linear += idx * perm_strides[i];
-        }
-        new_data[new_linear] = amp;
-    }
+    transpose_range(&mut new_data, &t.data, 0, &new_shape, &new_strides, &steps);
 
     Tensor {
         data: new_data,


### PR DESCRIPTION
## Summary

Contractions at or above `m*k*n = 2^18` go to faer's matmul; the hand-written loop with
its sparsity skip keeps everything below. The crossover exists because routing everything
to faer costs 23% on `tn/scalar_depth_20q/4`, where the operands are too small to cover
its packing.

A row-major array is its own transpose read column-major, so `C = A*B` is issued as
`C^T = B^T * A^T` over the same buffers with no repacking.

Stacked on #147.

## Scope

- [x] Performance improvement

## Benchmarks

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `tn/scalar_depth_20q/7` | 155.6 ms | 89.3 ms | -42.6% | -0.4% | PASS |
| `tn/scalar_depth_20q/6` | 22.3 ms | 20.9 ms | -6.4% | +4.1% | PASS |
| `tn/scalar_depth_20q/5` | 5.68 ms | 5.74 ms | +1.1% | +3.0% | noise |
| `tn/scalar_depth_20q/4` | 3.19 ms | 3.20 ms | +0.3% | -0.6% | noise |
| `tn/scalar_hea_l2/20` | 372.93 us | 422.22 us | +13.2% | +0.2% | FAIL, waived |
| `tn/scalar_hea_l2/30` | 565.86 us | 637.85 us | +12.7% | -2.3% | FAIL, waived |
| `tn/scalar_hea_l2/40` | 757.40 us | 853.69 us | +12.7% | -0.4% | FAIL, waived |
| `tn/scalar_hea_l2/50` | 944.26 us | 1068.2 us | +13.1% | +2.5% | FAIL, waived |
| `tn/random_d10/4` | 51.79 us | 56.41 us | +8.9% | +4.9% | FAIL, waived |
| `tn/random_d10/8` | 150.90 us | 170.82 us | +13.2% | -1.4% | FAIL, waived |
| `tn/random_d10/12` | 293.33 us | 305.24 us | +4.1% | -1.0% | FAIL, waived |

Full Criterion tier. Same-directory builds, not `bench_ab.sh`; see Hotspot notes.

Regression verdict: WAIVER

Seven rows regress, none of which ever call faer. The cause is linked code size rather
than execution: a build with the crossover raised past every reachable size, so the new
code is linked but never called, carries the same +13%. `#[inline(never)]` and `#[cold]`
were both tried and neither recovers it.

The waiver is granted because the deep row saves about 66 ms per iteration while the
seven regressed rows together cost under 0.2 ms, roughly 300 to 1. The recovery is
#149 immediately above this in the stack, which puts six of the seven back at or below
their pre-faer times; the remaining one is `tn/random_d10/4` at +9.3% net, and that row
carries the widest control in this table.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2094)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (12)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

## Hotspot notes

`bench_ab.sh` cannot resolve this change and its numbers should not be used for it. The
script builds its reference in a separate worktree, so the two binaries differ in embedded
paths and therefore in code layout, and its control columns compare each binary only
against itself. Under the script the seven rows above read **-10.3% to -13.2%**, the
opposite sign, a 25 point swing from build directory alone. The table above is from
builds made in one directory. `benches/README.md` gains a section describing the limit.

This matters for the CI gate here. The gate benches eight statevector, stabilizer, and
compiled_sampler rows that this diff cannot reach, and this diff instantiates a new faer
generic, which is exactly the kind of change that moves unrelated rows through layout. If
a gate row fails, check its control column before treating it as a real regression.

Two things that did not bite. Forcing faer everywhere costs 23% at 4 layers, which is
what sets the crossover. And the sparsity skip handicap did not matter: faer wins at 7
layers while doing about twice the arithmetic, because the skip only pays on operands
sparse enough to hit it.

## Risks and rollback

One threshold constant and one function. Setting `MIN_FAER_GEMM_WORK` to `usize::MAX`
disables the faer path without touching anything else, and reverting the commit removes
the instantiation entirely.
