### PR TITLE
test: pin thread-count determinism and add miri and TSan CI jobs

### DIFF
--- a/.github/tsan-suppressions.txt
+++ b/.github/tsan-suppressions.txt
@@ -1,0 +1,6 @@
+# ThreadSanitizer does not model standalone atomic fences, and Rayon's work-stealing
+# deque (crossbeam-deque over crossbeam-epoch) synchronizes epoch reclamation with
+# them, so the handoff is reported as a race. Scoped to those crates: a real race in
+# this repository's kernels symbolizes under prism_q and stays visible.
+race:crossbeam_epoch
+race:crossbeam_deque

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,81 @@ jobs:
       - name: Tests
         run: cargo nextest run --features "$CI_DIST_FEATURES"
 
+  # Miri interprets the determinism target, which drives every parallel kernel family
+  # at cfg(miri)-reduced sizes, and rejects undefined behavior in the SendPtr
+  # partitioning paths (aliasing, provenance, data races) that no native test can see.
+  # SIMD dispatch resolves to the scalar fallbacks under the interpreter, so the vector
+  # intrinsics stay out of reach; the sanitizer job below covers native execution.
+  # Interpreting the full suite is not viable, hence the single-target scope.
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # Tree Borrows instead of Stacked Borrows: crossbeam-epoch's intrusive list
+      # (rayon's deque) casts an interior Entry pointer back to its container, which
+      # Stacked Borrows rejects inside the dependency before any project code runs.
+      # Leak checking is off because the global Rayon pool never joins its workers,
+      # so threads alive at process exit would fail every run. Isolation is off so
+      # the thread cap below reaches the interpreted program. The memory caps are
+      # pinned because the interpreter cannot execute the host memory probe behind
+      # them (a foreign function on every OS). Deterministic floats: miri otherwise
+      # perturbs math-function results per call to model their unspecified
+      # precision, which fails the bitwise thread-count comparison through the
+      # sin/cos in gate-matrix preparation.
+      MIRIFLAGS: >-
+        -Zmiri-tree-borrows -Zmiri-ignore-leaks -Zmiri-disable-isolation
+        -Zmiri-deterministic-floats
+      RAYON_NUM_THREADS: "2"
+      PRISM_MAX_SV_QUBITS: "26"
+      PRISM_MAX_DM_QUBITS: "13"
+      PRISM_MAX_PROB_QUBITS: "26"
+      PRISM_MAX_EXPORT_QUBITS: "26"
+      PRISM_MAX_DENSE_OUTCOME_BITS: "26"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      # The runner's default toolchain stays stable; the explicit +nightly is what
+      # routes cargo at the toolchain the action installed.
+      - name: Miri over the partitioning kernels
+        run: cargo +nightly miri test --features parallel --test determinism
+
+  # ThreadSanitizer runs the parallel kernels on real threads and reports data races
+  # the SAFETY comments only argue away. -Zbuild-std instruments std so its
+  # synchronization is visible to the tool; the explicit --target keeps RUSTFLAGS away
+  # from build scripts. backend_equivalence adds the parallel crossover circuits at
+  # 16q/20q on top of the determinism target's kernel sweep.
+  tsan:
+    name: ThreadSanitizer
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      RUSTFLAGS: -Zsanitizer=thread
+      TSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/tsan-suppressions.txt
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      # Runner kernels hand out 32 bits of mmap randomness, outside the range the
+      # TSan shadow mapping tolerates.
+      - name: Lower ASLR entropy for TSan
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
+      # The runner's default toolchain stays stable; the explicit +nightly is what
+      # routes cargo at the toolchain the action installed.
+      - name: ThreadSanitizer over the parallel kernels
+        run: >-
+          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu
+          --features parallel --test determinism --test backend_equivalence
+
   # `rust-version` is published to crates.io, and every other job runs on stable, far
   # ahead of the floor. 1.87 rather than the edition-2024 floor of 1.85: the SIMD kernels
   # call `std::arch` intrinsics from `#[target_feature]` functions without an inner unsafe

