### PR TITLE
feat: native multi-qubit Pauli rotation gate with ladder fallback

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -464,6 +464,46 @@ fn bench_statevector_qaoa(c: &mut Criterion) {
     group.finish();
 }
 
+// One first-order Trotter step of the seeded Jordan-Wigner two-body operator,
+// truncated to the 200 largest coefficients. The recognizing constructor
+// lowers weight-1 and ZZ terms, so the native arm mixes named rotations with
+// `PauliRot` strings; the ladder arm pre-expands those strings, so the delta
+// isolates the native kernel against the fused CNOT-ladder form.
+fn trotter_step_circuit(n: usize) -> Circuit {
+    let terms = circuits::jordan_wigner_hamiltonian(n, 200, SEED);
+    let dt = 0.05;
+    let mut c = Circuit::new(n, 0);
+    for (coefficient, factors) in &terms {
+        if factors.is_empty() {
+            continue;
+        }
+        c.add_pauli_rotation(2.0 * coefficient * dt, factors);
+    }
+    c
+}
+
+fn bench_statevector_trotter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statevector/trotter");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let native = trotter_step_circuit(n);
+        let ladder = prism_q::circuit::expand_pauli_rotations(&native).into_owned();
+        group.bench_with_input(BenchmarkId::new("native", n), &native, |b, circ| {
+            b.iter(|| {
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("ladder", n), &ladder, |b, circ| {
+            b.iter(|| {
+                run_with(BackendKind::Statevector, circ, 42).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
 // Gates on the parallel `DiagonalBatch` sweep: the fused stream carrying a
 // `DiagonalBatch` is pinned by `fusion_diag_mixed_batches_and_matches_unfused`.
 fn bench_statevector_diag_mixed(c: &mut Criterion) {
@@ -2214,6 +2254,7 @@ criterion_group! {
     bench_statevector_qpe,
     bench_statevector_hea,
     bench_statevector_qaoa,
+    bench_statevector_trotter,
     bench_statevector_diag_mixed,
     bench_statevector_qv,
     bench_statevector_w_state,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -86,7 +86,7 @@ actually grow past what memory holds.
 
 Full-state simulation in a flat `Vec<Complex64>` of 2^n amplitudes. The primary backend for circuits up to ~28 qubits.
 
-Gate kernels use enum dispatch with specialized routines for CX, CZ, SWAP, Cu, MCU, Rzz, BatchRzz, BatchPhase, DiagonalBatch, and MultiFused. Single-qubit gates go through `PreparedGate1q` with FMA-vectorized SIMD. MultiFused gates use a three-tier tiled kernel (L2 16K / L3 131K / individual passes) for cache locality. MultiFused batches where all gates are diagonal dispatch to a dedicated fast path (1 complex multiply/element vs 4+2 for full 2×2).
+Gate kernels use enum dispatch with specialized routines for CX, CZ, SWAP, Cu, MCU, Rzz, BatchRzz, BatchPhase, DiagonalBatch, MultiFused, and PauliRot (one pass over `(j, j ^ xmask)` pairs for `exp(-i θ P / 2)`, a parity-phase sweep when the string is Z-only; backends without the kernel receive the CNOT-ladder lowering from `expand_pauli_rotations`). Single-qubit gates go through `PreparedGate1q` with FMA-vectorized SIMD. MultiFused gates use a three-tier tiled kernel (L2 16K / L3 131K / individual passes) for cache locality. MultiFused batches where all gates are diagonal dispatch to a dedicated fast path (1 complex multiply/element vs 4+2 for full 2×2).
 
 Rayon parallelism at ≥14 qubits with `par_chunks_mut` and `MIN_PAR_ELEMS = 4096` per task. BMI2 `_pext_u64` accelerates BatchPhase, BatchRzz, and DiagonalBatch LUT indexing.
 

--- a/docs/architecture/ir.md
+++ b/docs/architecture/ir.md
@@ -47,6 +47,7 @@ payloads.
 | `BatchPhase(Box<BatchPhaseData>)` | Batched cphase with shared control | 16B |
 | `BatchRzz(Box<BatchRzzData>)` | Batched ZZ rotations | 16B |
 | `DiagonalBatch(Box<DiagonalBatchData>)` | Mixed diagonal 1q/2q batch | 16B |
+| `PauliRot(Box<PauliRotData>)` | Multi-qubit Pauli rotation, boxed angle plus letters | 16B |
 
 ```admonish note title="Qubit ordering"
 `q[0]` is the least significant bit. Applying `x q[0]` produces state index 1, not 2.

--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -34,8 +34,9 @@ A circuit that has been through [fusion](../architecture/fusion.md) is not
 exportable: fused blocks, tiled multi-gate passes, and diagonal batches carry
 matrices with no OpenQASM spelling, and `to_qasm3` returns `ExportUnsupported`
 naming the instruction index. Export the circuit before fusing it, or the template
-a `PreparedCircuit` binds. A `QftBlock` is the one exception, expanded to its
-textbook Hadamard, controlled-phase, and swap sequence on the way out.
+a `PreparedCircuit` binds. `QftBlock` and `PauliRot` are the exceptions: export
+expands the first to its textbook Hadamard, controlled-phase, and swap sequence
+and the second to its CNOT-ladder lowering on the way out.
 
 ## Declarations and measurement
 

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1593,6 +1593,10 @@ impl Backend for DistributedStatevectorBackend {
         self.is_single_rank() && self.inner.supports_qft_block()
     }
 
+    fn supports_pauli_rotation(&self) -> bool {
+        self.is_single_rank() && self.inner.supports_pauli_rotation()
+    }
+
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
         let size = self.context.size();
         // Before the local validations: those read `num_qubits`, so ranks given

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -436,6 +436,15 @@ pub trait Backend {
         false
     }
 
+    /// Whether this backend has a native kernel for `Gate::PauliRot`.
+    ///
+    /// Native support is currently limited to the host CPU statevector. Other
+    /// backends receive the CNOT-ladder lowering from
+    /// `circuit::expand_pauli_rotations` before dispatch.
+    fn supports_pauli_rotation(&self) -> bool {
+        false
+    }
+
     /// Export the current quantum state as a dense statevector.
     ///
     /// Returns a `Vec<Complex64>` of length 2^n containing the full amplitude

--- a/src/backend/stabilizer/kernels/mod.rs
+++ b/src/backend/stabilizer/kernels/mod.rs
@@ -393,7 +393,8 @@ impl StabilizerBackend {
             | Gate::MultiFused(_)
             | Gate::Fused2q(_)
             | Gate::Multi2q(_)
-            | Gate::QftBlock { .. } => {
+            | Gate::QftBlock { .. }
+            | Gate::PauliRot(_) => {
                 return Err(PrismError::BackendUnsupported {
                     backend: self.name().to_string(),
                     operation: format!(
@@ -717,7 +718,8 @@ impl StabilizerBackend {
             | Gate::MultiFused(_)
             | Gate::Fused2q(_)
             | Gate::Multi2q(_)
-            | Gate::QftBlock { .. } => {
+            | Gate::QftBlock { .. }
+            | Gate::PauliRot(_) => {
                 return Err(PrismError::BackendUnsupported {
                     backend: self.name().to_string(),
                     operation: format!(

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -533,7 +533,8 @@ impl StabilizerBackend {
             | Gate::MultiFused(_)
             | Gate::Fused2q(_)
             | Gate::Multi2q(_)
-            | Gate::QftBlock { .. } => Err(PrismError::BackendUnsupported {
+            | Gate::QftBlock { .. }
+            | Gate::PauliRot(_) => Err(PrismError::BackendUnsupported {
                 backend: self.name().to_string(),
                 operation: format!(
                     "non-Clifford gate `{}` (stabilizer backend supports Clifford gates only)",

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -17,6 +17,7 @@ use crate::backend::simd;
 use crate::backend::{MCU_QUBIT_BUF, is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
 use crate::circuit::{QftTextbookStep, qft_textbook_steps};
 use crate::gates::{BatchPhaseData, BatchRzzData, DiagEntry, Gate, diag_entries_phase};
+use crate::sim::unified_pauli::PauliAxis;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -1549,6 +1550,38 @@ fn fft_stage_pair_par(
     apply_group(state, 0);
 }
 
+/// Mix the pairs `(lo[i], hi[i ^ xlow])` of one Pauli-rotation pivot block.
+///
+/// `base` is the global index of `lo[0]` and must be a multiple of `lo.len()`,
+/// so `(base + i) & zmask` reads the pair's parity sign directly. `m_lo` and
+/// `m_hi` are the parity-even cross coefficients toward the pivot-clear and
+/// pivot-set side respectively.
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn pauli_rot_pair_halves(
+    lo: &mut [Complex64],
+    hi: &mut [Complex64],
+    base: usize,
+    xlow: usize,
+    zmask: usize,
+    c: f64,
+    m_lo: Complex64,
+    m_hi: Complex64,
+) {
+    for (i, amp_lo) in lo.iter_mut().enumerate() {
+        let k = i ^ xlow;
+        let a = *amp_lo;
+        let b = hi[k];
+        if ((base + i) & zmask).count_ones() & 1 == 0 {
+            *amp_lo = a * c + b * m_lo;
+            hi[k] = b * c + a * m_hi;
+        } else {
+            *amp_lo = a * c - b * m_lo;
+            hi[k] = b * c - a * m_hi;
+        }
+    }
+}
+
 impl StatevectorBackend {
     #[inline(always)]
     pub(super) fn apply_single_gate(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
@@ -1835,6 +1868,144 @@ impl StatevectorBackend {
                     let i = base + j;
                     let parity = ((i >> q0) ^ (i >> q1)) & 1;
                     *amp *= phases[parity];
+                }
+            });
+    }
+
+    /// Apply `exp(-i θ P / 2)` in one pass, `P` given as one letter per target.
+    ///
+    /// `P|j> = i^{num_y} (-1)^{popcount(j & zmask)} |j ^ xmask>`, so the gate
+    /// mixes each pair `(j, j ^ xmask)` with `cos(θ/2)` on the diagonal and a
+    /// sign-resolved `-i sin(θ/2) i^{num_y}` cross term. A Z-only string has
+    /// `xmask == 0` and reduces to parity phases on the diagonal.
+    #[inline(always)]
+    pub(super) fn apply_pauli_rot(&mut self, targets: &[usize], theta: f64, axes: &[PauliAxis]) {
+        let mut xmask = 0usize;
+        let mut zmask = 0usize;
+        let mut num_y = 0u32;
+        for (&q, axis) in targets.iter().zip(axes) {
+            let bit = 1usize << q;
+            match axis {
+                PauliAxis::X => xmask |= bit,
+                PauliAxis::Z => zmask |= bit,
+                PauliAxis::Y => {
+                    xmask |= bit;
+                    zmask |= bit;
+                    num_y += 1;
+                }
+            }
+        }
+        let c = (theta / 2.0).cos();
+        let s = (theta / 2.0).sin();
+        if xmask == 0 {
+            self.apply_parity_phase(zmask, Complex64::new(c, -s), Complex64::new(c, s));
+            return;
+        }
+
+        // Cross-term coefficient toward the pivot-set side of a pair; the
+        // opposite direction differs by the parity of `xmask & zmask`, which
+        // is the Y count, hoisted into `m_lo`.
+        let m_hi = match num_y % 4 {
+            0 => Complex64::new(0.0, -s),
+            1 => Complex64::new(s, 0.0),
+            2 => Complex64::new(0.0, s),
+            _ => Complex64::new(-s, 0.0),
+        };
+        let m_lo = if num_y % 2 == 1 { -m_hi } else { m_hi };
+        let pivot = usize::BITS as usize - 1 - xmask.leading_zeros() as usize;
+        let half = 1usize << pivot;
+        let block = half << 1;
+        let xlow = xmask ^ half;
+
+        #[cfg(feature = "parallel")]
+        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            self.apply_pauli_rot_pairs_par(pivot, xlow, zmask, c, m_lo, m_hi);
+            return;
+        }
+
+        for (chunk_idx, chunk) in self.state.chunks_mut(block).enumerate() {
+            let (lo, hi) = chunk.split_at_mut(half);
+            pauli_rot_pair_halves(lo, hi, chunk_idx * block, xlow, zmask, c, m_lo, m_hi);
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn apply_pauli_rot_pairs_par(
+        &mut self,
+        pivot: usize,
+        xlow: usize,
+        zmask: usize,
+        c: f64,
+        m_lo: Complex64,
+        m_hi: Complex64,
+    ) {
+        let half = 1usize << pivot;
+        let block = half << 1;
+        let num_blocks = self.state.len() / block;
+
+        if num_blocks >= 4 {
+            self.state
+                .par_chunks_mut(block)
+                .with_min_len(chunk_min_len(block))
+                .enumerate()
+                .for_each(|(chunk_idx, chunk)| {
+                    let (lo, hi) = chunk.split_at_mut(half);
+                    pauli_rot_pair_halves(lo, hi, chunk_idx * block, xlow, zmask, c, m_lo, m_hi);
+                });
+        } else {
+            // Tiles are a power of two above `xlow`, so `i ^ xlow` stays
+            // inside its tile and each (lo, hi) tile pair is disjoint.
+            let tile = MIN_PAR_ELEMS.max((xlow + 1).next_power_of_two());
+            for (chunk_idx, chunk) in self.state.chunks_mut(block).enumerate() {
+                let chunk_base = chunk_idx * block;
+                let (lo, hi) = chunk.split_at_mut(half);
+                lo.par_chunks_mut(tile)
+                    .zip(hi.par_chunks_mut(tile))
+                    .enumerate()
+                    .for_each(|(t, (lo_t, hi_t))| {
+                        pauli_rot_pair_halves(
+                            lo_t,
+                            hi_t,
+                            chunk_base + t * tile,
+                            xlow,
+                            zmask,
+                            c,
+                            m_lo,
+                            m_hi,
+                        );
+                    });
+            }
+        }
+    }
+
+    /// Multiply each amplitude by `even` or `odd` from the parity of its
+    /// index bits under `zmask`.
+    #[inline(always)]
+    fn apply_parity_phase(&mut self, zmask: usize, even: Complex64, odd: Complex64) {
+        #[cfg(feature = "parallel")]
+        if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            self.apply_parity_phase_par(zmask, even, odd);
+            return;
+        }
+
+        let phases = [even, odd];
+        for (i, amp) in self.state.iter_mut().enumerate() {
+            *amp *= phases[((i & zmask).count_ones() & 1) as usize];
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline(always)]
+    fn apply_parity_phase_par(&mut self, zmask: usize, even: Complex64, odd: Complex64) {
+        let phases = [even, odd];
+        self.state
+            .par_chunks_mut(MIN_PAR_ELEMS)
+            .enumerate()
+            .for_each(|(chunk_idx, chunk)| {
+                let base = chunk_idx * MIN_PAR_ELEMS;
+                for (j, amp) in chunk.iter_mut().enumerate() {
+                    *amp *= phases[(((base + j) & zmask).count_ones() & 1) as usize];
                 }
             });
     }

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -12,8 +12,9 @@
 //!
 //! # Gate support
 //!
-//! The full gate set, including MCU, every fused or batched variant, and a
-//! native `Gate::QftBlock` kernel on the CPU whole-state path.
+//! The full gate set, including MCU, every fused or batched variant, a native
+//! `Gate::QftBlock` kernel on the CPU whole-state path, and a native
+//! `Gate::PauliRot` kernel on the CPU path.
 //!
 //! # When to prefer this backend
 //!
@@ -368,6 +369,31 @@ impl StatevectorBackend {
                 }
                 Ok(())
             }
+            Gate::PauliRot(data) => {
+                let mut result = Ok(());
+                crate::circuit::pauli_rotation_lowering(data.theta, targets, &data.axes, {
+                    let (result, gpu) = (&mut result, &mut *gpu);
+                    move |step, tgts| {
+                        if result.is_err() {
+                            return;
+                        }
+                        *result = match &step {
+                            Gate::Cx => k::launch_apply_cx(&ctx, gpu, tgts[0], tgts[1]),
+                            _ => {
+                                let mat = step.matrix_2x2();
+                                if step.is_diagonal_1q() {
+                                    k::launch_apply_diagonal_1q(
+                                        &ctx, gpu, tgts[0], mat[0][0], mat[1][1],
+                                    )
+                                } else {
+                                    k::launch_apply_gate_1q(&ctx, gpu, tgts[0], mat)
+                                }
+                            }
+                        };
+                    }
+                });
+                result
+            }
             Gate::MultiFused(data) => {
                 if data.all_diagonal {
                     k::launch_apply_multi_fused_diagonal(&ctx, gpu, &data.gates)
@@ -636,6 +662,9 @@ impl StatevectorBackend {
             Gate::DiagonalBatch(data) => {
                 self.apply_diagonal_batch(&data.entries);
             }
+            Gate::PauliRot(data) => {
+                self.apply_pauli_rot(targets, data.theta, &data.axes);
+            }
             Gate::MultiFused(data) => {
                 if data.all_diagonal {
                     self.apply_multi_1q_diagonal(&data.gates);
@@ -697,6 +726,17 @@ impl Backend for StatevectorBackend {
         if !qft_block_enabled() {
             return false;
         }
+        #[cfg(feature = "gpu")]
+        {
+            self.gpu_context.is_none()
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            true
+        }
+    }
+
+    fn supports_pauli_rotation(&self) -> bool {
         #[cfg(feature = "gpu")]
         {
             self.gpu_context.is_none()

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -82,7 +82,8 @@ fn classify_op(gate: &Gate, targets: &[usize]) -> (String, OpKind) {
         | Gate::Fused2q(_)
         | Gate::BatchRzz(_)
         | Gate::DiagonalBatch(_)
-        | Gate::Multi2q(_) => OpKind::TwoQubit,
+        | Gate::Multi2q(_)
+        | Gate::PauliRot(_) => OpKind::TwoQubit,
         Gate::BatchPhase(_) => OpKind::Controlled {
             controls: vec![targets[0]],
             target: *targets.last().unwrap(),

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -28,7 +28,8 @@ pub mod qasm_export;
 pub use parameter::{ParamLink, Parameters};
 pub use prepared::PreparedCircuit;
 
-use crate::gates::Gate;
+use crate::gates::{Gate, PauliRotData};
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 pub use smallvec::{SmallVec, smallvec};
 
 /// A quantum circuit in PRISM-Q's internal representation.
@@ -81,6 +82,55 @@ impl Circuit {
             gate,
             targets: SmallVec::from_slice(targets),
         });
+    }
+
+    /// Append the Pauli rotation `exp(-i θ P / 2)` for the Pauli string `P`
+    /// given as one factor per qubit.
+    ///
+    /// Recognized forms lower at insert: a weight-1 string appends `Rx`, `Ry`,
+    /// or `Rz`, and a two-qubit `ZZ` string appends `Rzz`, so Clifford
+    /// recognition, diagonal batching, and fusion keep firing on them. Any
+    /// other string appends the native [`Gate::PauliRot`], factors sorted by
+    /// qubit.
+    ///
+    /// # Panics
+    /// Panics if `factors` is empty, names a qubit twice, or names a qubit out
+    /// of bounds.
+    pub fn add_pauli_rotation(&mut self, theta: f64, factors: &[PauliTerm]) {
+        assert!(
+            !factors.is_empty(),
+            "Pauli rotation needs at least one factor"
+        );
+        let mut sorted: SmallVec<[PauliTerm; 4]> = SmallVec::from_slice(factors);
+        sorted.sort_unstable_by_key(|term| term.qubit);
+        for pair in sorted.windows(2) {
+            assert_ne!(
+                pair[0].qubit, pair[1].qubit,
+                "Pauli rotation has duplicate factor on qubit {}",
+                pair[0].qubit
+            );
+        }
+        match sorted.as_slice() {
+            [term] => {
+                let gate = match term.axis {
+                    PauliAxis::X => Gate::Rx(theta),
+                    PauliAxis::Y => Gate::Ry(theta),
+                    PauliAxis::Z => Gate::Rz(theta),
+                };
+                self.add_gate(gate, &[term.qubit]);
+            }
+            [a, b] if a.axis == PauliAxis::Z && b.axis == PauliAxis::Z => {
+                self.add_gate(Gate::Rzz(theta), &[a.qubit, b.qubit]);
+            }
+            _ => {
+                let targets: SmallVec<[usize; 4]> = sorted.iter().map(|term| term.qubit).collect();
+                let axes: Vec<PauliAxis> = sorted.iter().map(|term| term.axis).collect();
+                self.add_gate(
+                    Gate::PauliRot(Box::new(PauliRotData { theta, axes })),
+                    &targets,
+                );
+            }
+        }
     }
 
     /// Append a measurement operation.
@@ -871,6 +921,87 @@ pub fn expand_qft_blocks(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
                     }),
                 }
             }
+        } else {
+            out.push(inst.clone());
+        }
+    }
+
+    std::borrow::Cow::Owned(circuit.with_instructions(out))
+}
+
+/// Emit the CNOT-ladder lowering of `exp(-i θ P / 2)` gate by gate.
+///
+/// Basis layer first (`H` for an X letter, `Sdg` then `H` for Y), a CX chain
+/// accumulating the parity on the last target, one `Rz(θ)`, then the chain and
+/// basis layer unwound. Shared by [`expand_pauli_rotations`] and the GPU
+/// inline expansion so both routes lower identically.
+pub(crate) fn pauli_rotation_lowering(
+    theta: f64,
+    targets: &[usize],
+    axes: &[PauliAxis],
+    mut emit: impl FnMut(Gate, &[usize]),
+) {
+    for (&q, axis) in targets.iter().zip(axes) {
+        match axis {
+            PauliAxis::X => emit(Gate::H, &[q]),
+            PauliAxis::Y => {
+                emit(Gate::Sdg, &[q]);
+                emit(Gate::H, &[q]);
+            }
+            PauliAxis::Z => {}
+        }
+    }
+    for pair in targets.windows(2) {
+        emit(Gate::Cx, &[pair[0], pair[1]]);
+    }
+    emit(Gate::Rz(theta), &[targets[targets.len() - 1]]);
+    for pair in targets.windows(2).rev() {
+        emit(Gate::Cx, &[pair[0], pair[1]]);
+    }
+    for (&q, axis) in targets.iter().zip(axes) {
+        match axis {
+            PauliAxis::X => emit(Gate::H, &[q]),
+            PauliAxis::Y => {
+                emit(Gate::H, &[q]);
+                emit(Gate::S, &[q]);
+            }
+            PauliAxis::Z => {}
+        }
+    }
+}
+
+/// Expand `Gate::PauliRot` instructions to the CNOT-ladder lowering.
+///
+/// Backends without the native kernel call this before dispatch, the same
+/// probe-plus-expansion route as [`expand_qft_blocks`]. Returns
+/// `Cow::Borrowed` when there is nothing to expand.
+pub fn expand_pauli_rotations(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
+    let has_pauli_rot = circuit.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::PauliRot(_),
+                ..
+            }
+        )
+    });
+    if !has_pauli_rot {
+        return std::borrow::Cow::Borrowed(circuit);
+    }
+
+    let mut out: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len() * 2);
+    for inst in &circuit.instructions {
+        if let Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            targets,
+        } = inst
+        {
+            pauli_rotation_lowering(data.theta, targets, &data.axes, |gate, tgts| {
+                out.push(Instruction::Gate {
+                    gate,
+                    targets: SmallVec::from_slice(tgts),
+                });
+            });
         } else {
             out.push(inst.clone());
         }

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -5,8 +5,9 @@
 //! gate matrices agreeing to floating-point round-off rather than bit for bit.
 //! Angles carried inline (`rx`, `rz`, `rzz`, `p`) survive exactly.
 //!
-//! [`Gate::QftBlock`] expands to its textbook sequence before emission. Fusion
-//! payloads have no OpenQASM spelling and are rejected: `MultiFused`, `Multi2q`,
+//! [`Gate::QftBlock`] expands to its textbook sequence before emission, and
+//! [`Gate::PauliRot`] to its CNOT-ladder lowering. Fusion payloads have no
+//! OpenQASM spelling and are rejected: `MultiFused`, `Multi2q`,
 //! `BatchPhase`, `BatchRzz`, `DiagonalBatch`, a `Fused2q` outside the two-qubit
 //! families the parser builds, and a single-qubit matrix carrying a global phase
 //! no named rotation absorbs.
@@ -17,7 +18,7 @@ use std::f64::consts::{FRAC_PI_2, PI, TAU};
 use std::fmt::Write;
 
 use super::openqasm::Parser;
-use super::{Circuit, ClassicalCondition, Instruction, expand_qft_blocks};
+use super::{Circuit, ClassicalCondition, Instruction, expand_pauli_rotations, expand_qft_blocks};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
@@ -50,6 +51,7 @@ const EPS: f64 = 1e-12;
 /// ```
 pub fn to_qasm3(circuit: &Circuit) -> Result<String> {
     let expanded = expand_qft_blocks(circuit);
+    let expanded = expand_pauli_rotations(&expanded);
     let circuit = expanded.as_ref();
     let cregs = CregLayout::of(circuit)?;
 

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -10,6 +10,7 @@
 //! - Two-qubit gates (CX, CZ, SWAP) have dedicated application routines in
 //!   backends rather than materializing a 4×4 matrix.
 
+use crate::sim::unified_pauli::PauliAxis;
 use num_complex::Complex64;
 use smallvec::SmallVec;
 use std::f64::consts::{FRAC_1_SQRT_2, PI};
@@ -126,6 +127,16 @@ pub enum Gate {
     /// gates before execution.
     /// Boxless: `(u8, u8)` fits within the 16-byte enum slot.
     QftBlock { start: u8, num: u8 },
+
+    /// Multi-qubit Pauli rotation `exp(-i θ P / 2)`. The `PauliRotData` letter
+    /// at index `i` acts on the instruction's `targets[i]`.
+    ///
+    /// Built by [`crate::Circuit::add_pauli_rotation`], which lowers weight-1
+    /// strings to `Rx`/`Ry`/`Rz` and two-qubit `ZZ` to `Rzz`, so only the
+    /// residual multi-qubit strings construct this variant. The CPU
+    /// statevector applies it in one pass; backends without the kernel receive
+    /// the CNOT-ladder lowering from `circuit::expand_pauli_rotations`.
+    PauliRot(Box<PauliRotData>),
 }
 
 /// Analytic differentiation generator for a parametric gate.
@@ -148,6 +159,29 @@ pub enum GeneratorKind {
     RotZz,
     /// `P(θ)`: generator is the projector `|1⟩⟨1|` on `targets[0]`.
     Phase,
+}
+
+/// Data for a multi-qubit Pauli rotation `exp(-i θ P / 2)`.
+///
+/// `axes[i]` is the letter of `P` on the owning instruction's `targets[i]`.
+/// Fields are private so every construction path runs the recognizing
+/// lowering in [`crate::Circuit::add_pauli_rotation`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct PauliRotData {
+    pub(crate) theta: f64,
+    pub(crate) axes: Vec<PauliAxis>,
+}
+
+impl PauliRotData {
+    /// Rotation angle in radians.
+    pub fn theta(&self) -> f64 {
+        self.theta
+    }
+
+    /// Pauli letters aligned with the instruction targets.
+    pub fn axes(&self) -> &[PauliAxis] {
+        &self.axes
+    }
 }
 
 /// Data for a multi-controlled unitary gate.
@@ -427,6 +461,7 @@ impl Gate {
                 count_unique_qubits(data.edges.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
             }
             Gate::DiagonalBatch(data) => count_unique_diag_qubits(&data.entries),
+            Gate::PauliRot(data) => data.axes.len(),
             Gate::MultiFused(data) => data.gates.len(),
             Gate::Multi2q(data) => {
                 count_unique_qubits(data.gates.iter().flat_map(|&(q0, q1, _)| [q0, q1]))
@@ -510,6 +545,7 @@ impl Gate {
             | Gate::QftBlock { .. }
             | Gate::BatchRzz(_)
             | Gate::DiagonalBatch(_)
+            | Gate::PauliRot(_)
             | Gate::MultiFused(_)
             | Gate::Fused2q(_)
             | Gate::Multi2q(_) => {
@@ -584,6 +620,7 @@ impl Gate {
             Gate::Fused(_) => "fused",
             Gate::BatchPhase(_) => "batch_phase",
             Gate::QftBlock { .. } => "qft_block",
+            Gate::PauliRot(_) => "pauli_rot",
             Gate::BatchRzz(_) => "batch_rzz",
             Gate::DiagonalBatch(_) => "diagonal_batch",
             Gate::MultiFused(_) => "multi_fused",
@@ -621,6 +658,10 @@ impl Gate {
                      transform that calls Gate::inverse()."
                 )
             }
+            Gate::PauliRot(data) => Gate::PauliRot(Box::new(PauliRotData {
+                theta: -data.theta,
+                axes: data.axes.clone(),
+            })),
             Gate::BatchRzz(data) => Gate::BatchRzz(Box::new(BatchRzzData {
                 edges: data
                     .edges
@@ -870,6 +911,7 @@ impl Gate {
                 is_diag || is_antidiag
             }
             Gate::BatchPhase(_) | Gate::BatchRzz(_) | Gate::DiagonalBatch(_) => true,
+            Gate::PauliRot(data) => data.axes.iter().all(|axis| *axis == PauliAxis::Z),
             _ => false,
         }
     }
@@ -1055,6 +1097,17 @@ impl fmt::Display for Gate {
             Gate::MultiFused(data) => write!(f, "MF[{}]", data.gates.len()),
             Gate::BatchPhase(data) => write!(f, "BP[{}]", data.phases.len()),
             Gate::QftBlock { start, num } => write!(f, "QFT[{}..{}]", start, start + num),
+            Gate::PauliRot(data) => {
+                f.write_str("R[")?;
+                for axis in &data.axes {
+                    f.write_str(match axis {
+                        PauliAxis::X => "X",
+                        PauliAxis::Y => "Y",
+                        PauliAxis::Z => "Z",
+                    })?;
+                }
+                write!(f, "]({})", format_angle(data.theta))
+            }
             Gate::BatchRzz(data) => write!(f, "BZZ[{}]", data.edges.len()),
             Gate::DiagonalBatch(data) => write!(f, "BD[{}]", data.entries.len()),
             Gate::Multi2q(data) => write!(f, "M2[{}]", data.gates.len()),

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -844,6 +844,7 @@ pub(super) fn plan_temporal_clifford(
         #[cfg(feature = "gpu")]
         Accel::Gpu { .. } => {
             let expanded = crate::circuit::expand_qft_blocks(&tail);
+            let expanded = crate::circuit::expand_pauli_rotations(&expanded).into_owned();
             crate::circuit::fusion::fuse_circuit(&expanded, true).into_owned()
         }
     };

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -684,14 +684,37 @@ fn backend_from_initial_state(
     Ok(backend)
 }
 
-/// Fuse `circuit` for `backend` and apply it, leaving initialization to the
-/// caller. The start-state analogue of [`execute`], which owns the |0...0⟩ init.
-fn apply_fused_circuit(backend: &mut dyn Backend, circuit: &Circuit) -> Result<()> {
-    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
+/// Expand the gate forms `backend` has no native kernel for, `QftBlock` and
+/// `PauliRot`, leaving the stream borrowed when both probes accept it.
+fn expand_for_backend<'c>(
+    backend: &dyn Backend,
+    circuit: &'c Circuit,
+) -> std::borrow::Cow<'c, Circuit> {
+    use std::borrow::Cow;
+    let expanded = if backend.supports_qft_block() {
+        Cow::Borrowed(circuit)
     } else {
         crate::circuit::expand_qft_blocks(circuit)
     };
+    if backend.supports_pauli_rotation() {
+        return expanded;
+    }
+    match expanded {
+        Cow::Borrowed(borrowed) => crate::circuit::expand_pauli_rotations(borrowed),
+        Cow::Owned(owned) => {
+            let rotations = crate::circuit::expand_pauli_rotations(&owned);
+            if let Cow::Owned(expanded_rotations) = rotations {
+                return Cow::Owned(expanded_rotations);
+            }
+            Cow::Owned(owned)
+        }
+    }
+}
+
+/// Fuse `circuit` for `backend` and apply it, leaving initialization to the
+/// caller. The start-state analogue of [`execute`], which owns the |0...0⟩ init.
+fn apply_fused_circuit(backend: &mut dyn Backend, circuit: &Circuit) -> Result<()> {
+    let expanded = expand_for_backend(&*backend, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     backend.apply_instructions(&fused.instructions)
 }
@@ -750,11 +773,7 @@ fn shots_from_initial_state(
     check_initial_state_len(state, circuit.num_qubits)?;
     let plan = initial_state_plan(kind, circuit.num_qubits)?;
     let probe = plan.build(seed);
-    let expanded: std::borrow::Cow<'_, Circuit> = if probe.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
-    } else {
-        crate::circuit::expand_qft_blocks(circuit)
-    };
+    let expanded = expand_for_backend(&*probe, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, probe.supports_fused_gates());
 
     collect_shots(circuit, num_shots, seed, plan.resolved(), |shot_seed| {
@@ -916,11 +935,7 @@ fn try_backend_probabilities(backend: &dyn Backend) -> Result<Option<Probabiliti
 
 /// Core execution: fuse, init, apply, extract.
 fn execute(backend: &mut dyn Backend, circuit: &Circuit, opts: &SimOptions) -> Result<RunOutcome> {
-    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
-    } else {
-        crate::circuit::expand_qft_blocks(circuit)
-    };
+    let expanded = expand_for_backend(&*backend, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     execute_circuit(backend, &fused, opts)
 }
@@ -985,6 +1000,18 @@ pub(crate) fn prepared_route(kind: &BackendKind, template: &Circuit) -> Option<P
         )
     });
     if has_qft_block && !probe.supports_qft_block() {
+        return None;
+    }
+    let has_pauli_rot = template.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: crate::gates::Gate::PauliRot(_),
+                ..
+            }
+        )
+    });
+    if has_pauli_rot && !probe.supports_pauli_rotation() {
         return None;
     }
     Some(PreparedRoute {
@@ -1362,11 +1389,7 @@ fn try_terminal_statevector_backend(
 
     let accel = accel_for(kind, Family::Statevector, stripped.num_qubits);
     let mut backend = build_statevector(&accel, seed);
-    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
-        std::borrow::Cow::Borrowed(&stripped)
-    } else {
-        crate::circuit::expand_qft_blocks(&stripped)
-    };
+    let expanded = expand_for_backend(&backend, &stripped);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
@@ -2053,11 +2076,7 @@ fn grouped_expectation_statevector(
 
     let accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
     let mut backend = build_statevector(&accel, seed);
-    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
-    } else {
-        crate::circuit::expand_qft_blocks(circuit)
-    };
+    let expanded = expand_for_backend(&backend, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
@@ -2234,11 +2253,7 @@ fn expectation_values_statevector(
 
     let accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
     let mut backend = build_statevector(&accel, seed);
-    let expanded: std::borrow::Cow<'_, Circuit> = if backend.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
-    } else {
-        crate::circuit::expand_qft_blocks(circuit)
-    };
+    let expanded = expand_for_backend(&backend, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
@@ -2554,11 +2569,7 @@ fn run_shots_distributed(
     }
 
     let probe = DistributedStatevectorBackend::new(context.clone(), seed);
-    let expanded: std::borrow::Cow<'_, Circuit> = if probe.supports_qft_block() {
-        std::borrow::Cow::Borrowed(circuit)
-    } else {
-        crate::circuit::expand_qft_blocks(circuit)
-    };
+    let expanded = expand_for_backend(&probe, circuit);
     let fused = crate::circuit::fusion::fuse_circuit(&expanded, probe.supports_fused_gates());
     let opts = SimOptions::classical_only();
     let mut shots = Vec::with_capacity(num_shots);
@@ -2703,11 +2714,16 @@ fn run_shots_per_shot(
                 Ok(resolve_backend(&kind, sub, false))
             })
             .collect::<Result<_>>()?;
-        let fused_blocks: Vec<_> = partitions
+        let fused_blocks: Vec<std::borrow::Cow<'_, Circuit>> = partitions
             .iter()
             .zip(&block_plans)
             .map(|((sub, _, _), plan)| {
-                crate::circuit::fusion::fuse_circuit(sub, plan.supports_fused())
+                let probe = plan.build(seed);
+                let expanded = expand_for_backend(&*probe, sub);
+                std::borrow::Cow::Owned(
+                    crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused())
+                        .into_owned(),
+                )
             })
             .collect();
 
@@ -2731,7 +2747,9 @@ fn run_shots_per_shot(
         )
     } else {
         let plan = resolve_backend(&kind, circuit, has_partial_independence);
-        let fused = crate::circuit::fusion::fuse_circuit(circuit, plan.supports_fused());
+        let probe = plan.build(seed);
+        let expanded = expand_for_backend(&*probe, circuit);
+        let fused = crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused());
 
         collect_shots(circuit, num_shots, seed, plan.resolved(), |shot_seed| {
             let mut backend = plan.build(shot_seed);
@@ -2905,6 +2923,36 @@ pub(crate) fn run_shots_with_noise(
     } else {
         resolve_backend(&kind, circuit, false)
     };
+    // Noise events are indexed per instruction, so trajectories apply the
+    // stream raw and the Pauli-rotation lowering pass cannot run. The
+    // statevector applies the gate natively (its device path lowers inline);
+    // any other backend without the kernel is rejected before a shot starts.
+    let has_pauli_rot = circuit.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: crate::gates::Gate::PauliRot(_),
+                ..
+            } | Instruction::Conditional {
+                gate: crate::gates::Gate::PauliRot(_),
+                ..
+            }
+        )
+    });
+    if has_pauli_rot
+        && !matches!(plan, BackendPlan::Statevector { .. })
+        && !plan.build(seed).supports_pauli_rotation()
+    {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: format!("{:?}", plan.resolved()),
+            reason: "noisy trajectories apply the instruction stream raw so noise events \
+                     stay aligned to it, which leaves no room for the Pauli-rotation \
+                     lowering this backend needs; run on the statevector, or expand the \
+                     rotations with circuit::expand_pauli_rotations and attach the noise \
+                     model to the expanded circuit"
+                .into(),
+        });
+    }
     let route = plan.resolved();
     trajectory::run_trajectories(
         |s| plan.build(s),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -121,6 +121,11 @@ pub fn run_unfused_probs<B: Backend>(backend: &mut B, circuit: &Circuit) -> Vec<
     } else {
         prism_q::circuit::expand_qft_blocks(circuit)
     };
+    let expanded = if backend.supports_pauli_rotation() {
+        expanded
+    } else {
+        std::borrow::Cow::Owned(prism_q::circuit::expand_pauli_rotations(&expanded).into_owned())
+    };
     for instr in &expanded.instructions {
         backend.apply(instr).unwrap();
     }

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -69,8 +69,9 @@ fn phase_matrix(theta: f64) -> [[Complex64; 2]; 2] {
 
 // Non-Clifford circuit whose fused form walks the parallel kernel families:
 // 1q runs, CX with absorbable neighbors, Rzz and phase runs for the diagonal
-// batch tiers, plus Swap, Cu, and both Mcu shapes, which fuse into nothing and
-// keep their own index-bijection kernels.
+// batch tiers, the three Pauli-rotation branches (pair mix at low and high
+// pivot, Z-parity diagonal), plus Swap, Cu, and both Mcu shapes, which fuse
+// into nothing and keep their own index-bijection kernels.
 fn representative_dense_circuit(n: usize) -> Circuit {
     let mut c = Circuit::new(n, 0);
     for q in 0..n {
@@ -88,6 +89,10 @@ fn representative_dense_circuit(n: usize) -> Circuit {
     for q in 0..n {
         c.add_gate(Gate::P(0.05 + 0.02 * q as f64), &[q]);
     }
+    c.add_pauli_rotation(0.19, &[PauliTerm::x(0), PauliTerm::y(2), PauliTerm::z(4)]);
+    c.add_pauli_rotation(0.27, &[PauliTerm::z(1), PauliTerm::z(3), PauliTerm::z(5)]);
+    c.add_pauli_rotation(0.33, &[PauliTerm::z(0), PauliTerm::x(n - 1)]);
+    c.add_pauli_rotation(0.21, &[PauliTerm::x(n - 3), PauliTerm::x(n - 1)]);
     c.add_gate(Gate::Swap, &[0, n - 1]);
     c.add_gate(Gate::Cu(Box::new(rx_matrix(0.4))), &[1, n - 2]);
     c.add_gate(

--- a/tests/golden_gpu.rs
+++ b/tests/golden_gpu.rs
@@ -175,7 +175,26 @@ fn gate_samples() -> Vec<Gate> {
             gates: vec![(0, 1, m4)],
         })),
         Gate::QftBlock { start: 0, num: 4 },
+        pauli_rot_sample(),
     ]
+}
+
+// `PauliRotData` has no public constructor; pull the gate out of the circuit
+// builder, whose recognizing lowering keeps a weight-3 mixed string native.
+fn pauli_rot_sample() -> Gate {
+    let mut circuit = prism_q::Circuit::new(3, 0);
+    circuit.add_pauli_rotation(
+        0.53,
+        &[
+            prism_q::PauliTerm::x(0),
+            prism_q::PauliTerm::y(1),
+            prism_q::PauliTerm::z(2),
+        ],
+    );
+    match &circuit.instructions[0] {
+        Instruction::Gate { gate, .. } => gate.clone(),
+        _ => unreachable!("add_pauli_rotation appends a gate"),
+    }
 }
 
 /// Maps each `Gate` variant to a target layout. Exhaustive by design.
@@ -210,6 +229,7 @@ fn representative(gate: &Gate) -> (usize, Vec<Instruction>) {
         Gate::QftBlock { start, num } => {
             (*start as usize..*start as usize + *num as usize).collect()
         }
+        Gate::PauliRot(data) => (0..data.axes().len()).map(|i| i + 1).collect(),
     };
     let mut insts: Vec<Instruction> = (0..N).map(|q| g(Gate::H, &[q])).collect();
     insts.push(g(gate.clone(), &targets));

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -871,3 +871,150 @@ fn weighted_observable_y_bearing_large_group_variance_pins_the_rotation_sign() {
     assert!(result.mean.abs() < 1e-12);
     assert!((result.variance.unwrap() - 10.0).abs() < 1e-12);
 }
+
+// ---- Pauli rotations ----
+
+// exp(-i t/2 X0 Y1 Z2)|000> = cos(t/2)|000> + sin(t/2)|011>: the string maps
+// |000> to X|0> (x) Y|0> (x) Z|0> = i|110> read q0-first, i.e. i times index 3,
+// and -i sin(t/2) * i = sin(t/2).
+#[test]
+fn pauli_rot_xyz_on_zero() {
+    use prism_q::PauliTerm;
+    let theta = 0.7f64;
+    let mut c = Circuit::new(3, 0);
+    c.add_pauli_rotation(theta, &[PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)]);
+    let sv = run_and_state(&c);
+    let (s, cos) = (theta / 2.0).sin_cos();
+    for (i, amp) in sv.iter().enumerate() {
+        let expected = match i {
+            0 => Complex64::new(cos, 0.0),
+            3 => Complex64::new(s, 0.0),
+            _ => Complex64::new(0.0, 0.0),
+        };
+        assert_amplitude(*amp, expected, &format!("index {i}"));
+    }
+}
+
+// exp(-i t/2 X0 X1)|00> = cos(t/2)|00> - i sin(t/2)|11>.
+#[test]
+fn pauli_rot_xx_on_zero() {
+    use prism_q::PauliTerm;
+    let theta = 1.1f64;
+    let mut c = Circuit::new(2, 0);
+    c.add_pauli_rotation(theta, &[PauliTerm::x(0), PauliTerm::x(1)]);
+    let sv = run_and_state(&c);
+    let (s, cos) = (theta / 2.0).sin_cos();
+    assert_amplitude(sv[0], Complex64::new(cos, 0.0), "|00>");
+    assert_amplitude(sv[1], Complex64::new(0.0, 0.0), "|01>");
+    assert_amplitude(sv[2], Complex64::new(0.0, 0.0), "|10>");
+    assert_amplitude(sv[3], Complex64::new(0.0, -s), "|11>");
+}
+
+// A Z-only weight-3 string is diagonal: on H^3|000>, every basis state picks
+// up e^{-i t/2} at even parity of its three bits and e^{+i t/2} at odd.
+#[test]
+fn pauli_rot_zzz_applies_parity_phases() {
+    use prism_q::PauliTerm;
+    let theta = 0.9f64;
+    let mut c = Circuit::new(3, 0);
+    for q in 0..3 {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c.add_pauli_rotation(theta, &[PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)]);
+    let sv = run_and_state(&c);
+    let amp = 1.0 / (8.0f64).sqrt();
+    for (i, actual) in sv.iter().enumerate() {
+        let sign = if (i as u32).count_ones().is_multiple_of(2) {
+            -1.0
+        } else {
+            1.0
+        };
+        let expected = Complex64::from_polar(amp, sign * theta / 2.0);
+        assert_amplitude(*actual, expected, &format!("index {i}"));
+    }
+}
+
+// The recognizing constructor lowers weight-1 strings to the named rotation
+// and two-qubit ZZ to Rzz, with factors sorted by qubit.
+#[test]
+fn pauli_rot_constructor_lowers_recognized_forms() {
+    use prism_q::PauliTerm;
+    let mut c = Circuit::new(3, 0);
+    c.add_pauli_rotation(0.3, &[PauliTerm::x(1)]);
+    c.add_pauli_rotation(0.4, &[PauliTerm::y(0)]);
+    c.add_pauli_rotation(0.5, &[PauliTerm::z(2)]);
+    c.add_pauli_rotation(0.6, &[PauliTerm::z(2), PauliTerm::z(0)]);
+    let gates: Vec<_> = c
+        .instructions
+        .iter()
+        .map(|inst| match inst {
+            Instruction::Gate { gate, targets } => (gate.clone(), targets.to_vec()),
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(gates[0], (Gate::Rx(0.3), vec![1]));
+    assert_eq!(gates[1], (Gate::Ry(0.4), vec![0]));
+    assert_eq!(gates[2], (Gate::Rz(0.5), vec![2]));
+    assert_eq!(gates[3], (Gate::Rzz(0.6), vec![0, 2]));
+}
+
+// exp(-i t/2 P) followed by its inverse restores the prepared state exactly
+// up to floating-point roundoff.
+#[test]
+fn pauli_rot_inverse_round_trips() {
+    use prism_q::PauliTerm;
+    let factors = [PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(3)];
+    let mut c = Circuit::new(4, 0);
+    for q in 0..4 {
+        c.add_gate(Gate::Ry(0.4 + 0.2 * q as f64), &[q]);
+    }
+    c.add_pauli_rotation(0.8, &factors);
+    let rot = match c.instructions.last().unwrap() {
+        Instruction::Gate { gate, targets } => (gate.inverse(), targets.clone()),
+        _ => unreachable!(),
+    };
+    c.instructions.push(Instruction::Gate {
+        gate: rot.0,
+        targets: rot.1,
+    });
+
+    let mut reference = Circuit::new(4, 0);
+    for q in 0..4 {
+        reference.add_gate(Gate::Ry(0.4 + 0.2 * q as f64), &[q]);
+    }
+    let sv = run_and_state(&c);
+    let expected = run_and_state(&reference);
+    for (i, (a, e)) in sv.iter().zip(&expected).enumerate() {
+        assert_amplitude(*a, *e, &format!("index {i}"));
+    }
+}
+
+// The native kernel against the textbook CNOT-ladder lowering of the same
+// string on the same backend, from a non-symmetric product state.
+#[test]
+fn pauli_rot_matches_ladder_lowering() {
+    use prism_q::PauliTerm;
+    let factors = [
+        PauliTerm::x(0),
+        PauliTerm::y(1),
+        PauliTerm::z(2),
+        PauliTerm::x(3),
+    ];
+    let mut c = Circuit::new(4, 0);
+    for q in 0..4 {
+        c.add_gate(Gate::Ry(0.3 + 0.15 * q as f64), &[q]);
+        c.add_gate(Gate::Rz(0.1 + 0.07 * q as f64), &[q]);
+    }
+    c.add_pauli_rotation(0.65, &factors);
+
+    let expanded = prism_q::circuit::expand_pauli_rotations(&c);
+    assert!(
+        matches!(expanded, std::borrow::Cow::Owned(_)),
+        "expansion must rewrite the native gate"
+    );
+    let sv = run_and_state(&c);
+    let lowered = run_and_state(&expanded);
+    for (i, (a, e)) in sv.iter().zip(&lowered).enumerate() {
+        assert_amplitude(*a, *e, &format!("index {i}"));
+    }
+}

--- a/tests/pauli_rot_correctness.rs
+++ b/tests/pauli_rot_correctness.rs
@@ -1,0 +1,234 @@
+//! Pipeline coverage for the native Pauli rotation: the statevector keeps the
+//! native gate through fusion, every declining backend receives the ladder
+//! expansion, and both routes agree at parallel-kernel sizes.
+
+mod common;
+
+use common::{MPS_EPS, SEED, SV_EPS, assert_probs_close};
+use num_complex::Complex64;
+use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::backend::mps::MpsBackend;
+use prism_q::backend::sparse::SparseBackend;
+use prism_q::backend::statevector::StatevectorBackend;
+use prism_q::circuit::{Circuit, Instruction, expand_pauli_rotations};
+use prism_q::gates::Gate;
+use prism_q::{BackendKind, PauliTerm, sim};
+
+fn trotter_like_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.23 + 0.11 * q as f64), &[q]);
+    }
+    c.add_pauli_rotation(0.41, &[PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)]);
+    c.add_pauli_rotation(0.29, &[PauliTerm::z(0), PauliTerm::z(2), PauliTerm::z(3)]);
+    c.add_pauli_rotation(0.37, &[PauliTerm::x(1), PauliTerm::x(3)]);
+    c.add_pauli_rotation(0.19, &[PauliTerm::z(0), PauliTerm::y(n - 1)]);
+    // Top-qubit pivot with a nonzero low X-mask, so the tiled pair kernel
+    // pairs across permuted tile indices rather than identity ones.
+    c.add_pauli_rotation(0.23, &[PauliTerm::x(n - 3), PauliTerm::y(n - 1)]);
+    c
+}
+
+fn state_of(backend: &mut StatevectorBackend, circuit: &Circuit) -> Vec<Complex64> {
+    sim::run_on(backend, circuit).unwrap();
+    backend.state_vector().to_vec()
+}
+
+// Native route pin, per the QftBlock lesson: the fused stream the statevector
+// executes must still contain the native gate, not just produce matching
+// amplitudes.
+#[test]
+fn fusion_keeps_the_native_gate() {
+    let circuit = trotter_like_circuit(16);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+    let native_count = fused
+        .instructions
+        .iter()
+        .filter(|inst| {
+            matches!(
+                inst,
+                Instruction::Gate {
+                    gate: Gate::PauliRot(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        native_count, 5,
+        "fusion must pass PauliRot through untouched"
+    );
+    assert!(StatevectorBackend::new(SEED).supports_pauli_rotation());
+}
+
+// Native kernel against the ladder lowering across the parallel threshold,
+// covering the low-pivot, high-pivot, and Z-diagonal kernel branches.
+#[test]
+fn native_matches_ladder_at_parallel_sizes() {
+    for n in [6, 16] {
+        let circuit = trotter_like_circuit(n);
+        let expanded = expand_pauli_rotations(&circuit);
+        assert!(matches!(expanded, std::borrow::Cow::Owned(_)));
+        let native = state_of(&mut StatevectorBackend::new(SEED), &circuit);
+        let lowered = state_of(&mut StatevectorBackend::new(SEED), &expanded);
+        // 1e-12 rather than SV_EPS: one native pass against a ladder of tens
+        // of gates accumulates only rounding, not backend error.
+        for (i, (a, e)) in native.iter().zip(&lowered).enumerate() {
+            let diff = (a - e).norm();
+            assert!(diff < 1e-12, "{n}q amplitude {i}: |diff| = {diff:e}");
+        }
+    }
+}
+
+// A weight-k string lowers to 2(k-1) CX around one Rz, plus the basis layer.
+#[test]
+fn ladder_lowering_shape() {
+    let mut c = Circuit::new(4, 0);
+    c.add_pauli_rotation(
+        0.5,
+        &[
+            PauliTerm::x(0),
+            PauliTerm::y(1),
+            PauliTerm::z(2),
+            PauliTerm::z(3),
+        ],
+    );
+    let expanded = expand_pauli_rotations(&c);
+    let count = |wanted: fn(&Gate) -> bool| {
+        expanded
+            .instructions
+            .iter()
+            .filter(|inst| matches!(inst, Instruction::Gate { gate, .. } if wanted(gate)))
+            .count()
+    };
+    assert_eq!(count(|g| matches!(g, Gate::PauliRot(_))), 0);
+    assert_eq!(count(|g| matches!(g, Gate::Cx)), 6);
+    assert_eq!(count(|g| matches!(g, Gate::Rz(_))), 1);
+    // X basis change: H twice; Y: Sdg + H in, H + S out.
+    assert_eq!(count(|g| matches!(g, Gate::H)), 4);
+    assert_eq!(count(|g| matches!(g, Gate::Sdg)), 1);
+    assert_eq!(count(|g| matches!(g, Gate::S)), 1);
+}
+
+#[test]
+fn expansion_borrows_without_native_gates() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_pauli_rotation(0.3, &[PauliTerm::z(0), PauliTerm::z(1)]);
+    assert!(matches!(
+        expand_pauli_rotations(&c),
+        std::borrow::Cow::Borrowed(_)
+    ));
+}
+
+// Declining backends receive the ladder through the sim-layer expansion: a
+// raw PauliRot reaching MPS or sparse dispatch panics on arity, and the
+// density matrix would pay two extra conjugation passes per gate.
+#[test]
+fn declining_backends_match_statevector_through_expansion() {
+    let circuit = trotter_like_circuit(6);
+    let reference = common::sv_reference_probs(&circuit);
+
+    let cases: [(&str, Box<dyn Backend>, f64); 3] = [
+        ("mps", Box::new(MpsBackend::new(SEED, 64)), MPS_EPS),
+        ("sparse", Box::new(SparseBackend::new(SEED)), SV_EPS),
+        (
+            "density_matrix",
+            Box::new(DensityMatrixBackend::new(SEED)),
+            SV_EPS,
+        ),
+    ];
+    for (label, mut backend, eps) in cases {
+        assert!(!backend.supports_pauli_rotation(), "{label}");
+        sim::run_on(&mut *backend, &circuit).unwrap();
+        let probs = backend.probabilities().unwrap();
+        assert_probs_close(&probs, &reference, eps, label);
+    }
+}
+
+// Mid-circuit measurement forces the per-shot route, which expands per block
+// plan before fusing; MPS erroring here would mean that expansion was skipped.
+#[test]
+fn per_shot_route_expands_for_mps() {
+    let mut c = trotter_like_circuit(4);
+    c.num_classical_bits = 2;
+    c.add_measure(0, 0);
+    c.add_pauli_rotation(0.31, &[PauliTerm::x(1), PauliTerm::y(2), PauliTerm::z(3)]);
+    c.add_measure(3, 1);
+
+    let sv = sim::simulate(&c)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .shots(32)
+        .unwrap();
+    let mps = sim::simulate(&c)
+        .backend(BackendKind::Mps { max_bond_dim: 64 })
+        .seed(SEED)
+        .shots(32)
+        .unwrap();
+    assert_eq!(sv.shots, mps.shots);
+}
+
+#[test]
+fn z_only_rotation_preserves_sparsity() {
+    let mut z_only = Circuit::new(3, 0);
+    z_only.add_pauli_rotation(0.4, &[PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)]);
+    assert!(z_only.is_sparse_friendly());
+    assert!(!z_only.is_clifford_only());
+    assert!(z_only.has_entangling_gates());
+
+    let mut mixed = Circuit::new(3, 0);
+    mixed.add_pauli_rotation(0.4, &[PauliTerm::x(0), PauliTerm::z(1), PauliTerm::z(2)]);
+    assert!(!mixed.is_sparse_friendly());
+}
+
+#[test]
+fn qasm_export_emits_the_lowering() {
+    let circuit = trotter_like_circuit(4);
+    let qasm = prism_q::circuit::qasm_export::to_qasm3(&circuit).unwrap();
+    assert!(!qasm.contains("pauli_rot"));
+    assert!(qasm.contains("cx"));
+}
+
+// Noise events are indexed per instruction, so the trajectory engine applies
+// the stream raw: the statevector serves the gate natively, and a backend
+// that needs the lowering is rejected with a typed error, never a panic.
+#[test]
+fn noisy_trajectories_run_native_and_reject_declining_backends() {
+    let circuit = trotter_like_circuit(4);
+    let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+
+    let sv = sim::simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(8)
+        .unwrap();
+    assert_eq!(sv.shots.len(), 8);
+
+    let err = sim::simulate(&circuit)
+        .backend(BackendKind::Mps { max_bond_dim: 64 })
+        .noise(&noise)
+        .seed(SEED)
+        .shots(8)
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        prism_q::PrismError::IncompatibleBackend { .. }
+    ));
+}
+
+#[test]
+#[should_panic(expected = "duplicate factor")]
+fn constructor_rejects_duplicate_qubits() {
+    let mut c = Circuit::new(2, 0);
+    c.add_pauli_rotation(0.1, &[PauliTerm::x(0), PauliTerm::z(0)]);
+}
+
+#[test]
+#[should_panic(expected = "at least one factor")]
+fn constructor_rejects_empty_strings() {
+    let mut c = Circuit::new(1, 0);
+    c.add_pauli_rotation(0.1, &[]);
+}


### PR DESCRIPTION
## Summary

Trotterized evolution of `exp(-i theta P / 2)` previously paid a CNOT ladder plus one `Rz` per string, 2(k-1) entangling passes each, because `Rzz` was the only multi-qubit rotation in the gate set. This adds `Gate::PauliRot` with a one-pass statevector kernel, a recognizing constructor (`Circuit::add_pauli_rotation`) that keeps weight-1 and two-qubit ZZ strings on the existing `Rx`/`Ry`/`Rz`/`Rzz` paths, and a `supports_pauli_rotation` probe plus `expand_pauli_rotations` pass, the same route `QftBlock` uses, that hands every declining backend, QASM export, and the GPU inline path the ladder lowering.

## Scope

- [x] New feature

## Benchmarks

Adjacent-binary A/B against `main` via `scripts/bench_ab.sh`, full Criterion at 30 samples, quiet host, worst same-code control spread 4.2%. Two earlier attempts were discarded before this one: the first compared identical binaries after a stale build fingerprint reused an overwritten executable, and the second ran under external host load with same-code controls up to 55%, so neither is a result.

The `trotter` rows are new, so they are first measurements rather than before/after. Both arms run the same 200-string Jordan-Wigner Trotter step (seeded fixture in `benches/circuits.rs`; 192 of the 199 rotations at 16q and 189 at 20q stay native, the rest lower to named rotations at insert); the ladder arm pre-expands the native strings. Each cell lists the two measured passes of the new binary.

| Benchmark | Before (ms) | After (ms) | Change |
| --- | --- | --- | --- |
| `statevector/trotter/native/16` | new row | 12.14 / 12.34 | first measurement |
| `statevector/trotter/ladder/16` | new row | 74.23 / 75.12 | native 6.1x faster than ladder |
| `statevector/trotter/native/20` | new row | 315.7 / 313.6 | first measurement |
| `statevector/trotter/ladder/20` | new row | 2610 / 2559 | native 8.2x faster than ladder |

Untouched-path control rows, same run:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `statevector/qaoa_l3/4` | 2.31 us | 2.37 us | +2.3% | -4.2% / -3.6% | yes, noise |
| `statevector/qaoa_l3/8` | 18.09 us | 17.90 us | -1.0% | -0.7% / -1.2% | yes, noise |
| `statevector/qaoa_l3/12` | 388.19 us | 367.13 us | -5.4% | -3.1% / -1.6% | reads faster, but within a control-sized band; treated as noise |
| `statevector/qaoa_l3/16` | 2.20 ms | 2.28 ms | +3.5% | -4.2% / -1.2% | yes, noise |
| `statevector/qaoa_l3/20` | 39.70 ms | 40.33 ms | +1.6% | -1.8% / +1.8% | yes, noise |

Regression verdict: PASS

The CI benchmark gate reports FAIL on `statevector/qft_textbook/22` (two of three runs) and once on `statevector/scalability_d5/22`, each row reading neutral in the runs that flag the other. Neither is reachable by this diff: a circuit with no Pauli rotation pays one capability probe, and both kernels are untouched. Building both binaries from one directory, which is what `benches/README.md` prescribes when a change adds linked code, puts the disputed row at +0.13% against same-code controls of -0.03% and +0.07%. Details in a comment below.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2259 tests, `PRISM_REQUIRE_GPU=1`)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new pub items carry the packing convention (letters align with instruction targets) and the lowering contract
- [x] Golden tests: hand-derived amplitudes for XYZ, XX, and Z-only strings, constructor lowerings, inverse round-trip, and native-vs-ladder equality in `tests/golden_small_circuits.rs`; route pins (fusion keeps the native gate, declining backends only pass through expansion, per-shot route expansion, ladder shape) in `tests/pauli_rot_correctness.rs`
- [x] GPU golden suite passes on a real device (`every_gate_variant_matches_cpu` covers the new variant through the inline expansion)

The determinism fixture gains all three kernel branches (low-pivot pair mix, high-pivot pair mix, Z-parity sweep), so the bitwise thread-count pin and the miri and TSan CI jobs interpret them.

## Hotspot notes

`apply_pauli_rot`, `pauli_rot_pair_halves`, and `apply_parity_phase` in `src/backend/statevector/kernels.rs`. Pairs `(j, j ^ xmask)` are mixed in one pass pivoting on the top X-mask bit; partitioning is `par_chunks_mut` over pivot blocks (or power-of-two tile pairs above `xlow` when blocks are scarce), a pure function of state size and gate shape, safe code only. The whole-row Trotter measurements above carry the timing story; no isolated-kernel claim is made. Dispatch-side cost on untouched circuits is one probe call per run, neutral per the control rows.

## Architecture or design changes

- [x] `docs/architecture/ir.md` (gate table), `docs/architecture/backends.md` (kernel list), `docs/guides/openqasm.md` (export expansion), and the statevector module doc updated

## Breaking changes

None. Additive API: `Circuit::add_pauli_rotation`, `Gate::PauliRot`, `PauliRotData` accessors, and a defaulted `Backend::supports_pauli_rotation`.

## Risks and rollback

The variant is only constructible through `Circuit::add_pauli_rotation`, so existing circuits cannot contain it and every prior route is behaviorally unchanged (control rows above). A backend route missed by the expansion audit fails loudly (`BackendUnsupported` from the tableau family, an arity panic elsewhere) rather than computing silently wrong amplitudes; the per-shot route, which lacked the expansion probe, gained it and is pinned by a test. Noisy trajectories apply the instruction stream raw so noise events stay index-aligned, which leaves no room for the lowering: the statevector serves the gate natively there (the device path lowers inline), and any other trajectory backend rejects the circuit with a typed `IncompatibleBackend` before a shot starts, also pinned by a test. Gradient and Python surfaces are deliberately untouched; `pauli_generator` returns `None` for the variant, so the gradient engines skip it.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers; deferred work is filed internally
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green
