### PR TITLE
ci(bench): cut the gate to eight rows and a cached reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,60 @@ jobs:
       - name: Verify the conventional-commit mapping and the pre-1.0 clamp
         run: bash scripts/release_bump_level_test.sh
 
+  # Builds the bench binary for each commit that lands on main and caches it, so
+  # the gate below can measure against a reference it did not have to compile.
+  # That is the whole benefit: one build instead of two. The checkout path also
+  # matches the gate's `head`, which costs nothing and keeps the two builds
+  # differing only in code. It is not claimed to fix anything: on this project's
+  # Windows host the build directory was measured not to change `.text` at all,
+  # and the ELF case that could differ is untested.
+  benchmark-reference:
+    name: Benchmark Reference Build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout at the path the gate uses
+        uses: actions/checkout@v7
+        with:
+          path: head
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+      - id: toolchain
+        run: echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          workspaces: head -> target
+
+      - name: Build the reference bench binary
+        working-directory: head
+        run: |
+          bash scripts/bench_ab.sh \
+            --bench circuits \
+            --features "$CI_BENCH_FEATURES" \
+            --build-only "$GITHUB_WORKSPACE/bench-ref-exe/circuits"
+
+      # Keyed on the commit, which already pins the lockfile it was built from,
+      # so hashing the lockfile as well would only miss on PRs that touch it. No
+      # restore-keys: a near-miss would silently measure against a commit the PR
+      # was not based on, which is worse than paying for the build.
+      - name: Cache it for the gate
+        uses: actions/cache/save@v4
+        with:
+          path: bench-ref-exe/circuits
+          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ env.CI_BENCH_FEATURES }}-${{ github.sha }}
+
   # Adjacent-binary A/B against the PR base; see scripts/bench_ci.sh. The
   # reference worktree sits beside the checkout, not inside it: `/target/` in
   # .gitignore is anchored to the repository root, so a nested worktree's build
-  # output would read as an untracked change and abort the A/B.
+  # output would read as an untracked change and abort the A/B. The worktree is
+  # the fallback path now: on a cache hit from the job above there is no
+  # reference build at all.
   benchmark-regression:
     name: Benchmark Regression
     runs-on: ubuntu-latest
@@ -237,6 +287,7 @@ jobs:
     env:
       PRISM_BENCH_REF: ${{ github.event.pull_request.base.sha }}
       PRISM_BENCH_REF_DIR: ${{ github.workspace }}/bench-ref
+      PRISM_BENCH_REF_EXE: ${{ github.workspace }}/bench-ref-exe/circuits
     steps:
       - name: Checkout head
         uses: actions/checkout@v7
@@ -267,21 +318,46 @@ jobs:
             echo "No Rust source or manifest change. Nothing to measure." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Prepare the reference worktree
-        if: steps.scope.outputs.run == 'true'
-        working-directory: head
-        run: git worktree add --detach "$PRISM_BENCH_REF_DIR" "$PRISM_BENCH_REF"
-
       - uses: dtolnay/rust-toolchain@stable
         if: steps.scope.outputs.run == 'true'
+
+      - id: toolchain
+        if: steps.scope.outputs.run == 'true'
+        run: echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      # A hit means the base commit went through Benchmark Reference Build, so
+      # its binary was compiled at this same path and the reference build below
+      # is skipped entirely. A miss falls back to the worktree, which still
+      # gates correctly, just slower and carrying the package-path term.
+      - name: Restore the reference bench binary
+        id: refexe
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: bench-ref-exe/circuits
+          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ env.CI_BENCH_FEATURES }}-${{ env.PRISM_BENCH_REF }}
+
+      - name: Prepare the reference worktree
+        if: steps.scope.outputs.run == 'true' && steps.refexe.outputs.cache-hit != 'true'
+        working-directory: head
+        run: git worktree add --detach "$PRISM_BENCH_REF_DIR" "$PRISM_BENCH_REF"
 
       - uses: Swatinem/rust-cache@v2
         if: steps.scope.outputs.run == 'true'
         with:
           cache-bin: false
