### PR TITLE
feat(circuit): export a Circuit to OpenQASM 3.0

### DIFF
--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -13,6 +13,7 @@ Fallible public APIs return `Result<T, PrismError>`. Error variants:
 | `InvalidClassicalBit` | Validation | Classical bit index exceeds register |
 | `GateArity` | Validation | Wrong number of qubits for gate |
 | `InvalidParameter` | Validation | Invalid gate parameter (NaN, etc.) |
+| `ExportUnsupported` | Export | Instruction with no OpenQASM 3.0 spelling |
 | `BackendUnsupported` | Runtime | Backend can't perform requested operation |
 | `IncompatibleBackend` | Runtime | Backend incompatible with circuit |
 

--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -16,6 +16,27 @@ let result = simulate(&circuit).seed(42).run().unwrap();
 
 `run_qasm(qasm, seed)` parses and simulates in one call.
 
+## Exporting
+
+```rust
+use prism_q::circuit::qasm_export;
+
+let qasm = qasm_export::to_qasm3(&circuit).expect("export error");
+```
+
+Export inverts the parser: re-parsing the result gives back the same instruction
+stream, with gate matrices agreeing to floating-point round-off and inline angles
+(`rx`, `rz`, `rzz`, `p`) surviving exactly. Qubits come out as one `qubit[n] q`
+register, classical bits as one `bit[m] c` register, split only where a condition
+compares against a register narrower than the whole.
+
+A circuit that has been through [fusion](../architecture/fusion.md) is not
+exportable: fused blocks, tiled multi-gate passes, and diagonal batches carry
+matrices with no OpenQASM spelling, and `to_qasm3` returns `ExportUnsupported`
+naming the instruction index. Export the circuit before fusing it, or the template
+a `PreparedCircuit` binds. A `QftBlock` is the one exception, expanded to its
+textbook Hadamard, controlled-phase, and swap sequence on the way out.
+
 ## Declarations and measurement
 
 ```text

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -23,6 +23,7 @@ pub mod openqasm;
 pub mod parameter;
 pub(crate) mod plan;
 pub mod prepared;
+pub mod qasm_export;
 
 pub use parameter::{ParamLink, Parameters};
 pub use prepared::PreparedCircuit;

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -46,6 +46,8 @@
 //!
 //! All parse failures return `PrismError::Parse` or `PrismError::UnsupportedConstruct`
 //! with the source line number. The parser never panics on user input.
+//!
+//! The reverse direction is [`qasm_export`](super::qasm_export).
 
 use num_complex::Complex64;
 
@@ -141,7 +143,7 @@ struct BlockState {
     depth: usize,
 }
 
-struct Parser<'a> {
+pub(crate) struct Parser<'a> {
     input: &'a str,
     qregs: HashMap<String, Register>,
     cregs: HashMap<String, Register>,
@@ -2254,7 +2256,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn u_matrix(theta: f64, phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
+    pub(crate) fn u_matrix(theta: f64, phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
         let c = (theta / 2.0).cos();
         let s = (theta / 2.0).sin();
         [
@@ -2275,7 +2277,12 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn cu_target_matrix(theta: f64, phi: f64, lam: f64, gamma: f64) -> [[Complex64; 2]; 2] {
+    pub(crate) fn cu_target_matrix(
+        theta: f64,
+        phi: f64,
+        lam: f64,
+        gamma: f64,
+    ) -> [[Complex64; 2]; 2] {
         let phase = Complex64::from_polar(1.0, gamma);
         let u = Self::u_matrix(theta, phi, lam);
         [
@@ -2284,7 +2291,7 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn xx_plus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
+    pub(crate) fn xx_plus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
         let zero = Complex64::new(0.0, 0.0);
         let one = Complex64::new(1.0, 0.0);
         let c = Complex64::new((theta / 2.0).cos(), 0.0);
@@ -2297,7 +2304,7 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn xx_minus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
+    pub(crate) fn xx_minus_yy_matrix(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
         let zero = Complex64::new(0.0, 0.0);
         let one = Complex64::new(1.0, 0.0);
         let c = Complex64::new((theta / 2.0).cos(), 0.0);
@@ -2339,7 +2346,7 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn ms_matrix(phi0: f64, phi1: f64, theta: f64) -> [[Complex64; 4]; 4] {
+    pub(crate) fn ms_matrix(phi0: f64, phi1: f64, theta: f64) -> [[Complex64; 4]; 4] {
         let zero = Complex64::new(0.0, 0.0);
         let c = Complex64::new((std::f64::consts::PI * theta).cos(), 0.0);
         let s = Complex64::new(0.0, -(std::f64::consts::PI * theta).sin());
@@ -2373,7 +2380,7 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn syc_matrix() -> [[Complex64; 4]; 4] {
+    pub(crate) fn syc_matrix() -> [[Complex64; 4]; 4] {
         let zero = Complex64::new(0.0, 0.0);
         let one = Complex64::new(1.0, 0.0);
         let neg_i = Complex64::new(0.0, -1.0);
@@ -2390,7 +2397,7 @@ impl<'a> Parser<'a> {
         ]
     }
 
-    fn sqrt_iswap_matrix(sign: f64) -> [[Complex64; 4]; 4] {
+    pub(crate) fn sqrt_iswap_matrix(sign: f64) -> [[Complex64; 4]; 4] {
         let zero = Complex64::new(0.0, 0.0);
         let one = Complex64::new(1.0, 0.0);
         let half = Complex64::new(std::f64::consts::FRAC_1_SQRT_2, 0.0);

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -1,0 +1,509 @@
+//! OpenQASM 3.0 export from a [`Circuit`].
+//!
+//! Inverts [`openqasm::parse`](super::openqasm::parse) over the constructs that
+//! parser produces: re-parsing an export yields the same instruction stream, with
+//! gate matrices agreeing to floating-point round-off rather than bit for bit.
+//! Angles carried inline (`rx`, `rz`, `rzz`, `p`) survive exactly.
+//!
+//! [`Gate::QftBlock`] expands to its textbook sequence before emission. Fusion
+//! payloads have no OpenQASM spelling and are rejected: `MultiFused`, `Multi2q`,
+//! `BatchPhase`, `BatchRzz`, `DiagonalBatch`, a `Fused2q` outside the two-qubit
+//! families the parser builds, and a single-qubit matrix carrying a global phase
+//! no named rotation absorbs.
+
+use num_complex::Complex64;
+use std::collections::BTreeSet;
+use std::f64::consts::{FRAC_PI_2, PI, TAU};
+use std::fmt::Write;
+
+use super::openqasm::Parser;
+use super::{Circuit, ClassicalCondition, Instruction, expand_qft_blocks};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+
+/// Agreement bound for recognizing a matrix as a named gate, matching the
+/// parser's own `resolve_controlled` threshold.
+const EPS: f64 = 1e-12;
+
+/// Render `circuit` as an OpenQASM 3.0 program.
+///
+/// Qubits become one `qubit[n] q` register. Classical bits become one `bit[m] c`
+/// register, cut at the boundaries of every register-valued condition so each
+/// condition still names a whole register; the pieces are then `c0`, `c1`, and so
+/// on, in bit order.
+///
+/// # Errors
+/// Returns [`PrismError::ExportUnsupported`], naming the instruction's index in
+/// the stream, for a gate with no OpenQASM 3.0 spelling.
+///
+/// # Examples
+/// ```
+/// use prism_q::circuit::{openqasm, qasm_export};
+/// use prism_q::{Circuit, Gate};
+///
+/// let mut circuit = Circuit::new(2, 0);
+/// circuit.add_gate(Gate::H, &[0]);
+/// circuit.add_gate(Gate::Cx, &[0, 1]);
+///
+/// let qasm = qasm_export::to_qasm3(&circuit).expect("export");
+/// assert_eq!(openqasm::parse(&qasm).expect("reparse").gate_count(), 2);
+/// ```
+pub fn to_qasm3(circuit: &Circuit) -> Result<String> {
+    let expanded = expand_qft_blocks(circuit);
+    let circuit = expanded.as_ref();
+    let cregs = CregLayout::of(circuit)?;
+
+    let mut out = String::with_capacity(96 + circuit.instructions.len() * 24);
+    out.push_str("OPENQASM 3.0;\ninclude \"stdgates.inc\";\n");
+    if circuit.num_qubits > 0 {
+        let _ = writeln!(out, "qubit[{}] q;", circuit.num_qubits);
+    }
+    for (&(_, size), name) in cregs.segments.iter().zip(&cregs.names) {
+        let _ = writeln!(out, "bit[{size}] {name};");
+    }
+
+    for (index, inst) in circuit.instructions.iter().enumerate() {
+        match inst {
+            Instruction::Gate { gate, targets } => {
+                let _ = writeln!(out, "{} {};", require_head(gate, index)?, args(targets));
+            }
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => {
+                let _ = writeln!(out, "{} = measure q[{qubit}];", cregs.bit(*classical_bit));
+            }
+            Instruction::Reset { qubit } => {
+                let _ = writeln!(out, "reset q[{qubit}];");
+            }
+            Instruction::Barrier { qubits } => {
+                if qubits.is_empty() {
+                    return Err(PrismError::ExportUnsupported {
+                        index,
+                        reason: "barrier over no qubits".to_string(),
+                    });
+                }
+                let _ = writeln!(out, "barrier {};", args(qubits));
+            }
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => {
+                let _ = writeln!(
+                    out,
+                    "if ({}) {} {};",
+                    cregs.condition(condition, index)?,
+                    require_head(gate, index)?,
+                    args(targets)
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn args(targets: &[usize]) -> String {
+    targets
+        .iter()
+        .map(|q| format!("q[{q}]"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn require_head(gate: &Gate, index: usize) -> Result<String> {
+    gate_head(gate).ok_or_else(|| PrismError::ExportUnsupported {
+        index,
+        reason: format!("gate `{}` has no OpenQASM 3.0 spelling", gate.name()),
+    })
+}
+
+/// The gate name, parameters, and any `ctrl @` prefix, without the qubit
+/// arguments.
+fn gate_head(gate: &Gate) -> Option<String> {
+    Some(match gate {
+        Gate::Id => "id".to_string(),
+        Gate::X => "x".to_string(),
+        Gate::Y => "y".to_string(),
+        Gate::Z => "z".to_string(),
+        Gate::H => "h".to_string(),
+        Gate::S => "s".to_string(),
+        Gate::Sdg => "sdg".to_string(),
+        Gate::T => "t".to_string(),
+        Gate::Tdg => "tdg".to_string(),
+        Gate::SX => "sx".to_string(),
+        Gate::SXdg => "sxdg".to_string(),
+        Gate::Rx(theta) => format!("rx({theta})"),
+        Gate::Ry(theta) => format!("ry({theta})"),
+        Gate::Rz(theta) => format!("rz({theta})"),
+        Gate::P(theta) => format!("p({theta})"),
+        Gate::Rzz(theta) => format!("rzz({theta})"),
+        Gate::Cx => "cx".to_string(),
+        Gate::Cz => "cz".to_string(),
+        Gate::Swap => "swap".to_string(),
+        Gate::Fused(mat) => spell_1q(mat)?,
+        Gate::Fused2q(mat) => spell_2q(mat)?,
+        Gate::Cu(mat) => match gate.controlled_phase() {
+            Some(phase) => format!("cp({})", phase.arg()),
+            None => spell_cu(mat)?,
+        },
+        Gate::Mcu(data) if data.mat == Gate::X.matrix_2x2() => {
+            if data.num_controls == 2 {
+                "ccx".to_string()
+            } else {
+                "mcx".to_string()
+            }
+        }
+        Gate::Mcu(data) if data.num_controls >= 2 => format!(
+            "{}{}",
+            "ctrl @ ".repeat(data.num_controls as usize - 1),
+            spell_cu(&data.mat)?
+        ),
+        _ => return None,
+    })
+}
+
+/// A single-qubit matrix as `p`, `rz`, or `u`, or `None` when it carries a
+/// global phase none of those three absorb.
+fn spell_1q(mat: &[[Complex64; 2]; 2]) -> Option<String> {
+    let phase = mat[1][1].arg();
+    if close_2x2(&Gate::P(phase).matrix_2x2(), mat) {
+        return Some(format!("p({phase})"));
+    }
+    let theta = 2.0 * phase;
+    if close_2x2(&Gate::Rz(theta).matrix_2x2(), mat) {
+        return Some(format!("rz({theta})"));
+    }
+    let (theta, phi, lam, gamma) = zyz(mat);
+    if gamma.abs() < EPS && close_2x2(&Parser::u_matrix(theta, phi, lam), mat) {
+        return Some(format!("u({theta}, {phi}, {lam})"));
+    }
+    None
+}
+
+/// The controlled form, whose fourth parameter carries the global phase `u`
+/// cannot express.
+fn spell_cu(mat: &[[Complex64; 2]; 2]) -> Option<String> {
+    let (theta, phi, lam, gamma) = zyz(mat);
+    close_2x2(&Parser::cu_target_matrix(theta, phi, lam, gamma), mat)
+        .then(|| format!("cu({theta}, {phi}, {lam}, {gamma})"))
+}
+
+/// A two-qubit matrix as one of the named families the parser builds.
+fn spell_2q(mat: &[[Complex64; 4]; 4]) -> Option<String> {
+    if close_4x4(&Parser::syc_matrix(), mat) {
+        return Some("syc".to_string());
+    }
+    if close_4x4(&Parser::sqrt_iswap_matrix(1.0), mat) {
+        return Some("sqrt_iswap".to_string());
+    }
+    if close_4x4(&Parser::sqrt_iswap_matrix(-1.0), mat) {
+        return Some("sqrt_iswap_inv".to_string());
+    }
+    let (theta, beta) = xy_params(mat[1][1], mat[1][2]);
+    if close_4x4(&Parser::xx_plus_yy_matrix(theta, beta), mat) {
+        return Some(format!("xx_plus_yy({theta}, {beta})"));
+    }
+    let (theta, beta) = xy_params(mat[0][0], mat[0][3]);
+    if close_4x4(&Parser::xx_minus_yy_matrix(theta, beta), mat) {
+        return Some(format!("xx_minus_yy({theta}, {beta})"));
+    }
+    let (theta, phi0, phi1) = ms_params(mat);
+    if close_4x4(&Parser::ms_matrix(phi0, phi1, theta), mat) {
+        return Some(format!("ms({phi0}, {phi1}, {theta})"));
+    }
+    None
+}
+
+/// Euler angles and global phase of a single-qubit unitary, with the
+/// convention `mat = e^{i gamma} u(theta, phi, lambda)`.
+///
+/// `theta` lands in `[0, pi]` so `cos(theta / 2)` is the non-negative modulus of
+/// `mat[0][0]` and the phase of that entry is the whole of `gamma`. The two
+/// degenerate shapes take their own branch: an anti-diagonal matrix leaves
+/// `gamma` free and fixes it to zero, a diagonal one leaves `phi` free.
+fn zyz(mat: &[[Complex64; 2]; 2]) -> (f64, f64, f64, f64) {
+    let cos_half = mat[0][0].norm();
+    let sin_half = mat[1][0].norm();
+    let theta = 2.0 * sin_half.atan2(cos_half);
+    if cos_half < EPS {
+        (theta, mat[1][0].arg(), (-mat[0][1]).arg(), 0.0)
+    } else if sin_half < EPS {
+        let gamma = mat[0][0].arg();
+        (theta, 0.0, mat[1][1].arg() - gamma, gamma)
+    } else {
+        let gamma = mat[0][0].arg();
+        (
+            theta,
+            mat[1][0].arg() - gamma,
+            (-mat[0][1]).arg() - gamma,
+            gamma,
+        )
+    }
+}
+
+/// `(theta, beta)` of an XX+YY or XX-YY block from its `cos(theta / 2)` entry
+/// and the off-diagonal `-i sin(theta / 2) e^{-i beta}`.
+fn xy_params(cos_entry: Complex64, off: Complex64) -> (f64, f64) {
+    let theta = 2.0 * off.norm().atan2(cos_entry.re);
+    let beta = if off.norm() < EPS {
+        0.0
+    } else {
+        -(off.arg() + FRAC_PI_2)
+    };
+    (theta, beta)
+}
+
+/// `(theta, phi0, phi1)` of a Mølmer-Sørensen block, whose two off-diagonal
+/// entries carry the phase sum and the phase difference in turns.
+fn ms_params(mat: &[[Complex64; 4]; 4]) -> (f64, f64, f64) {
+    let theta = mat[0][3].norm().atan2(mat[0][0].re) / PI;
+    let turns = |entry: Complex64| {
+        if entry.norm() < EPS {
+            0.0
+        } else {
+            -(entry.arg() + FRAC_PI_2) / TAU
+        }
+    };
+    let sum = turns(mat[0][3]);
+    let diff = turns(mat[1][2]);
+    (theta, (sum + diff) / 2.0, (sum - diff) / 2.0)
+}
+
+fn close_2x2(a: &[[Complex64; 2]; 2], b: &[[Complex64; 2]; 2]) -> bool {
+    a.iter()
+        .zip(b)
+        .all(|(ra, rb)| ra.iter().zip(rb).all(|(x, y)| (x - y).norm() < EPS))
+}
+
+fn close_4x4(a: &[[Complex64; 4]; 4], b: &[[Complex64; 4]; 4]) -> bool {
+    a.iter()
+        .zip(b)
+        .all(|(ra, rb)| ra.iter().zip(rb).all(|(x, y)| (x - y).norm() < EPS))
+}
+
+/// Classical bits split into the registers the emitted conditions name.
+struct CregLayout {
+    segments: Vec<(usize, usize)>,
+    names: Vec<String>,
+}
+
+impl CregLayout {
+    fn of(circuit: &Circuit) -> Result<Self> {
+        let total = circuit.num_classical_bits;
+        let mut cuts = BTreeSet::from([0, total]);
+        for (index, inst) in circuit.instructions.iter().enumerate() {
+            let Instruction::Conditional { condition, .. } = inst else {
+                continue;
+            };
+            let (ClassicalCondition::RegisterEquals { offset, size, .. }
+            | ClassicalCondition::RegisterNotEquals { offset, size, .. }) = condition
+            else {
+                continue;
+            };
+            if offset + size > total {
+                return Err(PrismError::ExportUnsupported {
+                    index,
+                    reason: format!(
+                        "condition covers bits {offset}..{} but the circuit has {total}",
+                        offset + size
+                    ),
+                });
+            }
+            cuts.insert(*offset);
+            cuts.insert(offset + size);
+        }
+
+        let bounds: Vec<usize> = cuts.into_iter().collect();
+        let segments: Vec<(usize, usize)> = bounds
+            .windows(2)
+            .map(|pair| (pair[0], pair[1] - pair[0]))
+            .collect();
+        let names = if segments.len() == 1 {
+            vec!["c".to_string()]
+        } else {
+            (0..segments.len()).map(|i| format!("c{i}")).collect()
+        };
+        Ok(Self { segments, names })
+    }
+
+    /// # Panics
+    /// Panics if `bit` is past the circuit's classical register, which
+    /// [`Circuit::add_measure`] already rejects.
+    fn bit(&self, bit: usize) -> String {
+        let (position, &(offset, _)) = self
+            .segments
+            .iter()
+            .enumerate()
+            .find(|&(_, &(offset, size))| bit >= offset && bit < offset + size)
+            .expect("classical bit within the declared register");
+        format!("{}[{}]", self.names[position], bit - offset)
+    }
+
+    fn condition(&self, condition: &ClassicalCondition, index: usize) -> Result<String> {
+        Ok(match condition {
+            ClassicalCondition::BitIsOne(bit) => self.bit(*bit),
+            ClassicalCondition::BitIsZero(bit) => format!("!{}", self.bit(*bit)),
+            ClassicalCondition::RegisterEquals {
+                offset,
+                size,
+                value,
+            } => format!("{} == {value}", self.register(*offset, *size, index)?),
+            ClassicalCondition::RegisterNotEquals {
+                offset,
+                size,
+                value,
+            } => format!("{} != {value}", self.register(*offset, *size, index)?),
+        })
+    }
+
+    fn register(&self, offset: usize, size: usize, index: usize) -> Result<&str> {
+        self.segments
+            .iter()
+            .position(|&segment| segment == (offset, size))
+            .map(|position| self.names[position].as_str())
+            .ok_or_else(|| PrismError::ExportUnsupported {
+                index,
+                reason: format!(
+                    "condition covers bits {offset}..{}, which overlaps another condition's register",
+                    offset + size
+                ),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::openqasm;
+    use crate::circuit::{SmallVec, smallvec};
+
+    fn reparse(circuit: &Circuit) -> Circuit {
+        openqasm::parse(&to_qasm3(circuit).expect("export")).expect("reparse")
+    }
+
+    fn one_gate(gate: Gate, targets: &[usize]) -> Circuit {
+        let mut c = Circuit::new(targets.iter().max().unwrap() + 1, 0);
+        c.add_gate(gate, targets);
+        c
+    }
+
+    #[test]
+    fn named_gates_keep_their_name() {
+        for gate in [Gate::H, Gate::T, Gate::Sdg, Gate::SX, Gate::Id] {
+            assert_eq!(gate_head(&gate).unwrap(), gate.name());
+        }
+    }
+
+    #[test]
+    fn angles_survive_exactly() {
+        let round = reparse(&one_gate(Gate::Rx(0.735_193_628_1), &[0]));
+        let Instruction::Gate { gate, .. } = &round.instructions[0] else {
+            panic!("expected a gate");
+        };
+        assert_eq!(*gate, Gate::Rx(0.735_193_628_1));
+    }
+
+    #[test]
+    fn u3_matrix_round_trips() {
+        let mat = Parser::u_matrix(0.7, -1.3, 2.1);
+        let round = reparse(&one_gate(Gate::Fused(Box::new(mat)), &[0]));
+        let Instruction::Gate { gate, .. } = &round.instructions[0] else {
+            panic!("expected a gate");
+        };
+        assert!(close_2x2(&gate.matrix_2x2(), &mat));
+    }
+
+    #[test]
+    fn global_phase_on_a_fused_matrix_is_rejected() {
+        let phase = Complex64::from_polar(1.0, PI / 3.0);
+        let h = Gate::H.matrix_2x2();
+        let mat = [
+            [phase * h[0][0], phase * h[0][1]],
+            [phase * h[1][0], phase * h[1][1]],
+        ];
+        let circuit = one_gate(Gate::Fused(Box::new(mat)), &[0]);
+        assert!(matches!(
+            to_qasm3(&circuit),
+            Err(PrismError::ExportUnsupported { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn rz_carries_the_phase_u3_cannot() {
+        assert_eq!(
+            spell_1q(&Gate::Rz(0.9).matrix_2x2()).unwrap(),
+            format!("rz({})", 0.9_f64)
+        );
+    }
+
+    #[test]
+    fn controlled_unitary_keeps_its_global_phase() {
+        let mat = Gate::Rz(1.1).matrix_2x2();
+        let round = reparse(&one_gate(Gate::cu(mat), &[0, 1]));
+        let Instruction::Gate { gate, .. } = &round.instructions[0] else {
+            panic!("expected a gate");
+        };
+        assert!(close_4x4(&gate.matrix_4x4(), &Gate::cu(mat).matrix_4x4()));
+    }
+
+    #[test]
+    fn multi_controlled_x_uses_the_named_forms() {
+        assert_eq!(
+            gate_head(&Gate::mcu(Gate::X.matrix_2x2(), 2)).unwrap(),
+            "ccx"
+        );
+        assert_eq!(
+            gate_head(&Gate::mcu(Gate::X.matrix_2x2(), 4)).unwrap(),
+            "mcx"
+        );
+    }
+
+    #[test]
+    fn multi_controlled_unitary_chains_ctrl() {
+        let head = gate_head(&Gate::mcu(Gate::H.matrix_2x2(), 3)).unwrap();
+        assert!(head.starts_with("ctrl @ ctrl @ cu("), "{head}");
+    }
+
+    #[test]
+    fn fusion_payloads_are_rejected() {
+        let mut circuit = Circuit::new(2, 0);
+        circuit.instructions.push(Instruction::Gate {
+            gate: Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())),
+            targets: smallvec![0, 1],
+        });
+        assert!(matches!(
+            to_qasm3(&circuit),
+            Err(PrismError::ExportUnsupported { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn conditions_split_the_classical_register() {
+        let mut circuit = Circuit::new(1, 4);
+        circuit.add_measure(0, 0);
+        circuit.instructions.push(Instruction::Conditional {
+            condition: ClassicalCondition::RegisterEquals {
+                offset: 2,
+                size: 2,
+                value: 3,
+            },
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[0]),
+        });
+        let qasm = to_qasm3(&circuit).expect("export");
+        assert!(qasm.contains("bit[2] c0;\nbit[2] c1;"), "{qasm}");
+        assert!(qasm.contains("if (c1 == 3) x q[0];"), "{qasm}");
+        assert_eq!(
+            openqasm::parse(&qasm).expect("reparse").num_classical_bits,
+            4
+        );
+    }
+
+    #[test]
+    fn empty_barrier_has_no_spelling() {
+        let mut circuit = Circuit::new(2, 0);
+        circuit.add_barrier(&[]);
+        assert!(to_qasm3(&circuit).is_err());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,10 @@ pub enum PrismError {
     #[error("undefined register `{name}` at line {line}")]
     UndefinedRegister { name: String, line: usize },
 
+    /// Circuit holds an instruction with no OpenQASM 3.0 spelling.
+    #[error("cannot export instruction {index} to OpenQASM 3.0: {reason}")]
+    ExportUnsupported { index: usize, reason: String },
+
     /// Incompatible backend for the given circuit.
     #[error("backend `{backend}` is incompatible: {reason}")]
     IncompatibleBackend { backend: String, reason: String },

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -1,6 +1,7 @@
 //! Golden import tests for OpenQASM 3 exports from common quantum SDKs. Each
 //! test parses a representative exported QASM, verifies parse counts, and
-//! checks statevector probabilities against an analytic reference.
+//! checks statevector probabilities against an analytic reference. The export
+//! half round-trips the same programs and the generated corpus back out.
 
 mod common;
 
@@ -248,4 +249,267 @@ fn qiskit_legacy_qreg_creg_style() {
     let circuit = openqasm::parse(qasm).expect("parse");
     assert_eq!(circuit.num_qubits, 2);
     assert_eq!(circuit.num_classical_bits, 2);
+}
+
+// ---- Export round-trip ----
+
+use common::conformance::generated_cases;
+use common::{SV_EPS, sv_reference_probs};
+use prism_q::PrismError;
+use prism_q::circuit::qasm_export::to_qasm3;
+use prism_q::circuit::{Circuit, Instruction};
+use prism_q::gates::Gate;
+
+/// Matrix payloads are rebuilt from recovered Euler angles, so the round trip
+/// reproduces them to round-off rather than bit for bit. Inline angles and
+/// every other field match exactly.
+const PAYLOAD_EPS: f64 = 1e-12;
+
+fn round_trip(circuit: &Circuit) -> Circuit {
+    let qasm = to_qasm3(circuit).expect("export");
+    openqasm::parse(&qasm).unwrap_or_else(|err| panic!("reparse failed: {err}\n{qasm}"))
+}
+
+fn assert_streams_match(original: &Circuit, round: &Circuit, label: &str) {
+    assert_eq!(
+        original.num_qubits, round.num_qubits,
+        "{label}: qubit count"
+    );
+    assert_eq!(
+        original.num_classical_bits, round.num_classical_bits,
+        "{label}: classical bit count"
+    );
+    assert_eq!(
+        original.instructions.len(),
+        round.instructions.len(),
+        "{label}: instruction count"
+    );
+    for (i, (a, b)) in original
+        .instructions
+        .iter()
+        .zip(&round.instructions)
+        .enumerate()
+    {
+        assert!(
+            instructions_match(a, b),
+            "{label}: instruction {i} differs\n  before: {a:?}\n  after:  {b:?}"
+        );
+    }
+}
+
+fn instructions_match(a: &Instruction, b: &Instruction) -> bool {
+    match (a, b) {
+        (
+            Instruction::Gate {
+                gate: ga,
+                targets: ta,
+            },
+            Instruction::Gate {
+                gate: gb,
+                targets: tb,
+            },
+        ) => ta == tb && gates_match(ga, gb),
+        (
+            Instruction::Measure {
+                qubit: qa,
+                classical_bit: ca,
+            },
+            Instruction::Measure {
+                qubit: qb,
+                classical_bit: cb,
+            },
+        ) => qa == qb && ca == cb,
+        (Instruction::Reset { qubit: qa }, Instruction::Reset { qubit: qb }) => qa == qb,
+        (Instruction::Barrier { qubits: qa }, Instruction::Barrier { qubits: qb }) => qa == qb,
+        (
+            Instruction::Conditional {
+                condition: ca,
+                gate: ga,
+                targets: ta,
+            },
+            Instruction::Conditional {
+                condition: cb,
+                gate: gb,
+                targets: tb,
+            },
+        ) => ta == tb && gates_match(ga, gb) && format!("{ca:?}") == format!("{cb:?}"),
+        _ => false,
+    }
+}
+
+fn gates_match(a: &Gate, b: &Gate) -> bool {
+    if std::mem::discriminant(a) != std::mem::discriminant(b) {
+        return false;
+    }
+    match (a, b) {
+        (Gate::Fused(x), Gate::Fused(y)) | (Gate::Cu(x), Gate::Cu(y)) => {
+            close(x.iter().flatten(), y.iter().flatten())
+        }
+        (Gate::Fused2q(x), Gate::Fused2q(y)) => close(x.iter().flatten(), y.iter().flatten()),
+        (Gate::Mcu(x), Gate::Mcu(y)) => {
+            x.num_controls == y.num_controls
+                && close(x.mat.iter().flatten(), y.mat.iter().flatten())
+        }
+        _ => a == b,
+    }
+}
+
+fn close<'a>(
+    a: impl Iterator<Item = &'a num_complex::Complex64>,
+    b: impl Iterator<Item = &'a num_complex::Complex64>,
+) -> bool {
+    a.zip(b).all(|(x, y)| (x - y).norm() < PAYLOAD_EPS)
+}
+
+// The corpus `conformance_matrix.rs` runs across backends, reused here as the
+// round-trip measure: it reaches measurement, reset, and both condition shapes,
+// which the SDK programs above do not all carry.
+#[test]
+fn export_round_trips_the_generated_corpus() {
+    for case in generated_cases() {
+        let round = round_trip(&case.circuit);
+        assert_streams_match(&case.circuit, &round, &case.name());
+        assert_probs_close(
+            &sv_reference_probs(&round),
+            &sv_reference_probs(&case.circuit),
+            SV_EPS,
+            &case.name(),
+        );
+    }
+}
+
+#[test]
+fn export_round_trips_the_sdk_programs() {
+    let programs = [
+        (
+            "ionq_native",
+            r#"
+            OPENQASM 3.0;
+            qubit[2] q;
+            gpi(0.0) q[0];
+            gpi2(0.25) q[1];
+            ms(0.1, 0.2, 0.25) q[0], q[1];
+            "#,
+        ),
+        (
+            "google_sycamore",
+            r#"
+            OPENQASM 3.0;
+            qubit[2] q;
+            syc q[0], q[1];
+            sqrt_iswap q[0], q[1];
+            sqrt_iswap_inv q[0], q[1];
+            "#,
+        ),
+        (
+            "controlled_rotations",
+            r#"
+            OPENQASM 3.0;
+            qubit[3] q;
+            crx(pi / 3) q[0], q[1];
+            cry(pi / 4) q[0], q[1];
+            crz(pi / 5) q[0], q[1];
+            cp(pi / 2) q[0], q[2];
+            ch q[1], q[2];
+            ccx q[0], q[1], q[2];
+            "#,
+        ),
+        (
+            "xy_interactions",
+            r#"
+            OPENQASM 3.0;
+            qubit[2] q;
+            xx_plus_yy(0.6, 0.3) q[0], q[1];
+            xx_minus_yy(0.9, -0.4) q[0], q[1];
+            rzz(0.31) q[0], q[1];
+            "#,
+        ),
+        (
+            "qiskit_legacy_feedforward",
+            r#"
+            OPENQASM 2.0;
+            qreg q[2];
+            creg c[2];
+            u3(pi / 2, 0, pi) q[0];
+            barrier q[0], q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            if (c == 3) x q[0];
+            if (c != 1) z q[1];
+            "#,
+        ),
+        (
+            "mid_circuit_reset",
+            r#"
+            OPENQASM 3.0;
+            qubit[2] q;
+            bit[2] c;
+            h q[0];
+            c[0] = measure q[0];
+            reset q[0];
+            if (c[0]) x q[1];
+            if (!c[1]) y q[1];
+            "#,
+        ),
+    ];
+
+    for (label, qasm) in programs {
+        let circuit = openqasm::parse(qasm).expect("parse");
+        assert_streams_match(&circuit, &round_trip(&circuit), label);
+    }
+}
+
+// q[0] is the LSB: an export that reverses qubit order passes a shape check and
+// fails this one.
+#[test]
+fn export_preserves_qubit_order() {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    let qasm = to_qasm3(&circuit).expect("export");
+    assert!(qasm.contains("x q[0];"), "{qasm}");
+
+    let probs = sv_reference_probs(&openqasm::parse(&qasm).expect("reparse"));
+    assert!(
+        (probs[1] - 1.0).abs() < SV_EPS,
+        "expected |001>, got {probs:?}"
+    );
+}
+
+#[test]
+fn export_expands_a_qft_block() {
+    let circuit = prism_q::circuits::qft_circuit(4);
+    let round = round_trip(&circuit);
+    assert!(round.gate_count() > 1);
+    assert_probs_close(
+        &sv_reference_probs(&round),
+        &sv_reference_probs(&circuit),
+        SV_EPS,
+        "qft_4",
+    );
+}
+
+#[test]
+fn export_rejects_a_fused_circuit() {
+    let circuit = prism_q::circuits::hardware_efficient_ansatz(16, 2, 42);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+    assert!(to_qasm3(&circuit).is_ok());
+    assert!(matches!(
+        to_qasm3(&fused),
+        Err(PrismError::ExportUnsupported { .. })
+    ));
+}
+
+// The parameter surface hands out an unfused circuit per binding, so a swept
+// point exports like any other circuit.
+#[test]
+fn export_round_trips_a_bound_parameter_point() {
+    let mut template = Circuit::new(3, 0);
+    template.add_gate(Gate::Ry(0.0), &[0]);
+    template.add_gate(Gate::Cx, &[0, 1]);
+    template.add_gate(Gate::Rzz(0.0), &[1, 2]);
+    let params = prism_q::Parameters::all_rotations(&template);
+    let mut prepared = prism_q::PreparedCircuit::new(template, params).expect("prepare");
+
+    let bound = prepared.bind(&[0.41, 1.27]).expect("bind").clone();
+    assert_streams_match(&bound, &round_trip(&bound), "bound_point");
 }


### PR DESCRIPTION
## Summary

Nothing round-tripped: the parser read OpenQASM 3.0 in and there was no way back out,
which is the interop use case the dropped `serialization` feature left open.
`circuit::qasm_export::to_qasm3` closes it, built against the parameter surface from
#151 rather than around it.

## Scope

- [x] New feature

## Benchmarks

N/A, no hot-path changes. Export touches neither parsing nor fusion; the parser diff is
six `pub(crate)` markers so the matrix constructors can be reused rather than
reimplemented.

Regression verdict: PASS

## Design decisions

**Where it lives.** A free function beside `openqasm::parse`, not an inherent method
(`draw` and `svg` are also renderers and neither sits on `Circuit`) and not a `Display`
wrapper (export is fallible).

**Fused circuits.** Export is the inverse of the parser over the parser's own image,
which settles every payload without a per-variant rule: parameters are recovered from
the matrix and the re-synthesized matrix is verified against the payload before a
spelling is committed. `Cu`, `Mcu`, `Fused`, and `Fused2q` are parser outputs (`crx`,
`ccx`, `u3`/`gpi`/`r`, `ms`/`syc`/`sqrt_iswap`/`xx_±_yy`), so they come back under a
name. Every fusion product fails the check and returns `PrismError::ExportUnsupported`
with its instruction index. Rejected: lowering fused blocks to a named sequence, which
needs a KAK decomposition and emits a different stream anyway; and `U` plus a global
phase, which the parser has no `gphase` to read back.

Global phase is the difficulty on the single-qubit side. `p` and `rz` carry theirs and
are tried before `u`, which is exact only for a real `m00`; a controlled matrix goes
through `cu(theta, phi, lambda, gamma)`, whose fourth parameter is that phase, and a
multi-controlled one prefixes `ctrl @`. `QftBlock` is the one variant exported by
expansion rather than by name, reusing `expand_qft_blocks`.

**Other instructions.** `Measure`, `Reset`, and `Barrier` map to their statements and a
`Conditional` wraps the same gate spelling in `if (...)`. Classical bits emit as one
`bit[m] c` register, cut at the boundaries of any register-valued condition so each
condition still names a whole register, which is what a multi-`creg` source needs. An
empty barrier and a condition overlapping two registers are the two non-gate rejections.

## Correctness

- [x] `cargo nextest run --features parallel` (1944 passed)
- [x] `cargo test --doc --features parallel` (13 passed)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features`

Round trip is exact for inline angles (Rust's `f64` `Display` is the shortest
round-tripping form and the parser's literal path is correctly rounded) and agrees to
1e-12 for matrix payloads, which are rebuilt from recovered Euler angles.

The round-trip corpus is `conformance::generated_cases`, taken now rather than waiting
for the staged conformance row: that corpus already reaches measurement, reset, and both
condition shapes, and gating on an unstarted row would have left export tested against
nothing but hand-written programs. Six SDK-shaped programs cover the gate families it
does not reach (IonQ native, Sycamore, controlled rotations, XY interactions, legacy
feedforward, mid-circuit reset). `export_preserves_qubit_order` asserts the amplitude
rather than the shape, so an export that reverses `q[0]` as the LSB cannot pass.

`--all-features` was not run: the diff does not touch the MPI surface or feature wiring.

## Breaking changes

`PrismError` gains an `ExportUnsupported` variant. The enum is not `#[non_exhaustive]`,
so an exhaustive downstream match needs a new arm; nothing in this repo or the Python
bindings matches exhaustively.

## Risks and rollback

New module with no caller inside the crate, so the blast radius is the added error
variant. Reverting the commit removes both.

## Follow-up

The `input`/`output` declaration parser half stays open. `Parameters` already carries
slot names for it, and this change does not foreclose it: export emits no `input`
declarations, since the parser cannot yet read them back.