--- a/docs/architecture/threading-simd.md
+++ b/docs/architecture/threading-simd.md
@@ -42,4 +42,40 @@ The 2q tiled AVX2 path processes paired `k` and `k + 1` groups when the lower ta
 
 ## Determinism
 
-Same circuit + same seed = same result, regardless of thread count. Parallel backends use deterministic work partitioning.
+Reproducibility is a per-path contract, not a blanket guarantee. Gate application never
+reduces across tasks, so it is exactly reproducible; everything that sums floating-point
+values in parallel is reproducible to the last ulp only; the batched compiled sampler is
+reproducible only at a fixed thread count. `tests/determinism.rs` pins the dense
+unitary, terminal sampling, reduction, and compiled-sampler claims by running the same
+seeded circuits in scoped 1-thread and 4-thread pools; the trajectory, SPD, and
+stabilizer bullets stand on the mechanisms they state.
+
+- **Unitary evolution on the dense kernels: bitwise, at any thread count.** Gate kernels
+  partition the state into index-derived disjoint ranges (fixed chunk boundaries, index
+  bijections for the `SendPtr` kernels) and write elementwise, so the schedule cannot
+  reach any value. Pinned bitwise for representative fused circuits and a QFT.
+- **Terminal sampling on the dense route: bitwise for a given seed, at any thread
+  count**, when the measurement map covers the register directly. Shot thresholds are
+  drawn and sorted up front from the seeded generator, the probability vector is an
+  elementwise transform, and the CDF walk is sequential. A measurement map that compacts
+  into fewer outcomes builds its histogram through a parallel reduction and moves to the
+  ulp-stable class below.
+- **Noisy trajectory shots: bitwise for a given seed, at any thread count.** Each shot's
+  generator is seeded from the shot index, not the worker, and results are collected in
+  shot order.
+- **Parallel reductions: stable to about 1e-12, not bitwise.** Norms, measurement
+  collapse probabilities, reduced density matrices, and expectation values sum
+  deterministic per-chunk partials in Rayon's combine order, which varies with pool width
+  and work stealing. A mid-circuit measurement compares a seeded draw against such a sum,
+  so an outcome flip is possible in principle when the draw lands inside the ulp gap.
+- **Compiled (BTS) sampling: reproducible at a fixed thread count only.** The batched
+  sampler derives one RNG stream per worker and splits shots by
+  `rayon::current_num_threads()`, so a different pool width yields a different, equally
+  distributed shot set. Pin `RAYON_NUM_THREADS` when byte-identical shot payloads matter
+  across machines. The GPU analogue is documented in the [GPU guide](../guides/gpu.md).
+- **SPD analytic estimates: stable to about 1e-12 between runs.** Hash-order term
+  accumulation moves the last ulp even at a fixed thread count; tests carry that
+  tolerance.
+- **Stabilizer tableau: bitwise, at any thread count.** Row operations are integer and
+  exactly associative. MPS carries no bitwise claim: truncation runs through faer's
+  threaded SVD.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -27,8 +27,12 @@ memory latency, but on a contended host it adds noise to benchmarks.
 
 ## Determinism
 
-Same circuit plus same seed yields the same result regardless of thread count. Parallel
-backends use deterministic work partitioning, so reproducibility never costs correctness.
+Deterministic partitioning makes unitary evolution and seeded terminal sampling on the
+dense backends bitwise reproducible at any thread count. Parallel reductions (norms,
+collapse probabilities, expectation values) are stable to about 1e-12 but not bitwise,
+and the batched compiled sampler seeds one RNG stream per worker, so its shots reproduce
+only at a fixed thread count. The per-path contract is in
+[Threading, SIMD, and Memory Layout](../architecture/threading-simd.md).
 
 ## Tuning environment variables
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -66,11 +66,21 @@ use crate::sim::{Exactness, Placement, ResolvedBackend};
 /// Qubit count at which dense amplitude kernels switch to Rayon; the factored
 /// backend applies it per sub-state, the density matrix backend to its
 /// `2n`-qubit buffer.
