### PR TITLE
feat(backend): bound the sparse, MPS, and factored growth paths

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -48,6 +48,14 @@ through dispatch.
 | Dense probability output | `PRISM_MAX_PROB_QUBITS` | Same budget over `f64` |
 | Dense statevector export | `PRISM_MAX_EXPORT_QUBITS` | Same budget over `Complex64` |
 | Dense outcome sampling | `PRISM_MAX_DENSE_OUTCOME_BITS` | Same budget over two `f64` per outcome |
+| Sparse entry count | `PRISM_MAX_SPARSE_QUBITS` (the map holds at most `2^q` entries) | Same budget at 64 bytes per entry across the double-buffered maps |
+| Factored merged-block width | `PRISM_MAX_FACTORED_MERGE_QUBITS` | Same budget over `Complex64` |
+| MPS gate workspace | `PRISM_MAX_MPS_WORKSPACE_QUBITS` (at most `2^q` amplitudes of live contraction buffers) | Same budget over `Complex64` |
+
+The three growth caps are deliberately independent of `PRISM_MAX_SV_QUBITS`: the sparse,
+factored, and MPS backends exist to run above the statevector cap, so lowering that cap
+to steer routing must not shrink what they may hold. Their defaults come from the same
+detected-memory budget.
 
 The density-matrix cap is the tighter of its own override and half the statevector cap,
 computed in one place so dispatch-time validation and the backend's `init` guard cannot
@@ -64,9 +72,15 @@ restricted to circuits below 14 qubits, where a statevector replica is 256 KiB a
 thread pool stays in the tens of megabytes. Above it trajectories run serially with one
 live backend, bounded by the ordinary state cap.
 
-Three growth paths are not yet bounded and can still exhaust memory on an adversarial
-input: MPS bond dimension when `max_bond_dim` is set very high, sparse-state entry count
-when a circuit densifies, and the transient peak inside a factored sub-state merge.
+The three growth paths that once sat outside this contract are bounded at their growth
+events, each rejecting with an error naming its own backend before the allocation: a
+factored sub-state merge checks the merged block width against the statevector cap, the
+sparse map checks a branching gate's worst-case fan-out against the entry cap (so a
+rejection can fire one gate early on a state that would have deduplicated below it), and
+MPS gate application checks its live contraction-buffer total against the statevector
+budget. The MPS check bounds the workspace, not `max_bond_dim` itself: a large cap on a
+circuit whose bonds stay small is fine, and the rejection fires only when the bonds
+actually grow past what memory holds.
 
 ## Statevector
 

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -97,8 +97,9 @@ impl FactoredBackend {
     }
 
     /// Ensure all target qubits reside in the same sub-state, merging as needed.
