### PR TITLE
perf: on-device 1q density matrix and distributed exchange cuts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,11 @@ name = "bench_gpu"
 harness = false
 required-features = ["gpu"]
 
+[[bench]]
+name = "bench_distributed"
+harness = false
+required-features = ["distributed", "bench-internal"]
+
 [[example]]
 name = "dist_mpi_check"
 required-features = ["distributed-mpi"]

--- a/benches/README.md
+++ b/benches/README.md
@@ -82,6 +82,18 @@ both the working tree and the reference worktree.
 | `qec_decoder/rep_d3_r3`, `qec_decoder/rep_d5_r5` | Bulk union-find decode of sampled repetition-memory detector batches, 1k and 20k shots |
 | `qec_decoder/surface_d3_r3`, `qec_decoder/surface_d5_r5` | Bulk union-find decode of sampled rotated-surface-memory detector batches, 1k and 20k shots |
 
+### Distributed loopback benchmarks (bench_distributed)
+
+Requires `--features "parallel distributed bench-internal"`. Rank pairs run on the
+thread loopback transport, so exchanges move at memcpy speed: the rows resolve
+packing, copying, and per-gate dispatch cost, not network latency.
+
+| Group | What it measures |
+|-------|-----------------|
+| `distributed/steady_state_batched` | Fused QAOA behind one SWAP: batched-payload dispatch with a non-identity qubit map |
+| `distributed/boundary_swap_direct` | Repeated boundary SWAPs with relabeling off: the half-slice pack path |
+| `distributed/controlled_star_direct` | Controlled gates and a Multi2q star onto one global qubit with relabeling off |
+
 ## Circuit families
 
 All seeded with `0xDEAD_BEEF` for reproducibility.

