### PR TITLE
feat(gradient): differentiate the native Pauli rotation

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1406,6 +1406,87 @@ fn bench_gradient_prefix(c: &mut Criterion) {
     group.finish();
 }
 
+// A Trotter ansatz over the largest Jordan-Wigner strings of the seeded
+// two-body operator, on an alternating occupation reference. The recognizing
+// constructor lowers the weight-1 and ZZ generators, so the stream mixes named
+// rotations with `PauliRot` and the gradient runs over both.
+fn vqe_ansatz(n: usize, generators: &[Vec<PauliTerm>], values: &[f64]) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in (0..n).step_by(2) {
+        c.add_gate(Gate::X, &[q]);
+    }
+    for (theta, factors) in values.iter().zip(generators) {
+        c.add_pauli_rotation(*theta, factors);
+    }
+    c
+}
+
+/// One variational loop iteration: evaluate the weighted observable, take the
+/// adjoint gradient, step the parameters.
+///
+/// `rebuild` constructs the ansatz at every iteration, which is what a loop
+/// without a parameter surface does; `bind` holds one [`PreparedCircuit`] and
+/// rebinds. Both arms live in this one binary so an A/B compares them without a
+/// second build; see `benches/README.md` on why a reference worktree cannot
+/// resolve a change that adds linked code.
+///
+/// The `sweep_setup` group times the same two arms with no simulation. This one
+/// pays the evaluation and gradient cost the setup is amortized over, so the two
+/// rows together say what share of a real iteration the parameter surface moves.
+fn bench_vqe_loop(c: &mut Criterion) {
+    const GENERATORS: usize = 16;
+    const OBSERVABLE_TERMS: usize = 64;
+    const LEARNING_RATE: f64 = 0.01;
+
+    let mut group = c.benchmark_group("vqe");
+    configure_group(&mut group);
+
+    for &n in &[12, 16] {
+        let terms = circuits::jordan_wigner_hamiltonian(n, OBSERVABLE_TERMS, SEED);
+        let observable = PauliObservable::from_terms(terms.clone()).unwrap();
+        let generators: Vec<Vec<PauliTerm>> = terms
+            .iter()
+            .map(|(_, factors)| factors.clone())
+            .filter(|factors| !factors.is_empty())
+            .take(GENERATORS)
+            .collect();
+        let values: Vec<f64> = (0..generators.len())
+            .map(|k| 0.05 + 0.01 * k as f64)
+            .collect();
+
+        let template = vqe_ansatz(n, &generators, &values);
+        let params = Parameters::all_rotations(&template);
+
+        let iteration = |circuit: &Circuit| {
+            let energy = run_observable_expectation(circuit, &observable, 42).unwrap();
+            let grad = run_expectation_gradient(circuit, &terms, &params, 42).unwrap();
+            let stepped: Vec<f64> = values
+                .iter()
+                .zip(&grad.gradient)
+                .map(|(v, g)| v - LEARNING_RATE * g)
+                .collect();
+            (energy.mean, stepped)
+        };
+
+        group.bench_function(BenchmarkId::new("rebuild", n), |b| {
+            b.iter(|| {
+                let circuit = vqe_ansatz(n, &generators, &values);
+                black_box(iteration(&circuit));
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("bind", n), |b| {
+            let mut prepared = PreparedCircuit::new(template.clone(), params.clone()).unwrap();
+            b.iter(|| {
+                let circuit = prepared.bind(&values).unwrap();
+                black_box(iteration(circuit));
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_expectation(c: &mut Criterion) {
     let mut group = c.benchmark_group("expectation/pauli_sum");
     configure_group(&mut group);
@@ -2307,6 +2388,8 @@ criterion_group! {
     bench_gradient,
     bench_gradient_qaoa,
     bench_gradient_prefix,
+    // Variational loop iteration (rebuild vs rebind under simulation cost)
+    bench_vqe_loop,
     // Forward Pauli-sum expectation (parallel-sandwich neutrality)
     bench_expectation,
     bench_expectation_factored,

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -176,8 +176,11 @@ The method back-propagates two statevectors. With `U = U_L…U_1` and `|φ⟩ = 
 The `⟨λ|G|φ⟩` sandwich generalizes the forward `pauli_expectation_from_masks`
 kernel to two vectors (`pauli_sandwich`, Rayon-parallel at 16+ qubits).
 
-Differentiable gates are `Rx`, `Ry`, `Rz`, `Rzz`, and `P` (identified by
-`Gate::pauli_generator`, a method, so `Gate` stays 16 bytes). Trainable links on
+Differentiable gates are `Rx`, `Ry`, `Rz`, `Rzz`, `P`, and `PauliRot` (identified by
+`Gate::pauli_generator`, a method, so `Gate` stays 16 bytes). A multi-qubit Pauli
+rotation is `exp(-iθP/2)` like the named rotations, so its generator is the string
+itself: `GeneratorKind::RotPauli` borrows the letters off the gate, and the sandwich
+takes the masks they imply rather than a per-variant special case. Trainable links on
 other gates, non-unitary instructions, and `QftBlock` are rejected. Parameter
 identity is an index-based side table (`Parameters`, instruction→slot links
 recorded by `CircuitBuilder::param`); many gates may share a slot.
@@ -209,9 +212,11 @@ is the apparent exception, its generator being the projector `|1⟩⟨1|` with e
 `{0, 1}`, but `P(θ) = e^{iθ/2} Rz(θ)` and that scalar cancels against its conjugate in
 `⟨ψ|H|ψ⟩` wherever the gate sits, so the same shift applies.
 
-The differentiable gate set is unchanged: `Rx`, `Ry`, `Rz`, `Rzz`, and `P` are the only
-`Gate` variants carrying an angle inline, so parameter shift reaches no gate the adjoint
-rejects. Its reach is backends and circuit shapes, not gates.
+The differentiable gate set is the same one the adjoint takes: `Rx`, `Ry`, `Rz`, `Rzz`,
+`P`, and `PauliRot` are the `Gate` variants carrying a rotation angle, so parameter shift
+reaches no gate the adjoint rejects. Its reach is backends and circuit shapes, not gates.
+A `PauliRot` on a backend without the native kernel is shifted in the same place, because
+the ladder expansion happens below the forward evaluation the rule calls.
 
 Gates sharing a parameter slot are shifted one at a time and their contributions summed.
 Shifting them together is a different quantity: two `Rx(θ)` on one qubit under `⟨Z⟩` give

--- a/docs/architecture/fusion.md
+++ b/docs/architecture/fusion.md
@@ -92,6 +92,11 @@ steered has already happened.
 `DiagonalBatch` and `BatchPhase` have no recipe, so a template reaching either declines
 capture and re-fuses per binding.
 
+A gate the passes leave untouched still needs a site when it carries an angle. `PauliRot`
+holds its angle in a boxed payload rather than in the enum slot, and replay patches it
+exactly as it patches an `Rz`; without that site a bound rotation would keep the
+template's angle while every other payload moved.
+
 ## Fusion cost against apply cost
 
 Fusion cost tracks instruction count and is close to flat in qubit count, while gate

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -16,7 +16,9 @@ use super::{MIN_PAR_ELEMS, PARALLEL_THRESHOLD_QUBITS, SendPtr};
 use crate::backend::simd;
 use crate::backend::{MCU_QUBIT_BUF, is_phase_one, measurement_inv_norm, sorted_mcu_qubits};
 use crate::circuit::{QftTextbookStep, qft_textbook_steps};
-use crate::gates::{BatchPhaseData, BatchRzzData, DiagEntry, Gate, diag_entries_phase};
+use crate::gates::{
+    BatchPhaseData, BatchRzzData, DiagEntry, Gate, diag_entries_phase, pauli_rot_masks,
+};
 use crate::sim::unified_pauli::PauliAxis;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -1880,21 +1882,7 @@ impl StatevectorBackend {
     /// `xmask == 0` and reduces to parity phases on the diagonal.
     #[inline(always)]
     pub(super) fn apply_pauli_rot(&mut self, targets: &[usize], theta: f64, axes: &[PauliAxis]) {
-        let mut xmask = 0usize;
-        let mut zmask = 0usize;
-        let mut num_y = 0u32;
-        for (&q, axis) in targets.iter().zip(axes) {
-            let bit = 1usize << q;
-            match axis {
-                PauliAxis::X => xmask |= bit,
-                PauliAxis::Z => zmask |= bit,
-                PauliAxis::Y => {
-                    xmask |= bit;
-                    zmask |= bit;
-                    num_y += 1;
-                }
-            }
-        }
+        let (xmask, zmask, num_y) = pauli_rot_masks(targets, axes);
         let c = (theta / 2.0).cos();
         let s = (theta / 2.0).sin();
         if xmask == 0 {

--- a/src/circuit/parameter.rs
+++ b/src/circuit/parameter.rs
@@ -24,8 +24,8 @@ pub struct ParamLink {
 /// inferred from the links, so a value vector of the wrong length is rejected
 /// even when the trailing slots carry no link.
 ///
-/// Bindable gates are `Rx`, `Ry`, `Rz`, `Rzz`, and `P`, the `Gate` variants
-/// carrying an angle inline.
+/// Bindable gates are `Rx`, `Ry`, `Rz`, `Rzz`, `P`, and `PauliRot`, the `Gate`
+/// variants carrying a rotation angle.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Parameters {
     links: Vec<ParamLink>,
@@ -197,7 +197,7 @@ impl Parameters {
                 Instruction::Gate { gate, .. } => {
                     return Err(PrismError::InvalidParameter {
                         message: format!(
-                            "instruction {} (`{}`) carries no bindable angle; bindable gates are rx, ry, rz, rzz, p",
+                            "instruction {} (`{}`) carries no bindable angle; bindable gates are rx, ry, rz, rzz, p, pauli_rot",
                             link.instruction,
                             gate.name()
                         ),
@@ -331,6 +331,10 @@ fn angle_of(instruction: &Instruction) -> f64 {
             gate: Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::Rzz(t) | Gate::P(t),
             ..
         } => *t,
+        Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            ..
+        } => data.theta(),
         _ => unreachable!("parameter link validated as bindable"),
     }
 }
@@ -341,6 +345,10 @@ pub(crate) fn angle_mut(instruction: &mut Instruction) -> &mut f64 {
             gate: Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::Rzz(t) | Gate::P(t),
             ..
         } => t,
+        Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            ..
+        } => &mut data.theta,
         _ => unreachable!("parameter link validated as bindable"),
     }
 }

--- a/src/circuit/plan.rs
+++ b/src/circuit/plan.rs
@@ -338,6 +338,12 @@ impl Tracer {
 /// when the gate carries no angle-derived data.
 fn identity_prov(index: u32, inst: &Instruction) -> Prov {
     match inst {
+        // A Pauli rotation carries an angle at any width and no pass folds it
+        // into a matrix product, so it names itself for the angle recipe alone.
+        Instruction::Gate {
+            gate: Gate::PauliRot(_),
+            ..
+        } => vec![vec![Step::M1 { src: index }]],
         Instruction::Gate { gate, .. } => match gate.num_qubits() {
             1 => vec![vec![Step::M1 { src: index }]],
             2 => vec![vec![Step::M2 {
@@ -504,6 +510,10 @@ fn gate_angle(inst: &Instruction) -> f64 {
             gate: Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::Rzz(t) | Gate::P(t),
             ..
         } => *t,
+        Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            ..
+        } => data.theta(),
         _ => unreachable!("angle recipe names a gate carrying an angle"),
     }
 }
@@ -569,7 +579,7 @@ fn record_sites(
             }
             true
         }
-        Gate::Rx(_) | Gate::Ry(_) | Gate::Rz(_) | Gate::P(_) | Gate::Rzz(_) => {
+        Gate::Rx(_) | Gate::Ry(_) | Gate::Rz(_) | Gate::P(_) | Gate::Rzz(_) | Gate::PauliRot(_) => {
             let [single] = prov.as_slice() else {
                 return false;
             };
@@ -689,6 +699,10 @@ fn write_angle(inst: &mut Instruction, entry: usize, theta: f64) -> bool {
     match gate {
         Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::P(t) | Gate::Rzz(t) => {
             *t = theta;
+            true
+        }
+        Gate::PauliRot(d) => {
+            d.set_theta(theta);
             true
         }
         Gate::BatchRzz(d) => match d.edges.get_mut(entry) {

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -146,9 +146,10 @@ pub enum Gate {
 /// the enum. Each rotation variant is `exp(-i θ/2 G)` with the named Pauli
 /// generator `G` acting on the gate's `targets` (in order); `Phase` is the
 /// non-Pauli phase gate `diag(1, e^{iθ})` whose generator is the projector
-/// `|1⟩⟨1|` on `targets[0]`.
+/// `|1⟩⟨1|` on `targets[0]`. The borrow is of the gate the generator was read
+/// from, so a caller holding one cannot pair it with another gate's letters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GeneratorKind {
+pub enum GeneratorKind<'a> {
     /// `Rx(θ)`: generator `X` on `targets[0]`.
     RotX,
     /// `Ry(θ)`: generator `Y` on `targets[0]`.
@@ -159,6 +160,9 @@ pub enum GeneratorKind {
     RotZz,
     /// `P(θ)`: generator is the projector `|1⟩⟨1|` on `targets[0]`.
     Phase,
+    /// `PauliRot(θ)`: generator is the Pauli string whose letter at index `i`
+    /// acts on `targets[i]`.
+    RotPauli(&'a [PauliAxis]),
 }
 
 /// Data for a multi-qubit Pauli rotation `exp(-i θ P / 2)`.
@@ -178,10 +182,43 @@ impl PauliRotData {
         self.theta
     }
 
+    /// Overwrite the rotation angle, leaving the Pauli string alone. The
+    /// recognizing lowering runs on the string, so rebinding an angle cannot
+    /// invalidate it.
+    pub fn set_theta(&mut self, theta: f64) {
+        self.theta = theta;
+    }
+
     /// Pauli letters aligned with the instruction targets.
     pub fn axes(&self) -> &[PauliAxis] {
         &self.axes
     }
+}
+
+/// Pack the Pauli string of a rotation into `(xmask, zmask, num_y)`, where
+/// `xmask` covers X and Y letters and `zmask` covers Z and Y, and `axes[i]`
+/// acts on `targets[i]`.
+///
+/// The native kernel and the adjoint gradient both derive their masks here, so
+/// a change to the letter convention cannot move one without the other.
+#[inline]
+pub(crate) fn pauli_rot_masks(targets: &[usize], axes: &[PauliAxis]) -> (usize, usize, u32) {
+    let mut xmask = 0usize;
+    let mut zmask = 0usize;
+    let mut num_y = 0u32;
+    for (&q, axis) in targets.iter().zip(axes) {
+        let bit = 1usize << q;
+        match axis {
+            PauliAxis::X => xmask |= bit,
+            PauliAxis::Z => zmask |= bit,
+            PauliAxis::Y => {
+                xmask |= bit;
+                zmask |= bit;
+                num_y += 1;
+            }
+        }
+    }
+    (xmask, zmask, num_y)
 }
 
 /// Data for a multi-controlled unitary gate.
@@ -715,17 +752,19 @@ impl Gate {
 
     /// Return the analytic differentiation generator for a parametric gate,
     /// or `None` if the gate has no defined generator (all non-parametric
-    /// gates, and parametric gates whose angle is not stored inline as `f64`,
-    /// e.g. controlled unitaries built from a boxed matrix). Used by the
-    /// adjoint gradient engine to decide which instructions are differentiable.
+    /// gates, and parametric gates whose angle is not recoverable from the
+    /// variant, e.g. controlled unitaries built from a boxed matrix). Used by
+    /// the adjoint gradient engine to decide which instructions are
+    /// differentiable.
     #[inline]
-    pub fn pauli_generator(&self) -> Option<GeneratorKind> {
+    pub fn pauli_generator(&self) -> Option<GeneratorKind<'_>> {
         match self {
             Gate::Rx(_) => Some(GeneratorKind::RotX),
             Gate::Ry(_) => Some(GeneratorKind::RotY),
             Gate::Rz(_) => Some(GeneratorKind::RotZ),
             Gate::Rzz(_) => Some(GeneratorKind::RotZz),
             Gate::P(_) => Some(GeneratorKind::Phase),
+            Gate::PauliRot(data) => Some(GeneratorKind::RotPauli(&data.axes)),
             _ => None,
         }
     }

--- a/src/sim/gradient.rs
+++ b/src/sim/gradient.rs
@@ -11,8 +11,8 @@
 //!
 //! The differentiated circuit must be unitary (no measurement, reset, or
 //! conditional) on both paths. Differentiable gates are `Rx`, `Ry`, `Rz`,
-//! `Rzz`, and `P` for both: those are the only `Gate` variants carrying an
-//! angle inline, so the shift rule reaches no gate the adjoint rejects.
+//! `Rzz`, `P`, and `PauliRot` for both: those are the `Gate` variants carrying
+//! a rotation angle, so the shift rule reaches no gate the adjoint rejects.
 
 use num_complex::Complex64;
 
@@ -21,7 +21,7 @@ use crate::backend::{Backend, max_statevector_qubits, reserve_dense_output};
 use crate::circuit::parameter::{Parameters, angle_mut};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
-use crate::gates::{Gate, GeneratorKind};
+use crate::gates::{Gate, GeneratorKind, pauli_rot_masks};
 
 use super::unified_pauli::PauliTerm;
 use super::{BackendKind, i_pow, pauli_masks, pauli_sandwich};
@@ -242,7 +242,7 @@ fn build_lambda_and_value(
 /// Gradient contribution `d⟨H⟩/dθ` of a single trainable gate, from the
 /// generator sandwich `⟨λ|G|φ⟩` with `|φ⟩` on the output side of the gate.
 fn gradient_contribution(
-    kind: GeneratorKind,
+    kind: GeneratorKind<'_>,
     targets: &[usize],
     lambda: &[Complex64],
     phi: &[Complex64],
@@ -273,6 +273,10 @@ fn gradient_contribution(
                 }
             }
             -2.0 * acc.im
+        }
+        GeneratorKind::RotPauli(axes) => {
+            let (xmask, zmask, num_y) = pauli_rot_masks(targets, axes);
+            pauli_sandwich(lambda, phi, xmask, zmask, num_y).im
         }
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -553,7 +553,7 @@ impl<'c> Simulate<'c, Seeded> {
     /// Serves the cases [`Simulate::expectation_gradient`] declines: any
     /// backend with a native observable path, circuits containing `QftBlock`,
     /// and widths past the statevector cap. It differentiates the same gate set
-    /// (`Rx`, `Ry`, `Rz`, `Rzz`, `P`) at `1 + 2 * links` circuit evaluations
+    /// (`Rx`, `Ry`, `Rz`, `Rzz`, `P`, `PauliRot`) at `1 + 2 * links` circuit evaluations
     /// against the adjoint's one, so the adjoint stays the better choice where
     /// it applies. A backend with no native observable path reports
     /// `BackendUnsupported` naming itself. See

--- a/tests/expectation_gradient.rs
+++ b/tests/expectation_gradient.rs
@@ -44,6 +44,11 @@ fn shifted_gate(gate: &Gate, delta: f64) -> Gate {
         Gate::Rz(t) => Gate::Rz(t + delta),
         Gate::Rzz(t) => Gate::Rzz(t + delta),
         Gate::P(t) => Gate::P(t + delta),
+        Gate::PauliRot(data) => {
+            let mut shifted = data.clone();
+            shifted.set_theta(data.theta() + delta);
+            Gate::PauliRot(shifted)
+        }
         other => panic!("gate {} is not differentiable", other.name()),
     }
 }
@@ -392,6 +397,138 @@ fn shift_runs_on_the_tensor_network() {
 
     assert!((tn.value - routed.value).abs() < 1e-12);
     assert!((tn.gradient[0] - routed.gradient[0]).abs() < 1e-9);
+}
+
+// One Trotter step over every letter and weight the constructor can produce:
+// weight-1 X/Y/Z and ZZ lower to named rotations at insert, the rest stay
+// native. Slot order follows circuit order.
+fn trotter_fixture() -> Circuit {
+    let mut c = Circuit::new(4, 0);
+    for q in 0..4 {
+        c.add_gate(Gate::H, &[q]);
+    }
+    c.add_pauli_rotation(0.31, &[PauliTerm::x(0)]);
+    c.add_pauli_rotation(0.24, &[PauliTerm::y(1)]);
+    c.add_pauli_rotation(0.47, &[PauliTerm::z(2)]);
+    c.add_pauli_rotation(0.19, &[PauliTerm::z(0), PauliTerm::z(1)]);
+    c.add_pauli_rotation(0.53, &[PauliTerm::x(1), PauliTerm::y(2)]);
+    c.add_pauli_rotation(0.37, &[PauliTerm::x(0), PauliTerm::y(2), PauliTerm::z(3)]);
+    c.add_pauli_rotation(0.29, &[PauliTerm::y(0), PauliTerm::y(1), PauliTerm::y(3)]);
+    c.add_pauli_rotation(0.41, &[PauliTerm::z(1), PauliTerm::z(2), PauliTerm::z(3)]);
+    c
+}
+
+fn trotter_observable() -> Hamiltonian {
+    vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (0.7, vec![PauliTerm::x(2)]),
+        (-0.4, vec![PauliTerm::y(1), PauliTerm::z(3)]),
+    ]
+}
+
+#[test]
+fn pauli_rotation_gradients_match_finite_differences() {
+    let c = trotter_fixture();
+    let params = Parameters::all_rotations(&c);
+    assert_eq!(
+        params.num_slots(),
+        8,
+        "one slot per rotation, native or not"
+    );
+
+    let obs = trotter_observable();
+    let adjoint = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    let shift = run_expectation_gradient_shift(&c, &obs, &params, SEED).unwrap();
+
+    assert!((adjoint.value - expval(&c, &obs)).abs() < 1e-10);
+    for slot in 0..params.num_slots() {
+        let fd = finite_diff(&c, &obs, &params, slot);
+        assert!(
+            (adjoint.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: adjoint {} vs finite-diff {fd}",
+            adjoint.gradient[slot]
+        );
+        assert!(
+            (shift.gradient[slot] - adjoint.gradient[slot]).abs() < 1e-9,
+            "slot {slot}: shift {} vs adjoint {}",
+            shift.gradient[slot],
+            adjoint.gradient[slot]
+        );
+    }
+}
+
+// The lowered forms keep the gradients they had before the native variant
+// became differentiable: the constructor recognizes these strings at insert,
+// so nothing routes them through the new path.
+#[test]
+fn recognized_lowerings_still_differentiate_as_named_rotations() {
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_pauli_rotation(0.31, &[PauliTerm::x(0)]);
+    c.add_pauli_rotation(0.24, &[PauliTerm::y(1)]);
+    c.add_pauli_rotation(0.47, &[PauliTerm::z(0)]);
+    c.add_pauli_rotation(0.19, &[PauliTerm::z(0), PauliTerm::z(1)]);
+
+    let kinds: Vec<&str> = c.instructions[1..]
+        .iter()
+        .map(|inst| match inst {
+            Instruction::Gate { gate, .. } => gate.name(),
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(kinds, ["rx", "ry", "rz", "rzz"]);
+
+    let params = Parameters::all_rotations(&c);
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (0.6, vec![PauliTerm::x(1)]),
+    ];
+    let g = run_expectation_gradient(&c, &obs, &params, SEED).unwrap();
+    for slot in 0..params.num_slots() {
+        let fd = finite_diff(&c, &obs, &params, slot);
+        assert!((g.gradient[slot] - fd).abs() < 1e-6, "slot {slot}");
+    }
+}
+
+// The native gate is what carries the gradient, not a lowering that happens to
+// agree: the linked instruction is a `PauliRot` at differentiation time, and the
+// ladder expansion (a separate circuit, whose slot links its `Rz`) reproduces it.
+#[test]
+fn the_native_gate_carries_the_gradient() {
+    let mut native = Circuit::new(3, 0);
+    native.add_gate(Gate::H, &[0]);
+    native.add_gate(Gate::Cx, &[0, 1]);
+    native.add_pauli_rotation(0.63, &[PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)]);
+    let params = Parameters::all_rotations(&native);
+    assert_eq!(params.num_slots(), 1);
+    assert!(matches!(
+        native.instructions[params.links()[0].instruction],
+        Instruction::Gate {
+            gate: Gate::PauliRot(_),
+            ..
+        }
+    ));
+
+    let ladder = prism_q::circuit::expand_pauli_rotations(&native).into_owned();
+    let ladder_params = Parameters::all_rotations(&ladder);
+    assert_eq!(ladder_params.num_slots(), 1);
+    assert!(matches!(
+        ladder.instructions[ladder_params.links()[0].instruction],
+        Instruction::Gate {
+            gate: Gate::Rz(_),
+            ..
+        }
+    ));
+
+    let obs: Hamiltonian = vec![
+        (1.0, vec![PauliTerm::z(0), PauliTerm::z(2)]),
+        (0.5, vec![PauliTerm::x(1)]),
+    ];
+    let g = run_expectation_gradient(&native, &obs, &params, SEED).unwrap();
+    let lowered = run_expectation_gradient(&ladder, &obs, &ladder_params, SEED).unwrap();
+    assert!((g.value - lowered.value).abs() < 1e-12);
+    assert!((g.gradient[0] - lowered.gradient[0]).abs() < 1e-12);
+    assert!((g.gradient[0] - finite_diff(&native, &obs, &params, 0)).abs() < 1e-6);
 }
 
 #[test]

--- a/tests/parameter_binding.rs
+++ b/tests/parameter_binding.rs
@@ -5,7 +5,9 @@ use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::circuit::fusion::fuse_circuit;
-use prism_q::{Circuit, Gate, Instruction, ParamLink, Parameters, PreparedCircuit, circuits};
+use prism_q::{
+    Circuit, Gate, Instruction, ParamLink, Parameters, PauliTerm, PreparedCircuit, circuits,
+};
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -150,8 +152,28 @@ fn assert_payloads_match(a: &Gate, b: &Gate, what: &str) {
     }
 }
 
+// A Trotter layer over the native Pauli rotation: the strings the constructor
+// does not recognize stay as `PauliRot`, whose angle a binding has to reach
+// through the plan like any other rotation.
+fn trotter_layer(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.17 + 0.03 * q as f64), &[q]);
+    }
+    for q in 0..n - 2 {
+        c.add_pauli_rotation(
+            0.21 + 0.01 * q as f64,
+            &[PauliTerm::x(q), PauliTerm::y(q + 1), PauliTerm::z(q + 2)],
+        );
+        c.add_pauli_rotation(0.13, &[PauliTerm::y(q), PauliTerm::x(q + 2)]);
+        c.add_pauli_rotation(0.09, &[PauliTerm::z(q), PauliTerm::z(q + 1)]);
+    }
+    c
+}
+
 fn ansatz_cases() -> Vec<(&'static str, Circuit)> {
     vec![
+        ("trotter/12", trotter_layer(12)),
         ("hea/6", circuits::hardware_efficient_ansatz(6, 2, SEED)),
         ("hea/12", circuits::hardware_efficient_ansatz(12, 3, SEED)),
         ("hea/16", circuits::hardware_efficient_ansatz(16, 2, SEED)),
@@ -364,6 +386,48 @@ fn slot_that_no_gate_reads_binds_and_is_reported() {
         &statevector(&fuse_circuit(&narrow, true)),
         "widened slot set",
     );
+}
+
+// A replayed plan patches payloads in place, so a rotation it records no site
+// for keeps the template's angle while the states still look plausible. Read
+// the angle back off the fused stream rather than trusting agreement.
+#[test]
+fn a_bound_pauli_rotation_reaches_the_fused_stream() {
+    let template = trotter_layer(12);
+    let params = Parameters::all_rotations(&template);
+    let mut prepared = PreparedCircuit::new(template.clone(), params.clone()).unwrap();
+    assert!(prepared.reuses_fusion_plan());
+
+    let values = angles(params.num_slots(), 77);
+    let fused = prepared.bind_fused(&values).unwrap();
+    let bound: Vec<f64> = fused
+        .instructions
+        .iter()
+        .filter_map(|inst| match inst {
+            Instruction::Gate {
+                gate: Gate::PauliRot(data),
+                ..
+            } => Some(data.theta()),
+            _ => None,
+        })
+        .collect();
+    let expected: Vec<f64> = params
+        .links()
+        .iter()
+        .filter(|link| {
+            matches!(
+                template.instructions[link.instruction],
+                Instruction::Gate {
+                    gate: Gate::PauliRot(_),
+                    ..
+                }
+            )
+        })
+        .map(|link| values[link.slot])
+        .collect();
+    assert_eq!(bound.len(), 20, "two native rotations per site, 10 sites");
+
+    assert_eq!(bound, expected);
 }
 
 // A circuit with no parameters must still bind and fuse exactly as the


### PR DESCRIPTION
## Summary

`Gate::PauliRot` landed with no gradient support, so the gate that makes a Trotter
ansatz cheap to simulate could not be trained: `pauli_generator` returned `None`, and
the adjoint engine, parameter shift, and `Parameters` links all skipped the variant.
This adds the gradient half and, with it, the first measurement of a whole variational
loop iteration.

## Scope

- [x] New feature
- [x] Bug fix (fusion-plan angle site, below)
- [x] Documentation

## Representation

Two candidates were on the table. This takes the borrowed generator: `GeneratorKind<'a>`
gains `RotPauli(&'a [PauliAxis])` and `pauli_generator` returns `Option<GeneratorKind<'_>>`.

The alternative, a payload-free `RotPauli` marker whose consumers read the letters back
off the gate, keeps the enum lifetime-free at the cost of splitting one fact across two
values: a caller holding a marker can pair it with the wrong gate, and every consumer
repeats the match. The borrow makes that unrepresentable, and the letters are exactly what
the sandwich needs. It also collapses rather than adds: `(xmask, zmask, num_y)` computed
from targets and letters reproduces the existing `RotX`, `RotY`, `RotZ`, and `RotZz` arms
as special cases, so the new arm is the general one.

`Gate` is untouched and stays 16 bytes; the `size_of::<Gate>()` pin is unmodified. The
lifetime is the only breaking part of the surface, and every existing call site is
`pauli_generator().is_some()`, which is unaffected.

## Fusion plan

Making the variant bindable exposed a live bug rather than needing new machinery.
`FusionPlan::replay` patches payloads in place, and `record_sites` treated every gate the
passes leave untouched as carrying no angle. A bound `PauliRot` therefore kept the
template angle in the fused stream while every other payload moved, silently, with
`PreparedCircuit::bind_fused` returning a plausible circuit at the wrong point.

It now records an `Angle` recipe like `Rz` does.
`a_bound_pauli_rotation_reaches_the_fused_stream` reads the angles back off the fused
stream rather than trusting state agreement, and was confirmed to fail against the
pre-fix plan, where it read the template angles.

## Benchmarks

Two independent A/B runs of the same control set, before and after a review pass moved the
mask packing into a helper the native kernel and the gradient share. The second run is the
one that describes the pushed binary and is quoted here; the first agreed with it on every
row and on the verdict.

Controls first. Every row below is a path the diff reaches through `pauli_generator`,
`gradient_contribution`, or `apply_pauli_rot` without changing its behavior, so all of
them are expected to hold.

| Benchmark | Before | After | Change | Control (ref) | Control (new) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `gradient/hea_l2/adjoint/14` | 9.40 ms | 9.41 ms | +0.2% | +1.9% | -2.8% | yes |
| `gradient/hea_l2/adjoint/18` | 50.08 ms | 48.56 ms | -3.0% | +7.0% | +0.1% | unresolvable |
| `gradient/hea_l2/adjoint/20` | 529.24 ms | 530.52 ms | +0.2% | +0.9% | +1.7% | yes |
| `gradient/hea_l2/adjoint/22` | 2.640 s | 2.644 s | +0.1% | +0.5% | +0.6% | yes |
| `gradient/hea_l2/paramshift/14` | 84.13 ms | 81.42 ms | -3.2% | +3.9% | +0.3% | yes |
| `statevector/trotter/native/16` | 9.92 ms | 9.90 ms | -0.2% | +1.2% | +0.7% | yes |
| `statevector/trotter/ladder/16` | 56.38 ms | 56.04 ms | -0.6% | +0.6% | -0.3% | yes |
| `statevector/trotter/native/20` | 232.57 ms | 229.92 ms | -1.1% | +2.7% | +0.4% | yes |
| `statevector/trotter/ladder/20` | 1.930 s | 1.935 s | +0.3% | +0.5% | -0.5% | yes |

Adjacent-binary A/B against `main` (1bd7713), full Criterion at 30 samples,
`--features parallel`, i7-6700K, rustc 1.97.0.

`gradient/hea_l2/adjoint/18` is reported as unresolvable rather than as a pass. Its
same-code control moved 7.0%, above the gate itself, so this host cannot decide a 5%
question on that row and its -3.0% carries no information. The first run read +0.9% there
against a -3.1% control, which is the same verdict by a different route. Every other row
is noise against its own control, including the two `statevector/trotter/native` rows that
carry the kernel the helper extraction touched.

The `finitediff` and `paramshift` arms of `gradient/hea_l2` at 18 qubits and above are
omitted rather than measured: each iteration is `1 + 2 * links` forward evaluations at 88
parameters, so the five-pass A/B would have run for hours. The adjoint arm is the one this
diff reaches, and `paramshift/14` covers the shift path.

New rows, first measurement, full Criterion at 30 samples on the same host. There is no
before column: the arms are new linked code, which a reference worktree cannot resolve.

| Benchmark | Time |
| --- | ---: |
| `vqe/rebuild/12` | 1.887 ms |
| `vqe/bind/12` | 1.885 ms |
| `vqe/rebuild/16` | 18.884 ms |
| `vqe/bind/16` | 18.834 ms |

One iteration evaluates a 64-term Jordan-Wigner observable, takes the adjoint gradient,
and steps 16 parameters. The ansatz is a Trotter layer over the 16 largest strings of the
same operator, so the recognizing constructor lowers the weight-1 and ZZ generators and
the rest run as `PauliRot`; the gradient covers both forms.

The rebuild-against-bind delta is a measured null: 0.1% apart at 12 qubits and 0.3% at 16,
in both directions across two runs. An earlier run read `vqe/bind/12` 3.1% high with four
outliers and a confidence interval spanning the `rebuild` mean, which is why one run is
not a result on this pair. The null is not a noise-floor artifact: constructing the ansatz
costs about 5 microseconds, 0.03% of a 16-qubit iteration, so under simulation cost there
is almost nothing left for a parameter surface to save. `sweep_setup` remains the group
where the saving is visible, and these rows are what it is amortized against.

Regression verdict: PASS at 5.0%, with `gradient/hea_l2/adjoint/18` unresolvable on this
host rather than passing.

## Hotspot notes

`gradient_contribution` and `pauli_generator` are on the adjoint inner loop, called once
per parameter, and `apply_pauli_rot` runs once per gate application. The first two grew an
enum arm and no work on the existing paths, and the mask packing the third now shares sits
before the `2^n` sweep rather than inside it; the control rows
above are the check that adding the arm did not move inlining or layout. Splitting one
iteration at 16 qubits (release-profile triage, not the bench tier) reads 5.9 ms of
observable evaluation against 16.0 ms of gradient, so the adjoint is about three quarters
of the loop.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally, 2264 tests
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes

New cases in `tests/expectation_gradient.rs`:

- `pauli_rotation_gradients_match_finite_differences`: adjoint and shift against central
  finite differences on a Trotter fixture covering weight 1 through 3 over X, Y, and Z,
  including an all-Y string for the `i^{#Y}` phase and a Z-only string for the parity
  branch.
- `recognized_lowerings_still_differentiate_as_named_rotations`: weight-1 and ZZ strings
  lower at insert, so their gradients are pinned as `Rx`, `Ry`, `Rz`, and `Rzz` behavior
  rather than assumed to travel through the new path.
- `the_native_gate_carries_the_gradient`: asserts the linked instruction is a `PauliRot`
  when the gradient is taken, and cross-checks against the ladder expansion linked at its
  own `Rz`. A test named for the native path has to assert the native form runs, which is
  the lesson the previous change to this gate was built around.

`tests/parameter_binding.rs` gains a Trotter template to the shared ansatz cases, so the
stream-for-stream and plan-capture checks cover the variant, plus the angle-replay pin
described above.

## Architecture or design changes

- [x] `docs/architecture/engine.md`: the differentiable gate set and why the string is its
      own generator, on both the adjoint and the parameter-shift sections.
- [x] `docs/architecture/fusion.md`: why a gate the passes never touch still needs an
      angle site.

## Breaking changes

`GeneratorKind` gains a lifetime parameter and must be written `GeneratorKind<'_>` in a
signature; `pauli_generator` returns `Option<GeneratorKind<'_>>`. Callers that only test
`is_some()` are unaffected. `PauliRotData::set_theta` is added so an external caller can
rebind the angle of a gate that is now differentiable without going through `Parameters`.

## Risks and rollback

The gradient arm is additive: a circuit holding no `PauliRot` reaches none of it. The
fusion-plan change is the part with reach, since it alters what capture records for a
template holding the variant, though a template without one produces an identical plan. No
feature flag; rollback is a revert.

## Out of scope

Filed rather than widened into: a Python `pauli_rotation` constructor and the Python
parameter surface, an OpenQASM spelling for the native form (export lowers to the ladder
today, correct but not round-trip-stable), noisy gradients, and adjoint gradient V2. The
loop split above is the evidence the V2 deferral was waiting on, with the caveat that at
16 parameters against 64 observable terms the lambda build rather than the per-parameter
sandwich is the likely driver, and that split is not yet measured.

