### PR TITLE
feat(tn): reduced density matrix and native Pauli expectations

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -113,6 +113,22 @@ Shots and Pauli expectations answer from the per-qubit states rather than the `2
 
 Deferred contraction with a greedy min-size heuristic. Gates append tensors; contraction happens lazily at measurement or probability extraction. `MAX_PROB_QUBITS = 25` guards against exponential blowup.
 
+Two queries stay off the dense route by contracting the network against its conjugate.
+The bra copy's legs are shifted clear of the ket index space, and each qubit's boundary
+is either closed against its twin, which is a trace, or joined through an operator. A
+one-qubit reduced density matrix leaves that qubit's ket and bra indices open and
+returns a `2x2`; a Pauli expectation joins every non-identity factor through its
+operator and contracts to a scalar. Both follow the doubled network's cost rather than
+the qubit count. An identity factor is a closed leg rather than an appended tensor, so a
+weight-`k` observable adds `k` tensors and not `n`.
+
+Nothing about the planner changed: an index is open when exactly one tensor holds it,
+which the greedy ordering already carries through to its result.
+
+The reduced density matrix is the half of general-noise support the backend was missing,
+so the trajectory engine now runs amplitude damping, phase damping, thermal relaxation,
+and custom Kraus channels here under explicit dispatch.
+
 ## Factored
 
 Dynamic split-state simulation. Starts with n independent 1-qubit states, merges via tensor product only when 2q gates bridge groups. Parallel kernels match statevector patterns for sub-states ≥14 qubits. Selected when subsystem decomposition detects partial independence.

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -80,7 +80,8 @@ bounded only by their own representation.
 | Statevector | Dense (streams from amplitudes, no probability vector) | Dense |
 | Stabilizer, Factored Stabilizer | Compiled Clifford sampler | Sparse Pauli Dynamics, exact |
 | Stochastic / Deterministic Pauli | Not applicable | Native Pauli propagation |
-| Tensor Network, Density Matrix | Dense | Rejected, naming the backend |
+| Tensor Network | Dense | Native, one doubled-network contraction per observable |
+| Density Matrix | Dense | Rejected, naming the backend |
 
 Native sampling is deterministic from the seed alone: the same seed and shot
 count reproduce the same bitstrings. It is not shot-for-shot identical to the

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -26,7 +26,6 @@
 //! | --- | --- | --- |
 //! | `apply_1q_matrix` | Stabilizer, FactoredStabilizer | A tableau stores a state by its stabilizer group, closed under Clifford conjugation. A general 2x2 has no image in that group, and a Kraus branch is not even unitary. |
 //! | `reduced_density_matrix_1q` | Stabilizer, FactoredStabilizer | Derivable from a tableau, but the operator it feeds cannot be applied (row above), so the branch would be sampled and never used. |
-//! | `reduced_density_matrix_1q` | TensorNetwork | A local reduced state needs the network contracted with two indices left open, which the contraction planner does not express. Its only route is the full dense contraction behind `export_statevector`. |
 //! | `reduced_density_matrix_1q` | DistributedStatevector | Trajectories run shots on Rayon workers whose order differs per rank, so per-shot noise would issue rank collectives out of lockstep. `run_shots_with_noise` rejects the backend for that reason, which closes the only path here. |
 //! | `export_statevector` | DensityMatrix | A mixture of pure states has no statevector. Read `DensityMatrixBackend::purity` or reduce the state instead. |
 //! | `export_statevector` | FactoredStabilizer | Exports while one tableau covers every qubit; past that there is no joint tableau to expand. |

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -36,28 +36,28 @@
 //! result has the smallest total element count, preferring pairs sharing a leg.
 //! O(T·r·log T) for T tensors of rank at most r.
 //!
-//! # Shot and observable queries stay on the dense route
+//! # Observables contract natively; shots stay on the dense route
 //!
-//! Unlike the sparse, MPS, and factored backends, this one does not override
-//! `Backend::sample_basis_states` or `Backend::pauli_expectations`. Both report
-//! `BackendUnsupported` naming this backend, and shots continue to route through
-//! `probabilities()`.
+//! `Backend::pauli_expectations` and `Backend::reduced_density_matrix_1q` both
+//! answer by doubling the network against its conjugate: the bra copy's legs are
+//! shifted clear of the ket id space, and each qubit's boundary is either closed
+//! against its twin (a trace) or joined through an operator. No `2^n` vector is
+//! built, so neither query passes the dense ceiling.
 //!
-//! Sampling one bitstring from a deferred network means contracting it once per
-//! qubit to get each conditional, so a shot costs `n` contractions against the
-//! single contraction the dense route pays for the whole distribution. That is
-//! strictly worse whenever the statevector fits, and when it does not fit the
-//! per-qubit contractions do not fit either: the cost is set by treewidth, which
-//! conditioning does not reduce.
+//! An identity factor is a closed leg rather than an appended tensor, so a
+//! weight-`k` observable adds `k` tensors to a network of `2T`, not `n`.
 //!
-//! An exact scalar observable path does exist here, `expectation_zero_state`,
-//! which contracts `⟨0|U†PU|0⟩` without a statevector. It takes a circuit rather
-//! than an evolved backend, and this backend swaps its network for a dense
-//! statevector after any measurement, so reaching it from the trait hook would
-//! need a second contraction path carrying its own bra-side leg bookkeeping.
-//! Auto never selects this backend above the statevector cap (it picks sparse or
-//! MPS), so that path would serve explicit `BackendKind::TensorNetwork` requests
-//! only. Revisit if Auto starts routing wide low-treewidth circuits here.
+//! `Backend::sample_basis_states` is not overridden, and shots continue to route
+//! through `probabilities()`. Sampling one bitstring from a deferred network
+//! means contracting it once per qubit to get each conditional, so a shot costs
+//! `n` contractions against the single contraction the dense route pays for the
+//! whole distribution. That is strictly worse whenever the statevector fits, and
+//! when it does not fit the per-qubit contractions do not fit either: the cost is
+//! set by treewidth, which conditioning does not reduce.
+//!
+//! `expectation_zero_state` remains a separate path, contracting `⟨0|U†PU|0⟩`
+//! from a circuit rather than an evolved backend, and is what the QEC estimator
+//! ladder uses.
 
 use std::borrow::Cow;
 use std::cmp::Reverse;
@@ -1092,6 +1092,86 @@ impl TensorNetworkBackend {
         Ok(())
     }
 
+    /// Leg ids the bra copy uses, one entry per live ket leg.
+    ///
+    /// Every leg is shifted clear of the ket id space by [`Self::next_leg`], so a
+    /// bra tensor contracts only against other bra tensors. Callers then map back
+    /// to the ket id the legs they want summed over: an output leg mapped to
+    /// itself closes that qubit against its twin, which is a trace with identity.
+    fn bra_leg_map(&self) -> Vec<LegId> {
+        (0..self.next_leg).map(|leg| leg + self.next_leg).collect()
+    }
+
+    /// Pair every tensor with a conjugated twin whose legs are read off `bra_legs`.
+    fn double_through(&self, bra_legs: &[LegId]) -> Vec<Tensor> {
+        let mut network = Vec::with_capacity(self.tensors.len() * 2);
+        for tensor in &self.tensors {
+            network.push(tensor.clone());
+            network.push(Tensor {
+                data: tensor.data.iter().map(Complex64::conj).collect(),
+                shape: tensor.shape.clone(),
+                legs: tensor.legs.iter().map(|&leg| bra_legs[leg]).collect(),
+            });
+        }
+        network
+    }
+
+    /// Build the network for `tr_{q != qubit} |psi><psi|`, leaving `qubit`'s ket
+    /// and bra indices open.
+    ///
+    /// Returns the network and the two open leg ids as `(ket, bra)`.
+    fn double_for_partial_trace(&self, qubit: usize) -> (Vec<Tensor>, LegId, LegId) {
+        let ket_leg = self.output_legs[qubit];
+        let mut bra_legs = self.bra_leg_map();
+        for (q, &leg) in self.output_legs.iter().enumerate() {
+            if q != qubit {
+                bra_legs[leg] = leg;
+            }
+        }
+
+        let network = self.double_through(&bra_legs);
+        (network, ket_leg, ket_leg + self.next_leg)
+    }
+
+    /// Contract `<psi|P|psi>` for one joint Pauli observable, unnormalized.
+    ///
+    /// Qubits the observable omits carry identity, and an identity factor is a
+    /// leg closed directly against its twin rather than a tensor appended, which
+    /// keeps `n - k` tensors out of the network for a weight-`k` observable.
+    fn contract_pauli_sandwich(&self, axes: &[Option<PauliAxis>]) -> f64 {
+        let mut bra_legs = self.bra_leg_map();
+        for (q, axis) in axes.iter().enumerate() {
+            if axis.is_none() {
+                let leg = self.output_legs[q];
+                bra_legs[leg] = leg;
+            }
+        }
+
+        let mut network = self.double_through(&bra_legs);
+
+        let zero = Complex64::new(0.0, 0.0);
+        let one = Complex64::new(1.0, 0.0);
+        let i = Complex64::new(0.0, 1.0);
+        for (q, axis) in axes.iter().enumerate() {
+            let Some(axis) = axis else { continue };
+            let data = match axis {
+                PauliAxis::X => vec![zero, one, one, zero],
+                PauliAxis::Y => vec![zero, -i, i, zero],
+                PauliAxis::Z => vec![one, zero, zero, -one],
+            };
+            let ket_leg = self.output_legs[q];
+            network.push(Tensor {
+                data,
+                shape: smallvec::smallvec![2, 2],
+                legs: smallvec::smallvec![bra_legs[ket_leg], ket_leg],
+            });
+        }
+
+        let result = greedy_contract(&mut network);
+        debug_assert!(result.legs.is_empty(), "sandwich leaves every leg paired");
+        result.data[0].re
+    }
+
     /// Contract the full network and return the amplitude vector in
     /// computational basis order.
     fn contract_to_statevector(&self) -> Result<Vec<Complex64>> {
@@ -1112,7 +1192,7 @@ impl TensorNetworkBackend {
                     .legs
                     .iter()
                     .position(|l| l == target_leg)
-                    .unwrap_or(0)
+                    .expect("greedy_contract consumes every tensor, so output legs survive")
             })
             .collect();
 
@@ -1244,6 +1324,73 @@ impl Backend for TensorNetworkBackend {
 
     fn num_qubits(&self) -> usize {
         self.num_qubits
+    }
+
+    /// Contracts the network against its conjugate with every other qubit's
+    /// output leg closed, so the cost is set by the doubled network's treewidth
+    /// rather than by `2^n`.
+    ///
+    /// # Panics
+    ///
+    /// If `qubit` is outside the register.
+    fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
+        let (mut network, ket_leg, bra_leg) = self.double_for_partial_trace(qubit);
+        let rho = greedy_contract(&mut network);
+
+        let axis = |leg: LegId| {
+            rho.legs
+                .iter()
+                .position(|&l| l == leg)
+                .expect("partial trace leaves both open legs on the result")
+        };
+        let ket_stride = if axis(ket_leg) == 0 { 2 } else { 1 };
+        let bra_stride = if axis(bra_leg) == 0 { 2 } else { 1 };
+
+        Ok([
+            [rho.data[0], rho.data[bra_stride]],
+            [rho.data[ket_stride], rho.data[ket_stride + bra_stride]],
+        ])
+    }
+
+    fn supports_pauli_expectation(&self) -> bool {
+        true
+    }
+
+    /// Contracts `<psi|P|psi>` directly, so no `2^n` vector is built and the
+    /// dense query ceiling does not apply.
+    ///
+    /// # Errors
+    ///
+    /// [`PrismError::InvalidQubit`] for a factor outside the register, and
+    /// [`PrismError::InvalidParameter`] for two factors on one qubit.
+    fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
+        let mut axes: Vec<Option<PauliAxis>> = vec![None; self.num_qubits];
+        let mut expectations = Vec::with_capacity(observables.len());
+        let norm_sq = self.contract_pauli_sandwich(&axes);
+
+        for observable in observables {
+            axes.iter_mut().for_each(|axis| *axis = None);
+            for term in observable {
+                if term.qubit >= self.num_qubits {
+                    return Err(PrismError::InvalidQubit {
+                        index: term.qubit,
+                        register_size: self.num_qubits,
+                    });
+                }
+                if axes[term.qubit].is_some() {
+                    return Err(PrismError::InvalidParameter {
+                        message: format!(
+                            "tensor-network observable has duplicate factor on qubit {}",
+                            term.qubit
+                        ),
+                    });
+                }
+                axes[term.qubit] = Some(term.axis);
+            }
+            expectations.push(self.contract_pauli_sandwich(&axes) / norm_sq);
+        }
+
+        Ok(expectations)
     }
 
     fn supports_fused_gates(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! compiled sampling with Pauli-noise annotations. [`run_qec_program_reference`]
 //! runs small correctness checks through the reference path.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod backend;
 pub mod circuit;

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -239,6 +239,7 @@ impl BackendKind {
             | BackendKind::Mps { .. }
             | BackendKind::ProductState
             | BackendKind::Factored
+            | BackendKind::TensorNetwork
             | BackendKind::DensityMatrix => true,
             #[cfg(feature = "gpu")]
             BackendKind::AutoGpu { .. } | BackendKind::StatevectorGpu { .. } => true,
@@ -265,11 +266,11 @@ impl BackendKind {
     pub(crate) fn general_noise_backend_names() -> &'static str {
         #[cfg(feature = "gpu")]
         {
-            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, Factored, or DensityMatrix"
+            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, Factored, TensorNetwork, or DensityMatrix"
         }
         #[cfg(not(feature = "gpu"))]
         {
-            "Auto, Statevector, Sparse, Mps, ProductState, Factored, or DensityMatrix"
+            "Auto, Statevector, Sparse, Mps, ProductState, Factored, TensorNetwork, or DensityMatrix"
         }
     }
 }

--- a/tests/backend_equivalence.rs
+++ b/tests/backend_equivalence.rs
@@ -11,6 +11,7 @@ mod common;
 use common::{SEED, TN_EPS, assert_probs_close, run_fused_probs};
 use num_complex::Complex64;
 use prism_q::Instruction;
+use prism_q::PauliTerm;
 use prism_q::backend::Backend;
 use prism_q::backend::mps::MpsBackend;
 use prism_q::backend::product::ProductStateBackend;
@@ -511,6 +512,176 @@ fn tn_complex_circuit_matches_statevector() {
     c.add_gate(Gate::T, &[3]);
     c.add_gate(Gate::Rz(0.7), &[0]);
     assert_probs_tn(&run_tn_probs(&c), &run_and_probs(&c));
+}
+
+fn assert_rdm_matches_statevector(circuit: &Circuit) {
+    let mut tn = TensorNetworkBackend::new(SEED);
+    sim::run_on(&mut tn, circuit).unwrap();
+    let mut sv = StatevectorBackend::new(SEED);
+    sim::run_on(&mut sv, circuit).unwrap();
+
+    for q in 0..circuit.num_qubits {
+        let actual = tn.reduced_density_matrix_1q(q).unwrap();
+        let expected = sv.reduced_density_matrix_1q(q).unwrap();
+        for row in 0..2 {
+            for col in 0..2 {
+                assert!(
+                    (actual[row][col] - expected[row][col]).norm() < TN_EPS,
+                    "tn rdm q{q}[{row}][{col}]: {} vs {}",
+                    actual[row][col],
+                    expected[row][col]
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn tn_reduced_density_matrix_matches_statevector() {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Ry(0.6), &[1]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cz, &[1, 2]);
+    c.add_gate(Gate::Rx(1.1), &[3]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+    c.add_gate(Gate::S, &[0]);
+    assert_rdm_matches_statevector(&c);
+}
+
+// An untouched qubit leaves its ket and bra tensors sharing no leg, so the 2x2
+// comes out of join_disjoint as an outer product rather than a contraction.
+#[test]
+fn tn_reduced_density_matrix_with_idle_qubit_matches_statevector() {
+    let mut c = Circuit::new(5, 0);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::Rz(0.9), &[2]);
+    c.add_gate(Gate::Rx(0.4), &[4]);
+    assert_rdm_matches_statevector(&c);
+}
+
+// The ancilla is prepared in |1> before it is measured, so both backends take
+// the same branch and the tensor network answers from the dense tensor
+// replace_with_statevector leaves behind.
+#[test]
+fn tn_reduced_density_matrix_after_measurement_matches_statevector() {
+    let mut c = Circuit::new(3, 1);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::X, &[2]);
+    c.add_measure(2, 0);
+    c.add_gate(Gate::Ry(0.8), &[1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    assert_rdm_matches_statevector(&c);
+}
+
+fn assert_pauli_expectations_match_statevector(circuit: &Circuit, observables: &[Vec<PauliTerm>]) {
+    let mut tn = TensorNetworkBackend::new(SEED);
+    sim::run_on(&mut tn, circuit).unwrap();
+
+    let actual = tn.pauli_expectations(observables).unwrap();
+    let expected = sim::run_expectation_values(circuit, observables, SEED).unwrap();
+    assert_eq!(actual.len(), expected.len());
+    for (i, (a, b)) in actual.iter().zip(&expected).enumerate() {
+        assert!(
+            (a - b).abs() < TN_EPS,
+            "observable {i}: tn={a}, statevector={b}"
+        );
+    }
+}
+
+#[test]
+fn tn_pauli_expectations_match_statevector() {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Ry(0.6), &[1]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cz, &[1, 2]);
+    c.add_gate(Gate::Rx(1.1), &[3]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+    c.add_gate(Gate::S, &[0]);
+
+    let observables = vec![
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::x(2)],
+        vec![PauliTerm::y(3)],
+        vec![PauliTerm::z(0), PauliTerm::z(1)],
+        vec![PauliTerm::x(1), PauliTerm::y(2)],
+        vec![
+            PauliTerm::y(0),
+            PauliTerm::x(1),
+            PauliTerm::z(2),
+            PauliTerm::y(3),
+        ],
+        vec![],
+    ];
+    assert_pauli_expectations_match_statevector(&c, &observables);
+}
+
+// A weight-k observable appends k tensors and closes the other n-k legs
+// directly, so an idle qubit exercises the elided-identity path.
+#[test]
+fn tn_pauli_expectations_with_idle_qubit_match_statevector() {
+    let mut c = Circuit::new(5, 0);
+    c.add_gate(Gate::H, &[1]);
+    c.add_gate(Gate::Cx, &[1, 2]);
+    c.add_gate(Gate::Rz(0.9), &[2]);
+    c.add_gate(Gate::Rx(0.4), &[4]);
+
+    let observables = vec![
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::y(4)],
+        vec![PauliTerm::z(1), PauliTerm::z(2)],
+        vec![PauliTerm::x(1), PauliTerm::x(2), PauliTerm::y(4)],
+    ];
+    assert_pauli_expectations_match_statevector(&c, &observables);
+}
+
+// The builder terminal rejected this backend before it answered observables
+// natively, so the route matters as much as the trait method.
+#[test]
+fn tn_expectation_values_route_matches_auto() {
+    let mut c = Circuit::new(4, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Ry(0.6), &[1]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cz, &[1, 2]);
+    c.add_gate(Gate::Rx(1.1), &[3]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+
+    let observables = vec![
+        vec![PauliTerm::z(0), PauliTerm::z(1)],
+        vec![PauliTerm::x(1), PauliTerm::y(2)],
+        vec![PauliTerm::y(3)],
+    ];
+
+    let actual = sim::simulate(&c)
+        .backend(prism_q::BackendKind::TensorNetwork)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    let expected = sim::run_expectation_values(&c, &observables, SEED).unwrap();
+    for (i, (a, b)) in actual.iter().zip(&expected).enumerate() {
+        assert!((a - b).abs() < TN_EPS, "observable {i}: tn={a}, auto={b}");
+    }
+}
+
+#[test]
+fn tn_pauli_expectations_reject_duplicate_and_out_of_range_factors() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    let mut tn = TensorNetworkBackend::new(SEED);
+    sim::run_on(&mut tn, &c).unwrap();
+
+    assert!(
+        tn.pauli_expectations(&[vec![PauliTerm::z(0), PauliTerm::x(0)]])
+            .is_err()
+    );
+    assert!(tn.pauli_expectations(&[vec![PauliTerm::z(7)]]).is_err());
 }
 
 #[test]

--- a/tests/expectation_gradient.rs
+++ b/tests/expectation_gradient.rs
@@ -374,7 +374,7 @@ fn shift_differentiates_from_a_start_state() {
 }
 
 #[test]
-fn shift_on_a_backend_without_an_observable_path_names_it() {
+fn shift_runs_on_the_tensor_network() {
     let mut c = Circuit::new(2, 0);
     c.add_gate(Gate::H, &[0]);
     c.add_gate(Gate::Cx, &[0, 1]);
@@ -383,13 +383,15 @@ fn shift_on_a_backend_without_an_observable_path_names_it() {
     params.link(2, 0);
 
     let obs: Hamiltonian = vec![(1.0, vec![PauliTerm::z(0)])];
-    let err = simulate(&c)
+    let tn = simulate(&c)
         .backend(BackendKind::TensorNetwork)
         .seed(SEED)
         .expectation_gradient_shift(&obs, &params)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("tensornetwork"), "{err}");
+        .unwrap();
+    let routed = run_expectation_gradient_shift(&c, &obs, &params, SEED).unwrap();
+
+    assert!((tn.value - routed.value).abs() < 1e-12);
+    assert!((tn.gradient[0] - routed.gradient[0]).abs() < 1e-9);
 }
 
 #[test]

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -346,20 +346,12 @@ fn product_expectation_values_cover_each_axis_eigenstate() {
 // has no native observable path. The rejection has to name the backend that
 // cannot serve the request, not the route that selected it.
 #[test]
-fn backends_without_a_native_path_name_themselves() {
-    let c = entangled_non_clifford(5);
-    let observables = [vec![PauliTerm::z(0)]];
-    let err = simulate(&c)
-        .backend(BackendKind::TensorNetwork)
-        .seed(42)
-        .expectation_values(&observables)
-        .unwrap_err();
-    match err {
-        prism_q::PrismError::BackendUnsupported {
-            backend: reported, ..
-        } => assert_eq!(reported, "tensornetwork"),
-        other => panic!("expected a BackendUnsupported naming tensornetwork, got {other:?}"),
-    }
+fn tensor_network_expectation_values_match_statevector() {
+    assert_matches_statevector(
+        "tensor network expectation",
+        BackendKind::TensorNetwork,
+        &entangled_non_clifford(6),
+    );
 }
 
 // The native path validates observables before it runs, so a bad qubit index

--- a/tests/trajectory_correctness.rs
+++ b/tests/trajectory_correctness.rs
@@ -82,6 +82,31 @@ fn amplitude_damping_analytic_single_qubit() {
     );
 }
 
+// Each damping event reads the target's reduced density matrix, which the
+// tensor network answers by contracting against its conjugate with the other
+// qubit traced out.
+#[test]
+fn tensor_network_amplitude_damping_analytic() {
+    let gamma = 0.8;
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+
+    let noise = NoiseModel::with_amplitude_damping(&circuit, gamma);
+    let result =
+        run_shots_with_noise(BackendKind::TensorNetwork, &circuit, &noise, 5000, 42).unwrap();
+
+    for q in 0..2 {
+        let p_zero = result.shots.iter().filter(|s| !s[q]).count() as f64 / 5000.0;
+        assert!(
+            (p_zero - gamma).abs() < 0.05,
+            "q{q}: P(0) should be ~gamma={gamma}, got {p_zero}"
+        );
+    }
+}
+
 #[test]
 fn amplitude_damping_ground_state_unchanged() {
     let mut circuit = Circuit::new(1, 1);


### PR DESCRIPTION
## Summary

The tensor-network backend could answer neither `reduced_density_matrix_1q` nor
`pauli_expectations`, which cost it general-noise support and left observables on the
dense route. The contraction planner already leaves unpaired legs on its result, so the
gap was a caller, not a planner limitation: nothing built a network with legs
deliberately left open. Adds that builder and wires both queries onto it.

## Scope

- [x] New feature
- [x] Documentation
- [x] Build, CI, or tooling (docs.rs)

## What the builder does

Doubling the network against its conjugate covers both queries. The bra copy's legs are
shifted clear of the ket index space, and each qubit's boundary is either closed against
its twin, which is a trace, or joined through an operator.

- `reduced_density_matrix_1q` leaves one qubit's ket and bra indices open, returning a
  `2x2`.
- `pauli_expectations` joins every non-identity factor through its operator and
  contracts to a scalar. An identity factor is a closed leg rather than an appended
  tensor, so a weight-`k` observable adds `k` tensors to a network of `2T`, not `n`.

Neither builds a `2^n` vector, so the dense query ceiling does not apply to either.

Nothing about the planner changed. An index is open when exactly one tensor holds it:
`queue_slot_pairs` indexes candidates by shared leg so a singly-held leg never queues,
`pop_live_pair` terminates on "no two live tensors share a leg" regardless of free legs,
and `contract` already emits every unshared axis on its result.

## Benchmarks

**Inconclusive on this host. Deferred to the CI gate.** No claim is made either way.

No hot path changes: `expectation_zero_state`, `probabilities`, `greedy_contract`,
`contract`, and `transpose` are byte-identical, and neither new query has a bench row.
The runs below exist only because an earlier measurement on this file found 4.1% to
13.2% on rows that never execute the changed code, caused by linked code size alone.

`scripts/bench_ab.sh --filter '^tn/scalar_' --ref main --features "parallel bench-internal"`,
i7-6700K, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

`tn/scalar_hea_l2` across four runs. Runs 3 and 4 measure the **same two binaries**:

| Run | Samples | /20 | /30 | /40 | /50 | Worst control | Diff size |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 15 | +1.6% | +0.2% | +1.7% | +1.1% | 4.6% | RDM only |
| 2 | 15 | +5.3% | +4.4% | +0.9% | +0.2% | 36.8% | full |
| 3 | 20 | +15.6% | +16.4% | +18.0% | +17.9% | 22.4% | full |
| 4 | 20 | -6.7% | -3.4% | -4.0% | -0.0% | 11.1% | full |

Runs 3 and 4 disagree by roughly 20 points on identical code. Run 3 read as a resolvable
FAIL, with per-row controls at or under 5% on all four rows, and run 4 reverses the sign.
The reference-side absolute time for `hea_l2/20` across the four runs, all measuring the
same commit, is 350.7, 337.0, 326.7, 379.4 us, a spread of about 15%.

The conclusion is about the harness and the host, not the diff: a within-run control
column can read tight while the across-run spread on identical code is several times
larger, so a single run's PASS or FAIL on this row family is not evidence. This is a
known limitation of the method: `bench_ab.sh` builds its reference in a separate
worktree, so the two binaries differ in embedded paths and code layout, and the control
column cannot see that term. An earlier same-directory rebuild on this file produced the
same sign reversal from build directory alone.

Regression verdict: **UNRESOLVED on this host.** The CI gate builds both sides in one job
against the PR base and is the appropriate authority. If it flags a `tn/scalar_*` row,
read that row's control column before treating it as a regression.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2147 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes under `-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and signature do not carry
- [x] Golden fixtures against the statevector backend