-    /// Returns the sub-state index containing all targets.
-    fn ensure_same_substate(&mut self, targets: &[usize]) -> usize {
+    /// Returns the sub-state index containing all targets, or the memory-budget
+    /// error when a merge would need a dense block over the statevector cap.
+    fn ensure_same_substate(&mut self, targets: &[usize]) -> Result<usize> {
         let first_ss = self.qubit_to_substate[targets[0]];
         let mut need_merge: SmallVec<[usize; 4]> = SmallVec::new();
 
@@ -110,10 +111,38 @@ impl FactoredBackend {
         }
 
         for other_ss in need_merge {
-            self.merge_substates(first_ss, other_ss);
+            self.merge_substates(first_ss, other_ss)?;
         }
 
-        first_ss
+        Ok(first_ss)
+    }
+
+    /// Reject a merge whose dense block would exceed the statevector budget.
+    /// The transient peak also holds both source blocks, but they are bounded
+    /// by prior merges through this same gate, so the merged width carries the
+    /// contract.
+    fn check_merge_allocation(total_n: usize) -> Result<()> {
+        if total_n >= usize::BITS as usize {
+            return Err(crate::error::PrismError::IncompatibleBackend {
+                backend: "factored".to_string(),
+                reason: format!(
+                    "merging entangled sub-states needs a {total_n}-qubit dense block, \
+                     exceeding addressable memory"
+                ),
+            });
+        }
+        let cap = crate::backend::max_factored_merge_qubits();
+        if total_n > cap {
+            return Err(crate::error::PrismError::IncompatibleBackend {
+                backend: "factored".to_string(),
+                reason: format!(
+                    "merging entangled sub-states needs a {total_n}-qubit dense block, \
+                     exceeding the cap of {cap} on this machine \
+                     (set PRISM_MAX_FACTORED_MERGE_QUBITS to override)"
+                ),
+            });
+        }
+        Ok(())
     }
 
     /// Merge sub-state `src_idx` into `dst_idx` via tensor product.
@@ -122,13 +151,14 @@ impl FactoredBackend {
     /// also has sorted qubits. When one set of qubits is wholly less than the
     /// other, the kernel reduces to a SIMD-friendly Kronecker product with a
     /// contiguous inner loop. The interleaved case falls back to scalar scatter.
-    fn merge_substates(&mut self, dst_idx: usize, src_idx: usize) {
+    fn merge_substates(&mut self, dst_idx: usize, src_idx: usize) -> Result<()> {
+        let dst_n = self.substates[dst_idx].as_ref().unwrap().qubits.len();
+        let src_n = self.substates[src_idx].as_ref().unwrap().qubits.len();
+        let total_n = dst_n + src_n;
+        Self::check_merge_allocation(total_n)?;
+
         let src = self.substates[src_idx].take().unwrap();
         let dst = self.substates[dst_idx].as_ref().unwrap();
-
-        let dst_n = dst.qubits.len();
-        let src_n = src.qubits.len();
-        let total_n = dst_n + src_n;
         let total_dim = 1usize << total_n;
 
         let mut merged_qubits: SmallVec<[usize; 8]> = SmallVec::with_capacity(total_n);
@@ -172,6 +202,7 @@ impl FactoredBackend {
         for &q in &src.qubits {
             self.qubit_to_substate[q] = dst_idx;
         }
+        Ok(())
     }
 
     /// Central gate dispatch. Translates global qubit indices to local and
@@ -186,7 +217,7 @@ impl FactoredBackend {
         if let Gate::Multi2q(data) = gate {
             for &(q0, q1, ref mat) in &data.gates {
                 let tgts = [q0, q1];
-                let ss_idx = self.ensure_same_substate(&tgts);
+                let ss_idx = self.ensure_same_substate(&tgts)?;
                 let sub = self.substates[ss_idx].as_mut().unwrap();
                 let lq0 = Self::local_qubit(sub, q0);
                 let lq1 = Self::local_qubit(sub, q1);
@@ -206,9 +237,9 @@ impl FactoredBackend {
                     all_qubits.push(q);
                 }
             }
-            self.ensure_same_substate(&all_qubits)
+            self.ensure_same_substate(&all_qubits)?
         } else {
-            self.ensure_same_substate(targets)
+            self.ensure_same_substate(targets)?
         };
 
         #[cfg(feature = "parallel")]

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -93,6 +93,83 @@ pub(crate) fn max_dense_outcome_bits() -> usize {
     })
 }
 
+/// Entry cap for the sparse backend's amplitude map.
+///
+/// Derived from the memory budget at 64 bytes per entry, the worst-case peak
+/// across the double-buffered maps (24 payload bytes, table slot overhead, and
+/// load-factor headroom on both buffers). `PRISM_MAX_SPARSE_QUBITS` overrides
+/// the cap as a power of two: the map may hold at most `2^q` entries.
+pub(crate) fn max_sparse_entries() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let q =
+            configured_or_detected_dense_qubits("PRISM_MAX_SPARSE_QUBITS", 64, "sparse entry cap");
+        if q >= usize::BITS as usize - 1 {
+            usize::MAX
+        } else {
+            1usize << q
+        }
+    })
+}
+
+/// Merged-block qubit cap for the factored backend, checked at merge time.
+///
+/// Defaults to the detected-memory dense budget, independent of the
+/// statevector override: lowering `PRISM_MAX_SV_QUBITS` to steer routing must
+/// not shrink the block a factored run may legitimately hold.
+pub(crate) fn max_factored_merge_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_FACTORED_MERGE_QUBITS",
+            size_of::<Complex64>(),
+            "factored merge cap",
+        )
+    })
+}
+
+/// Workspace cap for MPS gate application, as `2^q` amplitudes of live
+/// contraction buffers. Independent of the statevector override for the same
+/// reason as the factored merge cap: MPS exists to run above that cap.
+fn max_mps_workspace_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        configured_or_detected_dense_qubits(
+            "PRISM_MAX_MPS_WORKSPACE_QUBITS",
+            size_of::<Complex64>(),
+            "MPS workspace cap",
+        )
+    })
+}
+
+/// MPS workspace cap in amplitudes: `2^q` from the budget above, or
+/// `u128::MAX` when detection is disabled. Read once per backend at
+/// construction so the per-gate check is a field compare, not an atomic load.
+pub(crate) fn mps_workspace_cap_elements() -> u128 {
+    let cap = max_mps_workspace_qubits();
+    if cap >= u128::BITS as usize {
+        u128::MAX
+    } else {
+        1u128 << cap
+    }
+}
+
+/// Error for a dense transient workspace of `elements` amplitudes over the
+/// MPS workspace budget: the growth-path analogue of the
+/// [`check_state_allocation`] rejection, for scratch whose natural unit is
+/// amplitudes rather than circuit qubits.
+#[cold]
+pub(crate) fn workspace_allocation_error(backend: &str, what: &str, elements: u128) -> PrismError {
+    let cap = max_mps_workspace_qubits();
+    PrismError::IncompatibleBackend {
+        backend: backend.to_string(),
+        reason: format!(
+            "{what} needs {elements} amplitudes of workspace, exceeding the cap of \
+             2^{cap} on this machine (set PRISM_MAX_MPS_WORKSPACE_QUBITS to override)"
+        ),
+    }
+}
+
 fn configured_or_detected_dense_qubits(
     env_var: &str,
     bytes_per_basis_state: usize,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -188,8 +188,9 @@ pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 
 pub(crate) use memory::{
     DM_QUBIT_CAP_ENV, check_state_allocation, dense_probability_len, dense_statevector_len,
-    max_dense_outcome_bits, max_density_matrix_qubits, max_statevector_qubits,
-    reserve_dense_output, tensor_probability_len,
+    max_dense_outcome_bits, max_density_matrix_qubits, max_factored_merge_qubits,
+    max_sparse_entries, max_statevector_qubits, mps_workspace_cap_elements, reserve_dense_output,
+    tensor_probability_len, workspace_allocation_error,
 };
 
 /// Whether `phase` equals `1+0i` within [`PHASE_IS_ONE_EPS`].

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -506,6 +506,10 @@ pub struct MpsBackend {
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
     truncation_discarded: f64,
+    /// [`crate::backend::mps_workspace_cap_elements`] read once at
+    /// construction, so the per-gate check is a field compare rather than an
+    /// atomic load.
+    workspace_cap: u128,
 }
 
 impl MpsBackend {
@@ -521,6 +525,7 @@ impl MpsBackend {
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
             truncation_discarded: 0.0,
+            workspace_cap: crate::backend::mps_workspace_cap_elements(),
         }
     }
 
@@ -578,16 +583,17 @@ impl MpsBackend {
 
     /// Restore the internal MPS site order to logical qubit order without
     /// changing the represented logical state.
-    pub fn canonicalize_logical_order(&mut self) {
+    pub fn canonicalize_logical_order(&mut self) -> Result<()> {
         let swap_mat = swap_matrix_4x4();
         for target_site in 0..self.num_qubits {
             while self.site_to_logical[target_site] != target_site {
                 let logical = target_site;
                 let site = self.logical_to_site[logical];
                 debug_assert!(site > target_site);
-                self.apply_virtual_swap(site - 1, &swap_mat);
+                self.apply_virtual_swap(site - 1, &swap_mat)?;
             }
         }
+        Ok(())
     }
 
     /// Inner product between two MPS values that share the same site
@@ -792,9 +798,14 @@ impl MpsBackend {
         self.logical_to_site[right_logical] = left_site;
     }
 
-    fn apply_virtual_swap(&mut self, left_site: usize, swap_mat: &[[Complex64; 4]; 4]) {
-        self.apply_adjacent_two_qubit(swap_mat, left_site, true);
+    fn apply_virtual_swap(
+        &mut self,
+        left_site: usize,
+        swap_mat: &[[Complex64; 4]; 4],
+    ) -> Result<()> {
+        self.apply_adjacent_two_qubit(swap_mat, left_site, true)?;
         self.swap_layout_labels(left_site);
+        Ok(())
     }
 
     #[inline(always)]
@@ -815,11 +826,23 @@ impl MpsBackend {
         gate: &[[Complex64; 4]; 4],
         left_site: usize,
         left_is_first_qubit: bool,
-    ) {
+    ) -> Result<()> {
         let right_site = left_site + 1;
         let bl = self.sites[left_site].bond_left;
         let bond_mid = self.sites[left_site].bond_right;
         let br = self.sites[right_site].bond_right;
+
+        // Live contraction buffers: theta, theta_prime, and the SVD input plus
+        // its internals at 4*bl*br each (about five at peak), and the right
+        // transpose at 2*bond_mid*br.
+        let workspace = 20u128 * bl as u128 * br as u128 + 2u128 * bond_mid as u128 * br as u128;
+        if workspace > self.workspace_cap {
+            return Err(crate::backend::workspace_allocation_error(
+                "mps",
+                "two-qubit gate application",
+                workspace,
+            ));
+        }
 
         let g = if left_is_first_qubit {
             *gate
@@ -1004,9 +1027,15 @@ impl MpsBackend {
             bond_right: br,
             data: right_data,
         };
+        Ok(())
     }
 
-    fn apply_two_qubit_gate(&mut self, gate: &[[Complex64; 4]; 4], q0: usize, q1: usize) {
+    fn apply_two_qubit_gate(
+        &mut self,
+        gate: &[[Complex64; 4]; 4],
+        q0: usize,
+        q1: usize,
+    ) -> Result<()> {
         let p0 = self.site_for_logical(q0);
         let p1 = self.site_for_logical(q1);
         let k = p0.min(p1);
@@ -1014,29 +1043,33 @@ impl MpsBackend {
         let left_is_first = p0 < p1;
 
         if m - k == 1 {
-            self.apply_adjacent_two_qubit(gate, k, left_is_first);
+            self.apply_adjacent_two_qubit(gate, k, left_is_first)?;
         } else {
             let swap_mat = swap_matrix_4x4();
             for s in (k + 1..m).rev() {
-                self.apply_virtual_swap(s, &swap_mat);
+                self.apply_virtual_swap(s, &swap_mat)?;
             }
-            self.apply_adjacent_two_qubit(gate, k, left_is_first);
+            self.apply_adjacent_two_qubit(gate, k, left_is_first)?;
         }
+        Ok(())
     }
 
     /// Apply BatchPhase via bubble routing: sweep control toward targets,
     /// applying each CU-phase+SWAP as a single 2-site operation. O(k) tensor
     /// ops instead of O(k²) for k non-adjacent phases.
-    fn apply_batch_phase_bubble(&mut self, control: usize, phases: &[(usize, Complex64)]) {
+    fn apply_batch_phase_bubble(
+        &mut self,
+        control: usize,
+        phases: &[(usize, Complex64)],
+    ) -> Result<()> {
         if phases.is_empty() {
-            return;
+            return Ok(());
         }
         if phases.len() == 1 {
             let (target, phase) = phases[0];
             let mat = [[ONE, ZERO], [ZERO, phase]];
             let g = cu_matrix_4x4(&mat);
-            self.apply_two_qubit_gate(&g, control, target);
-            return;
+            return self.apply_two_qubit_gate(&g, control, target);
         }
 
         let mut right: Vec<(usize, Complex64)> = Vec::new();
@@ -1059,22 +1092,22 @@ impl MpsBackend {
             let last_idx = right.len() - 1;
             for (idx, &(target, phase)) in right.iter().enumerate() {
                 while cur_pos + 1 < target {
-                    self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true);
+                    self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true)?;
                     cur_pos += 1;
                 }
                 if idx < last_idx {
                     let combined = cu_phase_swap_matrix(phase);
-                    self.apply_adjacent_two_qubit(&combined, cur_pos, true);
+                    self.apply_adjacent_two_qubit(&combined, cur_pos, true)?;
                     cur_pos += 1;
                 } else {
                     let mat = [[ONE, ZERO], [ZERO, phase]];
                     let g = cu_matrix_4x4(&mat);
-                    self.apply_adjacent_two_qubit(&g, cur_pos, true);
+                    self.apply_adjacent_two_qubit(&g, cur_pos, true)?;
                 }
             }
             while cur_pos > control {
                 cur_pos -= 1;
-                self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true);
+                self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true)?;
             }
         }
 
@@ -1085,23 +1118,24 @@ impl MpsBackend {
             for (idx, &(target, phase)) in left.iter().enumerate() {
                 while cur_pos > target + 1 {
                     cur_pos -= 1;
-                    self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true);
+                    self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true)?;
                 }
                 if idx < last_idx {
                     let combined = cu_phase_swap_matrix(phase);
-                    self.apply_adjacent_two_qubit(&combined, cur_pos - 1, true);
+                    self.apply_adjacent_two_qubit(&combined, cur_pos - 1, true)?;
                     cur_pos -= 1;
                 } else {
                     let mat = [[ONE, ZERO], [ZERO, phase]];
                     let g = cu_matrix_4x4(&mat);
-                    self.apply_adjacent_two_qubit(&g, cur_pos - 1, false);
+                    self.apply_adjacent_two_qubit(&g, cur_pos - 1, false)?;
                 }
             }
             while cur_pos < control {
-                self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true);
+                self.apply_adjacent_two_qubit(&swap_mat, cur_pos, true)?;
                 cur_pos += 1;
             }
         }
+        Ok(())
     }
 
     /// Contract N adjacent site tensors into Θ with shape (χ_left, 2^N, χ_right).
@@ -1346,18 +1380,43 @@ impl MpsBackend {
         }
     }
 