--- a/benches/bench_distributed.rs
+++ b/benches/bench_distributed.rs
@@ -1,0 +1,159 @@
+//! Loopback distributed benchmarks: thread-transport rank pairs measuring
+//! exchange-path and steady-state dispatch costs without an MPI environment.
+//! Loopback exchanges move at memcpy speed, so these rows resolve packing,
+//! copying, and per-gate dispatch cost rather than network latency.
+//!
+//! Runs with `cargo bench --bench bench_distributed --features "parallel
+//! distributed bench-internal"`.
+
+#![cfg(all(feature = "distributed", feature = "bench-internal"))]
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use num_complex::Complex64;
+use prism_q::DistributedStatevectorBackend;
+use prism_q::backend::Backend;
+use prism_q::circuit::{Circuit, fusion::fuse_circuit};
+use prism_q::circuits;
+use prism_q::distributed::loopback::run_ranks;
+use prism_q::gates::{Gate, Multi2qData};
+
+mod common;
+use common::{SEED, configure_group, is_fast};
+
+fn steady_sizes() -> &'static [usize] {
+    if is_fast() { &[12] } else { &[16] }
+}
+
+fn direct_sizes() -> &'static [usize] {
+    if is_fast() { &[14] } else { &[18] }
+}
+
+/// Fused QAOA behind one SWAP, so the qubit map is non-identity for every
+/// batched payload: the steady state the permuted-map dispatch pays for.
+fn bench_steady_state_batched(c: &mut Criterion) {
+    let mut group = c.benchmark_group("distributed/steady_state_batched");
+    configure_group(&mut group);
+
+    for &n in steady_sizes() {
+        let fused = fuse_circuit(&circuits::qaoa_circuit(n, 3, SEED), true).into_owned();
+        let mut prefix = Circuit::new(n, 0);
+        prefix.add_gate(Gate::Swap, &[0, n - 1]);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &fused, |b, fused| {
+            b.iter(|| {
+                let messages = run_ranks(2, |ctx| {
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend
+                        .init(fused.num_qubits, fused.num_classical_bits)
+                        .unwrap();
+                    backend.apply_instructions(&prefix.instructions).unwrap();
+                    backend.apply_instructions(&fused.instructions).unwrap();
+                    backend.exchange_messages()
+                });
+                std::hint::black_box(messages);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Boundary SWAPs in direct-exchange mode: the half-slice pack path.
+fn bench_boundary_swap_direct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("distributed/boundary_swap_direct");
+    configure_group(&mut group);
+
+    for &n in direct_sizes() {
+        let mut circuit = Circuit::new(n, 0);
+        circuit.add_gate(Gate::X, &[0]);
+        for _ in 0..8 {
+            circuit.add_gate(Gate::Swap, &[0, n - 1]);
+        }
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                let amplitudes = run_ranks(2, |ctx| {
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_relabel(false);
+                    backend
+                        .init(circ.num_qubits, circ.num_classical_bits)
+                        .unwrap();
+                    backend.apply_instructions(&circ.instructions).unwrap();
+                    backend.exchange_amplitudes()
+                });
+                std::hint::black_box(amplitudes);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Controlled gates and a Multi2q star onto one global qubit in
+/// direct-exchange mode: the sublattice pack and shared-run exchange paths.
+fn bench_controlled_star_direct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("distributed/controlled_star_direct");
+    configure_group(&mut group);
+
+    let c64 = |re: f64| Complex64::new(re, 0.0);
+    let z = c64(0.0);
+    let x_mat = [[z, c64(1.0)], [c64(1.0), z]];
+    let cx_mat = [
+        [c64(1.0), z, z, z],
+        [z, c64(1.0), z, z],
+        [z, z, z, c64(1.0)],
+        [z, z, c64(1.0), z],
+    ];
+    let cry_mat = |theta: f64| {
+        let (sin, cos) = (theta / 2.0).sin_cos();
+        [
+            [c64(1.0), z, z, z],
+            [z, c64(1.0), z, z],
+            [z, z, c64(cos), c64(-sin)],
+            [z, z, c64(sin), c64(cos)],
+        ]
+    };
+
+    for &n in direct_sizes() {
+        let top = n - 1;
+        let mut circuit = Circuit::new(n, 0);
+        for q in 0..3 {
+            circuit.add_gate(Gate::H, &[q]);
+        }
+        circuit.add_gate(Gate::Cx, &[0, top]);
+        circuit.add_gate(Gate::mcu(x_mat, 2), &[0, 1, top]);
+        let gates = vec![
+            (0, top, cx_mat),
+            (1, top, cry_mat(0.3)),
+            (2, top, cry_mat(0.8)),
+        ];
+        circuit.add_gate(
+            Gate::Multi2q(Box::new(Multi2qData { gates })),
+            &[0, 1, 2, top],
+        );
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                let amplitudes = run_ranks(2, |ctx| {
+                    let mut backend = DistributedStatevectorBackend::new(ctx, SEED);
+                    backend.set_relabel(false);
+                    backend
+                        .init(circ.num_qubits, circ.num_classical_bits)
+                        .unwrap();
+                    backend.apply_instructions(&circ.instructions).unwrap();
+                    backend.exchange_amplitudes()
+                });
+                std::hint::black_box(amplitudes);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = common::criterion_config();
+    targets =
+        bench_steady_state_batched,
+    bench_boundary_swap_direct,
+    bench_controlled_star_direct
+}
+criterion_main!(benches);

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -23,12 +23,15 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use num_complex::Complex64;
 use prism_q::backend::Backend;
-use prism_q::circuit::Circuit;
+use prism_q::circuit::{Circuit, Instruction};
 use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::gpu::GpuContext;
-use prism_q::{BackendKind, StabilizerBackend, StatevectorBackend};
+use prism_q::{
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, StabilizerBackend, StatevectorBackend, sim,
+};
 
 mod common;
 use common::{SEED, configure_group, is_fast, run_shots_with, run_with};
@@ -230,6 +233,111 @@ fn bench_gpu_measurement(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
                 run_with(kind.clone(), circ, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Noisy trajectory (general noise on the GPU statevector)
+// ============================================================================
+
+/// Kraus set for amplitude damping at rate `gamma`.
+fn amplitude_damping_kraus(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let c = |re: f64| Complex64::new(re, 0.0);
+    let zero = c(0.0);
+    vec![
+        [[c(1.0), zero], [zero, c((1.0 - gamma).sqrt())]],
+        [[zero, c(gamma.sqrt())], [zero, zero]],
+    ]
+}
+
+/// Custom Kraus amplitude damping after every gate. `Custom` keeps the
+/// channel on the general trajectory route, where branch probabilities
+/// come from `reduced_density_matrix_1q` per event.
+fn custom_kraus_noise(circuit: &Circuit) -> NoiseModel {
+    let kraus = amplitude_damping_kraus(0.05);
+    let after_gate = circuit
+        .instructions
+        .iter()
+        .map(|instr| match instr {
+            Instruction::Gate { targets, .. } => vec![NoiseEvent {
+                channel: NoiseChannel::Custom {
+                    kraus: kraus.clone(),
+                },
+                qubits: std::iter::once(targets[0]).collect(),
+            }],
+            _ => Vec::new(),
+        })
+        .collect();
+    NoiseModel {
+        after_gate,
+        readout: vec![None; circuit.num_classical_bits],
+    }
+}
+
+fn measured_random_circuit(n: usize) -> Circuit {
+    let mut circuit = circuits::random_circuit(n, 10, SEED);
+    circuit.num_classical_bits = n;
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn noisy_sweep_sizes() -> &'static [usize] {
+    if is_fast() { &[16] } else { &[20] }
+}
+
+const NOISY_SHOTS: usize = 2;
+
+fn run_shots_with_noise(
+    kind: BackendKind,
+    circuit: &Circuit,
+    noise: &NoiseModel,
+    num_shots: usize,
+    seed: u64,
+) -> prism_q::Result<prism_q::ShotsResult> {
+    sim::simulate(circuit)
+        .backend(kind)
+        .noise(noise)
+        .seed(seed)
+        .shots(num_shots)
+}
+
+fn bench_gpu_noisy_kraus(c: &mut Criterion) {
+    let Some(ctx) = shared_ctx() else { return };
+    let mut group = c.benchmark_group("gpu/noisy_kraus_d10");
+    configure_group(&mut group);
+    let kind = gpu_kind(&ctx);
+
+    for &n in noisy_sweep_sizes() {
+        let circuit = measured_random_circuit(n);
+        let noise = custom_kraus_noise(&circuit);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_shots_with_noise(kind.clone(), circ, &noise, NOISY_SHOTS, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// CPU statevector sibling of `gpu/noisy_kraus_d10` for crossover context.
+fn bench_cpu_noisy_kraus(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gpu_noisy_cpu/kraus_d10");
+    configure_group(&mut group);
+
+    for &n in noisy_sweep_sizes() {
+        let circuit = measured_random_circuit(n);
+        let noise = custom_kraus_noise(&circuit);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_shots_with_noise(BackendKind::Statevector, circ, &noise, NOISY_SHOTS, 42)
+                    .unwrap();
             });
         });
     }
@@ -729,6 +837,8 @@ criterion_group! {
     bench_gpu_decomposed,
     bench_gpu_direct_kernel,
     bench_gpu_measurement,
+    bench_gpu_noisy_kraus,
+    bench_cpu_noisy_kraus,
     bench_stab_cpu_clifford_d10,
     bench_stab_gpu_clifford_d10,
     bench_stab_direct_cpu_clifford_d10,

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -53,7 +53,11 @@ BTS sampling. Six entry points are available:
   matrix. Otherwise the API uses a host copy for correctness.
 
 When a GPU context is attached, `Backend::init` allocates state on the device instead
-of a host `Vec<Complex64>` and every instruction routes to a CUDA kernel.
+of a host `Vec<Complex64>` and every instruction routes to a CUDA kernel. On the hard
+statevector path (`StatevectorGpu`, `with_gpu`), a state that does not fit the
+currently free VRAM is rejected at `init` with an error naming the requested and free
+device memory; `GpuContext::max_qubits_for_statevector` reports the advisory cap from
+free memory.
 
 The three `BackendKind` entry points are also reachable from Python, from a build
 carrying the `gpu` feature. See [Python Bindings](python.md#gpu-backends).
@@ -119,7 +123,9 @@ equality tests.
   user-visible says whether a run executed on the device.
 - Stabilizer `probabilities()`, `export_tableau()`, and `export_statevector()` read
   back to the CPU.
-- A `Custom` Kraus noise event reads the full state back to the host, and every
-  trajectory shot rebuilds the backend, reallocating the device buffer.
+- Every trajectory shot rebuilds the backend, reallocating the device buffer
+  (measured at 0.1 ms per shot at 20 qubits, so not a practical cost). `Custom`
+  Kraus branch probabilities come from an on-device reduced-density-matrix
+  reduction (`rdm_qubit`), not a full-state readback.
 - Kernel design and crossover analysis live in the module docstrings on
   `src/gpu/kernels/dense.rs`.

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -199,11 +199,14 @@ fn required_local_qubits(gate: &Gate, targets: &[usize]) -> SmallVec<[usize; 8]>
         | Gate::DiagonalBatch(_) => {}
         Gate::Cu(_) | Gate::Mcu(_) => {
             if gate.controlled_phase().is_none() {
-                let target = match gate {
-                    Gate::Mcu(data) => targets[data.num_controls as usize],
-                    _ => targets[1],
+                let (target, mat) = match gate {
+                    Gate::Mcu(data) => (targets[data.num_controls as usize], &data.mat),
+                    Gate::Cu(mat) => (targets[1], &**mat),
+                    _ => unreachable!("outer match arm is Cu | Mcu"),
                 };
-                push(&mut req, target);
+                if !is_diagonal_2x2(mat) {
+                    push(&mut req, target);
+                }
             }
         }
         Gate::Fused2q(_) => {
@@ -414,14 +417,15 @@ impl DistributedStatevectorBackend {
         }
     }
 
-    /// Physically swap the qubits at a local and a global position, then update
-    /// the map. Only amplitudes whose local bit differs from this rank's bit of
-    /// the global position move, so each rank exchanges half its slice. Both
-    /// ranks enumerate their moving halves in ascending index order, which the
+    /// Exchange the moving half of a local/global SWAP with the partner rank.
+    /// Only amplitudes whose local bit differs from this rank's bit of the
+    /// global position move, so each rank exchanges half its slice. Both ranks
+    /// enumerate their moving halves in ascending index order, which the
     /// single-bit XOR relation between the two sets preserves, so the k-th
     /// received amplitude lands at the k-th moving index. Tiled by
-    /// `exchange_chunk` like the direct global exchange.
-    fn relabel_swap(&mut self, local_pos: usize, global_pos: usize) {
+    /// `exchange_chunk` like the direct global exchange. Pure data movement:
+    /// the qubit map is untouched.
+    fn half_slice_swap(&mut self, local_pos: usize, global_pos: usize) {
         let partner = self.context.rank() ^ (1usize << self.global_bit(global_pos));
         let gbit = self.rank_bit_set(global_pos);
         let stride = 1usize << local_pos;
@@ -451,6 +455,12 @@ impl DistributedStatevectorBackend {
             }
             off += count;
         }
+    }
+
+    /// Physically swap the qubits at a local and a global position, then update
+    /// the map.
+    fn relabel_swap(&mut self, local_pos: usize, global_pos: usize) {
+        self.half_slice_swap(local_pos, global_pos);
 
         let local_q = self.phys_map[local_pos];
         let global_q = self.phys_map[global_pos];
@@ -539,49 +549,80 @@ impl DistributedStatevectorBackend {
             return (Cow::Borrowed(gate), targets.into());
         }
         let ptargets: SmallVec<[usize; 4]> = targets.iter().map(|&q| self.qubit_map[q]).collect();
+        // A payload whose every index maps to itself is borrowed unchanged:
+        // once any relabel leaves the map non-identity, a per-application deep
+        // clone of every batched payload is the steady state otherwise.
+        let fixed = |q: usize| self.qubit_map[q] == q;
         let pgate = match gate {
             Gate::MultiFused(data) => {
-                let mut data = data.clone();
-                for entry in &mut data.gates {
-                    entry.0 = self.qubit_map[entry.0];
+                if data.gates.iter().all(|&(q, _)| fixed(q)) {
+                    Cow::Borrowed(gate)
+                } else {
+                    let mut data = data.clone();
+                    for entry in &mut data.gates {
+                        entry.0 = self.qubit_map[entry.0];
+                    }
+                    Cow::Owned(Gate::MultiFused(data))
                 }
-                Cow::Owned(Gate::MultiFused(data))
             }
             Gate::Multi2q(data) => {
-                let mut data = data.clone();
-                for entry in &mut data.gates {
-                    entry.0 = self.qubit_map[entry.0];
-                    entry.1 = self.qubit_map[entry.1];
+                if data.gates.iter().all(|&(q0, q1, _)| fixed(q0) && fixed(q1)) {
+                    Cow::Borrowed(gate)
+                } else {
+                    let mut data = data.clone();
+                    for entry in &mut data.gates {
+                        entry.0 = self.qubit_map[entry.0];
+                        entry.1 = self.qubit_map[entry.1];
+                    }
+                    Cow::Owned(Gate::Multi2q(data))
                 }
-                Cow::Owned(Gate::Multi2q(data))
             }
             Gate::BatchPhase(data) => {
-                let mut data = data.clone();
-                for entry in &mut data.phases {
-                    entry.0 = self.qubit_map[entry.0];
+                if data.phases.iter().all(|&(q, _)| fixed(q)) {
+                    Cow::Borrowed(gate)
+                } else {
+                    let mut data = data.clone();
+                    for entry in &mut data.phases {
+                        entry.0 = self.qubit_map[entry.0];
+                    }
+                    Cow::Owned(Gate::BatchPhase(data))
                 }
-                Cow::Owned(Gate::BatchPhase(data))
             }
             Gate::BatchRzz(data) => {
-                let mut data = data.clone();
-                for entry in &mut data.edges {
-                    entry.0 = self.qubit_map[entry.0];
-                    entry.1 = self.qubit_map[entry.1];
+                if data.edges.iter().all(|&(q0, q1, _)| fixed(q0) && fixed(q1)) {
+                    Cow::Borrowed(gate)
+                } else {
+                    let mut data = data.clone();
+                    for entry in &mut data.edges {
+                        entry.0 = self.qubit_map[entry.0];
+                        entry.1 = self.qubit_map[entry.1];
+                    }
+                    Cow::Owned(Gate::BatchRzz(data))
                 }
-                Cow::Owned(Gate::BatchRzz(data))
             }
             Gate::DiagonalBatch(data) => {
-                let mut data = data.clone();
-                for entry in &mut data.entries {
-                    match entry {
-                        DiagEntry::Phase1q { qubit, .. } => *qubit = self.qubit_map[*qubit],
-                        DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
-                            *q0 = self.qubit_map[*q0];
-                            *q1 = self.qubit_map[*q1];
+                let entry_fixed = |entry: &DiagEntry| match *entry {
+                    DiagEntry::Phase1q { qubit, .. } => fixed(qubit),
+                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
+                        fixed(q0) && fixed(q1)
+                    }
+                };
+                if data.entries.iter().all(entry_fixed) {
+                    Cow::Borrowed(gate)
+                } else {
+                    let mut data = data.clone();
+                    for entry in &mut data.entries {
+                        match entry {
+                            DiagEntry::Phase1q { qubit, .. } => *qubit = self.qubit_map[*qubit],
+                            DiagEntry::Phase2q { q0, q1, .. }
+                            | DiagEntry::Parity2q { q0, q1, .. } => {
+                                *q0 = self.qubit_map[*q0];
+                                *q1 = self.qubit_map[*q1];
+                            }
                         }
                     }
+                    Cow::Owned(Gate::DiagonalBatch(data))
                 }
-                Cow::Owned(Gate::DiagonalBatch(data))
             }
             _ => Cow::Borrowed(gate),
         };
@@ -734,44 +775,67 @@ impl DistributedStatevectorBackend {
     }
 
     /// Apply a 2x2 matrix to a global target qubit, gated by local control
-    /// qubits (all must be 1). Exchanges with the partner rank, then combines
-    /// only the controlled indices; uncontrolled indices keep their own value.
+    /// qubits (all must be 1). Only the control-selected sublattice is
+    /// consumed, so with `k` controls each rank packs and exchanges `len / 2^k`
+    /// amplitudes instead of the full slice. Both ranks enumerate the same
+    /// sublattice in ascending index order, so the exchange stays aligned.
+    /// Tiled by `exchange_chunk` like the direct global exchange.
     fn apply_global_controlled_1q(
         &mut self,
         local_controls: &[usize],
         target: usize,
         mat: [[Complex64; 2]; 2],
     ) {
-        let partner = self.context.rank() ^ (1usize << self.global_bit(target));
-        let len = self.inner.state.len();
-        if self.recv.len() != len {
-            self.recv.resize(len, Complex64::new(0.0, 0.0));
+        if local_controls.is_empty() {
+            self.apply_global_1q(target, mat);
+            return;
         }
-        self.count_exchange(len);
-        self.context
-            .comm()
-            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
-
+        let partner = self.context.rank() ^ (1usize << self.global_bit(target));
         let (c_self, c_remote) = if self.rank_bit_set(target) {
             (mat[1][1], mat[1][0])
         } else {
             (mat[0][0], mat[0][1])
         };
 
-        if local_controls.is_empty() {
-            simd::combine_global_half(&mut self.inner.state, &self.recv, c_self, c_remote);
-            return;
-        }
-        let ctrl_mask: usize = local_controls.iter().map(|&c| 1usize << c).sum();
-        for (i, amp) in self.inner.state.iter_mut().enumerate() {
-            if i & ctrl_mask == ctrl_mask {
-                *amp = c_self * *amp + c_remote * self.recv[i];
+        let mut ctrl_pos: SmallVec<[usize; 4]> = local_controls.iter().copied().collect();
+        ctrl_pos.sort_unstable();
+        let index_of = |flat: usize| {
+            let mut i = flat;
+            for &p in &ctrl_pos {
+                let low = i & ((1usize << p) - 1);
+                i = ((i >> p) << (p + 1)) | (1usize << p) | low;
             }
+            i
+        };
+        let moving = self.inner.state.len() >> ctrl_pos.len();
+        let chunk = self.exchange_chunk.min(moving).max(1);
+        if self.pack.len() != chunk {
+            self.pack.resize(chunk, Complex64::new(0.0, 0.0));
+        }
+        if self.recv.len() != chunk {
+            self.recv.resize(chunk, Complex64::new(0.0, 0.0));
+        }
+        let mut off = 0;
+        while off < moving {
+            let count = (off + chunk).min(moving) - off;
+            for (k, slot) in self.pack[..count].iter_mut().enumerate() {
+                *slot = self.inner.state[index_of(off + k)];
+            }
+            self.count_exchange(count);
+            self.context
+                .comm()
+                .sendrecv_c64(partner, &self.pack[..count], &mut self.recv[..count]);
+            for (k, &remote) in self.recv[..count].iter().enumerate() {
+                let i = index_of(off + k);
+                self.inner.state[i] = c_self * self.inner.state[i] + c_remote * remote;
+            }
+            off += count;
         }
     }
 
     /// Apply a controlled gate (one target, zero or more controls) whose qubit
     /// set may span local and global qubits. Covers Cx, Cu, and Mcu uniformly.
+    /// A diagonal target matrix needs no communication regardless of the split.
     fn apply_controlled_dist(
         &mut self,
         controls: &[usize],
@@ -791,6 +855,24 @@ impl DistributedStatevectorBackend {
 
         if target < local {
             self.apply_local_controlled_1q(&local_controls, target, mat);
+        } else if is_diagonal_2x2(&mat) {
+            // A global diagonal target contributes its rank bit: scale the
+            // control-selected sublattice by the selected diagonal entry.
+            let d = if self.rank_bit_set(target) {
+                mat[1][1]
+            } else {
+                mat[0][0]
+            };
+            if local_controls.is_empty() {
+                simd::scale_complex_slice(&mut self.inner.state, d);
+                return;
+            }
+            let ctrl_mask: usize = local_controls.iter().map(|&c| 1usize << c).sum();
+            for (i, amp) in self.inner.state.iter_mut().enumerate() {
+                if i & ctrl_mask == ctrl_mask {
+                    *amp *= d;
+                }
+            }
         } else {
             self.apply_global_controlled_1q(&local_controls, target, mat);
         }
@@ -942,27 +1024,7 @@ impl DistributedStatevectorBackend {
             }
             (true, false) | (false, true) => {
                 let (local_q, global_q) = if a < local { (a, b) } else { (b, a) };
-                let partner = self.context.rank() ^ (1usize << self.global_bit(global_q));
-                let len = self.inner.state.len();
-                if self.recv.len() != len {
-                    self.recv.resize(len, Complex64::new(0.0, 0.0));
-                }
-                self.count_exchange(len);
-                self.context
-                    .comm()
-                    .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
-                // The global bit is fixed on this rank. Entries where the local
-                // bit differs take the partner value at the flipped local index.
-                let global_bit = self.rank_bit_set(global_q);
-                let half = 1usize << local_q;
-                let len = self.inner.state.len();
-                for i in 0..len {
-                    let local_bit = (i >> local_q) & 1 == 1;
-                    if local_bit != global_bit {
-                        let partner_idx = i ^ half;
-                        self.inner.state[i] = self.recv[partner_idx];
-                    }
-                }
+                self.half_slice_swap(local_q, global_q);
             }
         }
     }
@@ -1032,6 +1094,73 @@ impl DistributedStatevectorBackend {
             acc += mat[row][basis(1 - g, 0)] * self.recv[sib0];
             acc += mat[row][basis(1 - g, 1)] * self.recv[sib1];
             self.inner.state[i] = acc;
+        }
+    }
+
+    /// Apply a run of two qubit gates that all pair a local qubit with the same
+    /// global qubit. One exchange serves the whole run: after it this rank holds
+    /// both halves of the pair subspace, so each entry updates the local slice
+    /// and the mirrored partner copy together, exactly as the partner does with
+    /// the roles flipped. Sums run in canonical basis order so both ranks
+    /// produce bit-identical copies and stay in lockstep without further
+    /// communication.
+    fn apply_2q_run_one_global(
+        &mut self,
+        global_q: usize,
+        entries: &[(usize, usize, [[Complex64; 4]; 4])],
+    ) {
+        let partner = self.context.rank() ^ (1usize << self.global_bit(global_q));
+        let len = self.inner.state.len();
+        if self.recv.len() != len {
+            self.recv.resize(len, Complex64::new(0.0, 0.0));
+        }
+        self.count_exchange(len);
+        self.context
+            .comm()
+            .sendrecv_c64(partner, &self.inner.state, &mut self.recv);
+
+        let g = self.rank_bit_set(global_q) as usize;
+        let state = &mut self.inner.state;
+        let recv = &mut self.recv[..len];
+        for &(q0, q1, ref mat) in entries {
+            let (local_q, global_is_q0) = if q0 == global_q {
+                (q1, true)
+            } else {
+                (q0, false)
+            };
+            let half = 1usize << local_q;
+            let basis = |gbit: usize, lbit: usize| -> usize {
+                if global_is_q0 {
+                    (gbit << 1) | lbit
+                } else {
+                    (lbit << 1) | gbit
+                }
+            };
+            // Slot order: state[i0], state[i1], recv[i0], recv[i1].
+            let slots = [basis(g, 0), basis(g, 1), basis(1 - g, 0), basis(1 - g, 1)];
+            let zero = Complex64::new(0.0, 0.0);
+            let mut base = 0;
+            while base < len {
+                for i0 in base..base + half {
+                    let i1 = i0 | half;
+                    let mut by_col = [zero; 4];
+                    by_col[slots[0]] = state[i0];
+                    by_col[slots[1]] = state[i1];
+                    by_col[slots[2]] = recv[i0];
+                    by_col[slots[3]] = recv[i1];
+                    let mut outs = [zero; 4];
+                    for (out, &row) in outs.iter_mut().zip(slots.iter()) {
+                        for (c, &amp) in by_col.iter().enumerate() {
+                            *out += mat[row][c] * amp;
+                        }
+                    }
+                    state[i0] = outs[0];
+                    state[i1] = outs[1];
+                    recv[i0] = outs[2];
+                    recv[i1] = outs[3];
+                }
+                base += half << 1;
+            }
         }
     }
 
@@ -1127,8 +1256,37 @@ impl DistributedStatevectorBackend {
                 Ok(())
             }
             Gate::Multi2q(data) => {
-                for &(q0, q1, ref mat) in &data.gates {
-                    self.apply_2q_dist(q0, q1, mat);
+                // Consecutive entries sharing one global qubit have the same
+                // partner (a CNOT star onto one qubit); one exchange serves
+                // the whole run.
+                let local = self.local_qubits();
+                let one_global_on = |entry: &(usize, usize, [[Complex64; 4]; 4])| {
+                    let (q0, q1, _) = *entry;
+                    match (q0 < local, q1 < local) {
+                        (true, false) => Some(q1),
+                        (false, true) => Some(q0),
+                        _ => None,
+                    }
+                };
+                let mut i = 0;
+                while i < data.gates.len() {
+                    let Some(g) = one_global_on(&data.gates[i]) else {
+                        let (q0, q1, ref mat) = data.gates[i];
+                        self.apply_2q_dist(q0, q1, mat);
+                        i += 1;
+                        continue;
+                    };
+                    let mut end = i + 1;
+                    while end < data.gates.len() && one_global_on(&data.gates[end]) == Some(g) {
+                        end += 1;
+                    }
+                    if end - i == 1 {
+                        let (q0, q1, ref mat) = data.gates[i];
+                        self.apply_2q_one_global(q0, q1, mat);
+                    } else {
+                        self.apply_2q_run_one_global(g, &data.gates[i..end]);
+                    }
+                    i = end;
                 }
                 Ok(())
             }
@@ -1371,10 +1529,8 @@ impl DistributedStatevectorBackend {
     /// or relabeling is disabled.
     fn apply_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         if self.global_qubits == 0 {
-            return self.inner.apply(&Instruction::Gate {
-                gate: gate.clone(),
-                targets: targets.into(),
-            });
+            self.inner.dispatch_gate(gate, targets);
+            return Ok(());
         }
         if self.relabel {
             self.touch_instruction(gate, targets);
@@ -1392,10 +1548,8 @@ impl DistributedStatevectorBackend {
         }
         let (pgate, ptargets) = self.to_physical(gate, targets);
         if self.instruction_qubits_local(&pgate, &ptargets) {
-            return self.inner.apply(&Instruction::Gate {
-                gate: pgate.into_owned(),
-                targets: ptargets,
-            });
+            self.inner.dispatch_gate(pgate.as_ref(), &ptargets);
+            return Ok(());
         }
         let pgate = pgate.as_ref();
         if pgate.num_qubits() == 1 {

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -905,6 +905,129 @@ fn tiled_exchange_splits_messages_not_volume() {
     );
 }
 
+#[test]
+fn boundary_swap_direct_exchanges_half_the_slice() {
+    relax_min_local_qubits();
+    let circuit = {
+        let mut b = CircuitBuilder::new(5);
+        b.x(0).swap(0, 4);
+        b.build()
+    };
+    let full = loopback_exchange_stats(&circuit, 2, usize::MAX, false);
+    assert_eq!(
+        full,
+        (1, 8),
+        "only the moving half of the 16-amplitude slice crosses"
+    );
+    let tiled = loopback_exchange_stats(&circuit, 2, 4, false);
+    assert_eq!(tiled, (2, 8), "8 moving amplitudes in chunks of 4");
+    assert_loopback_matches(&circuit, &[2, 4]);
+}
+
+#[test]
+fn local_controls_cut_the_controlled_exchange_volume() {
+    relax_min_local_qubits();
+    let x_mat = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    // One local control selects half the slice.
+    let single = {
+        let mut b = CircuitBuilder::new(5);
+        b.h(0).cx(0, 4);
+        b.build()
+    };
+    let stats = loopback_exchange_stats(&single, 2, usize::MAX, false);
+    assert_eq!(stats, (1, 8), "one control selects len/2 of the slice");
+
+    // Two local controls select a quarter.
+    let double = {
+        let mut b = CircuitBuilder::new(5);
+        b.h(0).h(1).mcu(x_mat, &[0, 1], 4);
+        b.build()
+    };
+    let stats = loopback_exchange_stats(&double, 2, usize::MAX, false);
+    assert_eq!(stats, (1, 4), "two controls select len/4 of the slice");
+    let tiled = loopback_exchange_stats(&double, 2, 2, false);
+    assert_eq!(tiled, (2, 4), "4 sublattice amplitudes in chunks of 2");
+
+    assert_loopback_matches(&single, &[2, 4]);
+    assert_loopback_matches(&double, &[2, 4]);
+}
+
+#[test]
+fn diagonal_cu_with_global_target_is_communication_free() {
+    relax_min_local_qubits();
+    let diag = [
+        [Complex64::cis(0.3), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::cis(0.7)],
+    ];
+    // The prep pays for x(4); the trailing h(0) makes the phase visible in
+    // probabilities. The diagonal cu itself must add no exchange, so the
+    // prep-only circuit and the full circuit report identical counters.
+    let prep_only = {
+        let mut b = CircuitBuilder::new(5);
+        b.x(4).h(0).h(0);
+        b.build()
+    };
+    let with_cu = {
+        let mut b = CircuitBuilder::new(5);
+        b.x(4).h(0).cu(diag, 0, 4).h(0);
+        b.build()
+    };
+    for relabel in [false, true] {
+        let base = loopback_exchange_stats(&prep_only, 2, usize::MAX, relabel);
+        let full = loopback_exchange_stats(&with_cu, 2, usize::MAX, relabel);
+        assert_eq!(
+            base, full,
+            "diagonal cu on a global target adds no exchange (relabel {relabel})"
+        );
+    }
+    assert_loopback_matches(&with_cu, &[2, 4]);
+}
+
+#[test]
+fn multi2q_star_shares_one_exchange_per_run() {
+    relax_min_local_qubits();
+    // Fan-out onto one global qubit, the syndrome-extraction shape: three
+    // same-partner entries share a single exchange.
+    let c = |re: f64| Complex64::new(re, 0.0);
+    let z = c(0.0);
+    let cx_mat = [
+        [c(1.0), z, z, z],
+        [z, c(1.0), z, z],
+        [z, z, z, c(1.0)],
+        [z, z, c(1.0), z],
+    ];
+    let cry_mat = |theta: f64| {
+        let (sin, cos) = (theta / 2.0).sin_cos();
+        [
+            [c(1.0), z, z, z],
+            [z, c(1.0), z, z],
+            [z, z, c(cos), c(-sin)],
+            [z, z, c(sin), c(cos)],
+        ]
+    };
+    let mut circuit = Circuit::new(5, 0);
+    {
+        let gates = vec![(0, 4, cx_mat), (1, 4, cry_mat(0.3)), (2, 4, cry_mat(0.8))];
+        for q in 0..3 {
+            circuit.add_gate(crate::gates::Gate::H, &[q]);
+        }
+        circuit.add_gate(
+            crate::gates::Gate::Multi2q(Box::new(crate::gates::Multi2qData { gates })),
+            &[0, 1, 2, 4],
+        );
+    }
+    let stats = loopback_exchange_stats(&circuit, 2, usize::MAX, false);
+    assert_eq!(
+        stats,
+        (1, 16),
+        "the three-entry run exchanges the slice once, not per entry"
+    );
+    assert_loopback_matches(&circuit, &[2, 4]);
+}
+
 fn inst_h(q: usize) -> crate::circuit::Instruction {
     crate::circuit::Instruction::Gate {
         gate: crate::gates::Gate::H,

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -593,8 +593,11 @@ impl StatevectorBackend {
         Ok(())
     }
 
+    /// Apply a gate to the host state without constructing an owned
+    /// [`Instruction`]. The distributed backend dispatches its local gates
+    /// through this to avoid deep-cloning boxed gate payloads per application.
     #[inline(always)]
-    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
+    pub(crate) fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
         match gate {
             Gate::Rzz(theta) => self.apply_rzz(targets[0], targets[1], *theta),
             Gate::Cx => self.apply_cx(targets[0], targets[1]),

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -119,25 +119,35 @@ pub(super) fn rdm_sum_add(
     (a.0 + b.0, a.1 + b.1, a.2 + b.2)
 }
 
+/// Reject a device statevector that cannot fit the currently free VRAM.
+///
+/// Guards the hard GPU path before the allocation is attempted, so an
+/// over-VRAM circuit surfaces a budget error naming the request and the free
+/// memory instead of the raw driver failure. A context that cannot report
+/// free memory (stub device) falls through to the allocation attempt, whose
+/// own error stays authoritative; so does a lost race against another process
+/// allocating between this check and the allocation.
 #[cfg(feature = "gpu")]
-fn reduced_density_matrix_from_state(state: &[Complex64], qubit: usize) -> [[Complex64; 2]; 2] {
-    let half = 1usize << qubit;
-    let block_size = half << 1;
-    let mut p0 = 0.0f64;
-    let mut p1 = 0.0f64;
-    let mut r = Complex64::new(0.0, 0.0);
-
-    for block in state.chunks(block_size) {
-        let (b0, b1, br) = rdm_block_sums(block, half);
-        p0 += b0;
-        p1 += b1;
-        r += br;
+fn check_device_budget(context: &GpuContext, num_qubits: usize) -> crate::error::Result<()> {
+    if num_qubits >= usize::BITS as usize - 4 {
+        return Ok(());
     }
-
-    [
-        [Complex64::new(p0, 0.0), r.conj()],
-        [r, Complex64::new(p1, 0.0)],
-    ]
+    let Ok(free) = context.vram_available() else {
+        return Ok(());
+    };
+    let needed = (1usize << num_qubits) * 16;
+    if needed > free {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: "statevector-gpu".to_string(),
+            reason: format!(
+                "circuit has {num_qubits} qubits needing {} MiB of device memory, \
+                 exceeding the {} MiB free on the GPU",
+                needed >> 20,
+                free >> 20
+            ),
+        });
+    }
+    Ok(())
 }
 
 /// Insert a zero bit at `bit_pos`, shifting all higher bits left by one.
@@ -562,6 +572,9 @@ impl StatevectorBackend {
 
         #[cfg(feature = "gpu")]
         if let Some(ctx) = self.gpu_context.clone() {
+            if !self.gpu_soft {
+                check_device_budget(&ctx, self.num_qubits)?;
+            }
             match GpuState::from_host_amplitudes(ctx, &state) {
                 Ok(gpu) => {
                     self.state.clear();
@@ -692,13 +705,6 @@ impl Backend for StatevectorBackend {
     }
 
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
-        crate::backend::check_state_allocation(
-            "statevector",
-            num_qubits,
-            crate::backend::max_statevector_qubits(),
-            "PRISM_MAX_SV_QUBITS",
-        )?;
-
         #[cfg(feature = "parallel")]
         crate::backend::init_thread_pool();
 
@@ -706,8 +712,13 @@ impl Backend for StatevectorBackend {
         self.pending_norm = 1.0;
         crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
 
+        // The device path is budgeted by VRAM, not by the host cap: the host
+        // vector is never allocated while the state lives on the device.
         #[cfg(feature = "gpu")]
         if let Some(ctx) = self.gpu_context.clone() {
+            if !self.gpu_soft {
+                check_device_budget(&ctx, num_qubits)?;
+            }
             match GpuState::new(ctx, num_qubits) {
                 Ok(state) => {
                     self.state.clear();
@@ -721,6 +732,13 @@ impl Backend for StatevectorBackend {
                 }
             }
         }
+
+        crate::backend::check_state_allocation(
+            "statevector",
+            num_qubits,
+            crate::backend::max_statevector_qubits(),
+            "PRISM_MAX_SV_QUBITS",
+        )?;
 
         let dim = 1usize << num_qubits;
         if self.state.len() == dim {
@@ -816,8 +834,11 @@ impl Backend for StatevectorBackend {
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         #[cfg(feature = "gpu")]
         if let Some(gpu) = self.gpu_state.as_ref() {
-            let state = gpu.export_statevector()?;
-            return Ok(reduced_density_matrix_from_state(&state, qubit));
+            return crate::gpu::kernels::dense::reduced_density_matrix_1q(
+                gpu.context(),
+                gpu,
+                qubit,
+            );
         }
         Ok(self.reduced_density_matrix_one(qubit))
     }

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -107,11 +107,14 @@ impl GpuDevice {
         }
     }
 
-    /// Maximum qubits representable as a Complex64 statevector in the total VRAM.
+    /// Maximum qubits representable as a Complex64 statevector in the currently
+    /// free VRAM.
     ///
-    /// Computed as `floor(log2(vram_bytes / 16))`. Each amplitude is two f64s = 16 bytes.
+    /// Computed as `floor(log2(vram_available / 16))`. Each amplitude is two f64s =
+    /// 16 bytes. Free memory moves with other processes sharing the device, so the
+    /// value is advisory and can differ between calls.
     pub fn max_qubits_for_statevector(&self) -> Result<usize> {
-        let bytes = self.vram_bytes()?;
+        let bytes = self.vram_available()?;
         let elements = bytes / 16;
         if elements == 0 {
             return Ok(0);

--- a/src/gpu/kernels/dense.rs
+++ b/src/gpu/kernels/dense.rs
@@ -374,6 +374,93 @@ extern "C" __global__ void measure_prob_one_finalize(
     if (tid == 0) result[0] = sdata[0];
 }
 
+// rdm_qubit: per-block reduction of the four 1q reduced-density-matrix sums over
+// amplitude pairs (i0, i1 = i0 | 1<<qubit): sum |a0|^2, sum |a1|^2, and sum
+// a1 * conj(a0) (re, im). Pair index p maps to i0 by inserting a zero bit at
+// `qubit`. Each block reduces 2*BLOCK_SIZE pairs into out_partials[4*blockIdx..].
+// Shared memory holds four blockDim.x columns.
+
+extern "C" __global__ void rdm_qubit(
+    const double2 *state, unsigned long long pairs, int qubit, double *out_partials)
+{
+    extern __shared__ double sdata[];
+    double *s0 = sdata;
+    double *s1 = sdata + blockDim.x;
+    double *sr = sdata + 2 * blockDim.x;
+    double *si = sdata + 3 * blockDim.x;
+    unsigned long long tid = threadIdx.x;
+    unsigned long long low_mask = (1ULL << qubit) - 1ULL;
+    double p0 = 0.0, p1 = 0.0, rr = 0.0, ri = 0.0;
+    unsigned long long p = (unsigned long long)blockIdx.x * (blockDim.x * 2) + tid;
+    for (int rep = 0; rep < 2; ++rep) {
+        if (p < pairs) {
+            unsigned long long i0 = ((p & ~low_mask) << 1) | (p & low_mask);
+            double2 a0 = state[i0];
+            double2 a1 = state[i0 | (1ULL << qubit)];
+            p0 += a0.x*a0.x + a0.y*a0.y;
+            p1 += a1.x*a1.x + a1.y*a1.y;
+            rr += a1.x*a0.x + a1.y*a0.y;
+            ri += a1.y*a0.x - a1.x*a0.y;
+        }
+        p += blockDim.x;
+    }
+    s0[tid] = p0; s1[tid] = p1; sr[tid] = rr; si[tid] = ri;
+    __syncthreads();
+    for (unsigned long long stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s0[tid] += s0[tid + stride];
+            s1[tid] += s1[tid + stride];
+            sr[tid] += sr[tid + stride];
+            si[tid] += si[tid + stride];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        out_partials[4 * blockIdx.x + 0] = s0[0];
+        out_partials[4 * blockIdx.x + 1] = s1[0];
+        out_partials[4 * blockIdx.x + 2] = sr[0];
+        out_partials[4 * blockIdx.x + 3] = si[0];
+    }
+}
+
+// Single-block reduction of the four-column partials (length 4*count) into
+// result[0..4]. Same shape as measure_prob_one_finalize; replaces a
+// 4*num_blocks-element D2H plus a host sum with one 32-byte D2H.
+extern "C" __global__ void rdm_qubit_finalize(
+    const double *partials, unsigned int count, double *result)
+{
+    extern __shared__ double sdata[];
+    double *s0 = sdata;
+    double *s1 = sdata + blockDim.x;
+    double *sr = sdata + 2 * blockDim.x;
+    double *si = sdata + 3 * blockDim.x;
+    unsigned int tid = threadIdx.x;
+    double p0 = 0.0, p1 = 0.0, rr = 0.0, ri = 0.0;
+    for (unsigned int i = tid; i < count; i += blockDim.x) {
+        p0 += partials[4 * i + 0];
+        p1 += partials[4 * i + 1];
+        rr += partials[4 * i + 2];
+        ri += partials[4 * i + 3];
+    }
+    s0[tid] = p0; s1[tid] = p1; sr[tid] = rr; si[tid] = ri;
+    __syncthreads();
+    for (unsigned int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            s0[tid] += s0[tid + stride];
+            s1[tid] += s1[tid + stride];
+            sr[tid] += sr[tid + stride];
+            si[tid] += si[tid + stride];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        result[0] = s0[0];
+        result[1] = s1[0];
+        result[2] = sr[0];
+        result[3] = si[0];
+    }
+}
+
 // measure_collapse: zero amplitudes where qubit bit != outcome.
 // Launch over 2^n threads, block size BLOCK_SIZE.
 
@@ -1251,6 +1338,100 @@ pub(crate) fn measure_prob_one(ctx: &GpuContext, state: &GpuState, qubit: usize)
     let prob_raw = host_result[0];
     let norm_sq = state.pending_norm() * state.pending_norm();
     Ok((prob_raw * norm_sq).clamp(0.0, 1.0))
+}
+
+/// One-qubit reduced density matrix from the device state, `pending_norm²`
+/// applied. Two reduction launches and a 32-byte readback replace the
+/// full-state export the host fallback would need.
+pub(crate) fn reduced_density_matrix_1q(
+    ctx: &GpuContext,
+    state: &GpuState,
+    qubit: usize,
+) -> Result<[[Complex64; 2]; 2]> {
+    let n = state.num_qubits();
+    if qubit >= n {
+        return Err(PrismError::InvalidQubit {
+            index: qubit,
+            register_size: n,
+        });
+    }
+    let pairs: u64 = 1u64 << (n - 1);
+    let elems_per_block = 2u64 * BLOCK_SIZE as u64;
+    let num_blocks = pairs.div_ceil(elems_per_block).max(1) as u32;
+
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let stage1 = device.function("rdm_qubit")?;
+    let stage2 = device.function("rdm_qubit_finalize")?;
+    let shared_bytes = 4 * BLOCK_SIZE * std::mem::size_of::<f64>() as u32;
+    let stage1_cfg = LaunchConfig {
+        grid_dim: (num_blocks, 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: shared_bytes,
+    };
+    let stage2_cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: shared_bytes,
+    };
+
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let partials = super::ensure_capacity(
+        &mut scratch.measure_partials,
+        device,
+        4 * num_blocks as usize,
+    )?;
+
+    let qubit_i = qubit as i32;
+    {
+        let mut builder = stream.launch_builder(&stage1);
+        let state_buf = state.buffer().raw();
+        builder
+            .arg(state_buf)
+            .arg(&pairs)
+            .arg(&qubit_i)
+            .arg(partials.raw_mut());
+        // SAFETY: signature matches kernel; num_blocks * 2*BLOCK_SIZE covers pairs and
+        // out_partials holds 4*num_blocks f64s.
+        unsafe {
+            builder
+                .launch(stage1_cfg)
+                .map_err(|e| launch_err("rdm_qubit", e))?;
+        }
+    }
+
+    let result = super::ensure_capacity(&mut scratch.rdm_result, device, 4)?;
+    let count_u32 = num_blocks;
+    {
+        let mut builder = stream.launch_builder(&stage2);
+        builder
+            .arg(scratch.measure_partials.as_ref().unwrap().raw())
+            .arg(&count_u32)
+            .arg(result.raw_mut());
+        // SAFETY: signature matches kernel; one block of BLOCK_SIZE threads, grid-stride
+        // loop over `count_u32` four-column partials. Both buffers held by the scratch guard.
+        unsafe {
+            builder
+                .launch(stage2_cfg)
+                .map_err(|e| launch_err("rdm_qubit_finalize", e))?;
+        }
+    }
+
+    let mut host_result = [0.0_f64; 4];
+    scratch
+        .rdm_result
+        .as_ref()
+        .unwrap()
+        .copy_to_host(device, &mut host_result[..])?;
+    let norm_sq = state.pending_norm() * state.pending_norm();
+    let p0 = host_result[0] * norm_sq;
+    let p1 = host_result[1] * norm_sq;
+    let r = Complex64::new(host_result[2], host_result[3]) * norm_sq;
+    Ok([
+        [Complex64::new(p0, 0.0), r.conj()],
+        [r, Complex64::new(p1, 0.0)],
+    ])
 }
 
 /// Zeroes the losing branch only; renormalization is deferred to the caller

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -84,6 +84,9 @@ pub(crate) struct LauncherScratch {
     pub(crate) measure_partials: Option<GpuBuffer<f64>>,
     /// One-element output for the measure-prob finalize reduction.
     pub(crate) measure_result: Option<GpuBuffer<f64>>,
+    /// Four-element output for the reduced-density-matrix finalize reduction.
+    /// Separate from `measure_result`: readback length must match the buffer.
+    pub(crate) rdm_result: Option<GpuBuffer<f64>>,
 }
 
 /// Ensure `slot` has at least `host.len()` elements allocated, growing if not,
@@ -162,6 +165,8 @@ pub(crate) const KERNEL_NAMES: &[&str] = &[
     "apply_fused_2q",
     "measure_prob_one",
     "measure_prob_one_finalize",
+    "rdm_qubit",
+    "rdm_qubit_finalize",
     "measure_collapse",
     "compute_probabilities",
     "apply_multi_fused_diagonal",

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -192,7 +192,8 @@ impl GpuContext {
         self.device.vram_available()
     }
 
-    /// Maximum qubit count for a dense Complex64 statevector on this device.
+    /// Maximum qubit count for a dense Complex64 statevector in the currently
+    /// free VRAM of this device.
     pub fn max_qubits_for_statevector(&self) -> Result<usize> {
         self.device.max_qubits_for_statevector()
     }

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -2457,3 +2457,190 @@ fn auto_gpu_noisy_trajectories_match_cpu_auto() {
         );
     }
 }
+
+#[test]
+fn over_vram_init_reports_the_device_budget() {
+    let Some(f) = Fixture::try_new() else { return };
+    let over = f.ctx.max_qubits_for_statevector().unwrap() + 1;
+    let mut backend = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    match backend.init(over, 0).unwrap_err() {
+        prism_q::PrismError::IncompatibleBackend { backend, reason } => {
+            assert_eq!(backend, "statevector-gpu");
+            assert!(
+                reason.contains("free on the GPU"),
+                "expected the budget message, got: {reason}"
+            );
+            assert!(reason.contains(&format!("{over} qubits")));
+        }
+        other => panic!("expected the device budget error, got {other:?}"),
+    }
+}
+
+#[test]
+fn statevector_vram_advisory_tracks_free_memory() {
+    let Some(f) = Fixture::try_new() else { return };
+    let max = f.ctx.max_qubits_for_statevector().unwrap();
+    assert!(!f.ctx.fits_statevector(max + 1).unwrap());
+}
+
+fn rx_cx_t_instructions(n: usize) -> Vec<Instruction> {
+    let mut circuit = prism_q::Circuit::new(n, 0);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3 + 0.1 * q as f64), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        circuit.add_gate(Gate::T, &[q]);
+    }
+    circuit.instructions
+}
+
+#[test]
+fn gpu_reduced_density_matrix_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 10;
+    let mut cpu = StatevectorBackend::new(42);
+    cpu.init(n, 0).unwrap();
+    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    gpu.init(n, 0).unwrap();
+    for inst in &rx_cx_t_instructions(n) {
+        cpu.apply(inst).unwrap();
+        gpu.apply(inst).unwrap();
+    }
+    for q in 0..n {
+        let c = cpu.reduced_density_matrix_1q(q).unwrap();
+        let g = gpu.reduced_density_matrix_1q(q).unwrap();
+        for (i, row) in c.iter().enumerate() {
+            for (j, want) in row.iter().enumerate() {
+                let diff = (want - g[i][j]).norm();
+                assert!(
+                    diff < EPS,
+                    "qubit {q} rho[{i}][{j}]: cpu={want}, gpu={}",
+                    g[i][j]
+                );
+            }
+        }
+        let trace = g[0][0].re + g[1][1].re;
+        assert!((trace - 1.0).abs() < EPS, "qubit {q} trace={trace}");
+    }
+}
+
+#[test]
+fn gpu_reduced_density_matrix_after_measurement_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 10;
+    let mut cpu = StatevectorBackend::new(42);
+    cpu.init(n, 1).unwrap();
+    let mut gpu = StatevectorBackend::new(42).with_gpu(f.ctx.clone());
+    gpu.init(n, 1).unwrap();
+    let mut instructions = rx_cx_t_instructions(n);
+    instructions.push(Instruction::Measure {
+        qubit: 0,
+        classical_bit: 0,
+    });
+    for inst in &instructions {
+        cpu.apply(inst).unwrap();
+        gpu.apply(inst).unwrap();
+    }
+    assert_eq!(cpu.classical_results(), gpu.classical_results());
+    for q in 0..n {
+        let c = cpu.reduced_density_matrix_1q(q).unwrap();
+        let g = gpu.reduced_density_matrix_1q(q).unwrap();
+        for (i, row) in c.iter().enumerate() {
+            for (j, want) in row.iter().enumerate() {
+                let diff = (want - g[i][j]).norm();
+                assert!(
+                    diff < EPS,
+                    "qubit {q} rho[{i}][{j}]: cpu={want}, gpu={}",
+                    g[i][j]
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn statevector_gpu_custom_kraus_trajectories_match_cpu() {
+    use prism_q::{BackendKind, NoiseChannel, NoiseEvent, NoiseModel, simulate};
+
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 10;
+    let num_shots = 400;
+    let mut circuit = prism_q::Circuit::new(n, n);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    circuit.measure_all();
+
+    let gamma: f64 = 0.05;
+    let zero = Complex64::new(0.0, 0.0);
+    let kraus = vec![
+        [
+            [Complex64::new(1.0, 0.0), zero],
+            [zero, Complex64::new((1.0 - gamma).sqrt(), 0.0)],
+        ],
+        [[zero, Complex64::new(gamma.sqrt(), 0.0)], [zero, zero]],
+    ];
+    let after_gate = circuit
+        .instructions
+        .iter()
+        .map(|inst| match inst {
+            Instruction::Gate { targets, .. } => vec![NoiseEvent {
+                channel: NoiseChannel::Custom {
+                    kraus: kraus.clone(),
+                },
+                qubits: std::iter::once(targets[0]).collect(),
+            }],
+            _ => Vec::new(),
+        })
+        .collect();
+    let noise = NoiseModel {
+        after_gate,
+        readout: vec![None; n],
+    };
+
+    let cpu = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+    let gpu = simulate(&circuit)
+        .backend(BackendKind::StatevectorGpu {
+            context: f.ctx.clone(),
+        })
+        .noise(&noise)
+        .seed(42)
+        .shots(num_shots)
+        .unwrap();
+
+    let freq = |shots: &[Vec<bool>]| -> Vec<f64> {
+        let mut ones = vec![0usize; n];
+        for shot in shots {
+            for (q, one_count) in ones.iter_mut().enumerate() {
+                if shot[q] {
+                    *one_count += 1;
+                }
+            }
+        }
+        ones.into_iter()
+            .map(|c| c as f64 / shots.len() as f64)
+            .collect()
+    };
+    let cpu_freq = freq(&cpu.shots);
+    let gpu_freq = freq(&gpu.shots);
+    for q in 0..n {
+        let diff = (cpu_freq[q] - gpu_freq[q]).abs();
+        assert!(
+            diff < 0.15,
+            "qubit {q}: cpu freq={}, gpu freq={}, diff={diff}",
+            cpu_freq[q],
+            gpu_freq[q]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A Custom Kraus noise event on the GPU statevector read the full state back to
host per event, 99% of a trajectory shot at 20 qubits, leaving the device path
3.8x slower than the CPU statevector. A two-stage device reduction removes the
readback. On the distributed backend, the direct-exchange paths shipped more
than they consumed and every batched payload was deep-cloned per application;
each path now packs or batches to what it consumes, and payloads are borrowed
when their indices are unmapped. The device memory-budget contract also moves
to the right budget: an over-VRAM statevector fails at `init` with an error
naming the request and the free VRAM instead of the raw driver error.

## Scope

- [x] Performance improvement

## Benchmarks

Full Criterion tier, sample_size 30, quiet host (i7-6700K, GTX 1080 Ti,
rustc 1.97.0). The rows are new with this PR, so the before side comes from
the same bench targets run against the pre-change tree in adjacent builds on
the same host: the adjacent-binary method behind `scripts/bench_ab.sh`, run by
hand because the rows do not exist on the base commit.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `gpu/noisy_kraus_d10/20` (2 shots) | 5.466 s | 0.167 s | -96.9% | CPU sibling row moved +17.4%, see below | yes, improvement 30x the control spread |
| `distributed/steady_state_batched/16` | 12.89 ms | 7.77 ms | -47.4% | after-side repeats 8.53 / 7.77 ms (9%) | yes |
| `distributed/boundary_swap_direct/18` | 27.19 ms | 19.05 ms | -32.9% | after-side repeats 15.14 / 19.05 ms (23%) | timing exceeds its spread; the halved volume is pinned exactly by the counter test |
| `distributed/controlled_star_direct/18` | 20.75 ms | 11.12 ms | -43.2% | after-side repeats 11.25 / 11.12 ms (1%) | yes |

The control row `gpu_noisy_cpu/kraus_d10/20` runs code this diff cannot reach
and moved +17.4% (1.452 s to 1.705 s) immediately after the GPU-heavy row; a
reading between the two runs was 1.67 s, so the spread reads as sustained-load
thermals, not a code effect. The `gpu/random_d10` sweep re-read post-change
with no anomalies (42.9 us at 10q to 55.9 ms at 22q).

Component timing on the same host: the reduced-density-matrix readback was
11.4 ms/event at 20q (44.7 ms at 22q) and is 0.1 ms/event after the change;
noisy GPU shots go from 2.77 s to 89 ms at 20q, 10.5x faster than the CPU
statevector on the same circuit.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
      (2209 tests, `golden_gpu` 72/72 under `PRISM_REQUIRE_GPU=1`, zero skips)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes (also run with `bench-internal` so the new bench target is linted)
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry
- [x] New kernel has golden tests against the statevector backend:
      `gpu_reduced_density_matrix_matches_cpu`,
      `gpu_reduced_density_matrix_after_measurement_matches_cpu`, and
      `statevector_gpu_custom_kraus_trajectories_match_cpu`
- [x] GPU-affecting change runs `cargo test --features "parallel gpu" --test golden_gpu`

Four new exchange-counter tests pin the distributed traffic cuts exactly:
half-slice boundary SWAP, `len/2^k` controlled sublattice, zero-exchange
diagonal Cu/Mcu in both relabel modes, and one exchange per same-partner
Multi2q run.

## Hotspot notes

- `reduced_density_matrix_1q` (GPU arm): was `export_statevector` (a `2^n`
  amplitude readback plus a host reduce per Kraus event), now the
  `rdm_qubit` / `rdm_qubit_finalize` reduction pair with a 32-byte readback.
- Distributed exchange paths: `apply_swap_dist` mixed arm (now the shared
  `half_slice_swap`), `apply_global_controlled_1q` (sublattice pack),
  `apply_controlled_dist` (diagonal arm), `apply_global_multi_qubit`
  (same-partner run batching via `apply_2q_run_one_global`), `to_physical`
  and the local dispatch (payload clones removed).

## Breaking changes

- The hard GPU statevector path (`StatevectorGpu`, `with_gpu`) reports an
  over-VRAM state as `IncompatibleBackend` naming the requested and free
  device memory; previously it surfaced the raw driver error text.
- `GpuContext::max_qubits_for_statevector` reports the advisory from free
  VRAM instead of total, so its value can move between calls.
- A circuit above the host `PRISM_MAX_SV_QUBITS` cap that fits VRAM now runs
  on the hard device path instead of erroring: the host vector is never
  allocated there, so the host cap no longer gates it.

## Risks and rollback

- The mirrored run update in `apply_2q_run_one_global` keeps a lockstep copy
  of the partner slice; sums run in canonical basis order so both ranks stay
  bit-identical. The counter test and the loopback correctness sweeps pin it
  at 2 and 4 ranks, and the path is reachable only in direct-exchange mode
  (relabeling off or victim starvation).
- GPU changes sit behind the `gpu` feature and explicit opt-in backend kinds;
  host paths are untouched.
- The two commits revert independently: the GPU commit carries the kernel and
  budget contract, the distributed commit carries the exchange and dispatch
  changes including the `dispatch_gate` visibility it needs.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed as an issue or noted above
- [x] No secrets, credentials, or local config added
- [x] No new dependencies without a rationale
- [ ] CI is green