`cargo check --no-default-features` also passes: neither new path uses a Rayon-gated item.

Both new queries are pinned against the statevector by fixtures that discriminate bra
from ket. Transposing the reduced density matrix, or transposing the `Y` operator, each
makes the corresponding fixture fail; both were verified by making the change and
observing the failure, not by inspection.

## Two capability-boundary tests changed sides

`backends_without_a_native_path_name_themselves` (`tests/expectation_values.rs`) and
`shift_on_a_backend_without_an_observable_path_names_it`
(`tests/expectation_gradient.rs`) both used TensorNetwork as their only subject for "a
backend with no observable path". Both now assert the new behavior instead.

Worth a reviewer's attention: TensorNetwork was the last backend that could reach the
`BackendUnsupported` branch in `expectation_values_native`. Every other kind either
implements the trait method or is intercepted upstream, so that guard is now unreachable
in practice and is covered by no test. It is left in place because
`FactoredStabilizerBackend` still declines the trait method and would hit it if ever
routed there.

## Architecture or design changes

- [x] `docs/architecture/backends.md` and `docs/guides/capabilities.md` updated. The
      capability matrix listed tensor-network expectation values as rejected.
- [x] Design note written before the code, covering the open-index representation, how
      the greedy score ranks a pair carrying open legs, and the interaction with
      `MIN_PAR_ELEMS` and `MIN_FAER_GEMM_WORK`.