-    fn apply_adjacent_n_qubit(&mut self, gate: &[Complex64], dim: usize, start_site: usize) {
+    fn apply_adjacent_n_qubit(
+        &mut self,
+        gate: &[Complex64],
+        dim: usize,
+        start_site: usize,
+    ) -> Result<()> {
         let n = dim.trailing_zeros() as usize; // dim = 2^n
+        // Contraction, gate application, and decomposition each hold a
+        // (bl, 2^n, br) tensor, with the decomposition remainder and SVD input
+        // making about four live at peak.
+        let bl = self.sites[start_site].bond_left;
+        let br = self.sites[start_site + n - 1].bond_right;
+        let workspace = 4u128 * dim as u128 * bl as u128 * br as u128;
+        if workspace > self.workspace_cap {
+            return Err(crate::backend::workspace_allocation_error(
+                "mps",
+                "multi-qubit gate application",
+                workspace,
+            ));
+        }
+
         let (theta, bl, br) = self.contract_n_sites(start_site, n);
         let theta_prime = Self::apply_gate_to_theta(&theta, gate, dim, bl, br);
         self.decompose_n_sites(&theta_prime, start_site, n, bl, br);
+        Ok(())
     }
 
     /// Apply an N-qubit gate to arbitrary (possibly non-adjacent) qubits.
     ///
     /// SWAP-routes qubits into a contiguous block, applies the gate, then
     /// reverses the SWAPs. Returns nothing; modifies `self.sites` in place.
-    fn apply_n_qubit_gate(&mut self, gate: &[Complex64], dim: usize, qubits: &[usize]) {
+    fn apply_n_qubit_gate(
+        &mut self,
+        gate: &[Complex64],
+        dim: usize,
+        qubits: &[usize],
+    ) -> Result<()> {
         let n = qubits.len();
         debug_assert_eq!(dim, 1 << n);
 
@@ -1376,7 +1435,7 @@ impl MpsBackend {
         if contiguous {
             let qubit_order: Vec<usize> = indexed.iter().map(|&(_, role)| role).collect();
             let reordered_gate = Self::reorder_n_gate(gate, dim, &qubit_order, n);
-            self.apply_adjacent_n_qubit(&reordered_gate, dim, start);
+            self.apply_adjacent_n_qubit(&reordered_gate, dim, start)?;
         } else {
             let swap_mat = swap_matrix_4x4();
             let mut current_positions = sorted_positions;
@@ -1386,7 +1445,7 @@ impl MpsBackend {
                 let target_pos = start + i;
                 while current_positions[i] > target_pos {
                     let s = current_positions[i] - 1;
-                    self.apply_adjacent_two_qubit(&swap_mat, s, true);
+                    self.apply_adjacent_two_qubit(&swap_mat, s, true)?;
                     swap_log.push(s);
                     // Update any tracked qubit that was displaced
                     for cp in &mut current_positions[(i + 1)..n] {
@@ -1400,12 +1459,13 @@ impl MpsBackend {
 
             let qubit_order: Vec<usize> = indexed.iter().map(|&(_, role)| role).collect();
             let reordered_gate = Self::reorder_n_gate(gate, dim, &qubit_order, n);
-            self.apply_adjacent_n_qubit(&reordered_gate, dim, start);
+            self.apply_adjacent_n_qubit(&reordered_gate, dim, start)?;
 
             for &s in swap_log.iter().rev() {
-                self.apply_adjacent_two_qubit(&swap_mat, s, true);
+                self.apply_adjacent_two_qubit(&swap_mat, s, true)?;
             }
         }
+        Ok(())
     }
 
     /// Reorder an N-qubit gate matrix to match the physical qubit ordering.
@@ -1999,27 +2059,27 @@ impl MpsBackend {
         self.expand_subtree(0, 0, &mut scratch, &mut |idx, amp| out[idx] = convert(amp));
     }
 
-    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
+    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         match gate {
             Gate::Rzz(_) => {
                 let g = gate.matrix_4x4();
-                self.apply_two_qubit_gate(&g, targets[0], targets[1]);
+                self.apply_two_qubit_gate(&g, targets[0], targets[1])?;
             }
             Gate::Cx => {
                 let g = cx_matrix_4x4();
-                self.apply_two_qubit_gate(&g, targets[0], targets[1]);
+                self.apply_two_qubit_gate(&g, targets[0], targets[1])?;
             }
             Gate::Cz => {
                 let g = cz_matrix_4x4();
-                self.apply_two_qubit_gate(&g, targets[0], targets[1]);
+                self.apply_two_qubit_gate(&g, targets[0], targets[1])?;
             }
             Gate::Swap => {
                 let g = swap_matrix_4x4();
-                self.apply_two_qubit_gate(&g, targets[0], targets[1]);
+                self.apply_two_qubit_gate(&g, targets[0], targets[1])?;
             }
             Gate::Cu(mat) => {
                 let g = cu_matrix_4x4(mat);
-                self.apply_two_qubit_gate(&g, targets[0], targets[1]);
+                self.apply_two_qubit_gate(&g, targets[0], targets[1])?;
             }
             Gate::Mcu(data) => {
                 let num_ctrl = data.num_controls as usize;
@@ -2031,7 +2091,7 @@ impl MpsBackend {
                 let dim = 1usize << n;
                 let role_order: Vec<usize> = (0..n).collect();
                 let gate_mat = mcu_matrix(num_ctrl, &data.mat, &role_order);
-                self.apply_n_qubit_gate(&gate_mat, dim, &all_qubits);
+                self.apply_n_qubit_gate(&gate_mat, dim, &all_qubits)?;
             }
             Gate::BatchPhase(data) => {
                 let control = self.site_for_logical(targets[0]);
@@ -2040,12 +2100,12 @@ impl MpsBackend {
                     .iter()
                     .map(|&(qubit, phase)| (self.site_for_logical(qubit), phase))
                     .collect();
-                self.apply_batch_phase_bubble(control, &phases);
+                self.apply_batch_phase_bubble(control, &phases)?;
             }
             Gate::BatchRzz(data) => {
                 for &(q0, q1, theta) in &data.edges {
                     let g = Gate::Rzz(theta).matrix_4x4();
-                    self.apply_two_qubit_gate(&g, q0, q1);
+                    self.apply_two_qubit_gate(&g, q0, q1)?;
                 }
             }
             Gate::DiagonalBatch(data) => {
@@ -2053,7 +2113,7 @@ impl MpsBackend {
                     if let Some((q, mat)) = entry.as_1q_matrix() {
                         self.apply_single_qubit_gate(self.site_for_logical(q), &mat);
                     } else if let Some((q0, q1, mat)) = entry.as_2q_matrix() {
-                        self.apply_two_qubit_gate(&mat, q0, q1);
+                        self.apply_two_qubit_gate(&mat, q0, q1)?;
                     }
                 }
             }
@@ -2063,11 +2123,11 @@ impl MpsBackend {
                 }
             }
             Gate::Fused2q(mat) => {
-                self.apply_two_qubit_gate(mat, targets[0], targets[1]);
+                self.apply_two_qubit_gate(mat, targets[0], targets[1])?;
             }
             Gate::Multi2q(data) => {
                 for &(q0, q1, ref mat) in &data.gates {
-                    self.apply_two_qubit_gate(mat, q0, q1);
+                    self.apply_two_qubit_gate(mat, q0, q1)?;
                 }
             }
             single_qubit => {
@@ -2075,6 +2135,7 @@ impl MpsBackend {
                 self.apply_single_qubit_gate(self.site_for_logical(targets[0]), &mat);
             }
         }
+        Ok(())
     }
 }
 
@@ -2107,7 +2168,7 @@ impl Backend for MpsBackend {
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         match instruction {
-            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets),
+            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
             Instruction::Measure {
                 qubit,
                 classical_bit,
@@ -2124,7 +2185,7 @@ impl Backend for MpsBackend {
                 targets,
             } => {
                 if condition.evaluate(&self.classical_bits) {
-                    self.dispatch_gate(gate, targets);
+                    self.dispatch_gate(gate, targets)?;
                 }
             }
         }

--- a/src/backend/mps_tests.rs
+++ b/src/backend/mps_tests.rs
@@ -615,7 +615,7 @@ fn canonicalize_logical_order_preserves_state() {
 
     let mut b = run_mps(&c);
     let before = b.export_statevector().unwrap();
-    b.canonicalize_logical_order();
+    b.canonicalize_logical_order().unwrap();
     assert_eq!(b.logical_to_site, vec![0, 1, 2, 3, 4, 5]);
     let after = b.export_statevector().unwrap();
     for (i, (a, e)) in after.iter().zip(&before).enumerate() {

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -62,6 +62,9 @@ pub struct SparseBackend {
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
     epsilon: f64,
+    /// [`crate::backend::max_sparse_entries`] read once at construction, so the
+    /// per-gate growth check is a field compare rather than an atomic load.
+    entry_cap: usize,
 }
 
 impl SparseBackend {
@@ -74,6 +77,7 @@ impl SparseBackend {
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
             epsilon: DEFAULT_EPSILON,
+            entry_cap: crate::backend::max_sparse_entries(),
         }
     }
 
@@ -83,12 +87,40 @@ impl SparseBackend {
         self.state.retain(|_, amp| amp.norm_sqr() >= eps);
     }
 
+    /// Reject a gate whose worst-case fan-out would grow the map past the
+    /// entry budget. `factor` is the per-source-entry fan-out of the caller
+    /// (2 for a branching 1q gate, 4 for a dense 2q), so rejection can fire
+    /// one gate early on a state that would have deduplicated below the cap.
     #[inline(always)]
-    fn apply_single_qubit(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
+    fn check_entry_growth(&self, factor: usize) -> Result<()> {
+        let projected = self.state.len().saturating_mul(factor);
+        if projected > self.entry_cap {
+            return Err(self.entry_growth_error(projected));
+        }
+        Ok(())
+    }
+
+    #[cold]
+    fn entry_growth_error(&self, projected: usize) -> crate::error::PrismError {
+        crate::error::PrismError::IncompatibleBackend {
+            backend: "sparse".to_string(),
+            reason: format!(
+                "state holds {} entries and this gate can reach {projected}, \
+                 exceeding the cap of {} entries on this machine \
+                 (set PRISM_MAX_SPARSE_QUBITS to override)",
+                self.state.len(),
+                self.entry_cap
+            ),
+        }
+    }
+
+    #[inline(always)]
+    fn apply_single_qubit(&mut self, target: usize, mat: [[Complex64; 2]; 2]) -> Result<()> {
         if is_diagonal_2x2(&mat) {
             self.apply_diagonal_1q(target, mat[0][0], mat[1][1]);
-            return;
+            return Ok(());
         }
+        self.check_entry_growth(2)?;
 
         let mask = 1usize << target;
         let zero = Complex64::new(0.0, 0.0);
@@ -105,6 +137,7 @@ impl SparseBackend {
 
         std::mem::swap(&mut self.state, &mut self.swap_buf);
         self.prune();
+        Ok(())
     }
 
     /// A diagonal 2x2 scales amplitudes in place: no partner entries, no map rebuild.
@@ -167,7 +200,8 @@ impl SparseBackend {
     }
 
     #[inline(always)]
-    fn apply_cu(&mut self, control: usize, target: usize, mat: [[Complex64; 2]; 2]) {
+    fn apply_cu(&mut self, control: usize, target: usize, mat: [[Complex64; 2]; 2]) -> Result<()> {
+        self.check_entry_growth(2)?;
         let ctrl_mask = 1usize << control;
         let tgt_mask = 1usize << target;
         let zero = Complex64::new(0.0, 0.0);
@@ -187,10 +221,17 @@ impl SparseBackend {
 
         std::mem::swap(&mut self.state, &mut self.swap_buf);
         self.prune();
+        Ok(())
     }
 
     #[inline(always)]
-    fn apply_mcu(&mut self, controls: &[usize], target: usize, mat: [[Complex64; 2]; 2]) {
+    fn apply_mcu(
+        &mut self,
+        controls: &[usize],
+        target: usize,
+        mat: [[Complex64; 2]; 2],
+    ) -> Result<()> {
+        self.check_entry_growth(2)?;
         let ctrl_mask: usize = controls.iter().map(|&q| 1usize << q).fold(0, |a, b| a | b);
         let tgt_mask = 1usize << target;
         let zero = Complex64::new(0.0, 0.0);
@@ -210,6 +251,7 @@ impl SparseBackend {
 
         std::mem::swap(&mut self.state, &mut self.swap_buf);
         self.prune();
+        Ok(())
     }
 
     #[inline(always)]
@@ -284,7 +326,8 @@ impl SparseBackend {
         }
     }
 
-    fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) {
+    fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) -> Result<()> {
+        self.check_entry_growth(4)?;
         let mask0 = 1usize << q0;
         let mask1 = 1usize << q1;
         let zero = Complex64::new(0.0, 0.0);
@@ -311,6 +354,7 @@ impl SparseBackend {
 
         std::mem::swap(&mut self.state, &mut self.swap_buf);
         self.prune();
+        Ok(())
     }
 
     fn masked_prob(&self, mask: usize, bit_set: bool) -> f64 {
@@ -375,7 +419,7 @@ impl SparseBackend {
         });
     }
 
-    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) {
+    fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         match gate {
             Gate::Rzz(theta) => {
                 self.apply_rzz(targets[0], targets[1], *theta);
@@ -393,7 +437,7 @@ impl SparseBackend {
                 if let Some(phase) = gate.controlled_phase() {
                     self.apply_cu_phase(targets[0], targets[1], phase);
                 } else {
-                    self.apply_cu(targets[0], targets[1], **mat);
+                    self.apply_cu(targets[0], targets[1], **mat)?;
                 }
             }
             Gate::Mcu(data) => {
@@ -401,7 +445,7 @@ impl SparseBackend {
                 if let Some(phase) = gate.controlled_phase() {
                     self.apply_mcu_phase(&targets[..num_ctrl], targets[num_ctrl], phase);
                 } else {
-                    self.apply_mcu(&targets[..num_ctrl], targets[num_ctrl], data.mat);
+                    self.apply_mcu(&targets[..num_ctrl], targets[num_ctrl], data.mat)?;
                 }
             }
             Gate::BatchPhase(data) => {
@@ -417,15 +461,15 @@ impl SparseBackend {
             }
             Gate::MultiFused(data) => {
                 for &(target, mat) in &data.gates {
-                    self.apply_single_qubit(target, mat);
+                    self.apply_single_qubit(target, mat)?;
                 }
             }
             Gate::Fused2q(mat) => {
-                self.apply_fused_2q(targets[0], targets[1], mat);
+                self.apply_fused_2q(targets[0], targets[1], mat)?;
             }
             Gate::Multi2q(data) => {
                 for &(q0, q1, ref mat) in &data.gates {
-                    self.apply_fused_2q(q0, q1, mat);
+                    self.apply_fused_2q(q0, q1, mat)?;
                 }
             }
             other => {
@@ -435,9 +479,10 @@ impl SparseBackend {
                     other
                 );
                 let mat = other.matrix_2x2();
-                self.apply_single_qubit(targets[0], mat);
+                self.apply_single_qubit(targets[0], mat)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -460,7 +505,7 @@ impl Backend for SparseBackend {
 
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         match instruction {
-            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets),
+            Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,
             Instruction::Measure {
                 qubit,
                 classical_bit,
@@ -477,7 +522,7 @@ impl Backend for SparseBackend {
                 targets,
             } => {
                 if condition.evaluate(&self.classical_bits) {
-                    self.dispatch_gate(gate, targets);
+                    self.dispatch_gate(gate, targets)?;
                 }
             }
         }
@@ -490,8 +535,7 @@ impl Backend for SparseBackend {
     }
 
     fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
-        self.apply_single_qubit(qubit, *matrix);
-        Ok(())
+        self.apply_single_qubit(qubit, *matrix)
     }
 
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {

--- a/tests/growth_budget_oversize.rs
+++ b/tests/growth_budget_oversize.rs
@@ -1,0 +1,143 @@
+//! Oversize guards for the growth-path memory ceilings. Isolated in its own
+//! test binary: it overrides the per-path cap variables, which the helpers
+//! cache per process. Every rejection is decided before the growth allocation,
+//! so no test allocates an oversize state.
+
+use std::sync::Once;
+
+use prism_q::gates::Gate;
+use prism_q::{Circuit, FactoredBackend, MpsBackend, PrismError, SparseBackend, run_on};
+
+// Merge cap 8: a factored merge past 8 qubits rejects. MPS workspace cap
+// 2^8 = 256 amplitudes. Sparse cap 6: the map may hold at most 64 entries.
+// The statevector cap stays untouched: these ceilings must bind on their own.
+const MERGE_CAP: usize = 8;
+const SPARSE_ENTRY_CAP: usize = 1 << 6;
+
+fn small_caps() {
+    static SET: Once = Once::new();
+    SET.call_once(|| {
+        // SAFETY: set exactly once, and every reader in this binary is gated
+        // behind this `Once`, so no thread queries a cap while it is written.
+        unsafe {
+            std::env::set_var("PRISM_MAX_FACTORED_MERGE_QUBITS", "8");
+            std::env::set_var("PRISM_MAX_MPS_WORKSPACE_QUBITS", "8");
+            std::env::set_var("PRISM_MAX_SPARSE_QUBITS", "6");
+        }
+    });
+}
+
+fn assert_cap_error(err: PrismError, backend: &str) {
+    match err {
+        PrismError::IncompatibleBackend {
+            backend: named,
+            reason,
+        } => {
+            assert_eq!(named, backend, "wrong backend named: {reason}");
+            assert!(
+                reason.contains("exceeding the cap"),
+                "expected a cap rejection, got {reason}"
+            );
+        }
+        other => panic!("expected a clean cap error, got {other:?}"),
+    }
+}
+
+// Two independent blocks built by CX chains, then one bridging CX whose merge
+// would need a dense block of `left + right` qubits.
+fn bridged_blocks(left: usize, right: usize) -> Circuit {
+    let n = left + right;
+    let mut c = Circuit::new(n, 0);
+    c.add_gate(Gate::H, &[0]);
+    for q in 1..left {
+        c.add_gate(Gate::Cx, &[q - 1, q]);
+    }
+    c.add_gate(Gate::H, &[left]);
+    for q in left + 1..n {
+        c.add_gate(Gate::Cx, &[q - 1, q]);
+    }
+    c.add_gate(Gate::Cx, &[left - 1, left]);
+    c
+}
+
+// Brickwork of Ry layers and CX ladders: bond dimension doubles per brick
+// until the cap, so the MPS workspace grows deterministically.
+fn dense_entangler(n: usize, layers: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for layer in 0..layers {
+        for q in 0..n {
+            c.add_gate(Gate::Ry(0.3 + 0.1 * (layer * n + q) as f64), &[q]);
+        }
+        let offset = layer % 2;
+        for q in (offset..n - 1).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    c
+}
+
+fn h_wall(n: usize, hs: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..hs {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c
+}
+
+#[test]
+fn factored_merge_over_the_cap_is_rejected() {
+    small_caps();
+    let circuit = bridged_blocks(5, 5);
+    let mut backend = FactoredBackend::new(42);
+    let err = run_on(&mut backend, &circuit).unwrap_err();
+    assert_cap_error(err, "factored");
+}
+
+#[test]
+fn factored_merge_at_the_cap_still_runs() {
+    small_caps();
+    let circuit = bridged_blocks(MERGE_CAP / 2, MERGE_CAP / 2);
+    let mut backend = FactoredBackend::new(42);
+    run_on(&mut backend, &circuit).expect("an at-cap merge must run");
+}
+
+#[test]
+fn sparse_densifying_circuit_is_rejected() {
+    small_caps();
+    // Seven branching gates project past the 64-entry cap on the seventh.
+    let circuit = h_wall(8, 7);
+    let mut backend = SparseBackend::new(42);
+    let err = run_on(&mut backend, &circuit).unwrap_err();
+    assert_cap_error(err, "sparse");
+}
+
+#[test]
+fn sparse_state_at_the_cap_still_runs() {
+    small_caps();
+    let mut circuit = h_wall(8, 6);
+    for q in 1..8 {
+        circuit.add_gate(Gate::Cx, &[q - 1, q]);
+    }
+    let mut backend = SparseBackend::new(42);
+    let outcome = run_on(&mut backend, &circuit).expect("an at-cap state must run");
+    let probs = outcome.probabilities.expect("probabilities");
+    let nonzero = probs.iter().filter(|&p| p > 0.0).count();
+    assert_eq!(nonzero, SPARSE_ENTRY_CAP);
+}
+
+#[test]
+fn mps_workspace_over_the_cap_is_rejected() {
+    small_caps();
+    let circuit = dense_entangler(8, 6);
+    let mut backend = MpsBackend::new(42, 1 << 20);
+    let err = run_on(&mut backend, &circuit).unwrap_err();
+    assert_cap_error(err, "mps");
+}
+
+#[test]
+fn mps_low_bond_circuit_still_runs() {
+    small_caps();
+    let circuit = bridged_blocks(2, 2);
+    let mut backend = MpsBackend::new(42, 1 << 20);
+    run_on(&mut backend, &circuit).expect("a low-bond circuit must run");
+}


### PR DESCRIPTION
## Summary

Three growth paths could exhaust memory on adversarial input: the sparse entry
map on a densifying circuit, the MPS contraction workspace under a high bond
cap, and the dense block a factored merge materializes. Each now rejects
before the allocation with an error naming its own backend, closing the
growth-path half of the memory-budget contract; the factored check also
guards a previously wrapping `1 << total_n` shift. The caps default to the
detected-memory budget with per-path overrides deliberately independent of
`PRISM_MAX_SV_QUBITS`, because these backends exist to run above the
statevector cap and the existing gradient-oversize contract test pins that.

## Scope

- [x] Bug fix
- [x] New feature

## Benchmarks

Full Criterion tier (sample_size 30), `scripts/bench_ab.sh` against `main`
(`fb8c1e0`), quiet i7-6700K host. The deciding runs cover `^mps/` (19 rows)
and `^(sparse|factored)/` (52 rows), both PASS at 5% with every change inside
or below its control column. Representative rows:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `mps/hotspots/measure_reset_32q_r3` | 469.83 us | 468.31 us | -0.3% | -0.1% / -2.7% | yes |
| `mps/linear_chain_d10/16` | 728.78 us | 726.65 us | -0.3% | -0.4% / -0.5% | yes |
| `mps/random_d10/16` | 547.34 us | 527.79 us | -3.6% | +1.0% / +3.2% | yes |
| `sparse/low_entanglement/16` | 39.75 us | 38.54 us | -3.0% | +1.8% / +3.1% | yes |
| `sparse/sampling/64` | 651.85 us | 653.48 us | +0.3% | +1.0% / -0.4% | yes |
| `factored/dense/factored/16` | 4.33 ms | 4.33 ms | +0.1% | +0.5% / +0.3% | yes |
| `factored/random_d10/factored/24` | 911.56 ms | 910.01 ms | -0.2% | +0.5% / +0.1% | yes |
| `factored/dense/statevector/12` (untouched code) | 213.50 us | 223.93 us | +4.9% | +0.2% / -1.2% | yes, below gate |

Two earlier full-filter runs printed FAIL and both were measurement
artifacts, resolved by a three-reference-build comparison: two builds of
identical `main` source in different worktrees differed 19-29% on
`mps/hotspots/*` microrows while each binary's own control stayed under 4%,
so the outlier reference flipped the verdict. Two of three independent
reference builds agree with the new binary on every row. The first run also
surfaced a real cost: the per-gate cap check read an `OnceLock`, measured at
+2.9% to +4.5% on sub-5 us sparse rows; caps are now read once at backend
construction and the check is a field compare, which is the shape the
deciding runs measured.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
      (2215 tests, zero skips, `golden_gpu` under `PRISM_REQUIRE_GPU=1`)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on new and changed items carry the facts the signatures do not
- [x] New guards have their own test binary, `tests/growth_budget_oversize.rs`:
      over-cap rejection plus an at-cap positive run per backend, with tiny
      caps injected through the per-path variables so no test allocates an
      oversize state
- [x] The existing oversize binaries still pass, including
      `expectation_gradient_oversize`, which pins that MPS and factored keep
      answering above a lowered `PRISM_MAX_SV_QUBITS`

## Breaking changes

- A circuit that previously grew without bound on sparse, MPS, or factored
  until the allocator failed now returns `IncompatibleBackend` naming the
  backend, the demand, and the override variable.
- The sparse rejection projects a branching gate's worst-case fan-out (2x for
  1q, 4x for a dense 2q), so it can fire one gate before a state that would
  have deduplicated below the cap.
- Three new environment variables: `PRISM_MAX_SPARSE_QUBITS`,
  `PRISM_MAX_MPS_WORKSPACE_QUBITS`, `PRISM_MAX_FACTORED_MERGE_QUBITS`.

## Risks and rollback

- The MPS workspace estimate is a documented constant over the live
  contraction buffers; an underestimate would admit an allocation the budget
  misses, an overestimate rejects early. Both err loudly, and the caps are
  env-tunable without a rebuild.
- Internal MPS and sparse gate paths now return `Result`; the deciding bench
  runs bound the dispatch cost at noise on every resolvable row.
- Single commit; reverting it restores the unbounded behavior wholesale.