+///
+/// Under miri the four parallelism floors here drop so the same kernels split
+/// across real worker threads at sizes the interpreter can execute; a 14-qubit
+/// pass with the race detector on runs minutes per gate. `tests/determinism.rs`
+/// is the miri CI target that relies on this.
+#[cfg(not(miri))]
 pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 14;
+#[cfg(miri)]
+pub(crate) const PARALLEL_THRESHOLD_QUBITS: usize = 8;
 
 /// Minimum elements per Rayon task in amplitude loops.
-#[cfg(feature = "parallel")]
+#[cfg(all(feature = "parallel", not(miri)))]
 pub(crate) const MIN_PAR_ELEMS: usize = 4096;
+#[cfg(all(feature = "parallel", miri))]
+pub(crate) const MIN_PAR_ELEMS: usize = 64;
 
 /// `with_min_len` value giving each Rayon task at least [`MIN_PAR_ELEMS`]
 /// elements when the parallel iterator yields chunks of `chunk_size`.
@@ -82,14 +92,18 @@ pub(crate) fn chunk_min_len(chunk_size: usize) -> usize {
 
 /// Minimum iterations per Rayon task for index-driven loops whose
 /// per-iteration work is heavier than one element (MCU, batch phase).
-#[cfg(feature = "parallel")]
+#[cfg(all(feature = "parallel", not(miri)))]
 pub(crate) const MIN_PAR_ITERS: usize = 2048;
+#[cfg(all(feature = "parallel", miri))]
+pub(crate) const MIN_PAR_ITERS: usize = 32;
 
 /// Element count above which a full-buffer reduction is worth Rayon fan-out.
 /// Higher than [`PARALLEL_THRESHOLD_QUBITS`] because a reduction is one
 /// lightweight streaming pass, so the fan-out only pays past `2^16`.
-#[cfg(feature = "parallel")]
+#[cfg(all(feature = "parallel", not(miri)))]
 pub(crate) const MIN_PAR_REDUCE_ELEMS: usize = 1 << 16;
+#[cfg(all(feature = "parallel", miri))]
+pub(crate) const MIN_PAR_REDUCE_ELEMS: usize = 1 << 8;
 
 /// `sum |a|^2` over a dense amplitude buffer, SIMD per chunk and parallel above
 /// [`MIN_PAR_REDUCE_ELEMS`].

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -36,20 +36,33 @@ pub(super) const IDENTITY_EPS: f64 = 1e-12;
 
 use super::plan::{Place, Tracer};
 
+// Under miri the fusion floors drop to the reduced parallel threshold (see
+// `PARALLEL_THRESHOLD_QUBITS` in `backend/mod.rs`), so the fused kernel forms
+// appear at sizes the interpreter can execute. Native values are unchanged.
+
 /// Minimum qubit count for 1q fusion, reorder, and batching passes.
 ///
 /// Below 10 qubits, statevectors are small enough that gate execution is
 /// nanoseconds. The instruction-clone cost of fusion passes (allocating output
 /// Vec, cloning non-fuseable instructions) exceeds any simulation savings.
+#[cfg(not(miri))]
 const MIN_QUBITS_FOR_FUSION: usize = 10;
+#[cfg(miri)]
+const MIN_QUBITS_FOR_FUSION: usize = 8;
 
 /// Minimum qubit count for multi-gate tiled fusion to be profitable.
+#[cfg(not(miri))]
 const MIN_QUBITS_FOR_MULTI_FUSION: usize = 14;
+#[cfg(miri)]
+const MIN_QUBITS_FOR_MULTI_FUSION: usize = 8;
 
 /// Minimum qubit count for diagonal-family batch passes (BatchRzz, BatchPhase,
 /// DiagonalBatch) to be profitable. LUT kernel overhead needs enough state size
 /// to amortize.
+#[cfg(not(miri))]
 const MIN_QUBITS_FOR_DIAG_BATCH: usize = 16;
+#[cfg(miri)]
+const MIN_QUBITS_FOR_DIAG_BATCH: usize = 8;
 
 /// Minimum qubit count for post-phase-fusion 1q batching.
 ///
@@ -57,13 +70,19 @@ const MIN_QUBITS_FOR_DIAG_BATCH: usize = 16;
 /// batched into MultiFused for tiled execution. At 16q (1MB, L3-resident),
 /// tiling overhead exceeds savings. Profitable at 18q+ where DRAM bandwidth
 /// dominates.
+#[cfg(not(miri))]
 const MIN_QUBITS_FOR_POST_PHASE_BATCH: usize = 18;
+#[cfg(miri)]
+const MIN_QUBITS_FOR_POST_PHASE_BATCH: usize = 8;
 
 /// Minimum qubit count for two-qubit gate fusion (absorb 1q into CX/CZ) to be profitable.
 ///
 /// The generic 4×4 kernel does ~4x the FLOPs of specialized CX/CZ + SIMD 1q kernels.
 /// Benchmarked QV and random sweeps show memory-pass reduction wins from 12q.
+#[cfg(not(miri))]
 const MIN_QUBITS_FOR_2Q_FUSION: usize = 12;
+#[cfg(miri)]
+const MIN_QUBITS_FOR_2Q_FUSION: usize = 8;
 
 /// Bench-only kill switch for `reorder_disjoint_fused2q`. Reads
 /// `PRISM_NO_REORDER` once and caches the result. Toggle for A/B timing

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,0 +1,293 @@
+//! Thread-count determinism contract from `docs/architecture/threading-simd.md`:
+//! bitwise equality on the deterministic-partitioning paths, seeded sampling
+//! identity, and the 1e-12 stability bound on parallel reductions.
+
+#![cfg(feature = "parallel")]
+
+mod common;
+
+use common::SEED;
+use num_complex::Complex64;
+use prism_q::circuits::qft_circuit;
+use prism_q::{
+    BackendKind, Circuit, Gate, McuData, PauliTerm, StatevectorBackend, run_on, run_on_state,
+    run_shots_compiled, simulate,
+};
+
+#[cfg(not(miri))]
+const THREADS_HI: usize = 4;
+#[cfg(miri)]
+const THREADS_HI: usize = 2;
+
+// Miri sizes sit above the reduced parallel and fusion floors (8 under miri,
+// see backend/mod.rs), so the same fused parallel kernels run on a state the
+// interpreter can execute in minutes rather than hours.
+#[cfg(not(miri))]
+const DENSE_SIZES: &[usize] = &[10, 16, 18];
+#[cfg(miri)]
+const DENSE_SIZES: &[usize] = &[10];
+
+#[cfg(not(miri))]
+const QFT_SIZES: &[usize] = &[16, 20];
+#[cfg(miri)]
+const QFT_SIZES: &[usize] = &[10];
+
+#[cfg(not(miri))]
+const SAMPLING_QUBITS: usize = 16;
+#[cfg(miri)]
+const SAMPLING_QUBITS: usize = 10;
+
+#[cfg(not(miri))]
+const SAMPLING_SHOTS: usize = 4096;
+#[cfg(miri)]
+const SAMPLING_SHOTS: usize = 256;
+
+const REDUCTION_EPS: f64 = 1e-12;
+
+fn in_pool<T: Send>(threads: usize, op: impl FnOnce() -> T + Send) -> T {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .expect("scoped Rayon pool")
+        .install(op)
+}
+
+fn rx_matrix(theta: f64) -> [[Complex64; 2]; 2] {
+    let (s, c) = (theta / 2.0).sin_cos();
+    [
+        [Complex64::new(c, 0.0), Complex64::new(0.0, -s)],
+        [Complex64::new(0.0, -s), Complex64::new(c, 0.0)],
+    ]
+}
+
+fn phase_matrix(theta: f64) -> [[Complex64; 2]; 2] {
+    [
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::from_polar(1.0, theta)],
+    ]
+}
+
+// Non-Clifford circuit whose fused form walks the parallel kernel families:
+// 1q runs, CX with absorbable neighbors, Rzz and phase runs for the diagonal
+// batch tiers, plus Swap, Cu, and both Mcu shapes, which fuse into nothing and
+// keep their own index-bijection kernels.
+fn representative_dense_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::H, &[q]);
+        c.add_gate(Gate::Ry(0.31 + 0.07 * q as f64), &[q]);
+    }
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Rz(0.11 * (q + 1) as f64), &[q]);
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+        c.add_gate(Gate::Rx(0.23 + 0.05 * q as f64), &[q + 1]);
+    }
+    for q in (0..n - 1).step_by(2) {
+        c.add_gate(Gate::Rzz(0.17 + 0.03 * q as f64), &[q, q + 1]);
+    }
+    for q in 0..n {
+        c.add_gate(Gate::P(0.05 + 0.02 * q as f64), &[q]);
+    }
+    c.add_gate(Gate::Swap, &[0, n - 1]);
+    c.add_gate(Gate::Cu(Box::new(rx_matrix(0.4))), &[1, n - 2]);
+    c.add_gate(
+        Gate::Mcu(Box::new(McuData {
+            mat: rx_matrix(0.7),
+            num_controls: 2,
+        })),
+        &[0, 2, n - 3],
+    );
+    c.add_gate(
+        Gate::Mcu(Box::new(McuData {
+            mat: phase_matrix(0.9),
+            num_controls: 2,
+        })),
+        &[1, 3, n - 4],
+    );
+    c
+}
+
+fn amplitudes_with_threads(circuit: &Circuit, threads: usize) -> Vec<Complex64> {
+    in_pool(threads, || {
+        let mut backend = StatevectorBackend::new(SEED);
+        run_on(&mut backend, circuit).expect("statevector run");
+        backend.state_vector().to_vec()
+    })
+}
+
+fn assert_bitwise_equal(base: &[Complex64], other: &[Complex64], label: &str) {
+    assert_eq!(base.len(), other.len(), "{label}: length mismatch");
+    for (idx, (a, b)) in base.iter().zip(other).enumerate() {
+        assert!(
+            a.re.to_bits() == b.re.to_bits() && a.im.to_bits() == b.im.to_bits(),
+            "{label}: amplitude {idx} differs bitwise: {a} vs {b}"
+        );
+    }
+}
+
+#[test]
+fn unitary_amplitudes_bitwise_equal_across_thread_counts() {
+    for &n in DENSE_SIZES {
+        let circuit = representative_dense_circuit(n);
+        let base = amplitudes_with_threads(&circuit, 1);
+        let wide = amplitudes_with_threads(&circuit, THREADS_HI);
+        assert_bitwise_equal(&base, &wide, &format!("dense {n}q"));
+    }
+}
+
+#[test]
+fn qft_amplitudes_bitwise_equal_across_thread_counts() {
+    for &n in QFT_SIZES {
+        let circuit = qft_circuit(n);
+        let dim = 1usize << n;
+        let mut state: Vec<Complex64> = (0..dim)
+            .map(|i| Complex64::new((i as f64 * 0.7).sin() + 0.2, (i as f64 * 0.3).cos()))
+            .collect();
+        let norm = state.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt();
+        for amp in &mut state {
+            *amp /= norm;
+        }
+
+        let run = |threads: usize| {
+            in_pool(threads, || {
+                let mut backend = StatevectorBackend::new(SEED);
+                run_on_state(&mut backend, &circuit, &state).expect("qft run");
+                backend.state_vector().to_vec()
+            })
+        };
+        assert_bitwise_equal(&run(1), &run(THREADS_HI), &format!("qft {n}q"));
+    }
+}
+
+// Ignored under miri: four full circuit executions for kernels the other
+// tests already interpret; the sampling walk itself is safe sequential code.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn terminal_shots_and_counts_identical_across_thread_counts() {
+    let mut circuit = representative_dense_circuit(SAMPLING_QUBITS);
+    circuit.measure_all();
+
+    let shots = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(BackendKind::Statevector)
+                .seed(SEED)
+                .shots(SAMPLING_SHOTS)
+                .expect("shots")
+                .shots
+        })
+    };
+    assert_eq!(shots(1), shots(THREADS_HI), "terminal shots differ");
+
+    let counts = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(BackendKind::Statevector)
+                .seed(SEED)
+                .sample_counts(SAMPLING_SHOTS)
+                .expect("counts")
+                .counts
+        })
+    };
+    assert_eq!(counts(1), counts(THREADS_HI), "terminal counts differ");
+}
+
+// Collapse probabilities come from a Rayon reduction whose combine order moves
+// with the pool, so the post-measurement scale is ulp-stable, not bitwise.
+// The seeded outcomes still agree unless a draw lands inside that ulp gap.
+#[test]
+fn midcircuit_collapse_ulp_stable_across_thread_counts() {
+    let n = SAMPLING_QUBITS;
+    let mut circuit = Circuit::new(n, 2);
+    for q in 0..n {
+        circuit.add_gate(Gate::H, &[q]);
+        circuit.add_gate(Gate::Ry(0.29 + 0.05 * q as f64), &[q]);
+    }
+    for q in 0..n - 1 {
+        circuit.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    circuit.add_measure(3, 0);
+    circuit.add_reset(2);
+    for q in 0..n {
+        circuit.add_gate(Gate::Rx(0.13 + 0.04 * q as f64), &[q]);
+    }
+    circuit.add_measure(n - 1, 1);
+
+    let run = |threads: usize| {
+        in_pool(threads, || {
+            let mut backend = StatevectorBackend::new(SEED);
+            let outcome = run_on(&mut backend, &circuit).expect("collapse run");
+            (
+                outcome.classical_bits,
+                outcome.probabilities.expect("dense probabilities").to_vec(),
+            )
+        })
+    };
+    let (bits_base, probs_base) = run(1);
+    let (bits_wide, probs_wide) = run(THREADS_HI);
+
+    assert_eq!(bits_base, bits_wide, "seeded collapse outcomes differ");
+    let max_diff = probs_base
+        .iter()
+        .zip(&probs_wide)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f64, f64::max);
+    assert!(
+        max_diff <= REDUCTION_EPS,
+        "post-collapse probabilities differ by {max_diff:e}"
+    );
+}
+
+// Ignored under miri: the reduction it bounds is safe code, and the collapse
+// test interprets the same reduce shape at a fraction of the cost.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn expectation_values_ulp_stable_across_thread_counts() {
+    let circuit = representative_dense_circuit(SAMPLING_QUBITS);
+    let observables = vec![
+        vec![PauliTerm::z(0), PauliTerm::z(5)],
+        vec![PauliTerm::x(2)],
+        vec![PauliTerm::y(1), PauliTerm::z(7), PauliTerm::x(9)],
+    ];
+
+    let run = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(BackendKind::Statevector)
+                .seed(SEED)
+                .expectation_values(&observables)
+                .expect("expectation values")
+        })
+    };
+    let base = run(1);
+    let wide = run(THREADS_HI);
+    for (idx, (a, b)) in base.iter().zip(&wide).enumerate() {
+        assert!(
+            (a - b).abs() <= REDUCTION_EPS,
+            "observable {idx} differs by {:e}",
+            (a - b).abs()
+        );
+    }
+}
+
+// The batched compiled sampler derives one RNG stream per worker, so its shot
+// set is a function of the pool width: reproducible at a fixed thread count,
+// documented as thread-count-dependent in threading-simd.md.
+#[test]
+fn compiled_sampler_reproducible_at_fixed_thread_count() {
+    let mut circuit = prism_q::circuits::ghz_circuit(12);
+    circuit.measure_all();
+
+    let run = || {
+        in_pool(THREADS_HI, || {
+            run_shots_compiled(&circuit, 256, SEED)
+                .expect("compiled sampling")
+                .shots
+        })
+    };
+    assert_eq!(
+        run(),
+        run(),
+        "same seed and pool width must reproduce shots"
+    );
+}


