### PR TITLE
bench(tn): add wide-and-deep scalar rows over the faer arm

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -59,6 +59,7 @@ worth the disk.
 | `stabilizer_rank/shots_mid_circuit` | Clifford+T shot sampling with measurement, reset, and conditional gates |
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
 | `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
+| `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 
 The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -874,6 +874,35 @@ fn bench_tn_scalar_depth(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
+
+/// Wide and deep together, the only rows where width drives the faer arm.
+///
+/// `tn/scalar_hea_l2` sweeps the same widths two layers deep, where the largest
+/// intermediate holds 256 elements and no contraction reaches
+/// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
+/// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
+/// so a change to the crossover shows up here as a function of width. Seven
+/// layers would be the natural next row and is left out: its peak intermediate
+/// jumps to 16.8M elements and an iteration costs 3.3 s.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l6");
+    configure_group(&mut group);
+
+    for &n in &[20, 30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 6, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2093,6 +2122,7 @@ criterion_group! {
     bench_tn_linear_chain,
     bench_tn_scalar_expectation,
     bench_tn_scalar_depth,
+    bench_tn_scalar_wide_deep,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,


### PR DESCRIPTION
## Summary

Adds `tn/scalar_hea_l6`, the scalar contraction at 6 layers across 20 to 50 qubits. The
faer crossover from #148 is covered by two rows today, and only by accident:
`tn/scalar_depth_20q` was added to reach the rayon arms and happens to clear
`MIN_FAER_GEMM_WORK` at 6 and 7 layers, both of them at 20 qubits. Nothing exercises that
arm as qubit count grows, which is the regime this backend exists for.

Stacked on #149.

## Scope

- [x] Performance improvement (benchmark coverage only, no code change on the hot path)

## Benchmarks

N/A, no hot-path changes. The rows are new. `bench-fast` triage, which is triage and not
a measurement, reads 23 / 111 / 175 / 303 ms across the four widths.

Counter data behind the choice of 6 layers. `faer` counts contractions whose `m*k*n`
reaches `2^18`:

| layers | n=20 | n=30 | n=40 | n=50 | peak intermediate | n=50 time |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 0 | 0 | 0 | 0 | 4096 | 8 ms |
| 5 | 9 | 18 | 24 | 33 | 16384 | 28 ms |
| 6 | 12 | 20 | 29 | 37 | 1048576 | 303 ms |
| 7 | 16 | 28 | 41 | 53 | 16777216 | 3293 ms |

4 layers never reaches faer at any width. 7 layers is left out deliberately: its peak
intermediate is 16.8M elements and one iteration costs 3.3 s, which would dominate the
suite.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2094)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (12)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes

## Hotspot notes

Two things the sweep corrected. Peak intermediates are not flat in width once depth
rises, contrary to what the depth-2 rows suggest: at 6 layers n=20 peaks at 262144 while
n=30 and above reach 1048576. And the 7-layer peak is non-monotonic in width, 16.8M at
n=30 and n=50 against 1.05M at n=40, which is the greedy ordering picking a worse tree at
two of the four widths. That is unrelated to this PR and is filed for its own look.

## Risks and rollback

`bench-internal` only, so the default build and the CI gate are unaffected. At 303 ms per
iteration the widest row is the most expensive `tn/` row in the suite; drop the 50-qubit
entry if that becomes a problem.
