### PR TITLE
docs: name the peer-access condition on multi GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,9 @@ SVGs land in `bench_results/` (gitignored).
 
 - Expanded classical control: mid circuit branching beyond the current `if` form.
 - Multi GPU and distributed GPU execution: a GPU context currently binds a single
-  device, and the distributed backend is CPU only.
+  device, and the distributed backend is CPU only. Sharding one statevector
+  across devices also needs peer access between them, since a host-staged
+  exchange costs far more than the gate it serves.
 - ROCm (AMD GPU) ports of the CUDA statevector and stabilizer kernels.
 - Distributed noisy shots: noise models are rejected on the distributed backend
   because trajectory execution is not lockstep across ranks.

--- a/docs/guides/capabilities.md
+++ b/docs/guides/capabilities.md
@@ -132,7 +132,7 @@ estimated" without comparing a float against zero.
 | --- | --- | --- |
 | ROCm (AMD GPU) | Planned | No AMD device kernels; the GPU path is CUDA-only |
 | Distributed GPU | Planned | No multi-node GPU execution |
-| Multi-GPU | Planned | A GPU context binds a single device |
+| Multi-GPU | Planned | A GPU context binds a single device; sharding one statevector across devices also needs peer access between them to stay ahead of the host path |
 | Distributed noisy shots | Planned | Noise models are rejected on the distributed backend; trajectory execution is not lockstep across ranks |
 
 These targets are listed so the matrix reflects the roadmap rather than hiding


### PR DESCRIPTION
## Summary

Both places that list multi-GPU as planned said only that a GPU context binds one
device, which reads as though the remaining work is adding devices. The condition
that actually gates it is the interconnect: sharding one statevector puts a
shard-sized transfer into the gate stream, so without peer access between the
devices the exchange costs far more than the gate it serves and the sharded run
loses to the host path it was meant to beat. Both entries now say so.

## Scope

- [x] Documentation

## Benchmarks

N/A, no hot-path changes.

Regression verdict: PASS

## Correctness

No Rust changed, so the gate is unaffected by this diff; CI runs it regardless.
Both edits are prose inside existing entries, with no new headings, links, or
table columns.

## Breaking changes

None.

## Risks and rollback

Two sentences of documentation. Revert the commit.
