### PR TITLE
perf(tn): walk the serial transpose as an odometer

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -59,6 +59,7 @@ worth the disk.
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
 | `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
+| `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 
 The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs

--- a/benches/README.md
+++ b/benches/README.md
@@ -172,6 +172,20 @@ sizeable function, compare two binaries built from the same directory before tru
 this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
 the difference; both were tried and both left it intact.
 
+Building both binaries from one directory narrows the difference but does not remove it.
+To remove it, put both implementations in the same binary behind a switch read once at
+startup, and run that one binary twice:
+
+```rust
+static SCATTER: OnceLock<bool> = OnceLock::new();
+if *SCATTER.get_or_init(|| std::env::var("PRISM_TRANSPOSE_SCATTER").is_ok()) { .. }
+```
+
+Code, layout and embedded paths are then identical by construction, so the layout term
+cancels exactly rather than approximately, and the branch is paid on both sides. It costs
+one build rather than two. Use it whenever the change itself adds or removes linked code,
+which is the case this section's caveat exists for.
+
 The two binaries are never byte identical even from identical sources, because
 `[profile.bench] debug = "line-tables-only"` records the package path and the two
 worktrees differ. The script decides "same code" from git, not from `cmp`.

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -874,6 +874,35 @@ fn bench_tn_scalar_depth(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
+
+/// Wide and deep together, the only rows where width drives the faer arm.
+///
+/// `tn/scalar_hea_l2` sweeps the same widths two layers deep, where the largest
+/// intermediate holds 256 elements and no contraction reaches
+/// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
+/// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
+/// so a change to the crossover shows up here as a function of width. Seven
+/// layers would be the natural next row and is left out: its peak intermediate
+/// jumps to 16.8M elements and an iteration costs 3.3 s.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l6");
+    configure_group(&mut group);
+
+    for &n in &[20, 30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 6, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2093,6 +2122,7 @@ criterion_group! {
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
     bench_tn_scalar_depth,
+    bench_tn_scalar_wide_deep,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -115,13 +115,9 @@ impl Tensor {
 /// Fill `out` with transposed elements, `out[0]` being output index `start`.
 ///
 /// The output index is walked as an odometer over the permuted axes, so the
-/// source offset advances by addition. Only the initial `start` decomposition
-/// divides, which is once per call rather than once per axis per element. The
-/// odometer carries a fixed setup cost, so this is worth calling only for
-/// chunks large enough to amortize it, which is what the parallel path does.
+/// source offset advances by addition and only a nonzero `start` needs division.
 ///
 /// `steps[a]` is the source stride of the axis that output axis `a` came from.
-#[cfg(feature = "parallel")]
 fn transpose_range(
     out: &mut [Complex64],
     src: &[Complex64],
@@ -190,7 +186,6 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         stride *= new_shape[i];
     }
 
-    #[cfg(feature = "parallel")]
     let steps: SmallVec<[usize; 6]> = perm.iter().map(|&old_ax| old_strides[old_ax]).collect();
 
     #[cfg(feature = "parallel")]
@@ -217,23 +212,7 @@ fn transpose(t: &Tensor, perm: &[usize]) -> Tensor {
         };
     }
 
-    let perm_strides: SmallVec<[usize; 6]> = (0..rank)
-        .map(|old_ax| {
-            let new_ax = perm.iter().position(|&p| p == old_ax).unwrap();
-            new_strides[new_ax]
-        })
-        .collect();
-
-    for (old_linear, &amp) in t.data.iter().enumerate() {
-        let mut new_linear = 0usize;
-        let mut rem = old_linear;
-        for i in 0..rank {
-            let idx = rem / old_strides[i];
-            rem %= old_strides[i];
-            new_linear += idx * perm_strides[i];
-        }
-        new_data[new_linear] = amp;
-    }
+    transpose_range(&mut new_data, &t.data, 0, &new_shape, &new_strides, &steps);
 
     Tensor {
         data: new_data,


### PR DESCRIPTION
## Summary

`transpose` had two arms that disagreed. The parallel arm walked the permuted axes as an
odometer and advanced the source offset by addition; the serial arm decomposed each
output index from scratch, dividing once per axis per element. Both arms now share the
odometer walk, and the serial arm passes `start = 0`, so it divides not at all.

This began as an attempt to elide the two transpose copies per contraction. Counters
killed that plan before any of it was written; see Hotspot notes.

Stacked on #148, whose waiver this recovers.

## Scope

- [x] Performance improvement

## Benchmarks

Median of three passes per binary from six interleaved passes, `ref new new ref ref new`,
after a discarded warmup. Control is the full spread across a binary's own three passes.
Full Criterion tier, host at 10% background load.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `tn/scalar_hea_l2/20` | 410.0 us | 353.3 us | -13.8% | 0.9% | PASS |
| `tn/scalar_hea_l2/30` | 645.6 us | 559.2 us | -13.4% | 3.1% | PASS |
| `tn/scalar_hea_l2/40` | 863.9 us | 742.7 us | -14.0% | 2.4% | PASS |
| `tn/scalar_hea_l2/50` | 1071.1 us | 935.3 us | -12.7% | 1.5% | PASS |
| `tn/scalar_depth_20q/4` | 3.259 ms | 2.226 ms | -31.7% | 1.4% | PASS |
| `tn/scalar_depth_20q/5` | 5.737 ms | 4.920 ms | -14.2% | 5.0% | PASS |
| `tn/scalar_depth_20q/6` | 20.508 ms | 18.366 ms | -10.4% | 12.6% | see below |
| `tn/scalar_depth_20q/7` | 89.565 ms | 88.428 ms | -1.3% | 4.7% | noise |
| `tn/linear_chain/4` | 47.854 us | 47.462 us | -0.8% | 2.0% | noise |
| `tn/linear_chain/8` | 253.75 us | 178.30 us | -29.7% | 5.1% | PASS |
| `tn/linear_chain/12` | 1070.6 us | 755.68 us | -29.4% | 2.6% | PASS |
| `tn/random_d10/4` | 59.641 us | 56.738 us | -4.9% | 2.4% | unresolved |
| `tn/random_d10/8` | 170.79 us | 150.50 us | -11.9% | 1.0% | PASS |
| `tn/random_d10/12` | 307.45 us | 301.17 us | -2.0% | 0.5% | noise |

Regression verdict: PASS. Ten rows improve, four are nulls, none regress.

`scalar_depth_20q/6` carries a control wider than its own effect, set by one reference
pass at 22.443 ms against 19.933 and 20.508. The three post-change passes are 17.933,
18.366 and 18.605, so the two sets do not overlap; the separation carries that row rather
than the median delta.

`scalar_depth_20q/7` is a null and is supposed to be. At 7 layers the transposes clear
`MIN_PAR_ELEMS` and take the parallel arm, which this change does not touch.

### Layout control

The four `scalar_hea_l2` rows are the same four #148 regressed by 12.7% to 13.2% through
linked code size alone, and this commit deletes 23 lines from a hot function, which is
that same change class. A two-binary A/B cannot separate "the odometer is faster" from
"the deletion gave the layout penalty back".

Settled by putting both walks in one binary behind a switch read once at startup and
running that single binary twice, so code, layout and embedded paths are identical by
construction. Rows above are from that run. The gains are execution.

That control also demoted `tn/linear_chain/4`, which a two-binary A/B had scored -6.8%
and which reads -0.8% against a 4.3% control when layout is held fixed.

### Serial build

`--no-default-features` compiles the parallel arm out, so every transpose takes the new
walk at any size. No bench row covers that build. Best of three `probabilities()` calls
on `hardware_efficient_ansatz(n, 1)`, single-shot rather than Criterion:

| n | Before | After | Change |
| --: | --: | --: | --: |
| 16 | 6.33 ms | 1.29 ms | -80% |
| 18 | 27.83 ms | 5.21 ms | -81% |
| 20 | 127.10 ms | 37.74 ms | -70% |

At rank 20 the old walk paid 20 serially dependent divisions per element, which dominates
the cache behavior of either direction.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2094)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (12)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

The two walks were also checked for exact equivalence outside the test suite: both
transcribed into a standalone harness and swept over 701,605 cases covering ranks 0 to 7,
every permutation, and extents drawn from {1,2,3,4} and {2,3}, with zero mismatches in
both optimized and overflow-checked builds.

## Hotspot notes

Counters classified every operand permutation as identity, block swap (a cyclic rotation,
where the buffer read the other way round is already the matrix wanted, so a view would
do), or general.

| Row | calls | a id/swap/gen | b id/swap/gen | swap elements | gen elements |
| --- | ---: | ---: | ---: | ---: | ---: |
| `scalar_depth_20q/7` | 4425 | 1380/1945/1100 | 1150/2165/1110 | 27.7k | 23.2M |
| `scalar_hea_l2/50` | 14900 | 6180/5880/2840 | 6900/5080/2920 | 71.5k | 193k |

Block swaps are 43% of operands by count and 0.1% of moved elements on the deep row, so
serving them from a view buys nothing where the volume is. Ordering the shared-axis block
to suit the second operand instead of the first was better on 0 of 42175 calls. Both
ideas were dropped without being built.

What the counters did show is that the wide shallow rows move an average of 16 elements
per transposed tensor, so their 60% to 70% share of `contract` was per-call index
arithmetic rather than data movement, and every one of those tensors sits below
`MIN_PAR_ELEMS` and so took the dividing arm.

## Risks and rollback

One function, no public API, no behavioral change. Reverting restores the previous walk.