### PR DESCRIPTION
## Summary

The determinism section of the threading doc published a blanket claim ("same circuit + same seed = same result, regardless of thread count") that nothing tested, and the `SendPtr` disjointness arguments in the parallel kernels were checked by review alone. This PR adds the test that decides the claim, narrows the published contract to the paths where it is true, and puts miri and ThreadSanitizer jobs in CI over the parallel partitioning kernels.

## Scope

- [x] Documentation
- [x] Build, CI, or tooling

Plus a new test target, `tests/determinism.rs`.

## Benchmarks

N/A, no hot-path changes, verified at the binary level. The only source diff is `cfg(miri)` constant duals (parallel and fusion floors) that compile out of every native build. A section-level comparison of the bench executable built at the base commit and at this branch from the same directory hashes `.text` (7.47 MB of code), `.data`, `.pdata`, and `.reloc` byte-identical; the only delta in the whole image is 105 bytes of panic-location line numbers in `.rdata` at identical section size, from the shifted lines in the two touched files.

The CI gate fired because `src/` changed and failed twice on `statevector/qft_textbook/22`: +6.2% with its own same-code control at +4.8%, then +5.1% against a 5.0% threshold with controls +2.1% and -2.0%. Every other row read flat both times. Identical machine code cannot run 5% slower, so both readings are the runner, consistent with that row's history of unresolvable control spreads on loaded hosts. The `skip-bench` label carries this verdict.

