### PR TITLE
feat(circuit): guarded regions over spans of instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,12 @@ jobs:
           fetch-depth: 1
 
       - uses: dtolnay/rust-toolchain@stable
+      # `actions/cache` rejects a comma in a key, and the feature list carries
+      # one, so the key takes a slug of it rather than the list itself.
       - id: toolchain
-        run: echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+          echo "features=${CI_BENCH_FEATURES//,/-}" >> "$GITHUB_OUTPUT"
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -266,7 +270,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: bench-ref-exe/circuits
-          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ env.CI_BENCH_FEATURES }}-${{ github.sha }}
+          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ steps.toolchain.outputs.features }}-${{ github.sha }}
 
   # Adjacent-binary A/B against the PR base; see scripts/bench_ci.sh. The
   # reference worktree sits beside the checkout, not inside it: `/target/` in
@@ -323,7 +327,9 @@ jobs:
 
       - id: toolchain
         if: steps.scope.outputs.run == 'true'
-        run: echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(rustc -V | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+          echo "features=${CI_BENCH_FEATURES//,/-}" >> "$GITHUB_OUTPUT"
 
       # A hit means the base commit went through Benchmark Reference Build, so
       # its binary was compiled at this same path and the reference build below
@@ -335,7 +341,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: bench-ref-exe/circuits
-          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ env.CI_BENCH_FEATURES }}-${{ env.PRISM_BENCH_REF }}
+          key: bench-ref-exe-${{ runner.os }}-${{ steps.toolchain.outputs.version }}-${{ steps.toolchain.outputs.features }}-${{ env.PRISM_BENCH_REF }}
 
       - name: Prepare the reference worktree
         if: steps.scope.outputs.run == 'true' && steps.refexe.outputs.cache-hit != 'true'

--- a/docs/architecture/ir.md
+++ b/docs/architecture/ir.md
@@ -4,7 +4,7 @@
 
 Handwritten parser targeting a practical OpenQASM 3.0 subset. It processes input line by line and converts `&str` directly to `Circuit` IR with no intermediate AST.
 
-**Supported**: `qubit`/`bit` declarations, OpenQASM standard gates and aliases (x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot, cy, cz, cp/cphase, crx, cry, crz, ch, swap, ccx/toffoli, cswap/fredkin, cu, u1, u2, u3/u/U), Qiskit and exporter gates (sxdg, cs, csdg, csx, ccz, r, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, c3x, c4x, mcx, rccx, rc3x/rcccx), hardware-native gates (gpi, gpi2, ms, syc, sqrt_iswap, sqrt_iswap_inv), gate modifiers (`ctrl @`, `inv @`, `pow(k) @`), user-defined `gate` blocks, classical `if` conditionals, multi-register broadcast, measure, barrier, expression evaluator with math functions. OpenQASM 2.0 backward compatibility (`qreg`/`creg`, `measure q -> c` syntax).
+**Supported**: `qubit`/`bit` declarations, OpenQASM standard gates and aliases (x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot, cy, cz, cp/cphase, crx, cry, crz, ch, swap, ccx/toffoli, cswap/fredkin, cu, u1, u2, u3/u/U), Qiskit and exporter gates (sxdg, cs, csdg, csx, ccz, r, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, c3x, c4x, mcx, rccx, rc3x/rcccx), hardware-native gates (gpi, gpi2, ms, syc, sqrt_iswap, sqrt_iswap_inv), gate modifiers (`ctrl @`, `inv @`, `pow(k) @`), user-defined `gate` blocks, classical `if` conditionals with a single statement or a braced body, multi-register broadcast, measure, barrier, expression evaluator with math functions. OpenQASM 2.0 backward compatibility (`qreg`/`creg`, `measure q -> c` syntax).
 
 **Unsupported**: `for`/`while` loops, subroutines, classical expressions beyond `if`.
 
@@ -20,8 +20,36 @@ See the [OpenQASM Support guide](../guides/openqasm.md) for a user-facing walkth
 | `Measure` | `qubit`, `classical_bit` | Destructive measurement |
 | `Barrier` | `qubits` | Synchronization barrier |
 | `Conditional` | `condition`, `gate`, `targets` | Classical-controlled gate |
+| `Region` | `Box<GuardedRegion>` | Classical-controlled span of instructions |
 
 Targets use `SmallVec<[usize; 4]>`, inline storage for up to 4 qubits, no heap allocation for typical gates.
+
+### Guarded regions
+
+`Region` carries a condition and a body that runs, in order, only when the
+condition holds against the classical bits as they stand when control reaches
+it. The body admits any instruction, measurement and reset included, and may
+nest to `MAX_REGION_DEPTH`. The body is boxed, so `Instruction` stays at 96
+bytes.
+
+`GuardedRegion` caches the sorted union of the qubits its body touches, nested
+bodies included. Passes read that set rather than re-walking the body: fusion
+flushes exactly those qubits at the region boundary and is transparent
+elsewhere, and no pass fuses across the boundary because a region is not an
+`Instruction::Gate`.
+
+`Conditional` is the single-gate lowering of the same construct. `if (c) x q[0];`
+keeps that form, so the common guarded gate costs no allocation; anything else
+becomes a `Region`. Build either through `circuit::guarded`, which picks the
+form and returns `None` for an empty body.
+
+A circuit holding a region runs once per shot: measurement-conditioned execution
+has no single evolved distribution to sample, so the compiled samplers reject it
+and the run falls back to replay. Routes requiring a unitary circuit (adjoint
+gradients, exact expectation values, Pauli propagation, stabilizer-rank
+probabilities) reject a region for the same reason they reject a bare
+conditional. Noise models index one event slot per instruction, so they reject a
+region rather than leave its body noiseless.
 
 ## Gate enum
 

--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -66,8 +66,21 @@ OpenQASM 2.0 syntax also works: `qreg q[3];` / `creg c[3];` declarations and
 
 - Gate modifiers: `ctrl @`, `inv @`, `pow(k) @`.
 - User-defined `gate` blocks.
-- Classical `if` conditionals.
+- Classical `if` conditionals, guarding either a single statement or a braced
+  body. A braced body admits any supported statement, `measure` and `reset`
+  included, and may nest.
 - Multi-register broadcast, `barrier`, and an expression evaluator with math functions.