Neither threshold is retuned and neither gains an open-index variant. Both gate on
operand and result sizes, and an open leg enters those as an ordinary free extent.

`contract_to_statevector`'s `position(..).unwrap_or(0)` becomes an `expect`. It was dead
either way, but it is the same leg-lookup pattern the new code uses, and a missing leg
there produced a silently wrong statevector rather than a failure.

## docs.rs

The published docs have failed to build since `doc_auto_cfg` was removed in 1.92 and
merged into `doc_cfg` (rust-lang/rust#138907). Verified in both directions on
`rustc 1.99.0-nightly (2026-08-09)`: that toolchain reproduces the exact `E0557` from
the failing build log with the old attribute, and builds clean with the new one. The
change cannot affect CI or local builds, since `docsrs` is set only by docs.rs.

## Breaking changes

`BackendKind::TensorNetwork` joins `supports_general_noise`, and the backend now answers
`pauli_expectations`. Both are rejections becoming acceptances. `Auto` never selects this
backend, so no routing decision made on a caller's behalf moves. The error text from
`general_noise_backend_names` gains `TensorNetwork`.

## Risks and rollback

Both queries are new surface with no existing caller outside the trajectory engine and
the observable route, and both reach this backend only under explicit dispatch.

Noise cost is unmeasured: one doubled contraction per coherence-dependent noise event per
shot, with shots still funnelling through `probabilities()` under the dense ceiling, so
the regime where this is the right backend is narrow. A caller opts into that explicitly.

Rollback is per capability and needs no revert. Dropping `BackendKind::TensorNetwork`
from the `supports_general_noise` arm restores the previous noise rejection; returning
`false` from `supports_pauli_expectation` restores the previous observable rejection.
Either leaves the contraction code in place.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