Regression verdict: PASS (no native code change; the failing row is unmeasurable runner noise, evidence above).

## Correctness

Ran locally: `cargo fmt --check`, clippy at `-D warnings -D clippy::undocumented_unsafe_blocks`, nextest at `--features parallel` (2028 tests), doctests, a no-default-features test-target check, and the miri target (4 passed, 2 ignored by design, 168 s on the dev host). The TSan job needs a Linux nightly host and is validated by this PR's CI run.

What the determinism test established:

- Dense unitary evolution and full-register terminal sampling are bitwise identical between scoped 1-thread and 4-thread pools: representative fused circuit at 10/16/18 qubits, QFT at 16/20 qubits from a non-uniform start state, 4096 shots and counts maps compared exactly.
- Parallel reductions are ulp-stable only: mid-circuit collapse probabilities and expectation values agree to 1e-12 across pool widths, not bitwise, because the combine tree follows Rayon's split order.
- Batched compiled sampling derives one RNG stream per worker and splits shots by `rayon::current_num_threads()`, so the same seed at a different thread count yields a different, equally distributed shot set. The doc states this; the test pins reproducibility at a fixed width.

Miri flags carry their rationale as comments in the workflow: Tree Borrows (a Stacked Borrows false positive inside crossbeam-epoch), leak check off (the global Rayon pool never joins workers), isolation off with pinned memory caps (the host memory probe is a foreign function the interpreter cannot execute), deterministic floats (miri otherwise perturbs sin/cos results per call, which fails any bitwise cross-run comparison).

## Architecture or design changes

`docs/architecture/threading-simd.md` replaces the blanket determinism claim with the per-path contract; `docs/guides/performance.md` carries the short form.

## Breaking changes

None. Native behavior is unchanged; the narrowed doc describes behavior that already existed.

## Risks and rollback

The new jobs are additive and start as non-required checks; each rolls back by deleting a job block. TSan suppressions are scoped to crossbeam symbols, so a race in project kernels stays visible. The `cfg(miri)` floors affect only miri builds.

