### PR TITLE
feat(noise): rule-based noise model construction

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2036,6 +2036,35 @@ fn bench_noisy_sampling(c: &mut Criterion) {
         },
     );
 
+    // The correlated two-qubit branch, the only trajectory path that reads a
+    // two-qubit reduced density matrix and applies the selected operator as a
+    // `Fused2q`. One `2^n` reduction plus one `2^n` gate pass per event, plus a
+    // boxed 4x4 per event, against the single gate pass a Pauli branch costs.
+    // Same circuit shape and shot count as `trajectory_pauli`, so the pair is
+    // comparable; the noise differs and nothing else does.
+    let correlated_noise = prism_q::NoiseBuilder::new()
+        .after_gates_joint(
+            prism_q::GateFilter::all().named("cx"),
+            correlated_zz_channel(0.001),
+        )
+        .build(&non_clifford)
+        .unwrap();
+    group.bench_function(
+        BenchmarkId::new("trajectory_kraus_2q", "non_clifford_12q_512"),
+        |b| {
+            b.iter(|| {
+                run_shots_with_noise(
+                    BackendKind::Statevector,
+                    &non_clifford,
+                    &correlated_noise,
+                    512,
+                    SEED,
+                )
+                .unwrap();
+            });
+        },
+    );
+
     group.finish();
 }
 
@@ -2219,6 +2248,29 @@ fn depolarizing_kraus(p: f64) -> Vec<[[Complex64; 2]; 2]> {
     ]
 }
 