-          workspaces: |
-            head -> target
-            bench-ref -> target
+          key: head
+          workspaces: head -> target
+
+      # Only when the reference has to be compiled. Restoring this workspace on
+      # a cache hit would also re-save it empty at job end, making the next miss
+      # more expensive than it needs to be.
+      - uses: Swatinem/rust-cache@v2
+        if: steps.scope.outputs.run == 'true' && steps.refexe.outputs.cache-hit != 'true'
+        with:
+          cache-bin: false
+          key: ref
+          workspaces: bench-ref -> target
 
       - name: Benchmark regression gate
         if: steps.scope.outputs.run == 'true'

--- a/benches/README.md
+++ b/benches/README.md
@@ -133,7 +133,14 @@ cargo bench -- --baseline my_baseline
 ./scripts/bench_ab.sh --filter '^factored/noise_kraus/'
 ./scripts/bench_ab.sh -f '^density_matrix/' -r main -b circuits
 ./scripts/bench_ab.sh -f '^sparse/' --ref-dir /tmp/prism-q-ref   # cache the reference build
+./scripts/bench_ab.sh --build-only /tmp/ref-circuits             # build a reference to reuse
+./scripts/bench_ab.sh -f '^sparse/' --ref-exe /tmp/ref-circuits  # skip the reference build
 ```
+
+`--build-only` and `--ref-exe` are a pair: the first produces a bench binary through the
+same build path the A/B uses, the second consumes one and skips the reference build
+entirely. Nothing checks that the supplied executable was built from `--ref`, so whatever
+stores it owns that claim; the report records which of the two ways the reference arrived.
 
 The script builds the bench binary from the working tree, builds the same target
 from a reference git ref in a separate worktree, verifies the working tree did
@@ -174,10 +181,22 @@ controls are wide, the answer is "not measurable right now", not a number.
 
 ### What the reference worktree cannot resolve
 
-The reference binary is built in a separate worktree, so the two binaries differ in
-embedded paths and therefore in code layout. The control columns compare each binary
-against itself, so neither can see that difference. For a change to a hot loop's
-arithmetic this does not matter. For a change that adds or removes linked code it can
+Two claims have been filed under this heading, and only one of them survives
+measurement.
+
+The build directory does not, by itself, change code layout. The same commit built in
+the project directory and in a worktree produces byte-identical `.text` (9323520 bytes)
+and `.data`; the two images differ in 24 bytes out of 10797056, all metadata, being the
+COFF `TimeDateStamp` and a 16-byte PDB GUID. On MSVC `debug = "line-tables-only"` writes
+paths into the `.pdb` rather than the image, so there is no package path in the
+executable for the directory to change. Measured on x86_64-pc-windows-msvc; the ELF case
+is untested, and Linux keeps line tables in the binary, so the same is not assumed there.
+Do not explain a moved row by naming the build directory without measuring it.
+
+What does survive is the second claim, and it is the one worth acting on: a change that
+adds or removes linked code can move rows that never execute it. The control columns
+compare each binary against itself, so neither can see that. For a change to a hot loop's
+arithmetic it does not matter. For a change that adds or removes linked code it can
 invert the result.
 
 Adding a faer matmul call to `tensornetwork.rs` measured -10.3% to -13.2% on the four
@@ -188,27 +207,28 @@ reachable size, so the new code is linked but never called, carries the same +13
 is what identifies layout rather than execution as the cause.
 
 So: when a change adds a dependency call, instantiates a large generic, or deletes a
-sizeable function, compare two binaries built from the same directory before trusting
-this script. Marking the added function `#[inline(never)]` or `#[cold]` does not recover
-the difference; both were tried and both left it intact.
+sizeable function, take repeated runs before trusting this script. Marking the added
+function `#[inline(never)]` or `#[cold]` does not recover the difference; both were tried
+and both left it intact.
 
-Building both binaries from one directory narrows the difference but does not remove it.
-To remove it, put both implementations in the same binary behind a switch read once at
-startup, and run that one binary twice:
+Rebuilding from one directory does not address this, now that the directory is known not
+to matter for a fixed commit. To remove the term, put both implementations in the same
+binary behind a switch read once at startup, and run that one binary twice:
 
 ```rust
 static SCATTER: OnceLock<bool> = OnceLock::new();
 if *SCATTER.get_or_init(|| std::env::var("PRISM_TRANSPOSE_SCATTER").is_ok()) { .. }
 ```
 