+
+```qasm
+bit[2] c;
+qubit[3] q;
+c[0] = measure q[0];
+if (c[0]) {
+  x q[1];
+  c[1] = measure q[1];
+  if (c[1]) { reset q[2]; }
+}
+```
 
 ```admonish warning title="Not supported"
 `for` / `while` loops, subroutines, and classical expressions beyond `if`. A construct

--- a/examples/profile_circuit.rs
+++ b/examples/profile_circuit.rs
@@ -65,6 +65,7 @@ fn profile_one(circuit: &Circuit) -> IterProfile {
             Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => gate.name(),
             Instruction::Measure { .. } => "measure",
             Instruction::Reset { .. } => "reset",
+            Instruction::Region(_) => "if",
             Instruction::Barrier { .. } => continue,
         };
 

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -709,6 +709,7 @@ impl Backend for DensityMatrixBackend {
                 gate,
                 targets,
             } => self.apply_conditional(condition, gate, targets),
+            Instruction::Region(region) => self.apply_region(region),
         }
     }
 

--- a/src/backend/distributed_statevector/mod.rs
+++ b/src/backend/distributed_statevector/mod.rs
@@ -1674,6 +1674,11 @@ impl Backend for DistributedStatevectorBackend {
                 }
             }
             Instruction::Gate { gate, targets } => self.apply_gate(gate, targets),
+            // Every rank draws measurement outcomes from the same seeded RNG
+            // against an `Allreduce`d probability, so every rank holds the same
+            // classical bits and takes the same branch without a consensus
+            // exchange.
+            Instruction::Region(region) => self.apply_region(region),
         }
     }
 

--- a/src/backend/distributed_statevector/tests.rs
+++ b/src/backend/distributed_statevector/tests.rs
@@ -765,6 +765,30 @@ fn loopback_conditional_on_global_measurement() {
 }
 
 #[test]
+fn loopback_guarded_region_takes_the_same_branch_on_every_rank() {
+    relax_min_local_qubits();
+    // The region body measures and entangles, so a rank that disagreed on the
+    // branch would diverge in both the state and the classical bits.
+    let n = 4;
+    let mut b = CircuitBuilder::new_with_classical(n, 2);
+    b.x(n - 1);
+    b.measure(n - 1, 0);
+    b.guarded(crate::circuit::ClassicalCondition::BitIsOne(0), |body| {
+        body.x(0).cx(0, 1).measure(1, 1);
+    });
+    let circuit = b.build();
+    for &size in &[1usize, 2, 4, 8] {
+        let (probs, bits) = loopback_run(&circuit, size);
+        assert!(bits[0] && bits[1], "size {size}: both bits should be 1");
+        let expected = 0b11usize | (1usize << (n - 1));
+        assert!(
+            (probs[expected] - 1.0).abs() < TOL,
+            "size {size}: the region body should have run"
+        );
+    }
+}
+
+#[test]
 fn loopback_tiled_exchange_matches_full() {
     relax_min_local_qubits();
     // Every chunk size must match the statevector reference, so tiling the

--- a/src/backend/distributed_statevector/tiled.rs
+++ b/src/backend/distributed_statevector/tiled.rs
@@ -448,6 +448,14 @@ impl TiledStatevector {
                 self.reset(*qubit)
             }
             Instruction::Barrier { .. } => Ok(()),
+            Instruction::Region(region) => {
+                if region.condition().evaluate(&self.classical_bits) {
+                    for inner in region.body() {
+                        self.step(inner, batch)?;
+                    }
+                }
+                Ok(())
+            }
         }
     }
 
@@ -741,6 +749,47 @@ impl TiledStatevector {
         Ok(())
     }
 
+    /// Accumulate the dry pass counts, counting a guarded region as if it were
+    /// taken: the ratio is a rejection threshold, so over-counting is the safe
+    /// direction.
+    fn count_passes(
+        &self,
+        instructions: &[Instruction],
+        gate_passes: &mut u64,
+        gate_count: &mut u64,
+        open_batch: &mut bool,
+    ) -> Result<()> {
+        for instruction in instructions {
+            let (gate, targets) = match instruction {
+                Instruction::Gate { gate, targets } => (gate, targets),
+                Instruction::Conditional { gate, targets, .. } => (gate, targets),
+                Instruction::Barrier { .. } => continue,
+                Instruction::Region(region) => {
+                    self.count_passes(region.body(), gate_passes, gate_count, open_batch)?;
+                    continue;
+                }
+                Instruction::Measure { .. } | Instruction::Reset { .. } => {
+                    *open_batch = false;
+                    continue;
+                }
+            };
+            *gate_count += 1;
+            match self.translate(gate, targets)? {
+                Translated::Window(_) => {
+                    if !*open_batch {
+                        *gate_passes += 1;
+                        *open_batch = true;
+                    }
+                }
+                Translated::Pair(_) => {
+                    *gate_passes += 1;
+                    *open_batch = false;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Dry scheduling pass: count full-shard streaming passes without
     /// touching storage and reject a schedule whose passes-per-gate ratio
     /// exceeds the configured threshold.
@@ -748,30 +797,12 @@ impl TiledStatevector {
         let mut gate_passes = 0u64;
         let mut gate_count = 0u64;
         let mut open_batch = false;
-        for instruction in instructions {
-            let (gate, targets) = match instruction {
-                Instruction::Gate { gate, targets } => (gate, targets),
-                Instruction::Conditional { gate, targets, .. } => (gate, targets),
-                Instruction::Barrier { .. } => continue,
-                Instruction::Measure { .. } | Instruction::Reset { .. } => {
-                    open_batch = false;
-                    continue;
-                }
-            };
-            gate_count += 1;
-            match self.translate(gate, targets)? {
-                Translated::Window(_) => {
-                    if !open_batch {
-                        gate_passes += 1;
-                        open_batch = true;
-                    }
-                }
-                Translated::Pair(_) => {
-                    gate_passes += 1;
-                    open_batch = false;
-                }
-            }
-        }
+        self.count_passes(
+            instructions,
+            &mut gate_passes,
+            &mut gate_count,
+            &mut open_batch,
+        )?;
         if gate_count == 0 || gate_passes < MIN_PASSES_FOR_REJECTION {
             return Ok(());
         }

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -668,6 +668,7 @@ impl Backend for FactoredBackend {
                 }
                 Ok(())
             }
+            Instruction::Region(region) => self.apply_region(region),
         }
     }
 

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -877,6 +877,7 @@ impl Backend for FactoredStabilizerBackend {
                     sub.dispatch_gate(gate, &local)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -419,6 +419,21 @@ pub trait Backend {
         Ok(())
     }
 
+    /// Execute a guarded region's body iff its condition holds.
+    ///
+    /// Every backend routes [`Instruction::Region`] here, so the branch
+    /// semantics live in one place. The body reaches
+    /// [`apply_instructions`](Backend::apply_instructions), which keeps any
+    /// batching a backend overrides it with.
+    fn apply_region(&mut self, region: &crate::circuit::GuardedRegion) -> Result<()> {
+        let taken = region.condition().evaluate(self.classical_results());
+        if taken {
+            self.apply_instructions(region.body())
+        } else {
+            Ok(())
+        }
+    }
+
     /// Whether this backend can handle `Gate::Fused` variants.
     ///
     /// Backends that operate on symbolic gate representations (e.g. stabilizer

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -2188,6 +2188,7 @@ impl Backend for MpsBackend {
                     self.dispatch_gate(gate, targets)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/product.rs
+++ b/src/backend/product.rs
@@ -179,6 +179,7 @@ impl Backend for ProductStateBackend {
                     self.dispatch_gate(gate, targets)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -525,6 +525,7 @@ impl Backend for SparseBackend {
                     self.dispatch_gate(gate, targets)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/stabilizer/kernels/mod.rs
+++ b/src/backend/stabilizer/kernels/mod.rs
@@ -682,10 +682,23 @@ impl StabilizerBackend {
                 } if condition.evaluate(&self.classical_bits) => {
                     self.sgi_dispatch_gate(gate, targets)?;
                 }
+                Instruction::Region(region)
+                    if region.condition().evaluate(&self.classical_bits) =>
+                {
+                    self.sgi_region_body(region)?;
+                }
                 _ => {}
             }
         }
         Ok(())
+    }
+
+    /// Out of line so [`Self::apply_instructions_sgi`] keeps a plain call site
+    /// rather than becoming directly self-recursive, which is a per-gate cost
+    /// on every circuit for a branch most circuits never take.
+    #[inline(never)]
+    fn sgi_region_body(&mut self, region: &crate::circuit::GuardedRegion) -> Result<()> {
+        self.apply_instructions_sgi(region.body())
     }
 
     pub(super) fn dispatch_gate(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -721,7 +721,22 @@ impl StabilizerBackend {
     /// measurements, resets, and barriers. Routes through the SGI or
     /// word-batch bulk paths at the same thresholds as
     /// [`Backend::apply_instructions`].
+    ///
+    /// # Errors
+    /// A guarded region can hold a measurement or reset, which this path drops
+    /// by contract, so one is rejected rather than silently skipped.
     pub fn apply_gates_only(&mut self, instructions: &[Instruction]) -> Result<()> {
+        if instructions
+            .iter()
+            .any(|inst| matches!(inst, Instruction::Region(_)))
+        {
+            return Err(crate::error::PrismError::IncompatibleBackend {
+                backend: "Stabilizer".to_string(),
+                reason: "the gates-only path skips measurement and reset, so it cannot carry a \
+                         guarded region"
+                    .to_string(),
+            });
+        }
         let nw = self.num_words;
         if nw < MIN_WORDS_FOR_BATCH {
             for instruction in instructions {
@@ -1409,6 +1424,9 @@ impl Backend for StabilizerBackend {
                 Instruction::Reset { qubit } => {
                     return self.apply_reset_gpu(*qubit);
                 }
+                Instruction::Region(region) => {
+                    return self.apply_region(region);
+                }
             }
         }
         if self.lazy_destab
@@ -1444,6 +1462,7 @@ impl Backend for StabilizerBackend {
                     self.dispatch_gate(gate, targets)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -307,6 +307,7 @@ impl StatevectorBackend {
                     Ok(())
                 }
             }
+            Instruction::Region(region) => self.apply_region(region),
         }
     }
 
@@ -832,6 +833,7 @@ impl Backend for StatevectorBackend {
                     self.dispatch_gate(gate, targets);
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -764,7 +764,8 @@ pub(crate) fn expectation_zero_state(circuit: &Circuit, pauli_terms: &[PauliTerm
             Instruction::Barrier { .. } => {}
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
-            | Instruction::Conditional { .. } => {
+            | Instruction::Conditional { .. }
+            | Instruction::Region(_) => {
                 return Err(PrismError::BackendUnsupported {
                     backend: "tensor_network_scalar".to_string(),
                     operation: format!("non-unitary instruction {instruction:?}"),
@@ -1299,6 +1300,7 @@ impl Backend for TensorNetworkBackend {
                     self.dispatch_gate(gate, targets)?;
                 }
             }
+            Instruction::Region(region) => self.apply_region(region)?,
         }
         Ok(())
     }

--- a/src/circuit/builder.rs
+++ b/src/circuit/builder.rs
@@ -15,7 +15,7 @@
 use num_complex::Complex64;
 
 use super::parameter::Parameters;
-use super::{Circuit, ClassicalCondition, Instruction, SmallVec};
+use super::{Circuit, ClassicalCondition, Instruction, SmallVec, guarded};
 use crate::gates::Gate;
 
 /// Fluent builder for quantum circuits.
@@ -218,6 +218,28 @@ impl CircuitBuilder {
             gate,
             targets: targets.into(),
         });
+        self
+    }
+
+    /// Append a guarded region: everything `body` appends runs only when
+    /// `condition` holds at runtime, measurement and reset included.
+    ///
+    /// The body builder starts empty and shares this circuit's dimensions, so
+    /// its qubit and classical-bit indices are the enclosing circuit's. Nesting
+    /// is allowed to [`MAX_REGION_DEPTH`]; an empty body appends nothing.
+    ///
+    /// [`MAX_REGION_DEPTH`]: crate::circuit::MAX_REGION_DEPTH
+    pub fn guarded(
+        &mut self,
+        condition: ClassicalCondition,
+        body: impl FnOnce(&mut CircuitBuilder),
+    ) -> &mut Self {
+        let mut inner = CircuitBuilder::new(self.circuit.num_qubits);
+        inner.circuit.num_classical_bits = self.circuit.num_classical_bits;
+        body(&mut inner);
+        if let Some(inst) = guarded(condition, inner.circuit.instructions) {
+            self.circuit.instructions.push(inst);
+        }
         self
     }
 

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -94,6 +94,23 @@ fn classify_op(gate: &Gate, targets: &[usize]) -> (String, OpKind) {
     (label, kind)
 }
 
+fn condition_label(condition: &ClassicalCondition) -> String {
+    match condition {
+        ClassicalCondition::BitIsOne(b) => format!("c[{}]", b),
+        ClassicalCondition::BitIsZero(b) => format!("!c[{}]", b),
+        ClassicalCondition::RegisterEquals {
+            offset,
+            size,
+            value,
+        } => format!("c[{}..{}]=={}", offset, offset + size, value),
+        ClassicalCondition::RegisterNotEquals {
+            offset,
+            size,
+            value,
+        } => format!("c[{}..{}]!={}", offset, offset + size, value),
+    }
+}
+
 fn place_op(moments: &mut Vec<Vec<PlacedOp>>, moment: usize, op: PlacedOp) {
     if moment >= moments.len() {
         moments.resize_with(moment + 1, Vec::new);
@@ -142,32 +159,22 @@ pub(super) fn assign_moments(circuit: &Circuit) -> Vec<Vec<PlacedOp>> {
                 condition,
                 gate,
                 targets,
-            } => {
-                let cbit_label = match condition {
-                    ClassicalCondition::BitIsOne(b) => format!("c[{}]", b),
-                    ClassicalCondition::BitIsZero(b) => format!("!c[{}]", b),
-                    ClassicalCondition::RegisterEquals {
-                        offset,
-                        size,
-                        value,
-                    } => {
-                        format!("c[{}..{}]=={}", offset, offset + size, value)
-                    }
-                    ClassicalCondition::RegisterNotEquals {
-                        offset,
-                        size,
-                        value,
-                    } => {
-                        format!("c[{}..{}]!={}", offset, offset + size, value)
-                    }
-                };
-                PlacedOp {
-                    label: gate.to_string(),
-                    qubits: SmallVec::from_slice(targets),
-                    kind: OpKind::Conditional { cbit_label },
-                    gate: Some(gate.clone()),
-                }
-            }
+            } => PlacedOp {
+                label: gate.to_string(),
+                qubits: SmallVec::from_slice(targets),
+                kind: OpKind::Conditional {
+                    cbit_label: condition_label(condition),
+                },
+                gate: Some(gate.clone()),
+            },
+            Instruction::Region(region) => PlacedOp {
+                label: format!("if[{}]", region.body().len()),
+                qubits: SmallVec::from_slice(region.qubits()),
+                kind: OpKind::Conditional {
+                    cbit_label: condition_label(region.condition()),
+                },
+                gate: None,
+            },
         };
         place_op(&mut moments, d, op);
     });
@@ -804,6 +811,7 @@ fn render_summary(circuit: &Circuit) -> Vec<String> {
                 conditional_count += 1;
                 *gate_counts.entry(gate.name()).or_default() += 1;
             }
+            Instruction::Region(_) => conditional_count += 1,
         }
     }
 
@@ -854,6 +862,7 @@ fn render_summary(circuit: &Circuit) -> Vec<String> {
             Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
                 std::slice::from_ref(qubit)
             }
+            Instruction::Region(region) => region.qubits(),
             Instruction::Barrier { .. } => continue,
         };
         for &q in targets {

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -119,6 +119,7 @@ fn inst_qubits(inst: &Instruction) -> &[usize] {
             std::slice::from_ref(qubit)
         }
         Instruction::Barrier { qubits } => qubits,
+        Instruction::Region(region) => region.qubits(),
     }
 }
 

--- a/src/circuit/fusion_phase.rs
+++ b/src/circuit/fusion_phase.rs
@@ -231,6 +231,17 @@ pub fn fuse_controlled_phases<'a>(circuit: Cow<'a, Circuit>, t: &mut Tracer) -> 
                 );
                 output.push(inst.clone());
             }
+            Instruction::Region(region) => {
+                flush_phase_qubits_in_use(
+                    region.qubits(),
+                    false,
+                    &mut pending,
+                    &mut target_users,
+                    &mut output,
+                    &mut changed,
+                );
+                output.push(inst.clone());
+            }
             Instruction::Conditional { targets, .. } => {
                 flush_phase_qubits_in_use(
                     targets,

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -205,37 +205,26 @@ impl Circuit {
 
     /// Count of gate instructions (excludes measurements and barriers).
     pub fn gate_count(&self) -> usize {
-        self.instructions
-            .iter()
-            .filter(|i| {
-                matches!(
-                    i,
-                    Instruction::Gate { .. } | Instruction::Conditional { .. }
-                )
-            })
-            .count()
+        let mut count = 0;
+        for_each_gate(&self.instructions, &mut |_| count += 1);
+        count
     }
 
     /// Count T and Tdg gates in the circuit.
     pub fn t_count(&self) -> usize {
-        self.instructions
-            .iter()
-            .filter(|inst| match inst {
-                Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                    matches!(gate, Gate::T | Gate::Tdg)
-                }
-                _ => false,
-            })
-            .count()
+        let mut count = 0;
+        for_each_gate(&self.instructions, &mut |gate| {
+            if matches!(gate, Gate::T | Gate::Tdg) {
+                count += 1;
+            }
+        });
+        count
     }
 
     /// Returns true if the circuit contains any T or Tdg gates.
     pub fn has_t_gates(&self) -> bool {
-        self.instructions.iter().any(|inst| match inst {
-            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                matches!(gate, Gate::T | Gate::Tdg)
-            }
-            _ => false,
+        any_gate(&self.instructions, &mut |gate| {
+            matches!(gate, Gate::T | Gate::Tdg)
         })
     }
 
@@ -244,21 +233,13 @@ impl Circuit {
     /// When true, the stabilizer backend can simulate this circuit exactly
     /// in O(n^2) time regardless of qubit count.
     pub fn is_clifford_only(&self) -> bool {
-        self.instructions.iter().all(|inst| match inst {
-            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                gate.is_clifford()
-            }
-            _ => true,
-        })
+        !any_gate(&self.instructions, &mut |gate| !gate.is_clifford())
     }
 
     /// True if every gate is Clifford or T/Tdg.
     pub fn is_clifford_plus_t(&self) -> bool {
-        self.instructions.iter().all(|inst| match inst {
-            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)
-            }
-            _ => true,
+        !any_gate(&self.instructions, &mut |gate| {
+            !(gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg))
         })
     }
 
@@ -267,24 +248,14 @@ impl Circuit {
     /// always has exactly one non-zero amplitude, giving O(1) memory and O(n)
     /// per-gate cost regardless of qubit count.
     pub fn is_sparse_friendly(&self) -> bool {
-        self.instructions.iter().all(|inst| match inst {
-            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                gate.preserves_sparsity()
-            }
-            _ => true,
-        })
+        !any_gate(&self.instructions, &mut |gate| !gate.preserves_sparsity())
     }
 
     /// True if the circuit contains any multi-qubit (entangling) gates.
     ///
     /// When false, the product state backend can simulate in O(n) time.
     pub fn has_entangling_gates(&self) -> bool {
-        self.instructions.iter().any(|inst| match inst {
-            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => {
-                gate.num_qubits() >= 2
-            }
-            _ => false,
-        })
+        any_gate(&self.instructions, &mut |gate| gate.num_qubits() >= 2)
     }
 
     /// Herfindahl-Hirschman index of the qubit interaction graph partition.
@@ -314,7 +285,7 @@ impl Circuit {
         let mut seen_measurement = false;
         for inst in &self.instructions {
             match inst {
-                Instruction::Conditional { .. } => return false,
+                Instruction::Conditional { .. } | Instruction::Region(_) => return false,
                 Instruction::Measure { .. } => {
                     seen_measurement = true;
                 }
@@ -330,34 +301,27 @@ impl Circuit {
     }
 
     /// Extract the qubit-to-classical-bit mapping from all measurements.
+    ///
+    /// Measurements inside a guarded region are included; whether the region is
+    /// taken is a runtime fact, so the map covers what the circuit can write.
     pub fn measurement_map(&self) -> Vec<(usize, usize)> {
-        self.instructions
-            .iter()
-            .filter_map(|inst| match inst {
-                Instruction::Measure {
-                    qubit,
-                    classical_bit,
-                } => Some((*qubit, *classical_bit)),
-                _ => None,
-            })
-            .collect()
+        let mut out = Vec::new();
+        for_each_measure(&self.instructions, &mut |qubit, classical_bit| {
+            out.push((qubit, classical_bit))
+        });
+        out
     }
 
     pub fn without_measurements(&self) -> Circuit {
         let mut c = Circuit::new(self.num_qubits, self.num_classical_bits);
-        c.instructions = self
-            .instructions
-            .iter()
-            .filter(|inst| !matches!(inst, Instruction::Measure { .. }))
-            .cloned()
-            .collect();
+        c.instructions = strip_measurements(&self.instructions);
         c
     }
 
     pub fn has_resets(&self) -> bool {
-        self.instructions
-            .iter()
-            .any(|i| matches!(i, Instruction::Reset { .. }))
+        any_instruction(&self.instructions, &mut |i| {
+            matches!(i, Instruction::Reset { .. })
+        })
     }
 
     /// Partition qubits into independent (non-interacting) subsystems.
@@ -402,44 +366,38 @@ impl Circuit {
 
         // Build cbit → measurement qubit map for classical dependency tracking
         let mut cbit_to_qubit: Vec<Option<usize>> = vec![None; self.num_classical_bits.max(1)];
-        for inst in &self.instructions {
-            if let Instruction::Measure {
-                qubit,
-                classical_bit,
-            } = inst
-            {
-                cbit_to_qubit[*classical_bit] = Some(*qubit);
-            }
-        }
+        for_each_measure(&self.instructions, &mut |qubit, classical_bit| {
+            cbit_to_qubit[classical_bit] = Some(qubit);
+        });
 
+        let mut condition_bits: Vec<usize> = Vec::new();
         for inst in &self.instructions {
+            condition_bits.clear();
             let targets = match inst {
-                Instruction::Gate { targets, .. } => targets,
+                Instruction::Gate { targets, .. } => targets.as_slice(),
                 Instruction::Conditional {
                     condition, targets, ..
                 } => {
-                    match condition {
-                        ClassicalCondition::BitIsOne(bit) | ClassicalCondition::BitIsZero(bit) => {
-                            if let Some(mq) = cbit_to_qubit[*bit] {
-                                union(&mut parent, &mut rank, targets[0], mq);
-                            }
-                        }
-                        ClassicalCondition::RegisterEquals { offset, size, .. }
-                        | ClassicalCondition::RegisterNotEquals { offset, size, .. } => {
-                            for mq in cbit_to_qubit.iter().skip(*offset).take(*size).flatten() {
-                                union(&mut parent, &mut rank, targets[0], *mq);
-                            }
-                        }
-                    }
-                    targets
+                    collect_condition_bits(condition, &mut condition_bits);
+                    targets.as_slice()
+                }
+                Instruction::Region(region) => {
+                    collect_condition_bits(region.condition(), &mut condition_bits);
+                    collect_body_condition_bits(region.body(), &mut condition_bits);
+                    region.qubits()
                 }
                 _ => continue,
             };
-            if targets.len() >= 2 {
-                let first = targets[0];
-                for &t in &targets[1..] {
-                    union(&mut parent, &mut rank, first, t);
+            let Some(&first) = targets.first() else {
+                continue;
+            };
+            for &bit in &condition_bits {
+                if let Some(mq) = cbit_to_qubit.get(bit).copied().flatten() {
+                    union(&mut parent, &mut rank, first, mq);
                 }
+            }
+            for &t in &targets[1..] {
+                union(&mut parent, &mut rank, first, t);
             }
         }
 
@@ -470,23 +428,18 @@ impl Circuit {
         let max_cb = self.num_classical_bits.max(1);
         let mut old_to_new_classical: Vec<Option<usize>> = vec![None; max_cb];
 
-        for inst in &self.instructions {
-            if let Instruction::Measure {
-                qubit,
-                classical_bit,
-            } = inst
-            {
-                if old_to_new_qubit[*qubit].is_some()
-                    && old_to_new_classical[*classical_bit].is_none()
-                {
-                    let new_idx = classical_bits_used.len();
-                    old_to_new_classical[*classical_bit] = Some(new_idx);
-                    classical_bits_used.push(*classical_bit);
-                }
+        for_each_measure(&self.instructions, &mut |qubit, classical_bit| {
+            if old_to_new_qubit[qubit].is_some() && old_to_new_classical[classical_bit].is_none() {
+                let new_idx = classical_bits_used.len();
+                old_to_new_classical[classical_bit] = Some(new_idx);
+                classical_bits_used.push(classical_bit);
             }
-        }
+        });
 
         let mut sub = Circuit::new(qubit_set.len(), classical_bits_used.len());
+
+        let qubit_of = |q: usize| old_to_new_qubit[q].expect("membership checked by the caller");
+        let cbit_of = |c: usize| old_to_new_classical[c].unwrap_or(c);
 
         for inst in &self.instructions {
             match inst {
@@ -529,47 +482,20 @@ impl Circuit {
                             .push(Instruction::Barrier { qubits: new_qs });
                     }
                 }
-                Instruction::Conditional {
-                    condition,
-                    gate,
-                    targets,
-                } => {
+                Instruction::Conditional { targets, .. } => {
                     if targets.iter().all(|&t| old_to_new_qubit[t].is_some()) {
-                        let new_targets: SmallVec<[usize; 4]> = targets
-                            .iter()
-                            .map(|&t| old_to_new_qubit[t].unwrap())
-                            .collect();
-                        let new_condition = match condition {
-                            ClassicalCondition::BitIsOne(bit) => ClassicalCondition::BitIsOne(
-                                old_to_new_classical[*bit].unwrap_or(*bit),
-                            ),
-                            ClassicalCondition::BitIsZero(bit) => ClassicalCondition::BitIsZero(
-                                old_to_new_classical[*bit].unwrap_or(*bit),
-                            ),
-                            ClassicalCondition::RegisterEquals {
-                                offset,
-                                size,
-                                value,
-                            } => ClassicalCondition::RegisterEquals {
-                                offset: old_to_new_classical[*offset].unwrap_or(*offset),
-                                size: *size,
-                                value: *value,
-                            },
-                            ClassicalCondition::RegisterNotEquals {
-                                offset,
-                                size,
-                                value,
-                            } => ClassicalCondition::RegisterNotEquals {
-                                offset: old_to_new_classical[*offset].unwrap_or(*offset),
-                                size: *size,
-                                value: *value,
-                            },
-                        };
-                        sub.instructions.push(Instruction::Conditional {
-                            condition: new_condition,
-                            gate: gate.clone(),
-                            targets: new_targets,
-                        });
+                        sub.instructions
+                            .push(remap_instruction(inst, &qubit_of, &cbit_of));
+                    }
+                }
+                Instruction::Region(region) => {
+                    if region
+                        .qubits()
+                        .iter()
+                        .all(|&q| old_to_new_qubit[q].is_some())
+                    {
+                        sub.instructions
+                            .push(remap_instruction(inst, &qubit_of, &cbit_of));
                     }
                 }
             }
@@ -602,26 +528,23 @@ impl Circuit {
         let max_cb = self.num_classical_bits.max(1);
         let mut cbit_map: Vec<Option<(usize, usize)>> = vec![None; max_cb];
 
-        for inst in &self.instructions {
-            if let Instruction::Measure {
-                qubit,
-                classical_bit,
-            } = inst
-            {
-                let (comp_idx, _) = qubit_map[*qubit];
-                if cbit_map[*classical_bit].is_none() {
-                    let new_idx = classical_bits_per_comp[comp_idx].len();
-                    cbit_map[*classical_bit] = Some((comp_idx, new_idx));
-                    classical_bits_per_comp[comp_idx].push(*classical_bit);
-                }
+        for_each_measure(&self.instructions, &mut |qubit, classical_bit| {
+            let (comp_idx, _) = qubit_map[qubit];
+            if cbit_map[classical_bit].is_none() {
+                let new_idx = classical_bits_per_comp[comp_idx].len();
+                cbit_map[classical_bit] = Some((comp_idx, new_idx));
+                classical_bits_per_comp[comp_idx].push(classical_bit);
             }
-        }
+        });
 
         let mut subs: Vec<Circuit> = (0..k)
             .map(|i| Circuit::new(components[i].len(), classical_bits_per_comp[i].len()))
             .collect();
 
         let mut barrier_buf: Vec<SmallVec<[usize; 4]>> = (0..k).map(|_| SmallVec::new()).collect();
+
+        let qubit_of = |q: usize| qubit_map[q].1;
+        let cbit_of = |c: usize| cbit_map[c].map(|(_, nc)| nc).unwrap_or(c);
 
         // Pass 2: route each instruction to its component
         for inst in &self.instructions {
@@ -669,53 +592,20 @@ impl Circuit {
                         }
                     }
                 }
-                Instruction::Conditional {
-                    condition,
-                    gate,
-                    targets,
-                } => {
+                Instruction::Conditional { targets, .. } => {
                     let (comp_idx, _) = qubit_map[targets[0]];
-                    let new_targets: SmallVec<[usize; 4]> =
-                        targets.iter().map(|&t| qubit_map[t].1).collect();
-                    let new_condition = match condition {
-                        ClassicalCondition::BitIsOne(bit) => {
-                            let (_, nc) = cbit_map[*bit].unwrap_or((comp_idx, *bit));
-                            ClassicalCondition::BitIsOne(nc)
-                        }
-                        ClassicalCondition::BitIsZero(bit) => {
-                            let (_, nc) = cbit_map[*bit].unwrap_or((comp_idx, *bit));
-                            ClassicalCondition::BitIsZero(nc)
-                        }
-                        ClassicalCondition::RegisterEquals {
-                            offset,
-                            size,
-                            value,
-                        } => {
-                            let new_offset = cbit_map[*offset].map(|(_, nc)| nc).unwrap_or(*offset);
-                            ClassicalCondition::RegisterEquals {
-                                offset: new_offset,
-                                size: *size,
-                                value: *value,
-                            }
-                        }
-                        ClassicalCondition::RegisterNotEquals {
-                            offset,
-                            size,
-                            value,
-                        } => {
-                            let new_offset = cbit_map[*offset].map(|(_, nc)| nc).unwrap_or(*offset);
-                            ClassicalCondition::RegisterNotEquals {
-                                offset: new_offset,
-                                size: *size,
-                                value: *value,
-                            }
-                        }
+                    subs[comp_idx]
+                        .instructions
+                        .push(remap_instruction(inst, &qubit_of, &cbit_of));
+                }
+                Instruction::Region(region) => {
+                    let Some(&first) = region.qubits().first() else {
+                        continue;
                     };
-                    subs[comp_idx].instructions.push(Instruction::Conditional {
-                        condition: new_condition,
-                        gate: gate.clone(),
-                        targets: new_targets,
-                    });
+                    let (comp_idx, _) = qubit_map[first];
+                    subs[comp_idx]
+                        .instructions
+                        .push(remap_instruction(inst, &qubit_of, &cbit_of));
                 }
             }
         }
@@ -757,7 +647,8 @@ impl Circuit {
                 }
                 Instruction::Measure { .. }
                 | Instruction::Reset { .. }
-                | Instruction::Conditional { .. } => {
+                | Instruction::Conditional { .. }
+                | Instruction::Region(_) => {
                     split_at = i;
                     break;
                 }
@@ -828,6 +719,14 @@ fn for_each_placement(
                     qubit_depth[q] = d + 1;
                 }
             }
+            Instruction::Region(region) => {
+                let qubits = region.qubits();
+                let d = qubits.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
+                visit(inst, d);
+                for &q in qubits {
+                    qubit_depth[q] = d + 1;
+                }
+            }
             Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => {
                 let d = qubit_depth[*qubit];
                 visit(inst, d);
@@ -881,21 +780,17 @@ pub fn qft_textbook_steps(start: usize, num: usize) -> impl Iterator<Item = QftT
 /// Backends without native support call this before dispatch. Returns
 /// `Cow::Borrowed` when there is nothing to expand.
 pub fn expand_qft_blocks(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
-    let has_qft = circuit.instructions.iter().any(|inst| {
-        matches!(
-            inst,
-            Instruction::Gate {
-                gate: Gate::QftBlock { .. },
-                ..
-            }
-        )
-    });
-    if !has_qft {
+    if !any_bare_gate(&circuit.instructions, &mut |gate| {
+        matches!(gate, Gate::QftBlock { .. })
+    }) {
         return std::borrow::Cow::Borrowed(circuit);
     }
+    std::borrow::Cow::Owned(circuit.with_instructions(expanded_qft_blocks(&circuit.instructions)))
+}
 
-    let mut out: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len() * 2);
-    for inst in &circuit.instructions {
+fn expanded_qft_blocks(instructions: &[Instruction]) -> Vec<Instruction> {
+    let mut out: Vec<Instruction> = Vec::with_capacity(instructions.len() * 2);
+    for inst in instructions {
         if let Instruction::Gate {
             gate: Gate::QftBlock { start, num },
             ..
@@ -921,12 +816,16 @@ pub fn expand_qft_blocks(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
                     }),
                 }
             }
+        } else if let Instruction::Region(region) = inst {
+            out.push(Instruction::Region(Box::new(GuardedRegion::new(
+                region.condition().clone(),
+                expanded_qft_blocks(region.body()),
+            ))));
         } else {
             out.push(inst.clone());
         }
     }
-
-    std::borrow::Cow::Owned(circuit.with_instructions(out))
+    out
 }
 
 /// Emit the CNOT-ladder lowering of `exp(-i θ P / 2)` gate by gate.
@@ -976,21 +875,19 @@ pub(crate) fn pauli_rotation_lowering(
 /// probe-plus-expansion route as [`expand_qft_blocks`]. Returns
 /// `Cow::Borrowed` when there is nothing to expand.
 pub fn expand_pauli_rotations(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
-    let has_pauli_rot = circuit.instructions.iter().any(|inst| {
-        matches!(
-            inst,
-            Instruction::Gate {
-                gate: Gate::PauliRot(_),
-                ..
-            }
-        )
-    });
-    if !has_pauli_rot {
+    if !any_bare_gate(&circuit.instructions, &mut |gate| {
+        matches!(gate, Gate::PauliRot(_))
+    }) {
         return std::borrow::Cow::Borrowed(circuit);
     }
+    std::borrow::Cow::Owned(
+        circuit.with_instructions(expanded_pauli_rotations(&circuit.instructions)),
+    )
+}
 
-    let mut out: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len() * 2);
-    for inst in &circuit.instructions {
+fn expanded_pauli_rotations(instructions: &[Instruction]) -> Vec<Instruction> {
+    let mut out: Vec<Instruction> = Vec::with_capacity(instructions.len() * 2);
+    for inst in instructions {
         if let Instruction::Gate {
             gate: Gate::PauliRot(data),
             targets,
@@ -1002,12 +899,16 @@ pub fn expand_pauli_rotations(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit
                     targets: SmallVec::from_slice(tgts),
                 });
             });
+        } else if let Instruction::Region(region) = inst {
+            out.push(Instruction::Region(Box::new(GuardedRegion::new(
+                region.condition().clone(),
+                expanded_pauli_rotations(region.body()),
+            ))));
         } else {
             out.push(inst.clone());
         }
     }
-
-    std::borrow::Cow::Owned(circuit.with_instructions(out))
+    out
 }
 
 /// Condition for classically-controlled gate execution.
@@ -1063,6 +964,280 @@ impl ClassicalCondition {
     }
 }
 
+/// Deepest guarded-region nesting the parser accepts.
+///
+/// Every pass walks a region body recursively, so the depth is bounded at
+/// construction to keep those walks finite.
+pub const MAX_REGION_DEPTH: usize = 16;
+
+/// A guarded region: `body` executes in order iff `condition` holds.
+///
+/// The condition is evaluated once, against the classical bits as they stand
+/// when control reaches the region. Bits written by measurements inside a taken
+/// body are visible to later instructions.
+///
+/// Fields are private because [`GuardedRegion::qubits`] caches the union over
+/// the body; build a new region rather than editing one in place.
+#[derive(Debug, Clone)]
+pub struct GuardedRegion {
+    condition: ClassicalCondition,
+    body: Vec<Instruction>,
+    qubits: SmallVec<[usize; 4]>,
+}
+
+impl GuardedRegion {
+    /// Compute the body's qubit union once, so each pass reads it instead of
+    /// re-walking the body.
+    pub fn new(condition: ClassicalCondition, body: Vec<Instruction>) -> Self {
+        let mut qubits: SmallVec<[usize; 4]> = SmallVec::new();
+        collect_region_qubits(&body, &mut qubits);
+        qubits.sort_unstable();
+        qubits.dedup();
+        Self {
+            condition,
+            body,
+            qubits,
+        }
+    }
+
+    pub fn condition(&self) -> &ClassicalCondition {
+        &self.condition
+    }
+
+    pub fn body(&self) -> &[Instruction] {
+        &self.body
+    }
+
+    /// Sorted union of every qubit the body touches, nested regions included.
+    pub fn qubits(&self) -> &[usize] {
+        &self.qubits
+    }
+
+    /// Nesting depth, counting this region as 1.
+    pub fn depth(&self) -> usize {
+        1 + self
+            .body
+            .iter()
+            .filter_map(|inst| match inst {
+                Instruction::Region(inner) => Some(inner.depth()),
+                _ => None,
+            })
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+/// Visit every gate, including a guarded one, descending into region bodies.
+fn for_each_gate(instructions: &[Instruction], visit: &mut impl FnMut(&Gate)) {
+    for inst in instructions {
+        match inst {
+            Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => visit(gate),
+            Instruction::Region(region) => for_each_gate(region.body(), visit),
+            _ => {}
+        }
+    }
+}
+
+/// Short-circuiting scan over unguarded [`Instruction::Gate`] payloads only,
+/// which is the set the lowering passes rewrite.
+fn any_bare_gate(instructions: &[Instruction], pred: &mut impl FnMut(&Gate) -> bool) -> bool {
+    instructions.iter().any(|inst| match inst {
+        Instruction::Gate { gate, .. } => pred(gate),
+        Instruction::Region(region) => any_bare_gate(region.body(), pred),
+        _ => false,
+    })
+}
+
+/// Short-circuiting [`for_each_gate`].
+pub(crate) fn any_gate(instructions: &[Instruction], pred: &mut impl FnMut(&Gate) -> bool) -> bool {
+    instructions.iter().any(|inst| match inst {
+        Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => pred(gate),
+        Instruction::Region(region) => any_gate(region.body(), pred),
+        _ => false,
+    })
+}
+
+/// True when `pred` holds for `inst` or for anything inside a region body.
+fn any_instruction(
+    instructions: &[Instruction],
+    pred: &mut impl FnMut(&Instruction) -> bool,
+) -> bool {
+    instructions.iter().any(|inst| {
+        pred(inst)
+            || match inst {
+                Instruction::Region(region) => any_instruction(region.body(), pred),
+                _ => false,
+            }
+    })
+}
+
+fn strip_measurements(instructions: &[Instruction]) -> Vec<Instruction> {
+    instructions
+        .iter()
+        .filter(|inst| !matches!(inst, Instruction::Measure { .. }))
+        .filter_map(|inst| match inst {
+            // A region whose body was all measurements drops out entirely,
+            // rather than surviving as the empty region `guarded` never builds.
+            Instruction::Region(region) => guarded(
+                region.condition().clone(),
+                strip_measurements(region.body()),
+            ),
+            other => Some(other.clone()),
+        })
+        .collect()
+}
+
+/// Visit every measurement in `instructions`, descending into region bodies.
+fn for_each_measure(instructions: &[Instruction], visit: &mut impl FnMut(usize, usize)) {
+    for inst in instructions {
+        match inst {
+            Instruction::Measure {
+                qubit,
+                classical_bit,
+            } => visit(*qubit, *classical_bit),
+            Instruction::Region(region) => for_each_measure(region.body(), visit),
+            _ => {}
+        }
+    }
+}
+
+fn collect_condition_bits(condition: &ClassicalCondition, out: &mut Vec<usize>) {
+    match condition {
+        ClassicalCondition::BitIsOne(bit) | ClassicalCondition::BitIsZero(bit) => out.push(*bit),
+        ClassicalCondition::RegisterEquals { offset, size, .. }
+        | ClassicalCondition::RegisterNotEquals { offset, size, .. } => {
+            out.extend(*offset..offset.saturating_add(*size))
+        }
+    }
+}
+
+/// Every classical bit read by a condition anywhere in `body`, nested regions
+/// included. A subsystem partition that ignored these would split a circuit
+/// whose halves are coupled through the classical bits alone.
+fn collect_body_condition_bits(body: &[Instruction], out: &mut Vec<usize>) {
+    for inst in body {
+        match inst {
+            Instruction::Conditional { condition, .. } => collect_condition_bits(condition, out),
+            Instruction::Region(region) => {
+                collect_condition_bits(region.condition(), out);
+                collect_body_condition_bits(region.body(), out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn remap_condition(
+    condition: &ClassicalCondition,
+    cbit: &impl Fn(usize) -> usize,
+) -> ClassicalCondition {
+    match condition {
+        ClassicalCondition::BitIsOne(bit) => ClassicalCondition::BitIsOne(cbit(*bit)),
+        ClassicalCondition::BitIsZero(bit) => ClassicalCondition::BitIsZero(cbit(*bit)),
+        ClassicalCondition::RegisterEquals {
+            offset,
+            size,
+            value,
+        } => ClassicalCondition::RegisterEquals {
+            offset: cbit(*offset),
+            size: *size,
+            value: *value,
+        },
+        ClassicalCondition::RegisterNotEquals {
+            offset,
+            size,
+            value,
+        } => ClassicalCondition::RegisterNotEquals {
+            offset: cbit(*offset),
+            size: *size,
+            value: *value,
+        },
+    }
+}
+
+/// Rebuild `inst` under a qubit and classical-bit relabeling.
+///
+/// Callers must have established that every qubit `inst` touches has an image
+/// under `qubit`, which for a region means its whole body.
+fn remap_instruction(
+    inst: &Instruction,
+    qubit: &impl Fn(usize) -> usize,
+    cbit: &impl Fn(usize) -> usize,
+) -> Instruction {
+    match inst {
+        Instruction::Gate { gate, targets } => Instruction::Gate {
+            gate: gate.clone(),
+            targets: targets.iter().map(|&t| qubit(t)).collect(),
+        },
+        Instruction::Measure {
+            qubit: q,
+            classical_bit,
+        } => Instruction::Measure {
+            qubit: qubit(*q),
+            classical_bit: cbit(*classical_bit),
+        },
+        Instruction::Reset { qubit: q } => Instruction::Reset { qubit: qubit(*q) },
+        Instruction::Barrier { qubits } => Instruction::Barrier {
+            qubits: qubits.iter().map(|&q| qubit(q)).collect(),
+        },
+        Instruction::Conditional {
+            condition,
+            gate,
+            targets,
+        } => Instruction::Conditional {
+            condition: remap_condition(condition, cbit),
+            gate: gate.clone(),
+            targets: targets.iter().map(|&t| qubit(t)).collect(),
+        },
+        Instruction::Region(region) => Instruction::Region(Box::new(GuardedRegion::new(
+            remap_condition(region.condition(), cbit),
+            region
+                .body()
+                .iter()
+                .map(|inner| remap_instruction(inner, qubit, cbit))
+                .collect(),
+        ))),
+    }
+}
+
+fn collect_region_qubits(body: &[Instruction], out: &mut SmallVec<[usize; 4]>) {
+    for inst in body {
+        match inst {
+            Instruction::Gate { targets, .. }
+            | Instruction::Conditional { targets, .. }
+            | Instruction::Barrier { qubits: targets } => out.extend_from_slice(targets),
+            Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => out.push(*qubit),
+            Instruction::Region(inner) => out.extend_from_slice(inner.qubits()),
+        }
+    }
+}
+
+/// Build the guarded form of `body`, or `None` when the body is empty.
+///
+/// A single-gate body lowers to [`Instruction::Conditional`] so the common
+/// `if (c) x q[0];` keeps its allocation-free representation; anything else
+/// becomes an [`Instruction::Region`].
+pub fn guarded(condition: ClassicalCondition, mut body: Vec<Instruction>) -> Option<Instruction> {
+    if body.is_empty() {
+        return None;
+    }
+    if body.len() == 1
+        && let Instruction::Gate { .. } = &body[0]
+    {
+        let Some(Instruction::Gate { gate, targets }) = body.pop() else {
+            unreachable!("length and variant both checked above")
+        };
+        return Some(Instruction::Conditional {
+            condition,
+            gate,
+            targets,
+        });
+    }
+    Some(Instruction::Region(Box::new(GuardedRegion::new(
+        condition, body,
+    ))))
+}
+
 /// A single instruction in the circuit.
 #[derive(Debug, Clone)]
 pub enum Instruction {
@@ -1079,16 +1254,67 @@ pub enum Instruction {
     /// Backends should treat this as a no-op.
     Barrier { qubits: SmallVec<[usize; 4]> },
     /// Conditionally apply a gate based on classical measurement results.
+    ///
+    /// The single-gate lowering of [`Instruction::Region`]; see [`guarded`].
     Conditional {
         condition: ClassicalCondition,
         gate: Gate,
         targets: SmallVec<[usize; 4]>,
     },
+    /// Conditionally execute a span of instructions, measure and reset included.
+    ///
+    /// Boxed so the variant costs a pointer: `Instruction` is 96 bytes and this
+    /// keeps it there.
+    Region(Box<GuardedRegion>),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Every backend routes a conditional through ClassicalCondition::evaluate,
+    // so the variant semantics are pinned once here rather than per backend.
+    // Registers read bit `offset + i` as `1 << i`.
+    #[test]
+    fn classical_condition_evaluates_every_variant() {
+        let bits = [true, false, true];
+
+        assert!(ClassicalCondition::BitIsOne(0).evaluate(&bits));
+        assert!(!ClassicalCondition::BitIsOne(1).evaluate(&bits));
+        assert!(ClassicalCondition::BitIsZero(1).evaluate(&bits));
+        assert!(!ClassicalCondition::BitIsZero(0).evaluate(&bits));
+
+        let reg = |value| ClassicalCondition::RegisterEquals {
+            offset: 0,
+            size: 3,
+            value,
+        };
+        assert!(reg(0b101).evaluate(&bits));
+        assert!(!reg(0b100).evaluate(&bits));
+
+        let reg_ne = |value| ClassicalCondition::RegisterNotEquals {
+            offset: 0,
+            size: 3,
+            value,
+        };
+        assert!(reg_ne(0b100).evaluate(&bits));
+        assert!(!reg_ne(0b101).evaluate(&bits));
+    }
+
+    #[test]
+    fn classical_condition_register_honors_offset() {
+        let bits = [true, true, false, true];
+        let at = |offset| ClassicalCondition::RegisterEquals {
+            offset,
+            size: 2,
+            value: 0b01,
+        };
+        assert!(at(1).evaluate(&bits), "bits 1..3 are 1,0 so the value is 1");
+        assert!(
+            !at(0).evaluate(&bits),
+            "bits 0..2 are 1,1 so the value is 3"
+        );
+    }
 
     #[test]
     fn test_circuit_builder() {

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -22,6 +22,7 @@
 //! | Conditional inequality | `if (c != 0) x q[0];` | Register or bit `!=` |
 //! | Conditional bit literal | `if (c[0] == 1) x q[0];` | Bit equality vs `0` / `1` |
 //! | Conditional negation | `if (!c[0]) x q[0];` | Negated bit truthy test |
+//! | Guarded region | `if (c[0]) { x q[0]; measure q[1] -> c[1]; }` | Braced body, any statement, nestable |
 //! | Hex / binary literals | `if (c == 0xff) ...` | `0x`, `0b`, `0o` integer prefixes with optional `_` separators |
 //! | Boolean literals | `rx(true * pi) ...` | `true` / `false` evaluate to `1.0` / `0.0` |
 //! | Gate definition | `gate rxx(t) a,b { ... }` | User-defined gates |
@@ -32,7 +33,7 @@
 //!
 //! # Unsupported constructs (return `PrismError::UnsupportedConstruct`)
 //!
-//! - `defcal`, `extern`, `opaque`, `box`, `while`
+//! - `defcal`, `extern`, `opaque`, `box`, `while`, `switch`, `else`
 //! - `def` bodies that contain `measure`, `reset`, `bit`, `creg`, `return`,
 //!   or the `=measure` assignment shape (V1 supports unitary subroutines only)
 //! - `def` declarations with a return type
@@ -51,7 +52,9 @@
 
 use num_complex::Complex64;
 
-use crate::circuit::{Circuit, ClassicalCondition, Instruction, SmallVec, smallvec};
+use crate::circuit::{
+    Circuit, ClassicalCondition, Instruction, MAX_REGION_DEPTH, SmallVec, guarded, smallvec,
+};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 use std::collections::HashMap;
@@ -106,6 +109,7 @@ enum BlockKind {
     Gate,
     Def,
     For,
+    If,
 }
 
 #[derive(Clone, Copy)]
@@ -152,6 +156,7 @@ pub(crate) struct Parser<'a> {
     total_qubits: usize,
     total_cbits: usize,
     gate_expansion_depth: usize,
+    region_depth: usize,
     param_vars: Option<HashMap<String, f64>>,
     int_vars: Option<HashMap<String, i64>>,
 }
@@ -173,6 +178,7 @@ fn block_kind_name(kind: BlockKind) -> &'static str {
         BlockKind::Gate => "gate",
         BlockKind::Def => "def",
         BlockKind::For => "for",
+        BlockKind::If => "if",
     }
 }
 
@@ -453,6 +459,7 @@ impl<'a> Parser<'a> {
             total_qubits: 0,
             total_cbits: 0,
             gate_expansion_depth: 0,
+            region_depth: 0,
             param_vars: None,
             int_vars: None,
         }
@@ -519,11 +526,17 @@ impl<'a> Parser<'a> {
             .next()
             .unwrap_or(line);
 
-        if matches!(first_word, "gate" | "def" | "for") {
+        // A braced `if` is a guarded region and takes the block path; the
+        // one-statement `if (c) x q[0];` form has no brace and falls through to
+        // `parse_if_statement` below.
+        if matches!(first_word, "gate" | "def" | "for")
+            || (first_word == "if" && line.contains('{'))
+        {
             let kind = match first_word {
                 "gate" => BlockKind::Gate,
                 "def" => BlockKind::Def,
                 "for" => BlockKind::For,
+                "if" => BlockKind::If,
                 _ => unreachable!(),
             };
             let depth = update_brace_depth(0, line);
@@ -602,7 +615,7 @@ impl<'a> Parser<'a> {
 
         if matches!(
             first_word,
-            "defcal" | "opaque" | "while" | "box" | "extern" | "return"
+            "defcal" | "opaque" | "while" | "switch" | "box" | "extern" | "return" | "else"
         ) {
             return Err(PrismError::UnsupportedConstruct {
                 construct: first_word.to_string(),
@@ -624,6 +637,7 @@ impl<'a> Parser<'a> {
                 Ok(Vec::new())
             }
             BlockKind::For => self.expand_for_block(&state.buf, state.start_line),
+            BlockKind::If => self.parse_if_block(&state.buf, state.start_line),
         }
     }
 
@@ -1229,9 +1243,57 @@ impl<'a> Parser<'a> {
         Ok(out)
     }
 
-    /// Parse `if(creg==value) gate args` (OQ2) or `if (c[i]) gate args` (OQ3).
-    fn parse_if_statement(&self, line: &str, line_num: usize) -> Result<Vec<Instruction>> {
-        let rest = line.strip_prefix("if").unwrap().trim();
+    /// Parse `if (cond) { ... }` into a guarded region.
+    ///
+    /// The body reaches [`Parser::parse_lines`], so it admits any statement the
+    /// parser already accepts, nested regions included.
+    fn parse_if_block(&mut self, buf: &str, line_num: usize) -> Result<Vec<Instruction>> {
+        let (condition, body_str) = self.split_if_header(buf, line_num)?;
+
+        let open = body_str.find('{').ok_or_else(|| PrismError::Parse {
+            line: line_num,
+            message: "expected `{` after `if(...)` condition".to_string(),
+        })?;
+        let after_open = &body_str[open + 1..];
+        let close = find_matching_close_brace(after_open).ok_or_else(|| PrismError::Parse {
+            line: line_num,
+            message: "unmatched `{` in `if` body".to_string(),
+        })?;
+        let trailing = after_open[close + 1..].trim();
+        if !trailing.is_empty() {
+            let word = trailing
+                .split(|c: char| c.is_whitespace() || c == '(' || c == '{')
+                .next()
+                .unwrap_or(trailing);
+            return Err(PrismError::UnsupportedConstruct {
+                construct: word.to_string(),
+                line: line_num,
+            });
+        }
+
+        if self.region_depth >= MAX_REGION_DEPTH {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("`if` blocks nest deeper than {MAX_REGION_DEPTH}"),
+            });
+        }
+        self.region_depth += 1;
+        let body_lines = split_body_into_lines(after_open[..close].trim());
+        let refs: Vec<&str> = body_lines.iter().map(String::as_str).collect();
+        let body = self.parse_lines(&refs, line_num.saturating_sub(1));
+        self.region_depth -= 1;
+
+        Ok(guarded(condition, body?).into_iter().collect())
+    }
+
+    /// Split `if (cond) rest` into the parsed condition and the trimmed rest,
+    /// which is empty when the condition is the whole statement.
+    fn split_if_header<'s>(
+        &self,
+        line: &'s str,
+        line_num: usize,
+    ) -> Result<(ClassicalCondition, &'s str)> {
+        let rest = line.trim_start().strip_prefix("if").unwrap().trim();
         let open = rest.find('(').ok_or_else(|| PrismError::Parse {
             line: line_num,
             message: "expected `(` after `if`".to_string(),
@@ -1242,30 +1304,22 @@ impl<'a> Parser<'a> {
                 line: line_num,
                 message: "expected `)` in `if` condition".to_string(),
             })?;
-        let cond_str = after_open[..close_offset].trim();
-        let body_str = after_open[close_offset + 1..].trim();
+        let condition =
+            self.parse_classical_condition(after_open[..close_offset].trim(), line_num)?;
+        Ok((condition, after_open[close_offset + 1..].trim()))
+    }
 
+    /// Parse `if(creg==value) gate args` (OQ2) or `if (c[i]) gate args` (OQ3).
+    fn parse_if_statement(&self, line: &str, line_num: usize) -> Result<Vec<Instruction>> {
+        let (condition, body_str) = self.split_if_header(line, line_num)?;
         if body_str.is_empty() {
             return Err(PrismError::Parse {
                 line: line_num,
                 message: "expected gate after `if(...)` condition".to_string(),
             });
         }
-
-        let condition = self.parse_classical_condition(cond_str, line_num)?;
-
-        let gate_instrs = self.parse_gate_application(body_str, line_num)?;
-        Ok(gate_instrs
-            .into_iter()
-            .map(|inst| match inst {
-                Instruction::Gate { gate, targets } => Instruction::Conditional {
-                    condition: condition.clone(),
-                    gate,
-                    targets,
-                },
-                other => other,
-            })
-            .collect())
+        let body = self.parse_gate_application(body_str, line_num)?;
+        Ok(guarded(condition, body).into_iter().collect())
     }
 
     /// Parse a classical condition expression for `if (...)`.
@@ -1537,6 +1591,7 @@ impl<'a> Parser<'a> {
             total_qubits: max_qubit,
             total_cbits: self.total_cbits,
             gate_expansion_depth: self.gate_expansion_depth + 1,
+            region_depth: self.region_depth,
             param_vars: Some(var_map),
             int_vars: self.int_vars.clone(),
         };
@@ -1724,6 +1779,7 @@ impl<'a> Parser<'a> {
             total_qubits: max_qubit,
             total_cbits: self.total_cbits,
             gate_expansion_depth: self.gate_expansion_depth + 1,
+            region_depth: self.region_depth,
             param_vars: Some(float_vars),
             int_vars: Some(int_vars),
         };

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -97,6 +97,21 @@ fn test_unsupported_def_with_measurement() {
 }
 
 #[test]
+fn test_switch_rejected_by_name() {
+    let qasm = "OPENQASM 3.0;
+qubit[1] q;
+bit[2] c;
+switch (c) { case 0 { x q[0]; } }";
+    match parse(qasm).unwrap_err() {
+        PrismError::UnsupportedConstruct { construct, line } => {
+            assert_eq!(construct, "switch");
+            assert_eq!(line, 4);
+        }
+        other => panic!("expected UnsupportedConstruct, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_undefined_register() {
     let qasm = "OPENQASM 3.0;\nh q[0];";
     let err = parse(qasm).unwrap_err();

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -65,44 +65,80 @@ pub fn to_qasm3(circuit: &Circuit) -> Result<String> {
     }
 
     for (index, inst) in circuit.instructions.iter().enumerate() {
-        match inst {
-            Instruction::Gate { gate, targets } => {
-                let _ = writeln!(out, "{} {};", require_head(gate, index)?, args(targets));
-            }
-            Instruction::Measure {
-                qubit,
-                classical_bit,
-            } => {
-                let _ = writeln!(out, "{} = measure q[{qubit}];", cregs.bit(*classical_bit));
-            }
-            Instruction::Reset { qubit } => {
-                let _ = writeln!(out, "reset q[{qubit}];");
-            }
-            Instruction::Barrier { qubits } => {
-                if qubits.is_empty() {
-                    return Err(PrismError::ExportUnsupported {
-                        index,
-                        reason: "barrier over no qubits".to_string(),
-                    });
-                }
-                let _ = writeln!(out, "barrier {};", args(qubits));
-            }
-            Instruction::Conditional {
-                condition,
-                gate,
-                targets,
-            } => {
-                let _ = writeln!(
-                    out,
-                    "if ({}) {} {};",
-                    cregs.condition(condition, index)?,
-                    require_head(gate, index)?,
-                    args(targets)
-                );
-            }
-        }
+        emit(&mut out, inst, index, &cregs, 0)?;
     }
     Ok(out)
+}
+
+/// Write one instruction, recursing into guarded regions as a braced `if`.
+///
+/// `index` names the top-level instruction in any error, so an unexportable
+/// gate nested in a region is still located by the position a caller can see.
+fn emit(
+    out: &mut String,
+    inst: &Instruction,
+    index: usize,
+    cregs: &CregLayout,
+    depth: usize,
+) -> Result<()> {
+    let pad = "  ".repeat(depth);
+    match inst {
+        Instruction::Gate { gate, targets } => {
+            let _ = writeln!(
+                out,
+                "{pad}{} {};",
+                require_head(gate, index)?,
+                args(targets)
+            );
+        }
+        Instruction::Measure {
+            qubit,
+            classical_bit,
+        } => {
+            let _ = writeln!(
+                out,
+                "{pad}{} = measure q[{qubit}];",
+                cregs.bit(*classical_bit)
+            );
+        }
+        Instruction::Reset { qubit } => {
+            let _ = writeln!(out, "{pad}reset q[{qubit}];");
+        }
+        Instruction::Barrier { qubits } => {
+            if qubits.is_empty() {
+                return Err(PrismError::ExportUnsupported {
+                    index,
+                    reason: "barrier over no qubits".to_string(),
+                });
+            }
+            let _ = writeln!(out, "{pad}barrier {};", args(qubits));
+        }
+        Instruction::Conditional {
+            condition,
+            gate,
+            targets,
+        } => {
+            let _ = writeln!(
+                out,
+                "{pad}if ({}) {} {};",
+                cregs.condition(condition, index)?,
+                require_head(gate, index)?,
+                args(targets)
+            );
+        }
+        Instruction::Region(region) => {
+            let _ = writeln!(
+                out,
+                "{pad}if ({}) {{",
+                cregs.condition(region.condition(), index)?
+            );
+            for inner in region.body() {
+                emit(out, inner, index, cregs, depth + 1)?;
+            }
+            let _ = writeln!(out, "{pad}}}");
+        }
+    }
+    Ok(())
 }
 
 fn args(targets: &[usize]) -> String {
@@ -290,30 +326,49 @@ struct CregLayout {
     names: Vec<String>,
 }
 
+/// Record the register boundaries every condition in `inst` needs, descending
+/// into region bodies so a nested condition still names a whole register.
+fn cut_register_conditions(
+    inst: &Instruction,
+    index: usize,
+    total: usize,
+    cuts: &mut BTreeSet<usize>,
+) -> Result<()> {
+    let condition = match inst {
+        Instruction::Conditional { condition, .. } => condition,
+        Instruction::Region(region) => {
+            for inner in region.body() {
+                cut_register_conditions(inner, index, total, cuts)?;
+            }
+            region.condition()
+        }
+        _ => return Ok(()),
+    };
+    let (ClassicalCondition::RegisterEquals { offset, size, .. }
+    | ClassicalCondition::RegisterNotEquals { offset, size, .. }) = condition
+    else {
+        return Ok(());
+    };
+    if offset + size > total {
+        return Err(PrismError::ExportUnsupported {
+            index,
+            reason: format!(
+                "condition covers bits {offset}..{} but the circuit has {total}",
+                offset + size
+            ),
+        });
+    }
+    cuts.insert(*offset);
+    cuts.insert(offset + size);
+    Ok(())
+}
+
 impl CregLayout {
     fn of(circuit: &Circuit) -> Result<Self> {
         let total = circuit.num_classical_bits;
         let mut cuts = BTreeSet::from([0, total]);
         for (index, inst) in circuit.instructions.iter().enumerate() {
-            let Instruction::Conditional { condition, .. } = inst else {
-                continue;
-            };
-            let (ClassicalCondition::RegisterEquals { offset, size, .. }
-            | ClassicalCondition::RegisterNotEquals { offset, size, .. }) = condition
-            else {
-                continue;
-            };
-            if offset + size > total {
-                return Err(PrismError::ExportUnsupported {
-                    index,
-                    reason: format!(
-                        "condition covers bits {offset}..{} but the circuit has {total}",
-                        offset + size
-                    ),
-                });
-            }
-            cuts.insert(*offset);
-            cuts.insert(offset + size);
+            cut_register_conditions(inst, index, total, &mut cuts)?;
         }
 
         let bounds: Vec<usize> = cuts.into_iter().collect();

--- a/src/sim/compiled/mod.rs
+++ b/src/sim/compiled/mod.rs
@@ -2855,7 +2855,7 @@ pub(crate) fn defer_measure_reset_circuit(circuit: &Circuit) -> Result<Circuit> 
                     .instructions
                     .push(Instruction::Barrier { qubits: mapped });
             }
-            Instruction::Conditional { .. } => {
+            Instruction::Conditional { .. } | Instruction::Region(_) => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "CompiledSampler".to_string(),
                     reason: "deferred measurement sampling does not support classical conditionals"

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -803,7 +803,8 @@ pub(super) fn has_temporal_clifford_opportunity(kind: &BackendKind, circuit: &Ci
             }
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
-            | Instruction::Conditional { .. } => break,
+            | Instruction::Conditional { .. }
+            | Instruction::Region(_) => break,
             Instruction::Barrier { .. } => {}
         }
     }

--- a/src/sim/homological.rs
+++ b/src/sim/homological.rs
@@ -300,6 +300,12 @@ impl ErrorChainComplex {
                         m_words,
                     );
                 }
+                Instruction::Region(_) => {
+                    return Err(crate::error::PrismError::IncompatibleBackend {
+                        backend: "HomologicalDetectorModel".to_string(),
+                        reason: "error propagation does not support guarded regions".to_string(),
+                    });
+                }
             }
         }
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -990,26 +990,14 @@ pub(crate) fn prepared_route(kind: &BackendKind, template: &Circuit) -> Option<P
         return None;
     };
     let probe = plan.build(0);
-    let has_qft_block = template.instructions.iter().any(|inst| {
-        matches!(
-            inst,
-            Instruction::Gate {
-                gate: crate::gates::Gate::QftBlock { .. },
-                ..
-            }
-        )
+    let has_qft_block = crate::circuit::any_gate(&template.instructions, &mut |gate| {
+        matches!(gate, crate::gates::Gate::QftBlock { .. })
     });
     if has_qft_block && !probe.supports_qft_block() {
         return None;
     }
-    let has_pauli_rot = template.instructions.iter().any(|inst| {
-        matches!(
-            inst,
-            Instruction::Gate {
-                gate: crate::gates::Gate::PauliRot(_),
-                ..
-            }
-        )
+    let has_pauli_rot = crate::circuit::any_gate(&template.instructions, &mut |gate| {
+        matches!(gate, crate::gates::Gate::PauliRot(_))
     });
     if has_pauli_rot && !probe.supports_pauli_rotation() {
         return None;
@@ -1210,10 +1198,12 @@ fn supports_deferred_measurement_sampling(circuit: &Circuit) -> bool {
             .instructions
             .iter()
             .any(|inst| matches!(inst, Instruction::Measure { .. }))
-        && !circuit
-            .instructions
-            .iter()
-            .any(|inst| matches!(inst, Instruction::Conditional { .. }))
+        && !circuit.instructions.iter().any(|inst| {
+            matches!(
+                inst,
+                Instruction::Conditional { .. } | Instruction::Region(_)
+            )
+        })
 }
 
 fn is_clifford_sampler_kind(kind: &BackendKind) -> bool {
@@ -1739,6 +1729,7 @@ pub(super) fn has_nonunitary_or_classical_ops(circuit: &Circuit) -> bool {
             Instruction::Measure { .. }
                 | Instruction::Reset { .. }
                 | Instruction::Conditional { .. }
+                | Instruction::Region(_)
         )
     })
 }
@@ -2927,17 +2918,8 @@ pub(crate) fn run_shots_with_noise(
     // stream raw and the Pauli-rotation lowering pass cannot run. The
     // statevector applies the gate natively (its device path lowers inline);
     // any other backend without the kernel is rejected before a shot starts.
-    let has_pauli_rot = circuit.instructions.iter().any(|inst| {
-        matches!(
-            inst,
-            Instruction::Gate {
-                gate: crate::gates::Gate::PauliRot(_),
-                ..
-            } | Instruction::Conditional {
-                gate: crate::gates::Gate::PauliRot(_),
-                ..
-            }
-        )
+    let has_pauli_rot = crate::circuit::any_gate(&circuit.instructions, &mut |gate| {
+        matches!(gate, crate::gates::Gate::PauliRot(_))
     });
     if has_pauli_rot
         && !matches!(plan, BackendPlan::Statevector { .. })

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -376,6 +376,22 @@ impl NoiseModel {
         }
         self.validate()?;
 
+        // One event slot per top-level instruction, so a region's body has no
+        // slots to carry noise and would run noiselessly without this.
+        if let Some(index) = circuit
+            .instructions
+            .iter()
+            .position(|inst| matches!(inst, Instruction::Region(_)))
+        {
+            return Err(crate::error::PrismError::IncompatibleBackend {
+                backend: "NoiseModel".to_string(),
+                reason: format!(
+                    "noise events are indexed per instruction, which leaves the body of the \
+                     guarded region at instruction {index} without noise slots"
+                ),
+            });
+        }
+
         for (instr_idx, events) in self.after_gate.iter().enumerate() {
             for (event_idx, event) in events.iter().enumerate() {
                 for &qubit in &event.qubits {

--- a/src/sim/stabilizer_rank.rs
+++ b/src/sim/stabilizer_rank.rs
@@ -274,7 +274,7 @@ fn validate_stabilizer_rank_circuit(circuit: &Circuit) -> Result<()> {
                             .to_string(),
                 });
             }
-            Instruction::Conditional { .. } => {
+            Instruction::Conditional { .. } | Instruction::Region(_) => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "stabilizer_rank".into(),
                     reason:
@@ -722,9 +722,17 @@ pub fn stabilizer_inner_product(
 }
 
 fn validate_stabilizer_rank_shot_circuit(circuit: &Circuit) -> Result<()> {
-    for inst in &circuit.instructions {
+    validate_shot_instructions(&circuit.instructions)
+}
+
+fn validate_shot_instructions(instructions: &[Instruction]) -> Result<()> {
+    for inst in instructions {
         let gate = match inst {
             Instruction::Gate { gate, .. } | Instruction::Conditional { gate, .. } => gate,
+            Instruction::Region(region) => {
+                validate_shot_instructions(region.body())?;
+                continue;
+            }
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
             | Instruction::Barrier { .. } => {
@@ -951,6 +959,14 @@ fn process_mps_instruction(
             }
             Ok(())
         }
+        Instruction::Region(region) => {
+            if region.condition().evaluate(classical_bits) {
+                for inner in region.body() {
+                    process_mps_instruction(branches, inner, classical_bits, rng)?;
+                }
+            }
+            Ok(())
+        }
     }
 }
 
@@ -965,7 +981,8 @@ fn build_mps_branches_for_unitary(circuit: &Circuit, seed: u64) -> Result<Vec<We
             }
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
-            | Instruction::Conditional { .. } => {
+            | Instruction::Conditional { .. }
+            | Instruction::Region(_) => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: "stabilizer_rank".into(),
                     reason: "unitary branch preparation cannot include measurements, resets, or conditionals"

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -50,7 +50,8 @@ fn validate_clifford_t_unitary(circuit: &Circuit, backend: &'static str) -> Resu
             Instruction::Barrier { .. } => {}
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
-            | Instruction::Conditional { .. } => {
+            | Instruction::Conditional { .. }
+            | Instruction::Region(_) => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: backend.to_string(),
                     reason: "Pauli propagation requires a unitary Clifford+T circuit without measurements, resets, or conditionals"

--- a/tests/common/circuits.rs
+++ b/tests/common/circuits.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use prism_q::circuit::{Circuit, ClassicalCondition, Instruction, SmallVec};
+use prism_q::circuit::{Circuit, ClassicalCondition, Instruction, SmallVec, guarded};
 use prism_q::circuits as builtins;
 use prism_q::gates::Gate;
 
@@ -392,7 +392,37 @@ pub fn exact_small_cases() -> [CircuitCase; 18] {
     ]
 }
 
-pub fn measurement_cases() -> [CircuitCase; 4] {
+// The region body holds a gate, a measure, and a reset, so a backend that
+// handled only the guarded-gate case cannot pass it.
+pub fn measurement_reset_region() -> Circuit {
+    let mut circuit = Circuit::new(3, 2);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.instructions.push(
+        guarded(
+            ClassicalCondition::BitIsOne(0),
+            vec![
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: SmallVec::from_slice(&[1]),
+                },
+                Instruction::Reset { qubit: 0 },
+                Instruction::Measure {
+                    qubit: 1,
+                    classical_bit: 1,
+                },
+                Instruction::Gate {
+                    gate: Gate::Cx,
+                    targets: SmallVec::from_slice(&[1, 2]),
+                },
+            ],
+        )
+        .expect("body is not empty"),
+    );
+    circuit
+}
+
+pub fn measurement_cases() -> [CircuitCase; 5] {
     [
         CircuitCase::new(
             "deterministic_measurement",
@@ -413,6 +443,11 @@ pub fn measurement_cases() -> [CircuitCase; 4] {
             "measurement_reset_conditional",
             measurement_reset_conditional,
             CircuitCapabilities::new().product_separable(),
+        ),
+        CircuitCase::new(
+            "measurement_reset_region",
+            measurement_reset_region,
+            CircuitCapabilities::new(),
         ),
     ]
 }

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -368,8 +368,12 @@ impl GeneratedCase {
 
 /// One-line rendering of every instruction, in order.
 pub fn describe(circuit: &Circuit) -> String {
-    let mut parts: Vec<String> = Vec::with_capacity(circuit.instructions.len());
-    for instr in &circuit.instructions {
+    describe_instructions(&circuit.instructions)
+}
+
+fn describe_instructions(instructions: &[Instruction]) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(instructions.len());
+    for instr in instructions {
         parts.push(match instr {
             Instruction::Gate { gate, targets } => describe_gate(gate, targets),
             Instruction::Measure {
@@ -386,6 +390,11 @@ pub fn describe(circuit: &Circuit) -> String {
                 "if({}) {}",
                 describe_condition(condition),
                 describe_gate(gate, targets)
+            ),
+            Instruction::Region(region) => format!(
+                "if({}) {{{}}}",
+                describe_condition(region.condition()),
+                describe_instructions(region.body())
             ),
         });
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -158,10 +158,21 @@ pub fn is_clifford(circuit: &Circuit) -> bool {
                     return false;
                 }
             }
+            Instruction::Region(region) => {
+                if !is_clifford_body(region.body()) {
+                    return false;
+                }
+            }
             Instruction::Measure { .. }
             | Instruction::Reset { .. }
             | Instruction::Barrier { .. } => {}
         }
     }
     true
+}
+
+fn is_clifford_body(instructions: &[Instruction]) -> bool {
+    let mut probe = Circuit::new(1, 0);
+    probe.instructions = instructions.to_vec();
+    is_clifford(&probe)
 }

--- a/tests/guarded_regions.rs
+++ b/tests/guarded_regions.rs
@@ -1,0 +1,476 @@
+//! Guarded-region contract: parsing, execution, fusion, export, and the
+//! routes that reject a region.
+
+use prism_q::circuit::fusion::fuse_circuit;
+use prism_q::circuit::{
+    Circuit, ClassicalCondition, GuardedRegion, Instruction, MAX_REGION_DEPTH, SmallVec, guarded,
+    openqasm, qasm_export,
+};
+use prism_q::error::PrismError;
+use prism_q::gates::Gate;
+use prism_q::sim::unified_pauli::{PauliAxis, PauliTerm};
+use prism_q::{CircuitBuilder, simulate};
+
+const SEED: u64 = 42;
+
+fn region(inst: &Instruction) -> &GuardedRegion {
+    match inst {
+        Instruction::Region(region) => region,
+        other => panic!("expected a region, got {other:?}"),
+    }
+}
+
+fn probabilities(circuit: &Circuit) -> Vec<f64> {
+    simulate(circuit)
+        .seed(SEED)
+        .run()
+        .expect("simulation")
+        .probabilities
+        .expect("probabilities")
+        .to_vec()
+}
+
+#[test]
+fn instruction_stays_96_bytes() {
+    // The region body is boxed so the enum does not grow; inline growth here
+    // is the regression this pins.
+    assert_eq!(std::mem::size_of::<Instruction>(), 96);
+}
+
+#[test]
+fn single_gate_body_lowers_to_conditional() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\nif (c[0]) { x q[0]; }";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    assert!(matches!(
+        circuit.instructions[0],
+        Instruction::Conditional { .. }
+    ));
+}
+
+#[test]
+fn braced_body_becomes_a_region_over_its_qubits() {
+    let qasm = "OPENQASM 3.0;\nqubit[3] q;\nbit[2] c;\n\
+                if (c == 2) {\n  x q[2];\n  measure q[2] -> c[1];\n  reset q[0];\n}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    assert_eq!(circuit.instructions.len(), 1);
+    let region = region(&circuit.instructions[0]);
+    assert_eq!(region.body().len(), 3);
+    assert_eq!(region.qubits(), &[0, 2]);
+    assert_eq!(region.depth(), 1);
+    assert!(matches!(
+        region.condition(),
+        ClassicalCondition::RegisterEquals { value: 2, .. }
+    ));
+}
+
+#[test]
+fn empty_body_appends_nothing() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\nif (c[0]) { }";
+    assert!(
+        openqasm::parse(qasm)
+            .expect("parse")
+            .instructions
+            .is_empty()
+    );
+}
+
+#[test]
+fn nesting_reports_its_depth() {
+    let qasm = "OPENQASM 3.0;\nqubit[2] q;\nbit[2] c;\n\
+                if (c[0]) {\n  x q[0];\n  if (c[1]) {\n    x q[1];\n    z q[1];\n  }\n}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let outer = region(&circuit.instructions[0]);
+    assert_eq!(outer.depth(), 2);
+    assert_eq!(outer.qubits(), &[0, 1]);
+}
+
+fn nested_qasm(levels: usize) -> String {
+    let mut qasm = String::from("OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\n");
+    for _ in 0..levels {
+        qasm.push_str("if (c[0]) {\n");
+    }
+    qasm.push_str("x q[0];\nz q[0];\n");
+    for _ in 0..levels {
+        qasm.push_str("}\n");
+    }
+    qasm
+}
+
+#[test]
+fn nesting_to_the_bound_is_accepted() {
+    let circuit = openqasm::parse(&nested_qasm(MAX_REGION_DEPTH)).expect("parse at the bound");
+    assert_eq!(region(&circuit.instructions[0]).depth(), MAX_REGION_DEPTH);
+}
+
+#[test]
+fn nesting_past_the_bound_is_rejected() {
+    let mut qasm = String::from("OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\n");
+    for _ in 0..=MAX_REGION_DEPTH {
+        qasm.push_str("if (c[0]) {\n");
+    }
+    qasm.push_str("x q[0];\n");
+    for _ in 0..=MAX_REGION_DEPTH {
+        qasm.push_str("}\n");
+    }
+    let err = openqasm::parse(&qasm).expect_err("depth bound");
+    assert!(
+        matches!(&err, PrismError::Parse { message, .. } if message.contains("nest deeper")),
+        "unexpected error: {err:?}"
+    );
+}
+
+// `else` is stage-3 work. Until then it must reject by name with a line number
+// in every shape, the way `while` and `switch` do: a braced `if` body invites an
+// `else` after it, and falling through to gate parsing reports a register error
+// naming a brace.
+#[test]
+fn else_rejects_by_name_in_every_shape() {
+    let cases = [
+        (
+            "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) { x q[0]; } else { z q[0]; }",
+            4,
+        ),
+        (
+            "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) {
+  x q[0];
+}
+else {
+  z q[0];
+}",
+            7,
+        ),
+        (
+            "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) x q[0];
+else z q[0];",
+            5,
+        ),
+    ];
+    for (qasm, line) in cases {
+        match openqasm::parse(qasm).expect_err("else is unsupported") {
+            PrismError::UnsupportedConstruct {
+                construct,
+                line: at,
+            } => {
+                assert_eq!(construct, "else", "in {qasm:?}");
+                assert_eq!(at, line, "in {qasm:?}");
+            }
+            other => panic!("expected UnsupportedConstruct for {qasm:?}, got {other:?}"),
+        }
+    }
+}
+
+// A `def` body can expand to a non-gate instruction. Before regions the parser
+// emitted that instruction unguarded; the whole expansion is now one region.
+#[test]
+fn multi_instruction_expansion_stays_guarded() {
+    let qasm = "OPENQASM 3.0;\nqubit[2] q;\nbit[1] c;\n\
+                gate pair a, b { x a; cx a, b; }\nif (c[0]) pair q[0], q[1];";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    assert_eq!(circuit.instructions.len(), 1);
+    assert_eq!(region(&circuit.instructions[0]).body().len(), 2);
+}
+
+#[test]
+fn taken_and_untaken_bodies_run_and_skip() {
+    // q0 measures 1, so the body runs and flips q1 and q2.
+    let mut taken = CircuitBuilder::new_with_classical(3, 1);
+    taken.x(0).measure(0, 0).guarded(
+        ClassicalCondition::BitIsOne(0),
+        |body: &mut CircuitBuilder| {
+            body.x(1).x(2);
+        },
+    );
+    let probs = probabilities(&taken.build());
+    assert!((probs[0b111] - 1.0).abs() < 1e-12, "{probs:?}");
+
+    let mut untaken = CircuitBuilder::new_with_classical(3, 1);
+    untaken.measure(0, 0).guarded(
+        ClassicalCondition::BitIsOne(0),
+        |body: &mut CircuitBuilder| {
+            body.x(1).x(2);
+        },
+    );
+    let probs = probabilities(&untaken.build());
+    assert!((probs[0] - 1.0).abs() < 1e-12, "{probs:?}");
+}
+
+// A measurement inside a taken body writes a bit a later region reads.
+#[test]
+fn body_measurement_feeds_a_later_region() {
+    let mut circuit = CircuitBuilder::new_with_classical(3, 2);
+    circuit
+        .x(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.x(1).measure(1, 1);
+        })
+        .guarded(ClassicalCondition::BitIsOne(1), |body| {
+            body.x(2);
+        });
+    let probs = probabilities(&circuit.build());
+    assert!((probs[0b111] - 1.0).abs() < 1e-12, "{probs:?}");
+}
+
+#[test]
+fn nested_region_runs_only_when_both_conditions_hold() {
+    let inner_then_outer = |outer_bit: bool| {
+        let mut circuit = CircuitBuilder::new_with_classical(2, 2);
+        if outer_bit {
+            circuit.x(0);
+        }
+        circuit
+            .measure(0, 0)
+            .guarded(ClassicalCondition::BitIsOne(0), |body| {
+                body.guarded(ClassicalCondition::BitIsZero(1), |inner| {
+                    inner.x(1);
+                });
+            });
+        probabilities(&circuit.build())
+    };
+    // Outer taken, inner reads an unwritten bit that is 0, so q1 flips.
+    assert!((inner_then_outer(true)[0b11] - 1.0).abs() < 1e-12);
+    assert!((inner_then_outer(false)[0] - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn fusion_never_absorbs_a_region_and_flushes_only_its_qubits() {
+    let mut circuit = Circuit::new(16, 1);
+    circuit.add_measure(0, 0);
+    for q in 1..16 {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    circuit.instructions.push(
+        guarded(
+            ClassicalCondition::BitIsOne(0),
+            vec![Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[3]),
+            }],
+        )
+        .expect("body is not empty"),
+    );
+    // Two runs of single-qubit gates on every wire, split by the region on q3.
+    for q in 1..16 {
+        circuit.add_gate(Gate::T, &[q]);
+        circuit.add_gate(Gate::H, &[q]);
+    }
+
+    let fused = fuse_circuit(&circuit, true);
+    let regions = fused
+        .instructions
+        .iter()
+        .filter(|inst| matches!(inst, Instruction::Conditional { .. }))
+        .count();
+    assert_eq!(regions, 1, "the guarded gate must survive fusion");
+
+    let unfused = probabilities(&circuit);
+    let after = probabilities(fused.as_ref());
+    for (a, b) in unfused.iter().zip(&after) {
+        assert!((a - b).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn a_region_is_a_barrier_only_on_the_qubits_it_touches() {
+    // 12 qubits clears MIN_QUBITS_FOR_FUSION without reaching the tiled
+    // multi-qubit pass, so each wire's fused run is one instruction.
+    let mut circuit = Circuit::new(12, 1);
+    circuit.add_measure(0, 0);
+    for q in 1..12 {
+        circuit.add_gate(Gate::Rx(0.3), &[q]);
+    }
+    circuit.instructions.push(
+        guarded(
+            ClassicalCondition::BitIsOne(0),
+            vec![
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: SmallVec::from_slice(&[3]),
+                },
+                Instruction::Reset { qubit: 4 },
+            ],
+        )
+        .expect("body is not empty"),
+    );
+    for q in 1..12 {
+        circuit.add_gate(Gate::Rx(0.4), &[q]);
+    }
+
+    let fused = fuse_circuit(&circuit, true);
+    let fused_1q_on = |q: usize| {
+        fused
+            .instructions
+            .iter()
+            .filter(|inst| {
+                matches!(inst, Instruction::Gate { gate, targets }
+                    if gate.num_qubits() == 1 && targets.as_slice() == [q])
+            })
+            .count()
+    };
+    // q3 and q4 are inside the region, so their H runs stay split. Every other
+    // wire fuses its pair of Hs into one instruction.
+    assert_eq!(fused_1q_on(3), 2);
+    assert_eq!(fused_1q_on(4), 2);
+    assert_eq!(fused_1q_on(5), 1);
+}
+
+#[test]
+fn a_static_circuit_is_untouched_by_the_region_machinery() {
+    let mut circuit = Circuit::new(4, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::T, &[2]);
+    assert_eq!(circuit.gate_count(), 3);
+    assert_eq!(circuit.t_count(), 1);
+    assert!(circuit.has_terminal_measurements_only());
+    assert!(!circuit.is_clifford_only());
+}
+
+// Region-body gates count toward the predicates that pick a backend; missing
+// them would route a non-Clifford circuit to the stabilizer tableau.
+#[test]
+fn predicates_see_through_a_region_body() {
+    let mut circuit = CircuitBuilder::new_with_classical(2, 1);
+    circuit
+        .h(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.t(1).reset(1);
+        });
+    let circuit = circuit.build();
+    assert!(!circuit.is_clifford_only());
+    assert!(circuit.has_t_gates());
+    assert_eq!(circuit.t_count(), 1);
+    assert!(circuit.has_resets());
+    assert!(!circuit.has_terminal_measurements_only());
+    assert_eq!(circuit.gate_count(), 2);
+}
+
+// A region conditioned on a bit written in another component couples the two,
+// so the factored path cannot split them apart.
+#[test]
+fn a_region_couples_the_subsystems_its_condition_spans() {
+    let mut circuit = CircuitBuilder::new_with_classical(2, 1);
+    circuit
+        .h(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.x(1);
+        });
+    let circuit = circuit.build();
+    assert_eq!(circuit.independent_subsystems(), vec![vec![0, 1]]);
+}
+
+// `guarded` never builds an empty region, so stripping must not leave one.
+#[test]
+fn stripping_measurements_drops_a_region_it_empties() {
+    let mut circuit = CircuitBuilder::new_with_classical(2, 1);
+    circuit
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.measure(0, 0).measure(1, 0);
+        });
+    assert!(
+        circuit
+            .build()
+            .without_measurements()
+            .instructions
+            .is_empty()
+    );
+}
+
+#[test]
+fn export_round_trips_a_nested_region() {
+    let qasm = "OPENQASM 3.0;\nqubit[3] q;\nbit[2] c;\n\
+                h q[0];\nc[0] = measure q[0];\n\
+                if (c[0]) {\n  x q[1];\n  if (!c[1]) {\n    cx q[1], q[2];\n  }\n  reset q[2];\n}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let exported = qasm_export::to_qasm3(&circuit).expect("export");
+    let reparsed = openqasm::parse(&exported).expect("reparse");
+
+    let outer = region(&reparsed.instructions[2]);
+    assert_eq!(outer.body().len(), 3);
+    // The inner single-gate `if` lowers back to a conditional, so the region
+    // nesting collapses to one level on the round trip.
+    assert_eq!(outer.depth(), 1);
+    assert!(matches!(outer.body()[1], Instruction::Conditional { .. }));
+    assert_eq!(outer.qubits(), &[1, 2]);
+    assert_eq!(probabilities(&circuit), probabilities(&reparsed));
+}
+
+#[test]
+fn unitary_only_routes_reject_a_region() {
+    let mut circuit = CircuitBuilder::new_with_classical(2, 1);
+    circuit
+        .h(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.x(1).reset(1);
+        });
+    let circuit = circuit.build();
+    let observable = vec![PauliTerm {
+        qubit: 0,
+        axis: PauliAxis::Z,
+    }];
+
+    let err = simulate(&circuit)
+        .seed(SEED)
+        .expectation_values(&[observable])
+        .expect_err("expectation values require a unitary circuit");
+    assert!(
+        matches!(err, PrismError::IncompatibleBackend { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn the_compiled_sampler_rejects_a_region() {
+    let mut circuit = CircuitBuilder::new_with_classical(2, 2);
+    circuit
+        .h(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.x(1);
+        })
+        .measure(1, 1);
+    let circuit = circuit.build();
+    // The coarse predicate routes it to per-shot replay rather than the
+    // one-distribution sampler, which is the cliff the contract prices.
+    assert!(!circuit.has_terminal_measurements_only());
+    let shots = simulate(&circuit)
+        .seed(SEED)
+        .shots(64)
+        .expect("per-shot replay");
+    assert_eq!(shots.shots.len(), 64);
+}
+
+#[test]
+fn a_noise_model_rejects_a_region() {
+    use prism_q::sim::noise::NoiseModel;
+
+    let mut circuit = CircuitBuilder::new_with_classical(2, 1);
+    circuit
+        .h(0)
+        .measure(0, 0)
+        .guarded(ClassicalCondition::BitIsOne(0), |body| {
+            body.x(1).z(1);
+        });
+    let circuit = circuit.build();
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+    let err = noise
+        .validate_for(&circuit)
+        .expect_err("noise slots are per instruction");
+    assert!(
+        matches!(&err, PrismError::IncompatibleBackend { reason, .. } if reason.contains("noise slots")),
+        "{err:?}"
+    );
+}

--- a/tests/measurement_matrix.rs
+++ b/tests/measurement_matrix.rs
@@ -21,6 +21,7 @@ backend_matrix_outcome_tests! {
         measurement_sparse_reset_from_one_matches_statevector => "reset_from_one",
         measurement_sparse_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_sparse_reset_conditional_matches_statevector => "measurement_reset_conditional",
+        measurement_sparse_reset_region_matches_statevector => "measurement_reset_region",
     }
 }
 
@@ -44,6 +45,7 @@ backend_matrix_outcome_tests! {
         measurement_mps_reset_from_one_matches_statevector => "reset_from_one",
         measurement_mps_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_mps_reset_conditional_matches_statevector => "measurement_reset_conditional",
+        measurement_mps_reset_region_matches_statevector => "measurement_reset_region",
     }
 }
 
@@ -67,6 +69,7 @@ backend_matrix_outcome_tests! {
         measurement_tensor_network_reset_from_one_matches_statevector => "reset_from_one",
         measurement_tensor_network_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_tensor_network_reset_conditional_matches_statevector => "measurement_reset_conditional",
+        measurement_tensor_network_reset_region_matches_statevector => "measurement_reset_region",
     }
 }
 
@@ -90,6 +93,7 @@ backend_matrix_outcome_tests! {
         measurement_factored_reset_from_one_matches_statevector => "reset_from_one",
         measurement_factored_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_factored_reset_conditional_matches_statevector => "measurement_reset_conditional",
+        measurement_factored_reset_region_matches_statevector => "measurement_reset_region",
     }
 }
 
@@ -113,6 +117,7 @@ backend_matrix_outcome_tests! {
         measurement_stabilizer_reset_from_one_matches_statevector => "reset_from_one",
         measurement_stabilizer_reset_from_one_with_spectator_matches_statevector => "reset_from_one_with_spectator",
         measurement_stabilizer_reset_conditional_matches_statevector => "measurement_reset_conditional",
+        measurement_stabilizer_reset_region_matches_statevector => "measurement_reset_region",
     }
 }
 


### PR DESCRIPTION
## Summary

Classical control was one gate wide, so conditional syndrome extraction and any
measurement-conditioned block were unexpressible. `Instruction::Region` guards a span of
instructions instead: measure and reset become guardable, nesting is bounded at 16, and
the OpenQASM parser accepts `if (cond) { ... }`. Static circuits are unaffected, which the
benchmark table below is there to show.

## Scope

- [x] New feature

## Benchmarks

Adjacent-binary A/B against `ab5b952`, full Criterion tier (30 samples, not `bench-fast`),
on an otherwise idle i7-6700K. Every row is a control the diff cannot reach: no benchmark
circuit contains a guarded region, so the target is neutrality on static circuits.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `stabilizer/scaling/500` | 1.69 ms | 1.69 ms | +0.0% | -0.5% / -2.4% | yes |
| `statevector/scalability_d5/18` | 79.68 us | 79.71 us | +0.0% | -1.8% / +0.0% | yes |
| `statevector/qpe_t_gate/16q` | 2.44 ms | 2.43 ms | -0.7% | -4.7% / -1.8% | yes |
| `statevector/qaoa_l3/16` | 1.83 ms | 1.85 ms | +1.1% | -4.5% / -0.9% | yes |
| `compiled_sampler/noisy/noisy_500q_10k` | 30.83 ms | 30.84 ms | +0.0% | -4.3% / -0.3% | yes |
| `stabilizer/measurement/ghz_measure_all/500` | 861.16 us | 837.42 us | -2.8% | +0.5% / +3.9% | yes |
| `compiled_sampler/noiseless/noiseless_500q_10k` | n/a | n/a | unresolvable | -5.4% / -10.4% / -11.1% | unmeasured |
| `statevector/qft_textbook/20` | n/a | n/a | unresolvable | -7.0% / +25.5% / +19.8% | unmeasured |

Six rows resolved, all at noise level, largest resolved move -2.8%. `ghz_measure_all/500`
resolved on a later run than the other five; its number is from that run.

The last two rows would not resolve on this host across three runs: their same-code
control exceeded the 5% gate every time, and their readings straddle zero rather than
trending. `compiled_sampler/noiseless/noiseless_500q_10k` read -2.6%, +21.6%, and -6.4%;
`statevector/qft_textbook/20` read -0.6%, -5.5%, and +1.5%. Both are long-iteration rows
where host drift exceeds the gate. Reporting them as unmeasured rather than as passes.

One real regression was caught and fixed rather than waived. The first A/B put
`stabilizer/scaling/500` at +7.4% against a 1.7% same-code control, which is a result, not
noise. Adding the region arm made `apply_instructions_sgi` directly self-recursive, and
that function is the per-gate loop for this row: 500 qubits clears the 256-qubit SGI
threshold and 8 words clears the batch threshold. Moving the recursive call behind an
`#[inline(never)]` helper restored the row to +0.0%. A branch nearly no circuit takes must
not sit in a hot loop's own body.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel distributed"` passes locally (2156 tests)
- [x] `cargo test --doc --features parallel` passes (15)
- [x] `cargo clippy --all-targets --features "parallel distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on new `pub` items carry the packing convention, the size constraint, and
      the region-versus-conditional contract

No GPU device on this host, so `golden_gpu` did not run. The GPU statevector arm routes
through the same `Backend::apply_region` default as every other backend and adds no
kernel.

New coverage:

- `measurement_reset_region` joins the shared corpus in `tests/common/circuits.rs` with a
  body holding a gate, a reset, a measurement, and a CX. The measurement matrix runs it on
  sparse, MPS, factored, stabilizer, and tensor-network against the statevector. Product is
  left off deliberately: the body entangles and the case is not product-separable.
- `tests/guarded_regions.rs` covers the parse forms, the depth bound at and past the limit,
  nesting, a body measurement feeding a later region, the `Instruction` size pin, the
  fusion barrier scoped to the region's own qubits, the export round trip, and the route
  rejections.
- `loopback_guarded_region_takes_the_same_branch_on_every_rank` runs a body that both
  measures and entangles at rank counts 1, 2, 4, and 8. The distributed backend draws
  outcomes from a rank-replicated seeded RNG against an `Allreduce`d probability, so every
  rank holds the same classical bits; the test is the evidence, not a new mechanism.

## Hotspot notes

`apply_instructions_sgi` in `src/backend/stabilizer/kernels/mod.rs` is the per-gate loop
above 256 qubits and is the only hot path this diff touches. See the benchmark section for
the regression it produced and the fix. `inst_qubits` in `src/circuit/fusion.rs` gained one
match arm and still returns a borrowed slice, so no fusion pass allocates.

## Architecture or design changes

- [x] `docs/architecture/ir.md` gains the `Region` row and a section on the guarded-region
      contract; `docs/guides/openqasm.md` documents the braced `if` body.

A separate variant beat growing `Conditional` into a body, and the reason is
`inst_qubits`, which returns `&[usize]`. A `Conditional` carrying a body could not return a
borrowed target slice without either allocating on the fusion path or caching the same
qubit set anyway, so the unified shape would have charged every static circuit for a
feature it does not use. `GuardedRegion` caches that set behind the box instead, which
costs the enum nothing.

## Breaking changes

- `Instruction` gains a variant. Any external `match` over it stops compiling until it
  handles `Region`. This is the intended failure mode: a silently skipped region is a wrong
  answer.
- `if (c) mygate a, b;` on a multi-gate `gate` definition produced one `Conditional` per
  expanded gate and now produces one `Region`. Observable behavior is identical; the fusion
  flush widens from each gate's targets to the expansion's union.
- `else` and `switch` now return `UnsupportedConstruct` with a line number. They previously
  fell through to gate parsing and reported an undefined-register error naming a brace.
  Neither was ever executed.
- A noise model rejects a circuit containing a region, because its event slots are indexed
  per top-level instruction and a region body has none. Under-noising silently was the
  alternative.

## Risks and rollback

Blast radius is the `Instruction` enum, so it is wide but compiler-checked: every
exhaustive match was visited. The residual risk is wildcard arms the compiler cannot flag.
Those were audited by hand; the ones that mattered were the stabilizer SGI and gates-only
paths, which silently skipped a region, and the circuit predicates (`is_clifford_only`,
`t_count`, `has_resets` and peers), which would have missed a region body and could have
routed a non-Clifford circuit to the stabilizer tableau. Both are fixed and tested.

No feature flag guards this. Rolling back means reverting the commit. A circuit with no
region takes no new branch: the region predicate runs once per plan, never per instruction
or per shot.

## Known limitation

`MAX_REGION_DEPTH` binds the parser only. `CircuitBuilder::guarded` accepts unbounded
nesting and every pass recurses, so a pathologically nested programmatic build overflows
the stack rather than returning an error. Bounding it means making `guarded` fallible,
which is an API decision worth taking on its own rather than inside this diff.

## Pre-merge checklist

- [x] Commit message follows the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