+/// Kraus pair for correlated `ZZ` dephasing at rate `p`, in the
+/// `2*bit(q0) + bit(q1)` packing `NoiseChannel::Kraus2q` takes.
+fn correlated_zz_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = Complex64::new(0.0, 0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = Complex64::new(scale * sign, 0.0);
+        }
+        m
+    };
+    vec![
+        diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+        diag(p.sqrt(), [1.0, -1.0, -1.0, 1.0]),
+    ]
+}
+
+fn correlated_zz_channel(p: f64) -> prism_q::NoiseChannel {
+    prism_q::NoiseChannel::Kraus2q {
+        kraus: correlated_zz_kraus(p),
+    }
+}
+
 fn dm_backend(n: usize) -> DensityMatrixBackend {
     let circuit = circuits::random_circuit(n, 2, SEED);
     let mut backend = DensityMatrixBackend::new(42);
@@ -2253,6 +2305,16 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("depolarizing_2q", n), &n, |b, &n| {
             let mut backend = dm_backend(n);
             b.iter(|| backend.apply_2q_depolarizing(0, n - 1, 0.02));
+        });
+
+        // The general two-qubit channel `depolarizing_2q` now lowers onto. Both
+        // compile to one 16x16 superoperator and then sweep the same `4^n`
+        // buffer; at these widths the compile is under 0.01% of the row either
+        // way, so this reads the sweep and not the operator count.
+        let zz = correlated_zz_kraus(0.02);
+        group.bench_with_input(BenchmarkId::new("kraus_2q", n), &n, |b, &n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_kraus(0, n - 1, &zz));
         });
 
         for &(qubit, label) in &[(0usize, "measure_q0"), (n - 1, "measure_qtop")] {

--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -81,8 +81,8 @@ the `distributed-mpi` feature: `MpiComm`
 
 **Data types:**
 `CompiledSampler`, `CompiledDetectorSampler`, `DetectorSampleBatch`,
-`NoisyCompiledSampler`, `NoiseChannel`, `NoiseEvent`, `NoiseModel`, `ReadoutError`,
-`HomologicalSampler`, `ErrorChainComplex`
+`NoisyCompiledSampler`, `NoiseChannel`, `NoiseEvent`, `NoiseModel`, `NoiseBuilder`,
+`GateFilter`, `ReadoutError`, `HomologicalSampler`, `ErrorChainComplex`
 
 Not re-exported at the root but part of the documented surface: the `Backend` trait and
 `BasisSamples` at `prism_q::backend`, the density matrix backend at

--- a/docs/architecture/samplers.md
+++ b/docs/architecture/samplers.md
@@ -149,8 +149,25 @@ Backward Pauli propagation through circuit + noise sensitivity analysis. Each no
 
 `NoiseModel`: per-instruction noise events. Pauli and depolarizing channels are
 supported by every noisy engine. Amplitude damping, phase damping, thermal
-relaxation, two-qubit depolarizing, custom Kraus operators, and readout error
-require the trajectory engine.
+relaxation, two-qubit depolarizing, one- and two-qubit custom Kraus operators,
+and readout error require the trajectory engine.
+
+`NoiseBuilder` (`src/sim/noise_builder.rs`) compiles declarative rules into that
+same per-instruction vector: per-gate-type and per-qubit rates, idle
+decoherence against circuit layers, crosstalk through a coupling map, coherent
+over-rotation proportional to a rotation gate's own angle, reset error,
+pre-measurement error, and per-bit readout. Every rule is evaluated once at
+build time, so nothing it expresses reaches a per-shot or per-instruction loop.
+
+Two-qubit Kraus operators are indexed `K[t][t']` with `t = 2*bit(q0) +
+bit(q1)`, the packing `Gate::matrix_4x4` uses. The density matrix compiles the
+set into a 16x16 block superoperator (`apply_2q_kraus`, which
+`apply_2q_depolarizing` lowers onto). The trajectory engine draws a branch from
+`Tr(Kdagger K rho)` over `Backend::reduced_density_matrix_2q` and applies the
+normalized operator as a `Fused2q`. Only the host statevector implements that
+reduction, and `run_shots_with_noise` checks `Backend::supports_two_qubit_kraus`
+before the first shot, so an `Auto` route that picked another backend is named
+at dispatch rather than part way through a trajectory.
 
 ## Noisy engine routing and the observable-result contract
 
@@ -181,6 +198,14 @@ before allocating state: one event slot per instruction, channel parameters in
 range, distinct targets on a two-qubit channel, and every target inside the
 register. Bounds cannot be checked from the model alone, and a target outside
 the register reaches kernels that index amplitudes without one.
+
+A guarded region (`Instruction::Region`) is rejected whenever the model carries
+at least one quantum event: slots are indexed per top-level instruction, so a
+region body has none and would run noiselessly. A readout-only model has
+nothing to lose there and is accepted. Reaching noise inside a region body
+needs the event stream keyed by something other than a top-level index, which
+the compiled sampler, the homological builder, and the density-matrix evolution
+all walk today.
 
 Custom Kraus sets must be trace preserving, `sum_k Kdagger_k K_k = I` to 1e-9.
 The exact route applies a declared set literally while the trajectory route

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -20,7 +20,8 @@
 //! Supported: exact unitary evolution, basis-state probabilities, the one-qubit
 //! reduced density matrix, projective measurement with stochastic collapse,
 //! reset, classically-conditioned gates, exact one-qubit Kraus channels
-//! (`apply_1q_kraus`), two-qubit depolarizing (`apply_2q_depolarizing`), and
+//! (`apply_1q_kraus`), exact two-qubit Kraus channels (`apply_2q_kraus`, which
+//! `apply_2q_depolarizing` lowers onto), and
 //! exact `Tr(rho P)` expectation (`expectation_pauli`, reachable through
 //! `pauli_expectations`). Batched payload shapes (`QftBlock`, `BatchPhase`,
 //! `BatchRzz`, `DiagonalBatch`, `MultiFused`, `Multi2q`) carry qubit indices
@@ -501,12 +502,7 @@ impl DensityMatrixBackend {
 
     /// Apply symmetric two-qubit depolarizing on `(q0, q1)`:
     /// `rho -> (1-p) rho + (p/15) sum_{P != I(x)I} P rho P`, summed over the 15
-    /// non-identity two-qubit Paulis. The 16 two-qubit Pauli Kraus operators are
-    /// compiled once into a 16x16 block superoperator over the four-bit
-    /// `(q0-row, q1-row, q0-col, q1-col)` block, so the buffer is swept once.
-    ///
-    /// Block index `4*tr + tc` orders the two-qubit row value `tr` (bit 0 = q0,
-    /// bit 1 = q1) against the column value `tc`.
+    /// non-identity two-qubit Paulis.
     pub fn apply_2q_depolarizing(&mut self, q0: usize, q1: usize, p: f64) {
         let c1 = Complex64::new(1.0, 0.0);
         let c0 = Complex64::new(0.0, 0.0);
@@ -517,9 +513,7 @@ impl DensityMatrixBackend {
             [[c0, -ci], [ci, c0]],
             [[c1, c0], [c0, -c1]],
         ];
-        // K_(a,b) = weight * (paulis[b] (x) paulis[a]) with q0 as the low bit;
-        // S[4*tr+tc][4*trp+tcp] = sum_(a,b) K[tr][trp] * conj(K[tc][tcp]).
-        let mut s = [[Complex64::new(0.0, 0.0); 16]; 16];
+        let mut kraus = [[[c0; 4]; 4]; 16];
         for a in 0..4 {
             for b in 0..4 {
                 let w = if a == 0 && b == 0 {
@@ -527,19 +521,39 @@ impl DensityMatrixBackend {
                 } else {
                     (p / 15.0).sqrt()
                 };
-                let kentry = |t: usize, tp: usize| {
-                    Complex64::new(w, 0.0) * paulis[b][t >> 1][tp >> 1] * paulis[a][t & 1][tp & 1]
-                };
-                for tr in 0..4 {
-                    for trp in 0..4 {
-                        let kr = kentry(tr, trp);
-                        if kr == Complex64::new(0.0, 0.0) {
-                            continue;
-                        }
-                        for tc in 0..4 {
-                            for tcp in 0..4 {
-                                s[4 * tr + tc][4 * trp + tcp] += kr * kentry(tc, tcp).conj();
-                            }
+                let w = Complex64::new(w, 0.0);
+                let k = &mut kraus[4 * a + b];
+                for (t, row) in k.iter_mut().enumerate() {
+                    for (tp, entry) in row.iter_mut().enumerate() {
+                        *entry = w * paulis[a][t >> 1][tp >> 1] * paulis[b][t & 1][tp & 1];
+                    }
+                }
+            }
+        }
+        self.apply_2q_kraus(q0, q1, &kraus);
+    }
+
+    /// Apply a general two-qubit channel `rho -> sum_k K_k rho K_k^dagger` on
+    /// `(q0, q1)`. Each operator is indexed `K[t][t']` with
+    /// `t = 2 * bit(q0) + bit(q1)`, matching [`Gate::matrix_4x4`].
+    ///
+    /// The Kraus set is compiled once into a 16x16 block superoperator over the
+    /// four-bit `(q0-row, q1-row, q0-col, q1-col)` block, so the buffer is swept
+    /// once. Block index `4*tr + tc` orders the two-qubit row value `tr` against
+    /// the column value `tc`.
+    pub fn apply_2q_kraus(&mut self, q0: usize, q1: usize, kraus: &[[[Complex64; 4]; 4]]) {
+        // S[4*tr+tc][4*trp+tcp] = sum_k K_k[tr][trp] * conj(K_k[tc][tcp]).
+        let mut s = [[Complex64::new(0.0, 0.0); 16]; 16];
+        for k in kraus {
+            for tr in 0..4 {
+                for trp in 0..4 {
+                    let kr = k[tr][trp];
+                    if kr == Complex64::new(0.0, 0.0) {
+                        continue;
+                    }
+                    for tc in 0..4 {
+                        for tcp in 0..4 {
+                            s[4 * tr + tc][4 * trp + tcp] += kr * k[tc][tcp].conj();
                         }
                     }
                 }
@@ -551,10 +565,10 @@ impl DensityMatrixBackend {
         let mut positions = [q0, q1, q0 + n, q1 + n];
         positions.sort_unstable();
         let flat_offset = |tr: usize, tc: usize| {
-            (if tr & 1 != 0 { 1usize << (q0 + n) } else { 0 })
-                | (if tr & 2 != 0 { 1usize << (q1 + n) } else { 0 })
-                | (if tc & 1 != 0 { 1usize << q0 } else { 0 })
-                | (if tc & 2 != 0 { 1usize << q1 } else { 0 })
+            (if tr & 2 != 0 { 1usize << (q0 + n) } else { 0 })
+                | (if tr & 1 != 0 { 1usize << (q1 + n) } else { 0 })
+                | (if tc & 2 != 0 { 1usize << q0 } else { 0 })
+                | (if tc & 1 != 0 { 1usize << q1 } else { 0 })
         };
         let mut flats = [0usize; 16];
         for tr in 0..4 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -27,6 +27,7 @@
 //! | `apply_1q_matrix` | Stabilizer, FactoredStabilizer | A tableau stores a state by its stabilizer group, closed under Clifford conjugation. A general 2x2 has no image in that group, and a Kraus branch is not even unitary. |
 //! | `reduced_density_matrix_1q` | Stabilizer, FactoredStabilizer | Derivable from a tableau, but the operator it feeds cannot be applied (row above), so the branch would be sampled and never used. |
 //! | `reduced_density_matrix_1q` | DistributedStatevector | Trajectories run shots on Rayon workers whose order differs per rank, so per-shot noise would issue rank collectives out of lockstep. `run_shots_with_noise` rejects the backend for that reason, which closes the only path here. |
+//! | `reduced_density_matrix_2q` | Everything except Statevector | Feeds the branch weights of a correlated two-qubit Kraus channel, which needs the joint state of the pair. A tableau, a product state, and a factored register hold no joint amplitude for an arbitrary pair; MPS and sparse could answer but do not yet. `Backend::supports_two_qubit_kraus` reports the coverage, and `run_shots_with_noise` rejects on it before allocating state. |
 //! | `export_statevector` | DensityMatrix | A mixture of pure states has no statevector. Read `DensityMatrixBackend::purity` or reduce the state instead. |
 //! | `export_statevector` | FactoredStabilizer | Exports while one tableau covers every qubit; past that there is no joint tableau to expand. |
 //! | `init_from_amplitudes` | Everything except Statevector and DensityMatrix | The input is a dense `2^n` amplitude vector, and a tableau, a product state, or a factored register holds only the states its structure can express. MPS could decode one by sequential SVD, but the bond cap would truncate the state the caller supplied. |
@@ -497,6 +498,31 @@ pub trait Backend {
         Err(crate::error::PrismError::BackendUnsupported {
             backend: self.name().to_string(),
             operation: "reduced_density_matrix_1q".to_string(),
+        })
+    }
+
+    /// Whether this backend can run a [`NoiseChannel::Kraus2q`](crate::sim::noise::NoiseChannel)
+    /// branch, which needs both [`Backend::reduced_density_matrix_2q`] and a
+    /// `Gate::Fused2q` kernel. Checked before a shot starts, so an incapable
+    /// backend is named at dispatch rather than part way through a trajectory.
+    fn supports_two_qubit_kraus(&self) -> bool {
+        false
+    }
+
+    /// Compute the two-qubit reduced density matrix without collapsing the state.
+    ///
+    /// Indexed `rho[t][t']` with `t = 2 * bit(q0) + bit(q1)`, the packing
+    /// [`crate::gates::Gate::matrix_4x4`] uses, so `q0` is the high bit.
+    ///
+    /// # Panics
+    ///
+    /// Implementations index the two qubits as distinct bit positions, so
+    /// `q0 == q1` panics rather than returning a block read from overlapping
+    /// amplitudes.
+    fn reduced_density_matrix_2q(&self, _q0: usize, _q1: usize) -> Result<[[Complex64; 4]; 4]> {
+        Err(crate::error::PrismError::BackendUnsupported {
+            backend: self.name().to_string(),
+            operation: "reduced_density_matrix_2q".to_string(),
         })
     }
 

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -2922,6 +2922,67 @@ impl StatevectorBackend {
         ]
     }
 
+    /// `rho[t][t'] = sum_e psi[idx(t, e)] * conj(psi[idx(t', e)])`, where `t`
+    /// packs `q0` in bit 1 and `q1` in bit 0 and `e` runs over the remaining
+    /// `n - 2` qubits. Requires `q0 != q1`; the bit insertion is a bijection
+    /// onto the block bases only for distinct positions.
+    pub(super) fn reduced_density_matrix_two(&self, q0: usize, q1: usize) -> [[Complex64; 4]; 4] {
+        debug_assert_ne!(q0, q1);
+        let offsets = [
+            0usize,
+            1usize << q1,
+            1usize << q0,
+            (1usize << q0) | (1usize << q1),
+        ];
+        let (lo, hi) = (q0.min(q1), q0.max(q1));
+        let state = self.state.as_slice();
+        let groups = state.len() >> 2;
+        let block = |g: usize| {
+            let base = insert_zero_bit(insert_zero_bit(g, lo), hi);
+            let mut amps = [Complex64::new(0.0, 0.0); 4];
+            for (t, off) in offsets.iter().enumerate() {
+                amps[t] = state[base | off];
+            }
+            let mut out = [[Complex64::new(0.0, 0.0); 4]; 4];
+            for (t, row) in out.iter_mut().enumerate() {
+                for (tp, entry) in row.iter_mut().enumerate() {
+                    *entry = amps[t] * amps[tp].conj();
+                }
+            }
+            out
+        };
+        let add = |mut a: [[Complex64; 4]; 4], b: [[Complex64; 4]; 4]| {
+            for (row, brow) in a.iter_mut().zip(b.iter()) {
+                for (entry, bentry) in row.iter_mut().zip(brow.iter()) {
+                    *entry += bentry;
+                }
+            }
+            a
+        };
+        let zero = || [[Complex64::new(0.0, 0.0); 4]; 4];
+
+        #[cfg(feature = "parallel")]
+        let mut rho = if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
+            (0..groups)
+                .into_par_iter()
+                .with_min_len(MIN_PAR_ITERS)
+                .map(block)
+                .reduce(zero, add)
+        } else {
+            (0..groups).map(block).fold(zero(), add)
+        };
+        #[cfg(not(feature = "parallel"))]
+        let mut rho = (0..groups).map(block).fold(zero(), add);
+
+        let scale = self.pending_norm * self.pending_norm;
+        for row in rho.iter_mut() {
+            for entry in row.iter_mut() {
+                *entry *= scale;
+            }
+        }
+        rho
+    }
+
     #[cfg(feature = "parallel")]
     fn reduced_density_matrix_one_par(&self, qubit: usize) -> [[Complex64; 2]; 2] {
         let half = 1usize << qubit;

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -888,6 +888,26 @@ impl Backend for StatevectorBackend {
         Ok(self.reduced_density_matrix_one(qubit))
     }
 
+    fn supports_two_qubit_kraus(&self) -> bool {
+        #[cfg(feature = "gpu")]
+        if self.gpu_state.is_some() {
+            return false;
+        }
+        true
+    }
+
+    fn reduced_density_matrix_2q(&self, q0: usize, q1: usize) -> Result<[[Complex64; 4]; 4]> {
+        assert_ne!(q0, q1, "reduced_density_matrix_2q needs distinct qubits");
+        #[cfg(feature = "gpu")]
+        if self.gpu_state.is_some() {
+            return Err(crate::error::PrismError::BackendUnsupported {
+                backend: "statevector (device-resident)".to_string(),
+                operation: "reduced_density_matrix_2q".to_string(),
+            });
+        }
+        Ok(self.reduced_density_matrix_two(q0, q1))
+    }
+
     fn reset(&mut self, qubit: usize) -> Result<()> {
         #[cfg(feature = "gpu")]
         if self.gpu_state.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ pub use sim::homological::{
     ErrorChainComplex, HomologicalSampler, noisy_marginals_analytical, run_shots_homological,
 };
 pub use sim::noise::{
-    NoiseChannel, NoiseEvent, NoiseModel, NoisyCompiledSampler, ReadoutError, compile_noisy,
-    density_matrix_expectation_values, run_shots_noisy,
+    GateFilter, NoiseBuilder, NoiseChannel, NoiseEvent, NoiseModel, NoisyCompiledSampler,
+    ReadoutError, compile_noisy, density_matrix_expectation_values, run_shots_noisy,
 };
 pub use sim::stabilizer_rank::{
     StabRankResult, run_stabilizer_rank, run_stabilizer_rank_approx, stabilizer_inner_product,

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -2935,6 +2935,20 @@ pub(crate) fn run_shots_with_noise(
                 .into(),
         });
     }
+    // A correlated two-qubit Kraus branch reads a two-qubit reduced density
+    // matrix, which only the host statevector answers. Without this the model
+    // clears every routing gate and fails part way through the first shot, on a
+    // backend an Auto route may have picked for the caller.
+    if noise_model.has_two_qubit_kraus() && !plan.build(seed).supports_two_qubit_kraus() {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: format!("{:?}", plan.resolved()),
+            reason: "a two-qubit Kraus channel needs the two-qubit reduced density matrix \
+                     its branch probabilities are drawn from, which only the host \
+                     statevector provides; run on BackendKind::Statevector, or evaluate \
+                     the channel exactly on BackendKind::DensityMatrix"
+                .into(),
+        });
+    }
     let route = plan.resolved();
     trajectory::run_trajectories(
         |s| plan.build(s),

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -24,7 +24,7 @@ use crate::sim::compiled::{
 /// `NoiseModel::after_gate` entry contains a matching `NoiseEvent`. For
 /// Pauli-only noise on Clifford circuits, the compiled stabilizer sampler
 /// is used instead, see [`NoiseModel::is_pauli_only`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum NoiseChannel {
     /// Independent Pauli X/Y/Z error with given per-branch probabilities.
     Pauli { px: f64, py: f64, pz: f64 },
@@ -53,9 +53,49 @@ pub enum NoiseChannel {
     /// as well as populations. Call [`NoiseModel::validate`] in setup code to
     /// catch empty or non-finite custom channels before sampling.
     Custom { kraus: Vec<[[Complex64; 2]; 2]> },
+    /// General two-qubit channel described by a set of 4x4 Kraus operators.
+    ///
+    /// Each operator is indexed `K[t][t']` with `t = 2 * bit(qubits[0]) +
+    /// bit(qubits[1])`, the packing [`crate::gates::Gate::matrix_4x4`] uses, so
+    /// the first target is the high bit. Runs exactly on the density matrix and
+    /// on trajectory backends reporting [`Backend::supports_two_qubit_kraus`].
+    ///
+    /// Correlated `ZZ` dephasing of strength `p`, as the diagonal pair
+    /// `sqrt(1-p) I` and `sqrt(p) (Z (x) Z)`:
+    ///
+    /// ```
+    /// use num_complex::Complex64;
+    /// use prism_q::NoiseChannel;
+    ///
+    /// let p = 0.02_f64;
+    /// let diag = |scale: f64, signs: [f64; 4]| {
+    ///     let mut m = [[Complex64::new(0.0, 0.0); 4]; 4];
+    ///     for (t, sign) in signs.iter().enumerate() {
+    ///         m[t][t] = Complex64::new(scale * sign, 0.0);
+    ///     }
+    ///     m
+    /// };
+    /// let zz = NoiseChannel::Kraus2q {
+    ///     kraus: vec![
+    ///         diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+    ///         diag(p.sqrt(), [1.0, -1.0, -1.0, 1.0]),
+    ///     ],
+    /// };
+    /// zz.validate()?;
+    /// # Ok::<(), prism_q::PrismError>(())
+    /// ```
+    Kraus2q { kraus: Vec<[[Complex64; 4]; 4]> },
 }
 
 impl NoiseChannel {
+    /// Number of qubits an event carrying this channel must name.
+    pub fn num_qubits(&self) -> usize {
+        match self {
+            NoiseChannel::TwoQubitDepolarizing { .. } | NoiseChannel::Kraus2q { .. } => 2,
+            _ => 1,
+        }
+    }
+
     /// Per-Pauli `(px, py, pz)` probabilities for a Pauli or Depolarizing
     /// channel, `None` for every other channel.
     pub fn as_pauli(&self) -> Option<(f64, f64, f64)> {
@@ -124,27 +164,8 @@ impl NoiseChannel {
                     });
                 }
             }
-            NoiseChannel::Custom { kraus } => {
-                if kraus.is_empty() {
-                    return Err(crate::error::PrismError::InvalidParameter {
-                        message: "Custom Kraus channel must contain at least one operator".into(),
-                    });
-                }
-                for (op_idx, op) in kraus.iter().enumerate() {
-                    for (row_idx, row) in op.iter().enumerate() {
-                        for (col_idx, val) in row.iter().enumerate() {
-                            if !val.re.is_finite() || !val.im.is_finite() {
-                                return Err(crate::error::PrismError::InvalidParameter {
-                                    message: format!(
-                                        "Custom Kraus operator {op_idx} entry ({row_idx},{col_idx}) must be finite"
-                                    ),
-                                });
-                            }
-                        }
-                    }
-                }
-                validate_trace_preserving(kraus)?;
-            }
+            NoiseChannel::Custom { kraus } => validate_kraus_set("Custom", kraus)?,
+            NoiseChannel::Kraus2q { kraus } => validate_kraus_set("Kraus2q", kraus)?,
         }
         Ok(())
     }
@@ -155,13 +176,36 @@ impl NoiseChannel {
 /// that a channel scaled by a constant is rejected.
 const CPTP_TOLERANCE: f64 = 1e-9;
 
-fn validate_trace_preserving(kraus: &[[[Complex64; 2]; 2]]) -> Result<()> {
-    let mut sum = [[Complex64::new(0.0, 0.0); 2]; 2];
+/// Reject an empty operator set, a non-finite entry, and any deviation from
+/// `sum_k Kdagger_k K_k = I` past [`CPTP_TOLERANCE`]. Shared by the one-qubit
+/// and two-qubit dense channels, which differ only in `D`.
+fn validate_kraus_set<const D: usize>(name: &str, kraus: &[[[Complex64; D]; D]]) -> Result<()> {
+    if kraus.is_empty() {
+        return Err(crate::error::PrismError::InvalidParameter {
+            message: format!("{name} Kraus channel must contain at least one operator"),
+        });
+    }
+    for (op_idx, op) in kraus.iter().enumerate() {
+        for (row_idx, row) in op.iter().enumerate() {
+            for (col_idx, val) in row.iter().enumerate() {
+                if !val.re.is_finite() || !val.im.is_finite() {
+                    return Err(crate::error::PrismError::InvalidParameter {
+                        message: format!(
+                            "{name} Kraus operator {op_idx} entry ({row_idx},{col_idx}) must be finite"
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    let mut sum = [[Complex64::new(0.0, 0.0); D]; D];
     for op in kraus {
-        let effect = crate::sim::trajectory::kdagger_k(op);
-        for (row, effect_row) in effect.iter().enumerate() {
-            for (col, entry) in effect_row.iter().enumerate() {
-                sum[row][col] += entry;
+        for (row, sum_row) in sum.iter_mut().enumerate() {
+            for (col, entry) in sum_row.iter_mut().enumerate() {
+                for op_row in op.iter() {
+                    *entry += op_row[row].conj() * op_row[col];
+                }
             }
         }
     }
@@ -171,7 +215,7 @@ fn validate_trace_preserving(kraus: &[[[Complex64; 2]; 2]]) -> Result<()> {
             if (entry.re - expected).abs() > CPTP_TOLERANCE || entry.im.abs() > CPTP_TOLERANCE {
                 return Err(crate::error::PrismError::InvalidParameter {
                     message: format!(
-                        "Custom Kraus operators must be trace preserving: \
+                        "{name} Kraus operators must be trace preserving: \
                          sum of Kdagger K at ({row},{col}) is {entry}, expected {expected}"
                     ),
                 });
@@ -192,10 +236,11 @@ fn validate_probability(name: &str, value: f64) -> Result<()> {
 
 /// A noise channel bound to its target qubits; fires after the instruction
 /// its [`NoiseModel::after_gate`] slot is attached to.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct NoiseEvent {
     pub channel: NoiseChannel,
-    /// One qubit for single-qubit channels, two for `TwoQubitDepolarizing`.
+    /// As many entries as [`NoiseChannel::num_qubits`] requires, in the order
+    /// the channel indexes them.
     pub qubits: SmallVec<[usize; 2]>,
 }
 
@@ -227,7 +272,7 @@ impl NoiseEvent {
 }
 
 /// Classical bit-flip error applied to a measurement outcome.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReadoutError {
     /// Probability a measured 0 reads out as 1.
     pub p01: f64,
@@ -253,6 +298,7 @@ pub struct ReadoutError {
 /// assert_eq!(result.shots.len(), 100);
 /// # Ok::<(), prism_q::PrismError>(())
 /// ```
+#[derive(Debug)]
 pub struct NoiseModel {
     /// Events fired after each instruction, indexed by instruction position;
     /// length must equal the circuit's instruction count.
@@ -325,6 +371,25 @@ impl NoiseModel {
         self
     }
 
+    /// Set the readout error of one classical bit, leaving the rest alone.
+    ///
+    /// Indexed by classical bit rather than by qubit: a qubit measured into
+    /// several bits carries an independent rate per bit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit` is outside the classical register the model was built
+    /// for, matching the index-bounds policy of the circuit builders.
+    pub fn set_bit_readout_error(&mut self, bit: usize, p01: f64, p10: f64) -> &mut Self {
+        assert!(
+            bit < self.readout.len(),
+            "classical bit {bit} is outside the {}-bit register",
+            self.readout.len()
+        );
+        self.readout[bit] = Some(ReadoutError { p01, p10 });
+        self
+    }
+
     /// True when every channel is Pauli or Depolarizing and readout is ideal,
     /// the precondition for the compiled stabilizer sampling paths.
     pub fn is_pauli_only(&self) -> bool {
@@ -333,6 +398,15 @@ impl NoiseModel {
             .flat_map(|events| events.iter())
             .all(|e| e.channel.is_pauli())
             && self.readout.iter().all(|r| r.is_none())
+    }
+
+    /// True when any event carries a [`NoiseChannel::Kraus2q`], the one channel
+    /// needing a two-qubit reduction from the backend running the trajectory.
+    pub(crate) fn has_two_qubit_kraus(&self) -> bool {
+        self.after_gate
+            .iter()
+            .flat_map(|events| events.iter())
+            .any(|event| matches!(event.channel, NoiseChannel::Kraus2q { .. }))
     }
 
     pub fn has_noise(&self) -> bool {
@@ -377,19 +451,23 @@ impl NoiseModel {
         self.validate()?;
 
         // One event slot per top-level instruction, so a region's body has no
-        // slots to carry noise and would run noiselessly without this.
-        if let Some(index) = circuit
-            .instructions
-            .iter()
-            .position(|inst| matches!(inst, Instruction::Region(_)))
-        {
-            return Err(crate::error::PrismError::IncompatibleBackend {
-                backend: "NoiseModel".to_string(),
-                reason: format!(
-                    "noise events are indexed per instruction, which leaves the body of the \
-                     guarded region at instruction {index} without noise slots"
-                ),
-            });
+        // slots to carry noise and would run noiselessly without this. A model
+        // carrying no quantum events has nothing to lose there, so readout-only
+        // noise stays legal on a circuit with regions.
+        if self.after_gate.iter().any(|events| !events.is_empty()) {
+            if let Some(index) = circuit
+                .instructions
+                .iter()
+                .position(|inst| matches!(inst, Instruction::Region(_)))
+            {
+                return Err(crate::error::PrismError::IncompatibleBackend {
+                    backend: "NoiseModel".to_string(),
+                    reason: format!(
+                        "noise events are indexed per instruction, which leaves the body of the \
+                         guarded region at instruction {index} without noise slots"
+                    ),
+                });
+            }
         }
 
         for (instr_idx, events) in self.after_gate.iter().enumerate() {
@@ -421,10 +499,7 @@ impl NoiseModel {
                     }
                 })?;
 
-                let expected_qubits = match &event.channel {
-                    NoiseChannel::TwoQubitDepolarizing { .. } => 2,
-                    _ => 1,
-                };
+                let expected_qubits = event.channel.num_qubits();
                 if event.qubits.len() != expected_qubits {
                     return Err(crate::error::PrismError::InvalidParameter {
                         message: format!(
@@ -2573,8 +2648,8 @@ pub(crate) fn kraus_1q(channel: &NoiseChannel) -> Vec<[[Complex64; 2]; 2]> {
             out
         }
         NoiseChannel::Custom { kraus } => kraus.clone(),
-        NoiseChannel::TwoQubitDepolarizing { .. } => {
-            unreachable!("two-qubit depolarizing has no single-qubit Kraus lowering")
+        NoiseChannel::TwoQubitDepolarizing { .. } | NoiseChannel::Kraus2q { .. } => {
+            unreachable!("two-qubit channels have no single-qubit Kraus lowering")
         }
     }
 }
@@ -2584,6 +2659,9 @@ pub(crate) fn apply_noise_event_dm(dm: &mut DensityMatrixBackend, event: &NoiseE
     match &event.channel {
         NoiseChannel::TwoQubitDepolarizing { p } => {
             dm.apply_2q_depolarizing(event.qubits[0], event.qubits[1], *p);
+        }
+        NoiseChannel::Kraus2q { kraus } => {
+            dm.apply_2q_kraus(event.qubits[0], event.qubits[1], kraus);
         }
         other => {
             let kraus = kraus_1q(other);
@@ -2644,10 +2722,9 @@ fn evolve_density_matrix(
         if let Instruction::Gate { gate, targets } = inst {
             if targets.len() == 1
                 && !events.is_empty()
-                && events.iter().all(|event| {
-                    !matches!(event.channel, NoiseChannel::TwoQubitDepolarizing { .. })
-                        && event.qubits[0] == targets[0]
-                })
+                && events
+                    .iter()
+                    .all(|event| event.channel.num_qubits() == 1 && event.qubits[0] == targets[0])
             {
                 let channels: Vec<Vec<[[Complex64; 2]; 2]>> =
                     events.iter().map(|e| kraus_1q(&e.channel)).collect();
@@ -2741,6 +2818,11 @@ pub(crate) fn dm_expectation_values(
         })
         .collect()
 }
+
+#[path = "noise_builder.rs"]
+pub mod builder;
+
+pub use builder::{GateFilter, NoiseBuilder};
 
 #[cfg(test)]
 #[path = "noise_tests.rs"]

--- a/src/sim/noise_builder.rs
+++ b/src/sim/noise_builder.rs
@@ -1,0 +1,549 @@
+//! Rule-based construction of a [`NoiseModel`] against a circuit.
+//!
+//! Rules are declared once and compiled against an instruction stream by
+//! [`NoiseBuilder::build`], which emits the same per-instruction event vector
+//! the manual `after_gate` path builds. Nothing here runs per shot.
+
+use smallvec::smallvec;
+
+use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::error::{PrismError, Result};
+use crate::gates::Gate;
+use crate::sim::noise::{NoiseChannel, NoiseEvent, NoiseModel, ReadoutError};
+
+/// Which gates a rule fires after.
+///
+/// An unset field imposes no restriction, so [`GateFilter::all`] matches every
+/// gate on every qubit.
+#[derive(Debug, Clone, Default)]
+pub struct GateFilter {
+    arity: Option<usize>,
+    name: Option<String>,
+    qubits: Option<Vec<usize>>,
+    targets: Option<Vec<usize>>,
+}
+
+impl GateFilter {
+    pub fn all() -> Self {
+        Self::default()
+    }
+
+    /// Restrict to gates with exactly `arity` targets.
+    pub fn arity(mut self, arity: usize) -> Self {
+        self.arity = Some(arity);
+        self
+    }
+
+    /// Restrict to gates whose [`Gate::name`] equals `name`, such as `"cx"`.
+    ///
+    /// A name no gate in the circuit carries is not an error: the rule emits
+    /// nothing. Fusion renames gates (`"fused"`, `"fused_2q"`, `"multi_fused"`),
+    /// so build the model against the circuit the caller holds rather than a
+    /// fused stream.
+    pub fn named(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Restrict to the listed qubits, as an unordered set. Every rule kind
+    /// honours it: one acting per target emits events only on the targets in
+    /// the set, and one acting on a gate's whole target list, or on the
+    /// spectators of a target, fires only for targets the set admits.
+    pub fn on_qubits(mut self, qubits: impl IntoIterator<Item = usize>) -> Self {
+        let mut listed: Vec<usize> = qubits.into_iter().collect();
+        listed.sort_unstable();
+        listed.dedup();
+        self.qubits = Some(listed);
+        self
+    }
+
+    /// Restrict to gates whose target list equals `targets` in order.
+    ///
+    /// Directed, unlike [`GateFilter::on_qubits`]: `on_targets([0, 1])` matches
+    /// `cx(0, 1)` and not `cx(1, 0)`, which is what a calibration table keyed by
+    /// coupling-map edge needs.
+    pub fn on_targets(mut self, targets: impl IntoIterator<Item = usize>) -> Self {
+        self.targets = Some(targets.into_iter().collect());
+        self
+    }
+
+    fn matches(&self, gate: &Gate, targets: &[usize]) -> bool {
+        if self.arity.is_some_and(|arity| arity != targets.len()) {
+            return false;
+        }
+        if self.name.as_deref().is_some_and(|name| name != gate.name()) {
+            return false;
+        }
+        if self
+            .targets
+            .as_deref()
+            .is_some_and(|listed| listed != targets)
+        {
+            return false;
+        }
+        true
+    }
+
+    fn allows(&self, qubit: usize) -> bool {
+        self.qubits
+            .as_ref()
+            .is_none_or(|listed| listed.binary_search(&qubit).is_ok())
+    }
+}
+
+enum Rule {
+    PerTarget {
+        filter: GateFilter,
+        channel: NoiseChannel,
+    },
+    Joint {
+        filter: GateFilter,
+        channel: NoiseChannel,
+    },
+    Crosstalk {
+        filter: GateFilter,
+        coupling: Vec<(usize, usize)>,
+        channel: NoiseChannel,
+    },
+    OverRotation {
+        filter: GateFilter,
+        relative: f64,
+    },
+    Idle {
+        channel: NoiseChannel,
+    },
+    AfterReset {
+        channel: NoiseChannel,
+    },
+    BeforeMeasure {
+        channel: NoiseChannel,
+    },
+}
+
+/// Declarative noise-model construction.
+///
+/// Each method appends a rule; [`NoiseBuilder::build`] walks a circuit once and
+/// evaluates the rules in registration order at every instruction, so the event
+/// order inside a slot is the order the rules were declared. Rules match
+/// [`Instruction::Gate`] only: a [`Instruction::Conditional`] carries noise that
+/// would fire whether or not its gate ran, so it is left alone.
+///
+/// # Examples
+///
+/// ```
+/// use prism_q::{Circuit, Gate, GateFilter, NoiseBuilder, NoiseChannel};
+///
+/// let mut circuit = Circuit::new(3, 3);
+/// circuit.add_gate(Gate::H, &[0]);
+/// circuit.add_gate(Gate::Cx, &[0, 1]);
+///
+/// let noise = NoiseBuilder::new()
+///     .after_gates(GateFilter::all().arity(1), NoiseChannel::Depolarizing { p: 1e-4 })
+///     .after_gates(GateFilter::all().named("cx"), NoiseChannel::Depolarizing { p: 2e-3 })
+///     .on_idle_qubits(NoiseChannel::PhaseDamping { gamma: 1e-5 })
+///     .readout_error(2, 0.02, 0.03)
+///     .build(&circuit)?;
+///
+/// assert_eq!(noise.after_gate.len(), circuit.instructions.len());
+/// # Ok::<(), prism_q::PrismError>(())
+/// ```
+#[derive(Default)]
+pub struct NoiseBuilder {
+    rules: Vec<Rule>,
+    readout: Vec<(usize, ReadoutError)>,
+    uniform_readout: Option<ReadoutError>,
+}
+
+impl NoiseBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// One single-qubit channel on each matching target of each matching gate.
+    pub fn after_gates(mut self, filter: GateFilter, channel: NoiseChannel) -> Self {
+        self.rules.push(Rule::PerTarget { filter, channel });
+        self
+    }
+
+    /// One channel on a matching gate's whole target list, for the correlated
+    /// two-qubit channels ([`NoiseChannel::TwoQubitDepolarizing`],
+    /// [`NoiseChannel::Kraus2q`]). The rule fires only on gates whose target
+    /// count equals the channel's own arity.
+    pub fn after_gates_joint(mut self, filter: GateFilter, channel: NoiseChannel) -> Self {
+        self.rules.push(Rule::Joint { filter, channel });
+        self
+    }
+
+    /// One channel per spectator qubit coupled to a target of a matching gate.
+    ///
+    /// `coupling` is an undirected edge list. A single-qubit channel lands once
+    /// on each distinct spectator; a two-qubit channel lands on each
+    /// `(target, spectator)` pair with the target as its first qubit. Qubits
+    /// among the gate's own targets are not spectators of it, and a target the
+    /// filter's qubit set excludes contributes no spectators.
+    pub fn crosstalk(
+        mut self,
+        filter: GateFilter,
+        coupling: impl IntoIterator<Item = (usize, usize)>,
+        channel: NoiseChannel,
+    ) -> Self {
+        self.rules.push(Rule::Crosstalk {
+            filter,
+            coupling: coupling.into_iter().collect(),
+            channel,
+        });
+        self
+    }
+
+    /// A coherent rotation of `relative * theta` about a matching rotation
+    /// gate's own axis, appended after it: the gate turns `theta` into
+    /// `theta * (1 + relative)`.
+    ///
+    /// Fires on `rx`, `ry`, `rz`, and `p` only. The excess is emitted as a
+    /// one-qubit Kraus set, so the multi-qubit rotations (`rzz`, `pauli_rot`)
+    /// do not fit even though they carry a single angle. Other gates matching
+    /// `filter` are skipped.
+    pub fn over_rotation(mut self, filter: GateFilter, relative: f64) -> Self {
+        self.rules.push(Rule::OverRotation { filter, relative });
+        self
+    }
+
+    /// One single-qubit channel on every qubit no instruction of a layer
+    /// touches, fired at the end of the layer.
+    ///
+    /// Layers come from the greedy assignment [`Circuit::depth`] reports, so
+    /// the layer count a caller can print is the one the idle budget is charged
+    /// against. A layer's events ride its highest-indexed instruction. Greedy
+    /// assignment can place a later instruction in an earlier layer, and on
+    /// such a circuit a layer's idle events fire after the events of the layer
+    /// that follows it.
+    ///
+    /// The event count grows as layers times idle qubits, which on a wide
+    /// shallow circuit is most of the register on every layer. Every engine
+    /// walks that stream per shot.
+    pub fn on_idle_qubits(mut self, channel: NoiseChannel) -> Self {
+        self.rules.push(Rule::Idle { channel });
+        self
+    }
+
+    /// One single-qubit channel on the reset qubit, after each reset.
+    pub fn after_resets(mut self, channel: NoiseChannel) -> Self {
+        self.rules.push(Rule::AfterReset { channel });
+        self
+    }
+
+    /// One single-qubit channel on the measured qubit, immediately before each
+    /// measurement.
+    ///
+    /// Distinct from [`NoiseModel::readout`], which flips reported bits once at
+    /// the end of a shot: this damages the state the measurement then projects,
+    /// so a mid-circuit outcome feeding a classical conditional is the faulty
+    /// one. A purely classical fault that leaves the state intact is not
+    /// expressible this way.
+    ///
+    /// The channel is carried by the slot of the preceding instruction, so a
+    /// measurement at instruction 0 has nowhere to put it and
+    /// [`NoiseBuilder::build`] rejects the circuit; prepend a barrier to make
+    /// room. Sharing that slot with the preceding gate's own error means
+    /// declaration order decides which fires first, so declare this rule after
+    /// the gate rules.
+    pub fn before_measurements(mut self, channel: NoiseChannel) -> Self {
+        self.rules.push(Rule::BeforeMeasure { channel });
+        self
+    }
+
+    /// Readout error on one classical bit. Overrides any uniform rate whatever
+    /// order the two are declared in.
+    pub fn readout_error(mut self, bit: usize, p01: f64, p10: f64) -> Self {
+        self.readout.push((bit, ReadoutError { p01, p10 }));
+        self
+    }
+
+    /// Readout error on every classical bit of the register the model is built
+    /// for, including bits no measurement writes.
+    pub fn uniform_readout_error(mut self, p01: f64, p10: f64) -> Self {
+        self.uniform_readout = Some(ReadoutError { p01, p10 });
+        self
+    }
+
+    /// Compile the rules against `circuit`.
+    ///
+    /// # Errors
+    ///
+    /// Reports a per-bit readout rate outside the classical register, a
+    /// measurement at instruction 0 under a
+    /// [`before_measurements`](NoiseBuilder::before_measurements) rule, and
+    /// everything [`NoiseModel::validate_for`] rejects.
+    pub fn build(&self, circuit: &Circuit) -> Result<NoiseModel> {
+        let mut after_gate: Vec<Vec<NoiseEvent>> = vec![Vec::new(); circuit.instructions.len()];
+
+        let idle = self
+            .rules
+            .iter()
+            .any(|rule| matches!(rule, Rule::Idle { .. }))
+            .then(|| idle_qubits_by_layer(circuit));
+        let pre_measure = self
+            .rules
+            .iter()
+            .any(|rule| matches!(rule, Rule::BeforeMeasure { .. }))
+            .then(|| pre_measure_qubits(circuit))
+            .transpose()?;
+
+        for (idx, instr) in circuit.instructions.iter().enumerate() {
+            for rule in &self.rules {
+                emit(rule, idx, instr, &idle, &pre_measure, &mut after_gate);
+            }
+        }
+
+        let mut readout = vec![self.uniform_readout.clone(); circuit.num_classical_bits];
+        for (bit, error) in &self.readout {
+            if *bit >= readout.len() {
+                return Err(PrismError::InvalidParameter {
+                    message: format!(
+                        "readout error on classical bit {bit} is outside the {}-bit register",
+                        readout.len()
+                    ),
+                });
+            }
+            readout[*bit] = Some(error.clone());
+        }
+
+        let model = NoiseModel {
+            after_gate,
+            readout,
+        };
+        model.validate_for(circuit)?;
+        Ok(model)
+    }
+}
+
+fn emit(
+    rule: &Rule,
+    idx: usize,
+    instr: &Instruction,
+    idle: &Option<Vec<Vec<usize>>>,
+    pre_measure: &Option<Vec<Option<usize>>>,
+    after_gate: &mut [Vec<NoiseEvent>],
+) {
+    let slot = &mut after_gate[idx];
+    match rule {
+        Rule::PerTarget { filter, channel } => {
+            let Instruction::Gate { gate, targets } = instr else {
+                return;
+            };
+            if !filter.matches(gate, targets) {
+                return;
+            }
+            for &qubit in targets.iter().filter(|&&q| filter.allows(q)) {
+                slot.push(NoiseEvent {
+                    channel: channel.clone(),
+                    qubits: smallvec![qubit],
+                });
+            }
+        }
+        Rule::Joint { filter, channel } => {
+            let Instruction::Gate { gate, targets } = instr else {
+                return;
+            };
+            if targets.len() != channel.num_qubits()
+                || !filter.matches(gate, targets)
+                || !targets.iter().all(|&q| filter.allows(q))
+            {
+                return;
+            }
+            slot.push(NoiseEvent {
+                channel: channel.clone(),
+                qubits: targets.iter().copied().collect(),
+            });
+        }
+        Rule::Crosstalk {
+            filter,
+            coupling,
+            channel,
+        } => {
+            let Instruction::Gate { gate, targets } = instr else {
+                return;
+            };
+            if !filter.matches(gate, targets) {
+                return;
+            }
+            emit_crosstalk(filter, coupling, channel, targets, slot);
+        }
+        Rule::OverRotation { filter, relative } => {
+            let Instruction::Gate { gate, targets } = instr else {
+                return;
+            };
+            if !filter.matches(gate, targets) {
+                return;
+            }
+            let Some(channel) = over_rotation_channel(gate, *relative) else {
+                return;
+            };
+            for &qubit in targets.iter().filter(|&&q| filter.allows(q)) {
+                slot.push(NoiseEvent {
+                    channel: channel.clone(),
+                    qubits: smallvec![qubit],
+                });
+            }
+        }
+        Rule::Idle { channel } => {
+            let Some(idle) = idle else { return };
+            for &qubit in &idle[idx] {
+                slot.push(NoiseEvent {
+                    channel: channel.clone(),
+                    qubits: smallvec![qubit],
+                });
+            }
+        }
+        Rule::AfterReset { channel } => {
+            if let Instruction::Reset { qubit } = instr {
+                slot.push(NoiseEvent {
+                    channel: channel.clone(),
+                    qubits: smallvec![*qubit],
+                });
+            }
+        }
+        Rule::BeforeMeasure { channel } => {
+            let Some(pre_measure) = pre_measure else {
+                return;
+            };
+            if let Some(qubit) = pre_measure[idx] {
+                slot.push(NoiseEvent {
+                    channel: channel.clone(),
+                    qubits: smallvec![qubit],
+                });
+            }
+        }
+    }
+}
+
+fn emit_crosstalk(
+    filter: &GateFilter,
+    coupling: &[(usize, usize)],
+    channel: &NoiseChannel,
+    targets: &[usize],
+    slot: &mut Vec<NoiseEvent>,
+) {
+    let mut seen: Vec<usize> = Vec::new();
+    for &target in targets.iter().filter(|&&q| filter.allows(q)) {
+        let mut spectators: Vec<usize> = coupling
+            .iter()
+            .filter_map(|&(a, b)| match (a == target, b == target) {
+                (true, false) => Some(b),
+                (false, true) => Some(a),
+                _ => None,
+            })
+            .filter(|spectator| !targets.contains(spectator))
+            .collect();
+        spectators.sort_unstable();
+        spectators.dedup();
+
+        for spectator in spectators {
+            let qubits: SmallVec<[usize; 2]> = if channel.num_qubits() == 2 {
+                smallvec![target, spectator]
+            } else {
+                if seen.contains(&spectator) {
+                    continue;
+                }
+                seen.push(spectator);
+                smallvec![spectator]
+            };
+            slot.push(NoiseEvent {
+                channel: channel.clone(),
+                qubits,
+            });
+        }
+    }
+}
+
+/// The unitary an over-rotation of `relative` appends after `gate`, as a
+/// one-operator Kraus set. `None` for a gate carrying no single rotation angle.
+fn over_rotation_channel(gate: &Gate, relative: f64) -> Option<NoiseChannel> {
+    let excess = match gate {
+        Gate::Rx(theta) => Gate::Rx(relative * theta),
+        Gate::Ry(theta) => Gate::Ry(relative * theta),
+        Gate::Rz(theta) => Gate::Rz(relative * theta),
+        Gate::P(theta) => Gate::P(relative * theta),
+        _ => return None,
+    };
+    Some(NoiseChannel::Custom {
+        kraus: vec![excess.matrix_2x2()],
+    })
+}
+
+/// Qubits an instruction occupies. Empty for a barrier, which schedules
+/// rather than acts; [`idle_qubits_by_layer`] handles that case itself.
+fn instruction_qubits(instr: &Instruction) -> SmallVec<[usize; 4]> {
+    match instr {
+        Instruction::Gate { targets, .. } | Instruction::Conditional { targets, .. } => {
+            targets.clone()
+        }
+        Instruction::Measure { qubit, .. } | Instruction::Reset { qubit } => smallvec![*qubit],
+        Instruction::Barrier { qubits } => qubits.clone(),
+        Instruction::Region(region) => region.qubits().iter().copied().collect(),
+    }
+}
+
+/// For the highest-indexed instruction of each layer, the qubits that layer
+/// left idle; empty everywhere else.
+///
+/// Layer assignment is the greedy rule `Circuit::depth` reports: an instruction
+/// takes the earliest layer where every qubit it touches is free, and a barrier
+/// synchronizes its qubits to that layer without occupying it.
+fn idle_qubits_by_layer(circuit: &Circuit) -> Vec<Vec<usize>> {
+    let num_qubits = circuit.num_qubits;
+    let mut qubit_depth = vec![0usize; num_qubits];
+    let mut layers: Vec<(Vec<bool>, usize)> = Vec::new();
+
+    for (idx, instr) in circuit.instructions.iter().enumerate() {
+        let qubits = instruction_qubits(instr);
+        if qubits.is_empty() {
+            continue;
+        }
+        let layer = qubits.iter().map(|&q| qubit_depth[q]).max().unwrap_or(0);
+        if matches!(instr, Instruction::Barrier { .. }) {
+            for &qubit in &qubits {
+                qubit_depth[qubit] = layer;
+            }
+            continue;
+        }
+        while layers.len() <= layer {
+            layers.push((vec![false; num_qubits], 0));
+        }
+        let (touched, last) = &mut layers[layer];
+        for &qubit in &qubits {
+            touched[qubit] = true;
+            qubit_depth[qubit] = layer + 1;
+        }
+        *last = (*last).max(idx);
+    }
+
+    let mut idle = vec![Vec::new(); circuit.instructions.len()];
+    for (touched, last) in layers {
+        idle[last] = touched
+            .iter()
+            .enumerate()
+            .filter_map(|(qubit, &used)| (!used).then_some(qubit))
+            .collect();
+    }
+    idle
+}
+
+/// The qubit measured by instruction `idx + 1`, indexed by `idx`, so a
+/// pre-measurement channel rides the preceding instruction's slot.
+fn pre_measure_qubits(circuit: &Circuit) -> Result<Vec<Option<usize>>> {
+    if let Some(Instruction::Measure { .. }) = circuit.instructions.first() {
+        return Err(PrismError::InvalidParameter {
+            message: "pre-measurement noise needs a preceding instruction to attach to, and \
+                      instruction 0 is a measurement; prepend a barrier"
+                .into(),
+        });
+    }
+    let mut out = vec![None; circuit.instructions.len()];
+    for (idx, instr) in circuit.instructions.iter().enumerate().skip(1) {
+        if let Instruction::Measure { qubit, .. } = instr {
+            out[idx - 1] = Some(*qubit);
+        }
+    }
+    Ok(out)
+}

--- a/src/sim/trajectory.rs
+++ b/src/sim/trajectory.rs
@@ -241,7 +241,7 @@ fn apply_pauli_op(backend: &mut dyn Backend, qubit: usize, op: PauliOp) -> Resul
 
 /// Compute the branch effect `Kdagger K` for a single-qubit Kraus operator.
 #[inline]
-pub(crate) fn kdagger_k(k: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
+fn kdagger_k(k: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
     [
         [
             k[0][0].conj() * k[0][0] + k[1][0].conj() * k[1][0],
@@ -313,6 +313,76 @@ fn apply_custom_kraus(
     backend.apply_1q_matrix(qubit, &normalized)
 }
 
+/// Sample and apply one of a set of two-qubit Kraus operators, indexed
+/// `K[t][t']` with `t = 2 * bit(q0) + bit(q1)`.
+///
+/// Branch probabilities are `p_k = Tr(Kdagger K rho)` over the pair's reduced
+/// density matrix, so a correlated channel sees the coherence between the two
+/// qubits and not only their populations. Backends without
+/// [`Backend::reduced_density_matrix_2q`] report that rather than sampling a
+/// branch from an approximation.
+fn apply_custom_kraus_2q(
+    backend: &mut dyn Backend,
+    q0: usize,
+    q1: usize,
+    kraus: &[[[Complex64; 4]; 4]],
+    rng: &mut ChaCha8Rng,
+) -> Result<()> {
+    let rho = backend.reduced_density_matrix_2q(q0, q1)?;
+
+    let mut cumulative: smallvec::SmallVec<[f64; 16]> = smallvec::SmallVec::new();
+    let mut total = 0.0;
+    for k in kraus {
+        total += kraus_probability_2q(k, &rho);
+        cumulative.push(total);
+    }
+
+    if total <= JUMP_EPSILON {
+        return Ok(());
+    }
+
+    let r: f64 = rand::RngExt::random::<f64>(rng) * total;
+    let chosen = cumulative
+        .iter()
+        .position(|&c| r < c)
+        .unwrap_or(kraus.len() - 1);
+    let pk = if chosen == 0 {
+        cumulative[0]
+    } else {
+        cumulative[chosen] - cumulative[chosen - 1]
+    };
+    if pk <= JUMP_EPSILON {
+        return Ok(());
+    }
+
+    let inv = Complex64::new(1.0 / pk.sqrt(), 0.0);
+    let mut normalized = kraus[chosen];
+    for row in normalized.iter_mut() {
+        for entry in row.iter_mut() {
+            *entry *= inv;
+        }
+    }
+    backend.apply(&Instruction::Gate {
+        gate: Gate::Fused2q(Box::new(normalized)),
+        targets: smallvec![q0, q1],
+    })
+}
+
+/// `Tr(Kdagger K rho) = sum_{i,j,r} conj(K[r][i]) K[r][j] rho[j][i]`.
+fn kraus_probability_2q(k: &[[Complex64; 4]; 4], rho: &[[Complex64; 4]; 4]) -> f64 {
+    let mut p = Complex64::new(0.0, 0.0);
+    for i in 0..4 {
+        for j in 0..4 {
+            let mut effect = Complex64::new(0.0, 0.0);
+            for row in k.iter() {
+                effect += row[i].conj() * row[j];
+            }
+            p += effect * rho[j][i];
+        }
+    }
+    p.re.max(0.0)
+}
+
 fn apply_noise_event(
     backend: &mut dyn Backend,
     event: &NoiseEvent,
@@ -339,6 +409,9 @@ fn apply_noise_event(
             apply_two_qubit_depolarizing(backend, event.qubits[0], event.qubits[1], *p, rng)
         }
         NoiseChannel::Custom { kraus } => apply_custom_kraus(backend, event.qubits[0], kraus, rng),
+        NoiseChannel::Kraus2q { kraus } => {
+            apply_custom_kraus_2q(backend, event.qubits[0], event.qubits[1], kraus, rng)
+        }
     }
 }
 

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -677,6 +677,201 @@ fn density_matrix_dephasing_removes_coherence() {
     assert_probs(&backend.probabilities().unwrap(), &[0.25, 0.25, 0.25, 0.25]);
 }
 
+// A two-qubit Kraus set is indexed `K[t][t']` with `t = 2*bit(q0) + bit(q1)`,
+// so the first qubit named is the high bit. `diag(1, 1, -1, -1)` is therefore
+// `Z` on the first and identity on the second, and swapping the two qubit
+// arguments has to move the dephasing to the other qubit.
+#[test]
+fn density_matrix_two_qubit_kraus_orders_the_first_qubit_high() {
+    let p = 0.25f64;
+    let zero = Complex64::new(0.0, 0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = Complex64::new(scale * sign, 0.0);
+        }
+        m
+    };
+    // K0 = sqrt(1-p) I, K1 = sqrt(p) (Z (x) I): dephasing of strength p on the
+    // high qubit alone. On |++> that leaves <X> = 1 - 2p there and <X> = 1 on
+    // the untouched one.
+    let z_on_high = [
+        diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+        diag(p.sqrt(), [1.0, 1.0, -1.0, -1.0]),
+    ];
+
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+
+    for (q0, q1, x0, x1) in [(0, 1, 1.0 - 2.0 * p, 1.0), (1, 0, 1.0, 1.0 - 2.0 * p)] {
+        let mut backend = DensityMatrixBackend::new(common::SEED);
+        sim::run_on(&mut backend, &c).unwrap();
+        backend.apply_2q_kraus(q0, q1, &z_on_high);
+        let got = backend
+            .pauli_expectations(&[
+                vec![prism_q::PauliTerm::x(0)],
+                vec![prism_q::PauliTerm::x(1)],
+            ])
+            .unwrap();
+        assert!(
+            (got[0] - x0).abs() < EPS && (got[1] - x1).abs() < EPS,
+            "({q0},{q1}): expected ({x0}, {x1}), got ({}, {})",
+            got[0],
+            got[1]
+        );
+    }
+}
+
+// Correlated dephasing {sqrt(1-p) I, sqrt(p) Z(x)Z} maps |++> onto the mixture
+// (1-p)|++><++| + p|--><--|. Both single-qubit <X> read 1 - 2p, while <X0 X1>
+// stays at 1 because the two branches flip together. Independent single-qubit
+// dephasing at the same rate would give (1-2p)^2 there, so the joint term is
+// what separates a correlated channel from two local ones.
+#[test]
+fn density_matrix_correlated_zz_dephasing_keeps_the_joint_term() {
+    let p = 0.25f64;
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::H, &[1]);
+
+    let mut backend = DensityMatrixBackend::new(common::SEED);
+    sim::run_on(&mut backend, &c).unwrap();
+    let zero = Complex64::new(0.0, 0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = Complex64::new(scale * sign, 0.0);
+        }
+        m
+    };
+    let zz = [
+        diag((1.0f64 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+        diag(p.sqrt(), [1.0, -1.0, -1.0, 1.0]),
+    ];
+    backend.apply_2q_kraus(0, 1, &zz);
+
+    let got = backend
+        .pauli_expectations(&[
+            vec![prism_q::PauliTerm::x(0)],
+            vec![prism_q::PauliTerm::x(1)],
+            vec![prism_q::PauliTerm::x(0), prism_q::PauliTerm::x(1)],
+        ])
+        .unwrap();
+    let expected = [1.0 - 2.0 * p, 1.0 - 2.0 * p, 1.0];
+    for (i, (a, e)) in got.iter().zip(&expected).enumerate() {
+        assert!((a - e).abs() < EPS, "term {i}: expected {e}, got {a}");
+    }
+}
+
+// `reduced_density_matrix_2q` packs `t = 2*bit(q0) + bit(q1)`. On
+// (|00> + |01>)/sqrt(2), written with qubit 0 in the low state-index bit, the
+// occupied pair is t in {0, 2} when qubit 0 is named first and t in {0, 1}
+// when qubit 1 is, with every entry of the block equal to 1/2.
+#[test]
+fn statevector_two_qubit_reduced_density_matrix_orders_the_first_qubit_high() {
+    use prism_q::backend::Backend;
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+
+    let mut backend = StatevectorBackend::new(common::SEED);
+    sim::run_on(&mut backend, &c).unwrap();
+
+    for (q0, q1, occupied) in [(0usize, 1usize, [0usize, 2usize]), (1, 0, [0, 1])] {
+        let rho = backend.reduced_density_matrix_2q(q0, q1).unwrap();
+        for (t, row) in rho.iter().enumerate() {
+            for (tp, entry) in row.iter().enumerate() {
+                let expected = if occupied.contains(&t) && occupied.contains(&tp) {
+                    Complex64::new(0.5, 0.0)
+                } else {
+                    Complex64::new(0.0, 0.0)
+                };
+                assert_amplitude(*entry, expected, &format!("({q0},{q1}) rho[{t}][{tp}]"));
+            }
+        }
+    }
+}
+
+// `Gate::Fused2q` indexes its matrix `i*2 + j` with `i` on `targets[0]`, and the
+// two-qubit Kraus path relies on that packing. `diag(1, 1, -1, -1)` is `Z` on
+// the high index, so on `|++>` it takes the first-named target to `|->` and
+// leaves the other at `|+>`. A closing Hadamard on both turns that into the one
+// basis state with the first-named target set. Nothing else on the CPU path
+// pins this: the fused fixtures elsewhere are symmetric or are compared against
+// another `Fused2q`.
+#[test]
+fn fused_2q_orders_the_first_target_high() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let neg = Complex64::new(-1.0, 0.0);
+    let z_on_high = [
+        [one, zero, zero, zero],
+        [zero, one, zero, zero],
+        [zero, zero, neg, zero],
+        [zero, zero, zero, neg],
+    ];
+
+    // State index bit 0 is qubit 0, so naming qubit 0 first lands on index 1
+    // and naming qubit 1 first lands on index 2.
+    for (q0, q1, expected) in [
+        (0usize, 1usize, [0.0, 1.0, 0.0, 0.0]),
+        (1, 0, [0.0, 0.0, 1.0, 0.0]),
+    ] {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::Fused2q(Box::new(z_on_high)), &[q0, q1]);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        assert_probs(&run_and_probs(&c), &expected);
+    }
+}
+
+// A complex, non-Hermitian two-qubit Kraus operator. Every other two-qubit set
+// in the suite is real, and the Pauli depolarizing channel is invariant under
+// conjugating all its operators, so a conjugate swap in the superoperator sum
+// would survive them. `K = sqrt(p) |00><11|` moves the `|11>` population onto
+// `|00>` with an `i` phase that only the `K rho K^dagger` order reproduces.
+#[test]
+fn density_matrix_two_qubit_kraus_uses_the_conjugate_transpose() {
+    let p = 0.4f64;
+    let zero = Complex64::new(0.0, 0.0);
+    let mut keep = [[zero; 4]; 4];
+    for (t, row) in keep.iter_mut().enumerate() {
+        row[t] = Complex64::new(if t == 3 { (1.0 - p).sqrt() } else { 1.0 }, 0.0);
+    }
+    let mut jump = [[zero; 4]; 4];
+    jump[0][3] = Complex64::new(0.0, p.sqrt());
+
+    // Start from (|00> + |11>)/sqrt(2), which has coherence between the two
+    // levels the jump connects.
+    let mut c = Circuit::new(2, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+
+    let mut backend = DensityMatrixBackend::new(common::SEED);
+    sim::run_on(&mut backend, &c).unwrap();
+    backend.apply_2q_kraus(0, 1, &[keep, jump]);
+
+    // rho = 1/2 (|00><00| + |11><11|) with coherence sqrt(1-p)/2, plus the
+    // jump branch p/2 landing back on |00>. Populations: |00> = (1 + p)/2,
+    // |11> = (1 - p)/2. The jump term is |00><00| whatever the phase, so the
+    // diagonal alone does not test the conjugate; <X0 X1> does, and it reads
+    // sqrt(1-p) with the correct order.
+    let probs = backend.probabilities().unwrap();
+    assert_probs(&probs, &[(1.0 + p) / 2.0, 0.0, 0.0, (1.0 - p) / 2.0]);
+
+    let got = backend
+        .pauli_expectations(&[vec![prism_q::PauliTerm::x(0), prism_q::PauliTerm::x(1)]])
+        .unwrap();
+    assert!(
+        (got[0] - (1.0 - p).sqrt()).abs() < EPS,
+        "expected <X0 X1> = {}, got {}",
+        (1.0 - p).sqrt(),
+        got[0]
+    );
+}
+
 // ---- Start states ----
 
 // H (cos(pi/8)|0> + sin(pi/8)|1>) = ((c+s)|0> + (c-s)|1>)/sqrt(2), so

--- a/tests/noise_construction.rs
+++ b/tests/noise_construction.rs
@@ -1,0 +1,918 @@
+//! The rule-based noise builder and the channels it can reach.
+//!
+//! Channel semantics are anchored against hand-computed values in
+//! `tests/golden_small_circuits.rs`; what is pinned here is which events a rule
+//! set emits, where they land, and that the two exact routes agree.
+
+mod common;
+
+use num_complex::Complex64;
+use prism_q::circuit::{Circuit, ClassicalCondition, Instruction, guarded};
+use prism_q::sim::noise::{NoiseChannel, NoiseEvent, NoiseModel};
+use prism_q::{
+    BackendKind, CircuitBuilder, Gate, GateFilter, NoiseBuilder, PauliTerm, PrismError,
+    density_matrix_expectation_values, simulate,
+};
+use smallvec::smallvec;
+
+const SEED: u64 = 42;
+
+fn mixed_circuit() -> Circuit {
+    let mut c = Circuit::new(3, 3);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_barrier(&[0, 1, 2]);
+    c.add_reset(2);
+    c.add_gate(Gate::Rx(0.7), &[2]);
+    for q in 0..3 {
+        c.add_measure(q, q);
+    }
+    c
+}
+
+fn assert_same_events(built: &NoiseModel, manual: &NoiseModel) {
+    assert_eq!(built.after_gate.len(), manual.after_gate.len());
+    for (idx, (a, b)) in built
+        .after_gate
+        .iter()
+        .zip(manual.after_gate.iter())
+        .enumerate()
+    {
+        assert_eq!(a, b, "instruction {idx}");
+    }
+    assert_eq!(built.readout, manual.readout);
+}
+
+// Acceptance: a rule-based model reproduces the vector the manual constructor
+// builds, event for event and slot for slot.
+#[test]
+fn uniform_rule_matches_the_manual_constructor() {
+    let circuit = mixed_circuit();
+    let p = 0.012;
+    let branch = p / 3.0;
+
+    let built = NoiseBuilder::new()
+        .after_gates(
+            GateFilter::all(),
+            NoiseChannel::Pauli {
+                px: branch,
+                py: branch,
+                pz: branch,
+            },
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_same_events(&built, &NoiseModel::uniform_depolarizing(&circuit, p));
+}
+
+#[test]
+fn amplitude_damping_rule_matches_the_manual_constructor() {
+    let circuit = mixed_circuit();
+    let built = NoiseBuilder::new()
+        .after_gates(
+            GateFilter::all(),
+            NoiseChannel::AmplitudeDamping { gamma: 0.03 },
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_same_events(&built, &NoiseModel::with_amplitude_damping(&circuit, 0.03));
+}
+
+// Per-gate-type and per-qubit rates, the two selectors the constructors have no
+// way to express.
+#[test]
+fn rules_select_by_gate_name_and_by_qubit() {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::H, &[2]);
+
+    let one_qubit = NoiseChannel::Depolarizing { p: 0.001 };
+    let two_qubit = NoiseChannel::Depolarizing { p: 0.02 };
+    let noise = NoiseBuilder::new()
+        .after_gates(GateFilter::all().arity(1), one_qubit.clone())
+        .after_gates(GateFilter::all().named("cx"), two_qubit.clone())
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0], vec![event(&one_qubit, &[0])]);
+    assert_eq!(
+        noise.after_gate[1],
+        vec![event(&two_qubit, &[0]), event(&two_qubit, &[1])]
+    );
+    assert_eq!(noise.after_gate[2], vec![event(&one_qubit, &[2])]);
+
+    // The same rule narrowed to one qubit fires only there.
+    let narrowed = NoiseBuilder::new()
+        .after_gates(
+            GateFilter::all().named("cx").on_qubits([1]),
+            two_qubit.clone(),
+        )
+        .build(&circuit)
+        .unwrap();
+    assert!(narrowed.after_gate[0].is_empty());
+    assert_eq!(narrowed.after_gate[1], vec![event(&two_qubit, &[1])]);
+}
+
+fn event(channel: &NoiseChannel, qubits: &[usize]) -> NoiseEvent {
+    NoiseEvent {
+        channel: channel.clone(),
+        qubits: qubits.iter().copied().collect(),
+    }
+}
+
+// Acceptance: idle decoherence lands on the qubits a layer does not touch.
+// H on 0 and H on 1 share a layer, so only qubit 2 is idle and the single event
+// rides the layer's last instruction. A per-instruction rule would instead emit
+// two events per slot, and one that closed a layer at every instruction would
+// put an event on slot 0.
+#[test]
+fn idle_noise_fires_on_untouched_qubits_per_layer() {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::H, &[1]);
+
+    let idle = NoiseChannel::PhaseDamping { gamma: 0.02 };
+    let noise = NoiseBuilder::new()
+        .on_idle_qubits(idle.clone())
+        .build(&circuit)
+        .unwrap();
+
+    assert!(noise.after_gate[0].is_empty());
+    assert_eq!(noise.after_gate[1], vec![event(&idle, &[2])]);
+}
+
+// A circuit where every qubit is busy in every layer emits nothing. Packing
+// instructions in index order rather than greedily would split this into three
+// layers and charge two idle events against a register that never idles.
+#[test]
+fn idle_noise_charges_nothing_when_no_qubit_idles() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_gate(Gate::X, &[1]);
+
+    let noise = NoiseBuilder::new()
+        .on_idle_qubits(NoiseChannel::PhaseDamping { gamma: 0.02 })
+        .build(&circuit)
+        .unwrap();
+
+    assert!(
+        noise.after_gate.iter().all(|events| events.is_empty()),
+        "{:?}",
+        noise.after_gate
+    );
+}
+
+// A barrier synchronizes its qubits without occupying a layer, so the gate
+// after it starts a new one and the qubit the barrier crossed idles there.
+#[test]
+fn idle_noise_accounts_for_a_barrier() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_barrier(&[0, 1]);
+    circuit.add_gate(Gate::X, &[0]);
+
+    let idle = NoiseChannel::PhaseDamping { gamma: 0.02 };
+    let noise = NoiseBuilder::new()
+        .on_idle_qubits(idle.clone())
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0], vec![event(&idle, &[1])]);
+    assert!(noise.after_gate[1].is_empty());
+    assert_eq!(noise.after_gate[2], vec![event(&idle, &[1])]);
+}
+
+// A qubit left out of a circuit entirely still decoheres: amplitude damping at
+// gamma = 1 on the idle qubit of an X-prepared register drives it back to |0>,
+// so the joint distribution collapses onto the one basis state.
+#[test]
+fn idle_noise_reaches_a_qubit_no_instruction_names() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_gate(Gate::Id, &[0]);
+
+    let noise = NoiseBuilder::new()
+        .on_idle_qubits(NoiseChannel::AmplitudeDamping { gamma: 1.0 })
+        .build(&circuit)
+        .unwrap();
+
+    // Layers: {X0, X1} then {Id0}, so qubit 1 is idle in the second and decays.
+    let z = density_matrix_expectation_values(
+        &circuit,
+        &[vec![PauliTerm::z(0)], vec![PauliTerm::z(1)]],
+        Some(&noise),
+        SEED,
+    )
+    .unwrap();
+    assert!((z[0] + 1.0).abs() < 1e-12, "qubit 0 stays in |1>: {}", z[0]);
+    assert!(
+        (z[1] - 1.0).abs() < 1e-12,
+        "qubit 1 decays to |0>: {}",
+        z[1]
+    );
+}
+
+// Reset error: a deterministic X after the reset leaves the qubit in |1>.
+#[test]
+fn reset_noise_fires_after_a_reset() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_reset(0);
+
+    let noise = NoiseBuilder::new()
+        .after_resets(NoiseChannel::Pauli {
+            px: 1.0,
+            py: 0.0,
+            pz: 0.0,
+        })
+        .build(&circuit)
+        .unwrap();
+
+    assert!(noise.after_gate[0].is_empty());
+    let z =
+        density_matrix_expectation_values(&circuit, &[vec![PauliTerm::z(0)]], Some(&noise), SEED)
+            .unwrap();
+    assert!(
+        (z[0] + 1.0).abs() < 1e-12,
+        "expected |1>, got <Z> = {}",
+        z[0]
+    );
+}
+
+// Mid-circuit measurement error rides the preceding instruction's slot, so the
+// bit a conditional reads is the faulty one. Every measurement gets its own
+// deterministic flip: bit 0 reads 1 off a qubit prepared in |0>, and bit 1
+// reads 0 only if the conditional fired on that faulty bit and the second flip
+// then undid its X. A conditional that never fired would report bit 1 as 1.
+#[test]
+fn measurement_noise_reaches_the_bit_a_conditional_reads() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Id, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.instructions.push(
+        guarded(
+            ClassicalCondition::BitIsOne(0),
+            vec![Instruction::Gate {
+                gate: Gate::X,
+                targets: smallvec![1],
+            }],
+        )
+        .unwrap(),
+    );
+    circuit.add_measure(1, 1);
+
+    let noise = NoiseBuilder::new()
+        .before_measurements(NoiseChannel::Pauli {
+            px: 1.0,
+            py: 0.0,
+            pz: 0.0,
+        })
+        .build(&circuit)
+        .unwrap();
+    assert_eq!(noise.after_gate[0].len(), 1);
+    assert_eq!(noise.after_gate[0][0].qubits.as_slice(), &[0]);
+
+    let shots = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(64)
+        .unwrap();
+    for shot in &shots.shots {
+        assert_eq!(
+            shot,
+            &vec![true, false],
+            "flip must feed the guarded branch"
+        );
+    }
+}
+
+#[test]
+fn measurement_noise_needs_a_slot_before_the_measurement() {
+    let mut circuit = Circuit::new(1, 1);
+    circuit.add_measure(0, 0);
+
+    let err = NoiseBuilder::new()
+        .before_measurements(NoiseChannel::Depolarizing { p: 0.01 })
+        .build(&circuit)
+        .unwrap_err();
+    assert!(
+        matches!(&err, PrismError::InvalidParameter { message }
+            if message.contains("instruction 0 is a measurement")),
+        "{err:?}"
+    );
+}
+
+// Crosstalk names spectators through a coupling map: a Cx on (0, 1) reaches
+// qubit 2 through the 1-2 edge and nothing else, and the gate's own targets are
+// never their own spectators.
+#[test]
+fn crosstalk_fires_on_coupled_spectators_only() {
+    let mut circuit = Circuit::new(4, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+
+    let channel = NoiseChannel::Depolarizing { p: 0.005 };
+    let noise = NoiseBuilder::new()
+        .crosstalk(
+            GateFilter::all().arity(2),
+            [(0, 1), (1, 2), (2, 3)],
+            channel.clone(),
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0], vec![event(&channel, &[2])]);
+}
+
+// Two targets sharing one spectator give it a single one-qubit event, not one
+// per target.
+#[test]
+fn crosstalk_applies_a_shared_spectator_once() {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+
+    let channel = NoiseChannel::Depolarizing { p: 0.005 };
+    let noise = NoiseBuilder::new()
+        .crosstalk(
+            GateFilter::all().arity(2),
+            [(0, 2), (1, 2)],
+            channel.clone(),
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0], vec![event(&channel, &[2])]);
+}
+
+// A crosstalk rule honours the filter's qubit set: narrowing it to target 1
+// drops the spectators reached through target 0.
+#[test]
+fn crosstalk_honours_the_filter_qubit_set() {
+    let mut circuit = Circuit::new(4, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+
+    let channel = NoiseChannel::Depolarizing { p: 0.005 };
+    let noise = NoiseBuilder::new()
+        .crosstalk(
+            GateFilter::all().arity(2).on_qubits([1]),
+            [(0, 2), (1, 3)],
+            channel.clone(),
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0], vec![event(&channel, &[3])]);
+}
+
+// `on_targets` is directed, so a rule keyed on the edge (0, 1) leaves cx(1, 0)
+// alone. A coupling-map calibration table needs that distinction; `on_qubits`
+// is a set and cannot make it.
+#[test]
+fn on_targets_distinguishes_the_two_directions_of_an_edge() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::Cx, &[1, 0]);
+
+    let channel = NoiseChannel::Depolarizing { p: 0.02 };
+    let noise = NoiseBuilder::new()
+        .after_gates_joint(
+            GateFilter::all().on_targets([0, 1]),
+            NoiseChannel::TwoQubitDepolarizing { p: 0.02 },
+        )
+        .after_gates(GateFilter::all().on_targets([1, 0]), channel.clone())
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0].len(), 1);
+    assert_eq!(noise.after_gate[0][0].qubits.as_slice(), &[0, 1]);
+    assert_eq!(
+        noise.after_gate[1],
+        vec![event(&channel, &[1]), event(&channel, &[0])]
+    );
+}
+
+// A two-qubit crosstalk channel lands on the (target, spectator) pair with the
+// target first, which is the packing the channel's Kraus operators use.
+#[test]
+fn two_qubit_crosstalk_pairs_the_target_with_the_spectator() {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+
+    let noise = NoiseBuilder::new()
+        .crosstalk(
+            GateFilter::all().arity(2),
+            [(1, 2)],
+            NoiseChannel::TwoQubitDepolarizing { p: 0.004 },
+        )
+        .build(&circuit)
+        .unwrap();
+
+    assert_eq!(noise.after_gate[0].len(), 1);
+    assert_eq!(noise.after_gate[0][0].qubits.as_slice(), &[1, 2]);
+}
+
+// Coherent over-rotation: an rx(theta) under a relative excess of `eps` behaves
+// as rx(theta * (1 + eps)), so P(1) on |0> is sin^2(theta(1+eps)/2).
+#[test]
+fn over_rotation_scales_the_gate_angle() {
+    let theta = std::f64::consts::FRAC_PI_2;
+    let relative = 0.1;
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::Rx(theta), &[0]);
+
+    let noise = NoiseBuilder::new()
+        .over_rotation(GateFilter::all().named("rx"), relative)
+        .build(&circuit)
+        .unwrap();
+
+    let z =
+        density_matrix_expectation_values(&circuit, &[vec![PauliTerm::z(0)]], Some(&noise), SEED)
+            .unwrap();
+    let expected = (theta * (1.0 + relative)).cos();
+    assert!(
+        (z[0] - expected).abs() < 1e-12,
+        "expected <Z> = {expected}, got {}",
+        z[0]
+    );
+}
+
+#[test]
+fn over_rotation_skips_gates_with_no_single_angle() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+
+    let noise = NoiseBuilder::new()
+        .over_rotation(GateFilter::all(), 0.1)
+        .build(&circuit)
+        .unwrap();
+    assert!(noise.after_gate[0].is_empty());
+}
+
+// Acceptance: per-bit readout without reaching into `NoiseModel::readout`.
+#[test]
+fn per_bit_readout_is_reachable_from_both_construction_paths() {
+    let circuit = CircuitBuilder::new_with_classical(2, 2).h(0).build();
+
+    let built = NoiseBuilder::new()
+        .uniform_readout_error(0.01, 0.02)
+        .readout_error(1, 0.3, 0.4)
+        .build(&circuit)
+        .unwrap();
+    assert_eq!(built.readout[0].as_ref().unwrap().p01, 0.01);
+    assert_eq!(built.readout[1].as_ref().unwrap().p01, 0.3);
+
+    let mut manual = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+    manual.set_bit_readout_error(1, 0.3, 0.4);
+    assert!(manual.readout[0].is_none());
+    assert_eq!(manual.readout[1].as_ref().unwrap().p10, 0.4);
+}
+
+#[test]
+fn readout_error_outside_the_register_rejected() {
+    let circuit = CircuitBuilder::new_with_classical(1, 1).h(0).build();
+    let err = NoiseBuilder::new()
+        .readout_error(3, 0.1, 0.1)
+        .build(&circuit)
+        .unwrap_err();
+    assert!(
+        matches!(&err, PrismError::InvalidParameter { message }
+            if message.contains("classical bit 3")),
+        "{err:?}"
+    );
+}
+
+/// `sqrt(1-p) I` and `sqrt(p) (X (x) X)`, a correlated bit flip: the two qubits
+/// flip together or not at all, so `01` and `10` never appear.
+fn correlated_bit_flip(p: f64) -> NoiseChannel {
+    let zero = Complex64::new(0.0, 0.0);
+    let mut keep = [[zero; 4]; 4];
+    let mut flip = [[zero; 4]; 4];
+    for t in 0..4 {
+        keep[t][t] = Complex64::new((1.0 - p).sqrt(), 0.0);
+        flip[t][3 - t] = Complex64::new(p.sqrt(), 0.0);
+    }
+    NoiseChannel::Kraus2q {
+        kraus: vec![keep, flip],
+    }
+}
+
+// Acceptance: a two-qubit Kraus channel on the density matrix. The exact
+// mixture is (1-p)|00><00| + p|11><11|, hand-computed from the Kraus pair.
+#[test]
+fn two_qubit_kraus_runs_on_the_density_matrix() {
+    let p = 0.3;
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::Id, &[0]);
+
+    let noise = NoiseBuilder::new()
+        .after_gates_joint(GateFilter::all().arity(1), correlated_bit_flip(p))
+        .build(&circuit);
+    // A joint rule needs a gate whose arity matches the channel; a one-qubit
+    // gate is not one, so the rule stays silent.
+    assert!(noise.unwrap().after_gate[0].is_empty());
+
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    let noise = NoiseBuilder::new()
+        .after_gates_joint(GateFilter::all().arity(2), correlated_bit_flip(p))
+        .build(&circuit)
+        .unwrap();
+
+    let z = density_matrix_expectation_values(
+        &circuit,
+        &[
+            vec![PauliTerm::z(0)],
+            vec![PauliTerm::z(1)],
+            vec![PauliTerm::z(0), PauliTerm::z(1)],
+        ],
+        Some(&noise),
+        SEED,
+    )
+    .unwrap();
+    let expected = [1.0 - 2.0 * p, 1.0 - 2.0 * p, 1.0];
+    for (i, (a, e)) in z.iter().zip(&expected).enumerate() {
+        assert!((a - e).abs() < 1e-12, "term {i}: expected {e}, got {a}");
+    }
+}
+
+// Acceptance: the same channel on trajectories. A trajectory result is a
+// sampled estimate, so it is compared to the exact rate with a stated tolerance
+// at a fixed seed, never for equality. Three standard errors of a binomial at
+// 4096 shots and p = 0.3 is 3*sqrt(0.3*0.7/4096) = 0.0215.
+#[test]
+fn two_qubit_kraus_runs_on_trajectories() {
+    let p = 0.3;
+    let shots = 4096;
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+
+    let noise = NoiseBuilder::new()
+        .after_gates_joint(GateFilter::all().arity(2), correlated_bit_flip(p))
+        .build(&circuit)
+        .unwrap();
+
+    let result = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+
+    let mut both = 0usize;
+    for shot in &result.shots {
+        // Structural, not sampled: no operator of this channel produces a split
+        // outcome from |00>.
+        assert_eq!(
+            shot[0], shot[1],
+            "a correlated bit flip never produces a split outcome"
+        );
+        both += usize::from(shot[0]);
+    }
+    let measured = both as f64 / shots as f64;
+    assert!(
+        (measured - p).abs() < 0.0215,
+        "trajectory estimate {measured} against the exact {p}"
+    );
+}
+
+/// `sqrt(1-p) I` and `sqrt(p) (Z (x) I)`: dephasing of the high-index qubit
+/// alone, which is the first qubit the event names. Asymmetric under swapping
+/// the pair, unlike `X (x) X` or `Z (x) Z`.
+fn dephase_high_qubit(p: f64) -> NoiseChannel {
+    let zero = Complex64::new(0.0, 0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = Complex64::new(scale * sign, 0.0);
+        }
+        m
+    };
+    NoiseChannel::Kraus2q {
+        kraus: vec![
+            diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+            diag(p.sqrt(), [1.0, 1.0, -1.0, -1.0]),
+        ],
+    }
+}
+
+// The trajectory route composes three index conventions: the pair passed to
+// the two-qubit reduction, the row and column order the branch weight reads,
+// and the target order the selected operator is applied on. A channel symmetric
+// under the qubit swap tells none of them apart. Z on one qubit does: it
+// dephases whichever qubit the event names first, which reads as a loss of <X>
+// there and nowhere else, and swapping the event's qubits moves it.
+#[test]
+fn two_qubit_kraus_trajectory_dephases_the_first_named_qubit() {
+    let p = 0.5;
+    let shots = 2048;
+
+    for (q0, q1, x0, x1) in [(0usize, 1usize, 0.0, 1.0), (1, 0, 1.0, 0.0)] {
+        let mut circuit = Circuit::new(2, 2);
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::H, &[1]);
+        let mut noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+        noise.after_gate[1] = vec![NoiseEvent {
+            channel: dephase_high_qubit(p),
+            qubits: smallvec![q0, q1],
+        }];
+        // Read <X> by rotating into the Z basis before measuring.
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::H, &[1]);
+        circuit.add_measure(0, 0);
+        circuit.add_measure(1, 1);
+        noise
+            .after_gate
+            .resize_with(circuit.instructions.len(), Vec::new);
+
+        let result = simulate(&circuit)
+            .backend(BackendKind::Statevector)
+            .noise(&noise)
+            .seed(SEED)
+            .shots(shots)
+            .unwrap();
+
+        let mean = |bit: usize| {
+            let ones = result.shots.iter().filter(|s| s[bit]).count();
+            1.0 - 2.0 * (ones as f64 / shots as f64)
+        };
+        // Dephasing at p = 0.5 takes <X> to 0 on the named qubit and leaves the
+        // other at 1. Three standard errors at 2048 shots is 0.033.
+        assert!(
+            (mean(0) - x0).abs() < 0.04,
+            "({q0},{q1}) <X0>: expected {x0}, got {}",
+            mean(0)
+        );
+        assert!(
+            (mean(1) - x1).abs() < 0.04,
+            "({q0},{q1}) <X1>: expected {x1}, got {}",
+            mean(1)
+        );
+    }
+}
+
+// A branch weight that depends on the state, which every channel above hides
+// behind an effect proportional to the identity. The jump operator
+// sqrt(gamma) |00><11| has its effect supported on |11> alone, so the branch
+// rate tracks the |11> population instead of a constant, and the reduction the
+// weight is drawn from has to be the real one. Compared against the exact
+// mixture, not against another sampler.
+#[test]
+fn two_qubit_kraus_trajectory_branch_weight_reads_the_state() {
+    let gamma = 0.6f64;
+    let shots = 8192;
+    let zero = Complex64::new(0.0, 0.0);
+    let mut keep = [[zero; 4]; 4];
+    for (t, row) in keep.iter_mut().enumerate() {
+        row[t] = Complex64::new(if t == 3 { (1.0 - gamma).sqrt() } else { 1.0 }, 0.0);
+    }
+    let mut jump = [[zero; 4]; 4];
+    jump[0][3] = Complex64::new(gamma.sqrt(), 0.0);
+    let channel = NoiseChannel::Kraus2q {
+        kraus: vec![keep, jump],
+    };
+
+    // Ry puts qubit 0 at P(1) = 0.75 and the Cx copies it, so the |11> weight
+    // the jump reads is 0.75 rather than the 0.5 a Bell pair would give.
+    let theta = 2.0 * 0.25f64.sqrt().acos();
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Ry(theta), &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    let mut noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+    noise.after_gate[1] = vec![NoiseEvent {
+        channel,
+        qubits: smallvec![0, 1],
+    }];
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+    noise
+        .after_gate
+        .resize_with(circuit.instructions.len(), Vec::new);
+
+    let exact = density_matrix_expectation_values(
+        &circuit,
+        &[vec![PauliTerm::z(0)], vec![PauliTerm::z(1)]],
+        Some(&noise),
+        SEED,
+    )
+    .unwrap();
+
+    let result = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(shots)
+        .unwrap();
+    let mean = |bit: usize| {
+        let ones = result.shots.iter().filter(|s| s[bit]).count();
+        1.0 - 2.0 * (ones as f64 / shots as f64)
+    };
+
+    // Three standard errors at 8192 shots is 0.033. A weight drawn from a
+    // constant instead of the state would put <Z> at 1 - 2*0.75*(1-gamma/2),
+    // which is 0.175 away from the exact value here.
+    for (bit, expected) in exact.iter().enumerate() {
+        assert!(
+            (mean(bit) - expected).abs() < 0.035,
+            "bit {bit}: trajectory {} against the exact {expected}",
+            mean(bit)
+        );
+    }
+}
+
+// A two-qubit Kraus channel needs a backend that can reduce a pair, and only
+// the host statevector can. The rejection lands at dispatch, before a shot
+// allocates state, rather than part way through the first trajectory.
+#[test]
+fn two_qubit_kraus_rejected_on_a_backend_without_the_reduction() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+
+    let noise = NoiseBuilder::new()
+        .after_gates_joint(GateFilter::all().arity(2), correlated_bit_flip(0.1))
+        .build(&circuit)
+        .unwrap();
+
+    let err = simulate(&circuit)
+        .backend(BackendKind::Mps { max_bond_dim: 16 })
+        .noise(&noise)
+        .seed(SEED)
+        .shots(4)
+        .unwrap_err();
+    assert!(
+        matches!(&err, PrismError::IncompatibleBackend { reason, .. }
+            if reason.contains("two-qubit reduced density matrix")),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn two_qubit_kraus_rejects_a_non_trace_preserving_set() {
+    let zero = Complex64::new(0.0, 0.0);
+    let mut scaled = [[zero; 4]; 4];
+    for (t, row) in scaled.iter_mut().enumerate() {
+        row[t] = Complex64::new(0.5, 0.0);
+    }
+    let channel = NoiseChannel::Kraus2q {
+        kraus: vec![scaled],
+    };
+    assert!(channel.validate().is_err());
+    assert!(!channel.is_exactly_samplable());
+}
+
+// A guarded region leaves its body without event slots, so a model carrying
+// quantum events is still rejected. A readout-only model has nothing to lose
+// there and is accepted.
+#[test]
+fn guarded_regions_reject_quantum_events_but_not_readout_error() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.instructions.push(
+        guarded(
+            ClassicalCondition::BitIsOne(0),
+            vec![
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: smallvec![1],
+                },
+                Instruction::Reset { qubit: 1 },
+            ],
+        )
+        .unwrap(),
+    );
+
+    let with_events = NoiseBuilder::new()
+        .after_gates(GateFilter::all(), NoiseChannel::Depolarizing { p: 0.01 })
+        .build(&circuit)
+        .unwrap_err();
+    assert!(
+        matches!(&with_events, PrismError::IncompatibleBackend { reason, .. }
+            if reason.contains("guarded region")),
+        "{with_events:?}"
+    );
+
+    let readout_only = NoiseBuilder::new()
+        .uniform_readout_error(0.05, 0.05)
+        .build(&circuit)
+        .unwrap();
+    assert!(readout_only.after_gate.iter().all(|e| e.is_empty()));
+    assert!(readout_only.has_noise());
+}
+
+// The remaining single-angle rotations the rule accepts. Ry moves <X> off a
+// |0>-prepared qubit; Rz and P move <Y> off a |+>-prepared one.
+#[test]
+fn over_rotation_covers_every_rotation_it_accepts() {
+    let theta = std::f64::consts::FRAC_PI_2;
+    let relative = 0.1;
+
+    let mut ry = Circuit::new(1, 0);
+    ry.add_gate(Gate::Ry(theta), &[0]);
+    let noise = NoiseBuilder::new()
+        .over_rotation(GateFilter::all().named("ry"), relative)
+        .build(&ry)
+        .unwrap();
+    let z = density_matrix_expectation_values(&ry, &[vec![PauliTerm::z(0)]], Some(&noise), SEED)
+        .unwrap();
+    assert!(
+        (z[0] - (theta * (1.0 + relative)).cos()).abs() < 1e-12,
+        "ry: got {}",
+        z[0]
+    );
+
+    for (name, gate) in [("rz", Gate::Rz(theta)), ("p", Gate::P(theta))] {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(gate, &[0]);
+        let noise = NoiseBuilder::new()
+            .over_rotation(GateFilter::all().named(name), relative)
+            .build(&c)
+            .unwrap();
+        let y = density_matrix_expectation_values(&c, &[vec![PauliTerm::y(0)]], Some(&noise), SEED)
+            .unwrap();
+        assert!(
+            (y[0] - (theta * (1.0 + relative)).sin()).abs() < 1e-12,
+            "{name}: got {}",
+            y[0]
+        );
+    }
+}
+
+// Both dense Kraus arities reject an empty operator list and a non-finite
+// entry, and both name the variant in the message.
+#[test]
+fn dense_kraus_sets_reject_empty_and_non_finite() {
+    let zero = Complex64::new(0.0, 0.0);
+
+    let empty_1q = NoiseChannel::Custom { kraus: Vec::new() };
+    let empty_2q = NoiseChannel::Kraus2q { kraus: Vec::new() };
+    for (label, channel) in [("Custom", empty_1q), ("Kraus2q", empty_2q)] {
+        let err = channel.validate().unwrap_err();
+        assert!(
+            matches!(&err, PrismError::InvalidParameter { message }
+                if message.contains(label) && message.contains("at least one operator")),
+            "{err:?}"
+        );
+    }
+
+    let nan = Complex64::new(f64::NAN, 0.0);
+    let bad_1q = NoiseChannel::Custom {
+        kraus: vec![[[nan, zero], [zero, zero]]],
+    };
+    let mut bad_2q_op = [[zero; 4]; 4];
+    bad_2q_op[2][1] = nan;
+    let bad_2q = NoiseChannel::Kraus2q {
+        kraus: vec![bad_2q_op],
+    };
+    for (label, channel) in [("Custom", bad_1q), ("Kraus2q", bad_2q)] {
+        let err = channel.validate().unwrap_err();
+        assert!(
+            matches!(&err, PrismError::InvalidParameter { message }
+                if message.contains(label) && message.contains("must be finite")),
+            "{err:?}"
+        );
+    }
+}
+
+// Per-bit readout reaching a shot, not just the struct: bit 1 inverts on every
+// shot and bit 0 never does.
+#[test]
+fn per_bit_readout_reaches_the_reported_bits() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::Id, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+
+    let noise = NoiseBuilder::new()
+        .readout_error(1, 1.0, 1.0)
+        .build(&circuit)
+        .unwrap();
+
+    let result = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(32)
+        .unwrap();
+    for shot in &result.shots {
+        assert_eq!(shot, &vec![false, true], "only bit 1 carries readout error");
+    }
+}
+
+#[test]
+#[should_panic(expected = "outside the 2-bit register")]
+fn set_bit_readout_error_rejects_a_bit_outside_the_register() {
+    let circuit = CircuitBuilder::new_with_classical(2, 2).h(0).build();
+    let mut noise = NoiseModel::uniform_depolarizing(&circuit, 0.0);
+    noise.set_bit_readout_error(5, 0.1, 0.1);
+}


### PR DESCRIPTION
## Summary

`NoiseModel` offered three constructors, each applying one channel to every target of
every gate, so a model shaped like a device calibration table was not expressible: no
per-gate-type or per-qubit rates, no idle decoherence, no crosstalk, no coherent
over-rotation, no reset or mid-circuit measurement error, no two-qubit dense Kraus, and
readout error only uniform across bits although the backing storage was already per-bit.
`NoiseBuilder` closes that by compiling declarative rules into the same per-instruction
event vector the manual path builds, and `NoiseChannel::Kraus2q` closes the correlated
two-qubit case on both exact routes.

## Scope

- [x] New feature

## Benchmarks

Full Criterion tier, 30 samples, adjacent-binary A/B via `scripts/bench_ab.sh`.

Rule evaluation is plan-time, so the construction surface itself has no hot-path row.
What the diff does reach per shot or per instruction is the noise-event dispatch
(`apply_noise_event` grew a match arm), the density-matrix channel application
(`apply_2q_depolarizing` was rewritten to lower onto a general `apply_2q_kraus`), and
`validate_for`, which every noisy entry point calls once per run.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- | --- |
| `noisy_sampling/trajectory_pauli/non_clifford_12q_512` | 54.45 ms | 55.08 ms | +1.2% | +0.5% / +1.8% | yes, noise |
| `density_matrix/noisy_channels/depolarizing_2q/12` | 37.43 ms | 37.56 ms | +0.3% | -0.1% / +0.5% | yes, noise |
| `factored/noise_kraus/amplitude_damping/16` | 5.77 ms | 5.80 ms | +0.5% | -2.0% / +0.5% | yes, noise |
| `density_matrix/noisy_channels/kraus_depolarizing/12` | 23.40 ms | 23.48 ms | +0.3% | +0.0% / +0.7% | yes, noise |

Worst same-code control spread 2.0%. Every row is smaller than its own control, so all
four are noise rather than results in either direction.

`kraus_depolarizing/12` is the control the diff cannot reach: it sweeps the same `4^n`
buffer in the same file through `apply_1q_kraus`, whose kernel is untouched. If
`depolarizing_2q` had moved and this had not, the rewrite would be the cause; both stayed
flat.

`trajectory_pauli` is the row that had to resolve. `apply_noise_event` went from seven
match arms to eight, and it is inlined into the per-shot loop under `lto = "fat"`. That is
the shape of the 7.4% `stabilizer/scaling/500` regression an earlier change produced by
making a per-gate dispatch loop self-recursive, and nothing in this row takes the new arm.
It did not reproduce.

New rows, no `main` side to compare against:

| Benchmark | Absolute | Note |
| --- | ---: | --- |
| `noisy_sampling/trajectory_kraus_2q/non_clifford_12q_512` | 211.5 ms | Same circuit, depth, and shot count as `trajectory_pauli` at 55.1 ms, so a correlated branch costs about 3.8x a Pauli one: one `2^n` reduction plus one `2^n` gate pass plus a boxed 4x4 per event, against a single gate pass. |
| `density_matrix/noisy_channels/kraus_2q/10` | 2.46 ms | Against `depolarizing_2q/10` at 2.58 ms. |
| `density_matrix/noisy_channels/kraus_2q/12` | 37.54 ms | Against `depolarizing_2q/12` at 37.56 ms. Two Kraus operators or sixteen makes no difference; both rows read the `4^n` sweep, not the superoperator compile. |

A wider 13-row run left 11 rows unresolvable at a 40.4% worst control. Every one of them
is already recorded as unresolvable on this host, so that is host behavior rather than a
finding. Narrowing to the four rows that carry the claim took the worst control to 2.0%,
which is the run reported above. A third attempt earlier in the session read a 92% control
spread and was discarded rather than reported: a second worktree was building and testing
concurrently. The mutex convention covers `cargo bench`, but a concurrent `cargo build` or
`cargo test` voids a measurement just as thoroughly.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2330 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (17 doctests)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and signature do not carry
- [x] New channel has golden tests with hand-computed values

Channel semantics are anchored against closed-form values in
`tests/golden_small_circuits.rs`, not against another backend:

- `density_matrix_two_qubit_kraus_orders_the_first_qubit_high` pins the `t = 2*bit(q0) +
  bit(q1)` packing with an asymmetric operator, so swapping the two qubit arguments has to
  move the dephasing.
- `density_matrix_correlated_zz_dephasing_keeps_the_joint_term` separates a correlated
  channel from two local ones: `<X0 X1>` reads 1 where independent dephasing at the same
  rate would give `(1-2p)^2`.
- `density_matrix_two_qubit_kraus_uses_the_conjugate_transpose` uses a complex
  non-Hermitian operator. Every other two-qubit fixture is real, and the Pauli
  depolarizing channel is invariant under conjugating all its operators, so a conjugate
  swap in the superoperator sum would otherwise go undetected.
- `statevector_two_qubit_reduced_density_matrix_orders_the_first_qubit_high` pins the same
  packing on the reduction the trajectory branch weights are drawn from.
- `fused_2q_orders_the_first_target_high` closes a pre-existing hole rather than a new one.
  `Gate::matrix_4x4` documents that `targets[0]` indexes the high bit, and the whole
  two-qubit Kraus trajectory path rests on it, but no CPU golden pinned it: the only
  asymmetric `Fused2q` fixtures were device-gated in `tests/golden_gpu.rs`, and the rest
  compare one `Fused2q` matrix against another.

Trajectory results are compared to the exact mixture with a stated tolerance at a fixed
seed. `two_qubit_kraus_trajectory_dephases_the_first_named_qubit` uses `Z (x) I` because
the natural fixtures are swap-symmetric: with `X (x) X` or `Z (x) Z`, swapping the
reduction's qubits, swapping the `Fused2q` targets, or transposing the density-matrix
indices in the branch weight all leave the test green.
`two_qubit_kraus_trajectory_branch_weight_reads_the_state` uses a jump operator whose
effect is not proportional to the identity, so the branch rate tracks a population instead
of a constant and the reduction cannot be replaced by any trace-1 matrix.

## Hotspot notes

`apply_noise_event` (`src/sim/trajectory.rs`) is per noise event per instruction per shot
and gained one match arm. `evolve_density_matrix` swapped a `matches!` for
`NoiseChannel::num_qubits`, per instruction, against a `4^n` buffer sweep in the same
iteration. `validate_for` gained one `Vec`-header scan that short-circuits on the first
non-empty slot for any model carrying events. `apply_2q_depolarizing`'s per-call
superoperator build went from 3584 to 1536 complex multiplies and is under 0.01% of the
row at the benched widths.

`apply_custom_kraus_2q` boxes a 4x4 per event to dispatch it as a `Gate::Fused2q`, which
is an allocation on a per-shot path. Nothing else reaches that arm, so it cannot regress
an existing row, and the `trajectory_kraus_2q` absolute above is priced with it included.

## Architecture or design changes

- [x] `docs/architecture/samplers.md` and `docs/architecture/api-surface.md` updated

## Breaking changes

None for existing callers. `NoiseChannel` gains a variant, so an exhaustive external match
on it would need a new arm; `size_of::<NoiseChannel>()` is 32 before and after, since the
new payload is a `Vec` rather than an inline 4x4.

## Risks and rollback

The rule builder is additive: the three existing constructors are untouched and produce
byte-identical event vectors, pinned by `uniform_rule_matches_the_manual_constructor` and
`amplitude_damping_rule_matches_the_manual_constructor`. The riskiest edit is
`apply_2q_depolarizing`, which was rewritten to lower onto the general two-qubit Kraus
path with the block bit convention flipped so `q0` is the high bit. The individual Kraus
operators are the same set, not merely the same channel, and `depolarizing_2q/{10,12}`
measured flat; reverting that one function to its inline form restores the prior code
without touching the rest.

`Backend::supports_two_qubit_kraus` is the dispatch guard for the new channel. It defaults
to false, so a backend that cannot answer the two-qubit reduction is rejected before a
shot allocates state rather than part way through a trajectory.

One decision worth a reviewer's attention: `validate_for` still rejects
`Instruction::Region` when the model carries any quantum event, because event slots are
indexed per top-level instruction and a region body has none, so it would run silently
noiseless. Retiring that fully needs the event stream keyed by something other than a
top-level index, which `compile_noisy`, the homological builder, and
`evolve_density_matrix` all walk today. The rejection is narrowed instead: a model
carrying only readout error has nothing to lose in a region body and is now accepted,
which makes noisy feed-forward reachable for readout error and not for quantum channels.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