-Code, layout and embedded paths are then identical by construction, so the layout term
-cancels exactly rather than approximately, and the branch is paid on both sides. It costs
-one build rather than two. Use it whenever the change itself adds or removes linked code,
-which is the case this section's caveat exists for.
+One binary means one layout, so the term cancels exactly rather than approximately, and
+the branch is paid on both sides. It costs one build rather than two. Use it whenever the
+change itself adds or removes linked code, which is the case this section's caveat exists
+for.
 
-The two binaries are never byte identical even from identical sources, because
-`[profile.bench] debug = "line-tables-only"` records the package path and the two
-worktrees differ. The script decides "same code" from git, not from `cmp`.
+The two binaries are never byte identical even from identical sources, but not for the
+reason once given here: the difference is the link timestamp and the PDB GUID, 24 bytes
+in total, not an embedded package path. The script decides "same code" from git rather
+than from `cmp` because those bytes differ on every link.
 
 Reference-build cost: the first `--ref-dir` build is a cold build of the crate in
 a second package path (about 2m30s here); later runs against the same ref reuse
@@ -257,12 +277,12 @@ Until 2026-08, the two sides ran as separate `cargo bench` invocations with the
 head build between them, on a shared runner. A row a hosted runner cannot resolve
 now says so instead of reading as a result.
 
-The subset runs at `CI_BENCH_FEATURES=parallel,bench-fast` and covers larger
-CPU-only parameter points already present on the base branch. That tier pins
-samples to 10 and shortens the measurement windows, which is what keeps four
-passes affordable: at 100 samples, `statevector/qpe_t_gate/22q` alone would cost
-half an hour. The filters stay narrow so noise from tiny parameter sweeps does
-not dominate. A row missing from either side drops out of the comparison and the
+The subset runs at `CI_BENCH_FEATURES=parallel,bench-fast` and covers CPU-only
+parameter points already present on the base branch. That tier pins samples to 10
+and shortens the measurement windows, which is what keeps four passes affordable:
+at 100 samples, a single 22q statevector row would cost half an hour, which is why
+the set above tops out at 20. The filters stay narrow so noise from tiny parameter
+sweeps does not dominate. A row missing from either side drops out of the comparison and the
 row-count guard fails the run. This is a regression gate, not a replacement for
 the local suite a performance change needs.
 
@@ -277,14 +297,21 @@ Representative CI workloads:
 
 | Filter | Coverage |
 |--------|----------|
-| `statevector/scalability_d5/22` | Dense statevector scaling at a larger qubit count |
-| `statevector/qft_textbook/22` | Structured controlled phase and swap workload |
-| `statevector/qpe_t_gate/22q` | Phase estimation with non-Clifford gates |
-| `statevector/qaoa_l3/20` | QAOA workload with ZZ rotations and mixer layers |
-| `stabilizer/scaling/1000` | Large Clifford stabilizer backend path |
-| `stabilizer/measurement/ghz_measure_all/1000` | Large GHZ preparation plus terminal measurements |
-| `compiled_sampler/noiseless/noiseless_1000q_10k` | Compiled shot sampling path |
-| `compiled_sampler/noisy/noisy_1000q_10k` | Compiled Pauli-noise shot sampling path |
+| `statevector/scalability_d5/18` | Dense statevector scaling, above the post-phase rebatch floor |
+| `statevector/qft_textbook/20` | Structured controlled phase and swap workload |
+| `statevector/qpe_t_gate/16q` | Phase estimation with non-Clifford gates |
+| `statevector/qaoa_l3/16` | QAOA workload with ZZ rotations and mixer layers |
+| `stabilizer/scaling/500` | Clifford stabilizer backend path |
+| `stabilizer/measurement/ghz_measure_all/500` | GHZ preparation plus terminal measurements |
+| `compiled_sampler/noiseless/noiseless_500q_10k` | Compiled shot sampling path |
+| `compiled_sampler/noisy/noisy_500q_10k` | Compiled Pauli-noise shot sampling path |
+
+The sizes are the smallest that still exercise the pipeline that ships, not the smallest
+available: `MIN_QUBITS_FOR_DIAG_BATCH = 16` and `MIN_QUBITS_FOR_POST_PHASE_BATCH = 18` in
+`circuit/fusion.rs` are the floors, and `qft_textbook` has no 18 in its size list so it
+stays at 20. Six passes over the eight rows take about 75 seconds. On a quiet host they
+resolve the 5% gate: three same-code runs read worst control spreads of 6.0%, 7.1%, and
+5.9%, with no row moving more than 3.6% against an identical binary.
 
 Local reproduction, against `main` as the reference:
 
@@ -293,7 +320,15 @@ PRISM_BENCH_REF=main ./scripts/bench_ci.sh
 
 # Cache the reference build between runs:
 PRISM_BENCH_REF=main PRISM_BENCH_REF_DIR=/tmp/prism-q-ref ./scripts/bench_ci.sh
+
+# Or skip the reference build outright, given a binary already built from that ref:
+PRISM_BENCH_REF=main PRISM_BENCH_REF_EXE=/tmp/ref-circuits ./scripts/bench_ci.sh
 ```
+
+In CI the third form is the normal path: every push to `main` builds the bench binary and
+caches it under that commit, and the gate restores it for the PR base. The key is the
+commit alone, with no `restore-keys`, so a restore is either the binary for that exact
+base or nothing; a miss falls back to building the reference in a worktree.
 
 `PRISM_BENCH_REF=HEAD` on a clean tree builds both binaries from the same code,
 so every row is a control row and the report is this host's noise floor.

--- a/scripts/bench_ab.sh
+++ b/scripts/bench_ab.sh
@@ -34,6 +34,18 @@
 #   --ref-dir       reference worktree path. Persists between runs, so the
 #                   reference build is cached. Default: a temporary directory
 #                   removed on exit.
+#   --ref-exe       prebuilt reference executable. Skips the reference build and
+#                   the worktree entirely, so only the working tree is compiled.
+#                   Takes precedence over --ref-dir. The caller owns the claim
+#                   that the executable was built from --ref: nothing here can
+#                   check it, so key whatever cache supplies it on the ref sha,
+#                   the toolchain, and the feature list. The sha already pins the
+#                   lockfile it was built from.
+#   --build-only    build the working-tree bench binary, copy it to this path,
+#                   and exit without measuring. The producer side of --ref-exe:
+#                   the build runs through the same code path as the A/B's own
+#                   build, so a binary cached by one is what the other expects.
+#                   --filter is not required in this mode.
 #   --min-rows      fail when fewer than this many rows appear in all four
 #                   passes, catching a filter that stopped matching a renamed
 #                   benchmark id. Default: 1.
@@ -62,6 +74,8 @@ REF="HEAD"
 BENCH="circuits"
 FEATURES="parallel"
 REF_DIR=""
+REF_EXE=""
+BUILD_ONLY=""
 OUT=""
 MIN_ROWS=1
 THRESHOLD="${REGRESSION_THRESHOLD:-5.0}"
@@ -73,6 +87,8 @@ while [[ $# -gt 0 ]]; do
         --bench|-b)    BENCH="$2"; shift 2 ;;
         --features)    FEATURES="$2"; shift 2 ;;
         --ref-dir)     REF_DIR="$2"; shift 2 ;;
+        --ref-exe)     REF_EXE="$2"; shift 2 ;;
+        --build-only)  BUILD_ONLY="$2"; shift 2 ;;
         --min-rows)    MIN_ROWS="$2"; shift 2 ;;
         --out)         OUT="$2"; shift 2 ;;
         --threshold|-t) THRESHOLD="$2"; shift 2 ;;
@@ -81,7 +97,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$FILTER" ]]; then
+if [[ -z "$FILTER" && -z "$BUILD_ONLY" ]]; then
     echo "Error: --filter is required. Name the rows to compare." >&2
     exit 1
 fi
@@ -266,6 +282,12 @@ host_cpu() {
 
 # --- Build both binaries ---
 
+if [[ -n "$BUILD_ONLY" ]]; then
+    mkdir -p "$(dirname "$BUILD_ONLY")"
+    build_bench_exe "$PROJECT_DIR" "$BUILD_ONLY" "build-only"
+    exit 0
+fi
+
 REF_SHA="$(git rev-parse --short "$REF")"
 FINGERPRINT_BEFORE="$(tree_fingerprint)"
 
@@ -279,28 +301,45 @@ echo ""
 
 build_bench_exe "$PROJECT_DIR" "$WORKDIR/exe-new" "new"
 
-if [[ -d "$REF_DIR/.git" || -f "$REF_DIR/.git" ]]; then
-    echo ">>> reusing reference worktree $REF_DIR"
-    git -C "$REF_DIR" checkout --detach --force "$REF_SHA" >/dev/null 2>&1
-    git -C "$REF_DIR" clean -fdq
+if [[ -n "$REF_EXE" ]]; then
+    if [[ ! -f "$REF_EXE" ]]; then
+        echo "Error: --ref-exe '$REF_EXE' does not exist." >&2
+        exit 1
+    fi
+    echo ">>> using the supplied reference executable $REF_EXE"
+    cp "$REF_EXE" "$WORKDIR/exe-ref"
+    chmod +x "$WORKDIR/exe-ref"
+    REF_PROVENANCE="supplied via \`--ref-exe\`, not built here"
 else
-    echo ">>> adding reference worktree $REF_DIR at $REF_SHA"
-    git worktree add --detach --force "$REF_DIR" "$REF_SHA" >/dev/null
+    if [[ -d "$REF_DIR/.git" || -f "$REF_DIR/.git" ]]; then
+        echo ">>> reusing reference worktree $REF_DIR"
+        git -C "$REF_DIR" checkout --detach --force "$REF_SHA" >/dev/null 2>&1
+        git -C "$REF_DIR" clean -fdq
+    else
+        echo ">>> adding reference worktree $REF_DIR at $REF_SHA"
+        git worktree add --detach --force "$REF_DIR" "$REF_SHA" >/dev/null
+    fi
+
+    build_bench_exe "$REF_DIR" "$WORKDIR/exe-ref" "ref"
+    REF_PROVENANCE="built from a worktree at \`$REF_DIR\`"
+
+    # Only meaningful when a second build follows the first: it catches an editor
+    # save landing between them, which would leave two binaries that no longer
+    # differ by the change under test.
+    FINGERPRINT_AFTER="$(tree_fingerprint)"
+    if [[ "$FINGERPRINT_BEFORE" != "$FINGERPRINT_AFTER" ]]; then
+        echo "Error: the working tree changed between the two builds." >&2
+        echo "  The two binaries no longer differ by the change under test, so the" >&2
+        echo "  comparison would be meaningless. Re-run with the tree settled." >&2
+        exit 1
+    fi
 fi
 
-build_bench_exe "$REF_DIR" "$WORKDIR/exe-ref" "ref"
-
-FINGERPRINT_AFTER="$(tree_fingerprint)"
-if [[ "$FINGERPRINT_BEFORE" != "$FINGERPRINT_AFTER" ]]; then
-    echo "Error: the working tree changed between the two builds." >&2
-    echo "  The two binaries no longer differ by the change under test, so the" >&2
-    echo "  comparison would be meaningless. Re-run with the tree settled." >&2
-    exit 1
-fi
-
-# The two binaries are never byte identical even from identical sources, because
-# `debug = "line-tables-only"` records the package path and the worktrees differ.
-# Same code is decided from git instead.
+# The two binaries are never byte identical even from identical sources: the link
+# timestamp and the PDB GUID differ on every link. Same code is decided from git
+# instead. Those bytes are all that differs, measured 2026-08-17: the same commit
+# built in two directories has byte-identical `.text`, so the build directory is
+# not a reason to distrust a row on this target.
 if [[ -z "$(git status --porcelain)" && "$(git rev-parse HEAD)" == "$(git rev-parse "$REF_SHA")" ]]; then
     echo "Note: the working tree matches $REF exactly, so both binaries carry the"
     echo "      same code and every row is a control row. This is the same-code"
@@ -345,6 +384,7 @@ set +e
     echo "| --- | --- |"
     echo "| Filter | \`$FILTER\` |"
     echo "| Reference | \`$REF\` ($REF_SHA) |"
+    echo "| Reference binary | $REF_PROVENANCE |"
     echo "| Features | \`$FEATURES\` |"
     echo "| Pass order | ref, new discarded, then ref, new, new, ref (adjacent, no rebuild) |"
     echo "| Samples | ${PRISM_BENCH_SAMPLES:-30} |"

--- a/scripts/bench_ci.sh
+++ b/scripts/bench_ci.sh
@@ -6,11 +6,16 @@
 #
 # The filter covers representative hot paths rather than the full Criterion
 # suite, and `--min-rows` fails the run if one stops matching. `bench-fast` keeps
-# the four passes affordable: the 22q rows run seconds per iteration, where the
-# sample count sets the cost outright.
+# the four passes affordable: the widest rows run milliseconds per iteration, so
+# the sample count sets the cost outright.
 #
 # Environment:
 #   PRISM_BENCH_REF       git ref for the reference build (required)
+#   PRISM_BENCH_REF_EXE   prebuilt reference executable. When it names an
+#                         existing file the reference build is skipped and the
+#                         worktree is never created, which halves the build cost.
+#                         Ignored when the file is absent, so a cache miss falls
+#                         back to building the reference.
 #   PRISM_BENCH_REF_DIR   reference worktree path, cached between CI runs
 #   CI_BENCH_FEATURES     cargo feature list (default: parallel,bench-fast)
 #   REGRESSION_THRESHOLD  regression gate in percent (default: 5.0)
@@ -26,11 +31,21 @@ if [[ -z "${PRISM_BENCH_REF:-}" ]]; then
     exit 1
 fi
 
-# The `auto/` twins of the 22q rows are absent on purpose: dispatch resolves them
-# to the statevector rows above, doubling the most expensive pair for nothing.
-CIRCUITS_FILTER="^(statevector/(scalability_d5/22|qft_textbook/22|qpe_t_gate/22q|qaoa_l3/20)"
-CIRCUITS_FILTER+="|stabilizer/(scaling/1000|measurement/ghz_measure_all/1000)"
-CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_1000q_10k|noisy/noisy_1000q_10k))$"
+# Sizes are the smallest that still exercise the paths the gate exists to watch,
+# not the smallest available. `MIN_QUBITS_FOR_DIAG_BATCH = 16` and
+# `MIN_QUBITS_FOR_POST_PHASE_BATCH = 18` in `circuit/fusion.rs` are the floors:
+# below 16 the diagonal-batch families never form, and below 18 the post-phase
+# rebatch never runs, so a smaller row would gate a different pipeline than the
+# one that ships. `qft_textbook` has no 18 in its size list and stays at 20.
+# Six passes over these eight rows measured at 73-75s in total, against about six
+# minutes per pass for the 22q and 1000q set this replaces, which is the
+# difference between a gate that fits its timeout and one that does not.
+#
+# The `auto/` twins are absent on purpose: dispatch resolves them to the
+# statevector rows above, doubling the most expensive pair for nothing.
+CIRCUITS_FILTER="^(statevector/(scalability_d5/18|qft_textbook/20|qpe_t_gate/16q|qaoa_l3/16)"
+CIRCUITS_FILTER+="|stabilizer/(scaling/500|measurement/ghz_measure_all/500)"
+CIRCUITS_FILTER+="|compiled_sampler/(noiseless/noiseless_500q_10k|noisy/noisy_500q_10k))$"
 
 CIRCUITS_ROWS=8
 
@@ -43,7 +58,11 @@ args=(
     --out "$PROJECT_DIR/bench_results/ci-ab.md"
 )
 
-if [[ -n "${PRISM_BENCH_REF_DIR:-}" ]]; then
+if [[ -n "${PRISM_BENCH_REF_EXE:-}" && -f "${PRISM_BENCH_REF_EXE}" ]]; then
+    echo "Reference executable restored from cache; skipping the reference build."
+    args+=(--ref-exe "$PRISM_BENCH_REF_EXE")
+elif [[ -n "${PRISM_BENCH_REF_DIR:-}" ]]; then
+    echo "No cached reference executable; building the reference from a worktree."
     args+=(--ref-dir "$PRISM_BENCH_REF_DIR")
 fi
 


### PR DESCRIPTION
## Summary

The benchmark gate cost about six minutes per pass over six passes and rebuilt the
reference from scratch every run, against a 45 minute timeout. This cuts the row set to
the smallest sizes that still exercise the pipeline that ships, and lets the gate take a
prebuilt reference binary instead of compiling one. Six passes over the eight rows run in
73-75s, and every push to `main` now caches a reference binary the gate can restore.

Sizes are floored by `MIN_QUBITS_FOR_DIAG_BATCH = 16` and
`MIN_QUBITS_FOR_POST_PHASE_BATCH = 18`, not chosen for speed: below those the
diagonal-batch and post-phase-rebatch families never form, so a smaller row would gate a
different pipeline than the one that ships. `qft_textbook` has no 18 in its size list and
stays at 20. All eight ids were checked to exist before the filter was written.

## Scope

- [x] Build, CI, or tooling
- [x] Documentation

## Benchmarks

N/A for a speed claim, no hot-path changes. The measurements below are about the gate
itself, taken with a byte-identical reference binary so every row is a control row and any
nonzero Change is host noise.

Same-code floor, three runs on an idle host:

| Run | Rows | Worst same-code control spread | Largest change | Verdict |
| --- | ---: | ---: | ---: | --- |
| 1 | 8/8 | 6.0% | 2.3% | PASS |
| 2 | 8/8 | 7.1% | 3.3% | PASS |
| 3 | 8/8 | 5.9% | 3.6% | PASS |

No row moves beyond 3.6% against an identical binary, and the worst control lands on a
different row each run (`qft_textbook/20`, `scaling/500`, `qaoa_l3/16`), which is a noise
floor rather than an unstable row. Measurement time 75s, 73s, 74s.

Runs taken while a second bench process was active are excluded. They read control spreads
of 20.0% to 206.6% and produced a false FAIL at +88.2% on identical binaries, which is
what the single-process rule exists to prevent.

Regression verdict: PASS

## Correctness

No Rust changed, so the compile and test gate is unaffected by this diff; CI runs it
regardless. Shell syntax checked with `bash -n` on both scripts, and the workflow parses
as YAML. The cache-hit path cannot be exercised until this lands, since it needs a
push-to-main run to populate the first entry; the miss path is the existing worktree
build, unchanged.

## Documentation

`benches/README.md` carried a mechanism that does not hold up. It said the reference being
built in a separate worktree makes the two binaries differ in embedded paths and therefore
in code layout. Measured: the same commit built in the project directory and in a worktree
produces byte-identical `.text` (9323520 bytes) and `.data`, differing in 24 bytes of the
10797056-byte image, being the COFF `TimeDateStamp` and a 16-byte PDB GUID. On MSVC
`debug = "line-tables-only"` writes paths to the `.pdb`, not into the image, so there is no
package path there to shift anything. Measured on x86_64-pc-windows-msvc; the ELF case is
untested and not assumed, since Linux keeps line tables in the binary.

`--remap-path-prefix` was tried against the same question and reverted: `.text` was already
identical without it, so it changes nothing on this target while invalidating every cargo
fingerprint.

The separate claim that section had tangled with this one, that a change adding or removing
linked code can move rows that never execute it, is untouched and stays. That effect needs
no directory argument.

## Breaking changes

None. `--ref-dir` and the worktree path behave as before; the new options are additive and
the gate falls back to the old path on a cache miss.

## Risks and rollback

The gate could restore a stale reference binary if the cache key were loose. It is keyed on
the exact base commit with no `restore-keys`, so a restore is either the right binary or
nothing. Revert the commit to return to the previous row set and build path.
