### PR TITLE
feat(circuit): else, switch, and QEC feed-forward on guarded regions

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2369,6 +2369,164 @@ fn bench_density_matrix_noisy_shots(c: &mut Criterion) {
     group.finish();
 }
 
+/// Clifford layers over `n` qubits, emitted either as bare instructions or as
+/// one guarded region per layer.
+///
+/// The guard holds for every layer, so both forms execute the same gates.
+fn layered_clifford_body(circuit: &mut Circuit, n: usize, depth: usize, seed: u64) {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let cliffords = [Gate::H, Gate::S, Gate::Sdg, Gate::X, Gate::Y, Gate::Z];
+    for layer in 0..depth {
+        for q in 0..n {
+            let pick = rng.random_range(0..cliffords.len());
+            circuit.add_gate(cliffords[pick].clone(), &[q]);
+        }
+        for q in ((layer % 2)..n - 1).step_by(2) {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+}
+
+fn guarded_layers_circuit(n: usize, depth: usize, guard: Option<ClassicalCondition>) -> Circuit {
+    let mut circuit = Circuit::new(n, 1);
+    circuit.add_measure(0, 0);
+    for layer in 0..depth {
+        let mut body = Circuit::new(n, 1);
+        layered_clifford_body(&mut body, n, 1, SEED ^ layer as u64);
+        match &guard {
+            Some(condition) => {
+                if let Some(region) =
+                    prism_q::circuit::guarded(condition.clone(), body.instructions)
+                {
+                    circuit.instructions.push(region);
+                }
+            }
+            None => circuit.instructions.extend(body.instructions),
+        }
+    }
+    circuit
+}
+
+/// What a guard costs: identical Clifford layers, once wrapped in a per-layer
+/// guarded region that always holds and once emitted bare.
+///
+/// The statevector pair is dominated by fusion rather than by the branch, since
+/// no pass fuses inside a region body or across its boundary. The `nofuse_`
+/// pair on the stabilizer backend, which declines fused gates so the pass is
+/// skipped on both sides, is the one that prices the branch alone.
+fn bench_dynamic_guarded_region(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dynamic/guarded_region");
+    configure_group(&mut group);
+
+    for &n in &[16usize, 20] {
+        let taken = ClassicalCondition::BitIsZero(0);
+        let guarded_circuit = guarded_layers_circuit(n, 20, Some(taken));
+        let plain_circuit = guarded_layers_circuit(n, 20, None);
+
+        group.bench_function(format!("{n}"), |b| {
+            b.iter(|| run_with(BackendKind::Statevector, &guarded_circuit, SEED).unwrap());
+        });
+        group.bench_function(format!("unguarded_{n}"), |b| {
+            b.iter(|| run_with(BackendKind::Statevector, &plain_circuit, SEED).unwrap());
+        });
+
+        // The stabilizer backend declines fused gates, so the fusion pass is
+        // skipped for both forms and the pair prices the branch alone.
+        group.bench_function(format!("nofuse_{n}"), |b| {
+            b.iter(|| run_with(BackendKind::Stabilizer, &guarded_circuit, SEED).unwrap());
+        });
+        group.bench_function(format!("nofuse_unguarded_{n}"), |b| {
+            b.iter(|| run_with(BackendKind::Stabilizer, &plain_circuit, SEED).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+/// A region guarded on a bit no preceding measurement writes, so it can never
+/// be taken. Prices the coarse sampling predicate: the `absent` row is the same
+/// circuit with the region deleted.
+fn dead_region_circuit(n: usize, with_region: bool) -> Circuit {
+    let mut circuit = Circuit::new(n, n);
+    if with_region {
+        let mut body = Circuit::new(n, n);
+        body.add_gate(Gate::X, &[0]);
+        body.add_gate(Gate::Cx, &[0, 1]);
+        if let Some(region) =
+            prism_q::circuit::guarded(ClassicalCondition::BitIsOne(n - 1), body.instructions)
+        {
+            circuit.instructions.push(region);
+        }
+    }
+    layered_clifford_body(&mut circuit, n, 10, SEED);
+    for q in 0..n {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn bench_dynamic_dead_region(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dynamic/dead_region");
+    configure_group(&mut group);
+
+    for &n in &[16usize, 20] {
+        let with_region = dead_region_circuit(n, true);
+        let without_region = dead_region_circuit(n, false);
+
+        group.bench_function(format!("{n}"), |b| {
+            b.iter(|| run_shots_with(BackendKind::Auto, &with_region, 1_000, SEED).unwrap());
+        });
+        group.bench_function(format!("absent_{n}"), |b| {
+            b.iter(|| run_shots_with(BackendKind::Auto, &without_region, 1_000, SEED).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+/// A region that genuinely branches on a measured bit, so the run replays once
+/// per shot. The `terminal` row is the same circuit with the region deleted,
+/// which samples one evolved distribution.
+fn shot_cliff_circuit(n: usize, with_region: bool) -> Circuit {
+    let mut circuit = Circuit::new(n, n);
+    layered_clifford_body(&mut circuit, n, 6, SEED);
+    circuit.add_measure(0, 0);
+    if with_region {
+        let mut body = Circuit::new(n, n);
+        body.add_gate(Gate::X, &[1]);
+        body.add_gate(Gate::Cx, &[1, 2]);
+        if let Some(region) =
+            prism_q::circuit::guarded(ClassicalCondition::BitIsOne(0), body.instructions)
+        {
+            circuit.instructions.push(region);
+        }
+    }
+    for q in 1..n {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+fn bench_dynamic_shots(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dynamic/shots");
+    configure_group(&mut group);
+
+    let n = 16;
+    let with_region = shot_cliff_circuit(n, true);
+    let without_region = shot_cliff_circuit(n, false);
+
+    for &shots in &[1_000usize, 10_000] {
+        group.bench_function(format!("{shots}"), |b| {
+            b.iter(|| run_shots_with(BackendKind::Auto, &with_region, shots, SEED).unwrap());
+        });
+        group.bench_function(format!("terminal_{shots}"), |b| {
+            b.iter(|| run_shots_with(BackendKind::Auto, &without_region, shots, SEED).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
 /// Neutrality row: an untouched statevector row re-run under a density-matrix
 /// group name. The density-matrix backend shares no kernels with the
 /// statevector path, so this must stay within the 5% regression gate.
@@ -2484,6 +2642,10 @@ criterion_group! {
     bench_density_matrix_unitary_layers,
     bench_density_matrix_noisy_channels,
     bench_density_matrix_noisy_shots,
-    bench_density_matrix_neutrality
+    bench_density_matrix_neutrality,
+    // Dynamic circuits (guard cost, dead-region predicate, per-shot cliff)
+    bench_dynamic_guarded_region,
+    bench_dynamic_dead_region,
+    bench_dynamic_shots
 }
 criterion_main!(benches);

--- a/docs/architecture/ir.md
+++ b/docs/architecture/ir.md
@@ -51,6 +51,29 @@ probabilities) reject a region for the same reason they reject a bare
 conditional. Noise models index one event slot per instruction, so they reject a
 region rather than leave its body noiseless.
 
+`Circuit::fold_static_guards` runs once per shots or counts call and resolves the
+guards that cannot depend on a measurement. A condition reading only bits no preceding
+measurement writes is a function of the initial classical state, which every
+backend zeroes, so the guard is statically dead or statically taken and is
+dropped or inlined. That returns a circuit whose only guard can never fire to
+the terminal-measurement sampling path, worth 252x on `dynamic/dead_region/16`
+at 1000 shots. A circuit with no guard borrows through unchanged.
+
+### Condition language
+
+`ClassicalCondition` is a pure function of a bit slice: `BitIsOne`, `BitIsZero`,
+`RegisterEquals` and `RegisterNotEquals` over a contiguous range read as `u64`,
+and `Parity` over an arbitrary bit set compared against an expected value. The
+bit set is boxed, so the enum stays at the size the register variants set. The
+language is closed under negation (`ClassicalCondition::negate`), which is what
+lets `else` lower rather than grow the instruction.
+
+`else` emits the `then` guard followed by a second guard carrying the negated
+condition, and `switch` emits one `RegisterEquals` guard per case label with the
+`default` arm nested once per label to spell the conjunction of their negations.
+Both lowerings re-read the classical bits after an earlier body has run, so the
+parser rejects a source whose body measures into a bit its own guard reads.
+
 ## Gate enum
 
 `Gate` is a `Clone` enum kept at **16 bytes**. Simple variants carry parameters inline. Composite variants use `Box` to stay within the 16-byte budget for cache-friendly dispatch.

--- a/docs/architecture/qec-ir.md
+++ b/docs/architecture/qec-ir.md
@@ -8,12 +8,36 @@ OpenQASM semantics.
 
 `QecOp` stores gates, basis measurements, MPP-style Pauli-product
 measurements, resets, detector rows, observable includes, expectation-value
-metadata, postselection predicates, noise annotations, and tick separators.
+metadata, postselection predicates, feed-forward corrections, noise
+annotations, and tick separators.
 Record references can be absolute indices or `rec[-k]` style lookbacks.
 Construction validates qubit bounds, gate arity, finite coordinates and
 coefficients, finite probabilities, and measurement-record scope. Detector,
 observable, and postselection rows can be resolved to absolute measurement
 indices for later compilation into packed samplers.
+
+## Feed-forward
+
+`QecOp::Feedforward` conditions a body on the parity of a record list against an
+expected value, the shape a detector already has. It is a consumer of the
+guarded-region contract rather than a second conditional mechanism: the QEC
+record space and the classical bit vector are one address space, because the
+reference runner writes record `i` to classical bit `i`, so a resolved record
+index is directly the bit a `ClassicalCondition::Parity` reads. The op executes
+as the guarded instruction `circuit::guarded` picks for its body: a `Region`
+through `Backend::apply_region`, or a `Conditional` when the body is one gate.
+
+The body admits gates and resets only. Detectors and observables index the
+record space absolutely, so a measurement whose execution depended on a record
+would make every later index depend on the shot.
+
+The compiled QEC sampler evaluates a static affine map from random bits to
+outcomes, which a record-conditioned branch makes depend on the sample. It
+rejects by name and points at `run_qec_program_reference`, as do the deferred
+lowering and the density-matrix estimator. The detector-error-model derivation
+inherits the deferred lowering's rejection rather than carrying its own. The op
+is built through `QecProgram::feedforward`; the native text format does not
+spell it.
 
 ## Parsing
 

--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -69,6 +69,10 @@ OpenQASM 2.0 syntax also works: `qreg q[3];` / `creg c[3];` declarations and
 - Classical `if` conditionals, guarding either a single statement or a braced
   body. A braced body admits any supported statement, `measure` and `reset`
   included, and may nest.
+- `else` and `else if` arms, and `switch` with `case` and `default` arms. Both
+  lower to guards on the existing condition language rather than new syntax in
+  the IR.
+- Parity conditions, `if (c[0] ^ c[2])` or `if ((c[0] ^ c[2]) == 0)`.
 - Multi-register broadcast, `barrier`, and an expression evaluator with math functions.
 
 ```qasm
@@ -83,9 +87,16 @@ if (c[0]) {
 ```
 
 ```admonish warning title="Not supported"
-`for` / `while` loops, subroutines, and classical expressions beyond `if`. A construct
-that parses as valid OpenQASM but is unsupported returns `UnsupportedConstruct` rather
-than panicking; see the [Error Model](../architecture/api-surface.md).
+`while` loops and classical expressions beyond the condition language. A `for` loop
+with a compile-time trip count unrolls at parse time; a `def` subroutine inlines at
+its call site, but only a unitary one. A construct that parses as valid OpenQASM but
+is unsupported returns `UnsupportedConstruct` rather than panicking; see the
+[Error Model](../architecture/api-surface.md).
+
+`else` is rejected when the `if` body measures into a bit the condition reads, and
+`switch` when any arm measures into the switched register. Both lower to a chain of
+guards that re-read the classical bits, so such a source could otherwise take two arms
+of one choice. An `else` body may write freely: nothing re-reads after it.
 ```
 
 ```admonish note title="Qubit ordering"

--- a/src/circuit/draw.rs
+++ b/src/circuit/draw.rs
@@ -108,6 +108,18 @@ fn condition_label(condition: &ClassicalCondition) -> String {
             size,
             value,
         } => format!("c[{}..{}]!={}", offset, offset + size, value),
+        ClassicalCondition::Parity { bits, expected } => {
+            let terms = bits
+                .iter()
+                .map(|bit| format!("c[{bit}]"))
+                .collect::<Vec<_>>()
+                .join("^");
+            if *expected {
+                terms
+            } else {
+                format!("!({terms})")
+            }
+        }
     }
 }
 

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -31,6 +31,7 @@ pub use prepared::PreparedCircuit;
 use crate::gates::{Gate, PauliRotData};
 use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 pub use smallvec::{SmallVec, smallvec};
+use std::borrow::Cow;
 
 /// A quantum circuit in PRISM-Q's internal representation.
 #[derive(Debug, Clone)]
@@ -298,6 +299,38 @@ impl Circuit {
             }
         }
         true
+    }
+
+    /// Drop guards whose condition no measurement can reach, and inline the
+    /// ones that must be taken. Borrows unchanged when nothing folds.
+    ///
+    /// A condition reading only bits no preceding measurement writes evaluates
+    /// against the initial classical state, which every backend zeroes.
+    pub fn fold_static_guards(&self) -> Cow<'_, Circuit> {
+        let guarded = self.instructions.iter().any(|inst| {
+            matches!(
+                inst,
+                Instruction::Conditional { .. } | Instruction::Region(_)
+            )
+        });
+        if !guarded {
+            return Cow::Borrowed(self);
+        }
+        let mut state = FoldState {
+            written: vec![false; self.num_classical_bits],
+            zeros: vec![false; self.num_classical_bits],
+            folded: false,
+        };
+        let mut instructions = Vec::with_capacity(self.instructions.len());
+        fold_static_guards_into(&self.instructions, &mut state, &mut instructions);
+        if !state.folded {
+            return Cow::Borrowed(self);
+        }
+        Cow::Owned(Circuit {
+            num_qubits: self.num_qubits,
+            num_classical_bits: self.num_classical_bits,
+            instructions,
+        })
     }
 
     /// Extract the qubit-to-classical-bit mapping from all measurements.
@@ -930,9 +963,48 @@ pub enum ClassicalCondition {
         size: usize,
         value: u64,
     },
+    /// True when the XOR of the listed bits equals `expected`.
+    ///
+    /// The bits need not be contiguous, which is what a register comparison
+    /// cannot express and what a detector-style predicate over measurement
+    /// records needs. Boxed to keep the enum at the size the register variants
+    /// already set. An empty bit list has parity zero and no OpenQASM form, so
+    /// [`qasm_export`] rejects it.
+    Parity { bits: Box<[usize]>, expected: bool },
 }
 
 impl ClassicalCondition {
+    /// The condition that holds exactly when this one does not. Total: the
+    /// language is closed under negation.
+    pub fn negate(&self) -> ClassicalCondition {
+        match self {
+            ClassicalCondition::BitIsOne(bit) => ClassicalCondition::BitIsZero(*bit),
+            ClassicalCondition::BitIsZero(bit) => ClassicalCondition::BitIsOne(*bit),
+            ClassicalCondition::RegisterEquals {
+                offset,
+                size,
+                value,
+            } => ClassicalCondition::RegisterNotEquals {
+                offset: *offset,
+                size: *size,
+                value: *value,
+            },
+            ClassicalCondition::RegisterNotEquals {
+                offset,
+                size,
+                value,
+            } => ClassicalCondition::RegisterEquals {
+                offset: *offset,
+                size: *size,
+                value: *value,
+            },
+            ClassicalCondition::Parity { bits, expected } => ClassicalCondition::Parity {
+                bits: bits.clone(),
+                expected: !expected,
+            },
+        }
+    }
+
     pub fn evaluate(&self, classical_bits: &[bool]) -> bool {
         match self {
             ClassicalCondition::BitIsOne(bit) => classical_bits[*bit],
@@ -959,6 +1031,11 @@ impl ClassicalCondition {
                 } else {
                     !eq
                 }
+            }
+            ClassicalCondition::Parity { bits, expected } => {
+                bits.iter()
+                    .fold(false, |acc, &bit| acc ^ classical_bits[bit])
+                    == *expected
             }
         }
     }
@@ -1101,6 +1178,104 @@ fn for_each_measure(instructions: &[Instruction], visit: &mut impl FnMut(usize, 
     }
 }
 
+/// Which classical bits a preceding measurement may have written, plus the
+/// all-zero vector a statically decidable condition evaluates against.
+struct FoldState {
+    written: Vec<bool>,
+    zeros: Vec<bool>,
+    folded: bool,
+}
+
+impl FoldState {
+    /// `Some(value)` when no preceding measurement can have written a bit the
+    /// condition reads, so its value is fixed before the run starts.
+    fn static_value(&self, condition: &ClassicalCondition) -> Option<bool> {
+        let mut read = Vec::new();
+        collect_condition_bits(condition, &mut read);
+        if read
+            .iter()
+            .any(|&bit| bit >= self.written.len() || self.written[bit])
+        {
+            return None;
+        }
+        Some(condition.evaluate(&self.zeros))
+    }
+
+    fn mark_written(&mut self, body: &[Instruction]) {
+        let written = &mut self.written;
+        for_each_measure(body, &mut |_, classical_bit| {
+            if let Some(slot) = written.get_mut(classical_bit) {
+                *slot = true;
+            }
+        });
+    }
+}
+
+fn fold_static_guards_into(
+    instructions: &[Instruction],
+    state: &mut FoldState,
+    out: &mut Vec<Instruction>,
+) {
+    for inst in instructions {
+        match inst {
+            Instruction::Measure { classical_bit, .. } => {
+                if let Some(slot) = state.written.get_mut(*classical_bit) {
+                    *slot = true;
+                }
+                out.push(inst.clone());
+            }
+            Instruction::Conditional {
+                condition,
+                gate,
+                targets,
+            } => match state.static_value(condition) {
+                Some(true) => {
+                    state.folded = true;
+                    out.push(Instruction::Gate {
+                        gate: gate.clone(),
+                        targets: targets.clone(),
+                    });
+                }
+                Some(false) => state.folded = true,
+                None => out.push(inst.clone()),
+            },
+            Instruction::Region(region) => match state.static_value(region.condition()) {
+                Some(true) => {
+                    state.folded = true;
+                    fold_static_guards_into(region.body(), state, out);
+                }
+                Some(false) => state.folded = true,
+                None => {
+                    state.mark_written(region.body());
+                    out.push(inst.clone());
+                }
+            },
+            Instruction::Gate { .. } | Instruction::Reset { .. } | Instruction::Barrier { .. } => {
+                out.push(inst.clone())
+            }
+        }
+    }
+}
+
+/// True when a measurement anywhere in `body` writes a bit `condition` reads.
+///
+/// Lowering `else` and `switch` to a chain of guarded regions is only sound
+/// while this is false. Each region in the chain re-evaluates its condition
+/// after the earlier bodies have run, so a body that rewrites its own guard bits
+/// could take two arms of what the source wrote as one choice.
+pub(crate) fn body_writes_condition_bits(
+    body: &[Instruction],
+    condition: &ClassicalCondition,
+) -> bool {
+    let mut read = Vec::new();
+    collect_condition_bits(condition, &mut read);
+    let mut written = false;
+    for_each_measure(body, &mut |_, classical_bit| {
+        written |= read.contains(&classical_bit)
+    });
+    written
+}
+
 fn collect_condition_bits(condition: &ClassicalCondition, out: &mut Vec<usize>) {
     match condition {
         ClassicalCondition::BitIsOne(bit) | ClassicalCondition::BitIsZero(bit) => out.push(*bit),
@@ -1108,6 +1283,7 @@ fn collect_condition_bits(condition: &ClassicalCondition, out: &mut Vec<usize>) 
         | ClassicalCondition::RegisterNotEquals { offset, size, .. } => {
             out.extend(*offset..offset.saturating_add(*size))
         }
+        ClassicalCondition::Parity { bits, .. } => out.extend_from_slice(bits),
     }
 }
 
@@ -1151,6 +1327,10 @@ fn remap_condition(
             offset: cbit(*offset),
             size: *size,
             value: *value,
+        },
+        ClassicalCondition::Parity { bits, expected } => ClassicalCondition::Parity {
+            bits: bits.iter().map(|&bit| cbit(bit)).collect(),
+            expected: *expected,
         },
     }
 }
@@ -1299,6 +1479,21 @@ mod tests {
         };
         assert!(reg_ne(0b100).evaluate(&bits));
         assert!(!reg_ne(0b101).evaluate(&bits));
+
+        let parity = |list: &[usize], expected| ClassicalCondition::Parity {
+            bits: list.to_vec().into(),
+            expected,
+        };
+        assert!(parity(&[0, 1], true).evaluate(&bits), "one bit set is odd");
+        assert!(!parity(&[0, 2], true).evaluate(&bits), "two set is even");
+        assert!(parity(&[0, 2], false).evaluate(&bits));
+        assert!(parity(&[0], true).evaluate(&bits), "one bit is a bit test");
+        assert!(
+            !parity(&[0, 0], true).evaluate(&bits),
+            "a bit cancels itself"
+        );
+        assert!(!parity(&[], true).evaluate(&bits), "no bits is parity zero");
+        assert!(parity(&[], false).evaluate(&bits));
     }
 
     #[test]

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -23,6 +23,10 @@
 //! | Conditional bit literal | `if (c[0] == 1) x q[0];` | Bit equality vs `0` / `1` |
 //! | Conditional negation | `if (!c[0]) x q[0];` | Negated bit truthy test |
 //! | Guarded region | `if (c[0]) { x q[0]; measure q[1] -> c[1]; }` | Braced body, any statement, nestable |
+//! | Conditional parity | `if (c[0] ^ c[2]) x q[0];` | Parity over bits, optionally `(...) == 0` |
+//! | Else arm | `if (c[0]) { ... } else { ... }` | Lowers to a second guard on the negated condition |
+//! | Else-if chain | `if (c[0]) { ... } else if (c[1]) { ... }` | Nests under the negated arm |
+//! | Switch | `switch (c) { case 0 { ... } default { ... } }` | Lowers to one guard per case label |
 //! | Hex / binary literals | `if (c == 0xff) ...` | `0x`, `0b`, `0o` integer prefixes with optional `_` separators |
 //! | Boolean literals | `rx(true * pi) ...` | `true` / `false` evaluate to `1.0` / `0.0` |
 //! | Gate definition | `gate rxx(t) a,b { ... }` | User-defined gates |
@@ -33,7 +37,7 @@
 //!
 //! # Unsupported constructs (return `PrismError::UnsupportedConstruct`)
 //!
-//! - `defcal`, `extern`, `opaque`, `box`, `while`, `switch`, `else`
+//! - `defcal`, `extern`, `opaque`, `box`, `while`, `return`, `break`
 //! - `def` bodies that contain `measure`, `reset`, `bit`, `creg`, `return`,
 //!   or the `=measure` assignment shape (V1 supports unitary subroutines only)
 //! - `def` declarations with a return type
@@ -41,6 +45,10 @@
 //! - `pow(k) @` with non-integer k (fractional powers)
 //! - Bit literal comparisons against integers other than `0` / `1`
 //! - Negative integer literals in `if` register comparisons
+//! - `else` whose `if` body measures into a bit the condition reads, and
+//!   `switch` whose arm measures into the switched register: both lowerings
+//!   re-read the bits after an earlier body ran
+//! - `switch` with a `default` and more case labels than the region depth bound
 //! - `duration`, `stretch` outside `def` parameter lists
 //!
 //! # Error behaviour
@@ -110,6 +118,7 @@ enum BlockKind {
     Def,
     For,
     If,
+    Switch,
 }
 
 #[derive(Clone, Copy)]
@@ -179,6 +188,7 @@ fn block_kind_name(kind: BlockKind) -> &'static str {
         BlockKind::Def => "def",
         BlockKind::For => "for",
         BlockKind::If => "if",
+        BlockKind::Switch => "switch",
     }
 }
 
@@ -226,6 +236,169 @@ fn find_matching_close_paren(s: &str) -> Option<usize> {
         }
     }
     None
+}
+
+/// True when the next statement after a closed `if` block is its `else`.
+///
+/// An `else` on its own line would otherwise reach the top-level dispatcher,
+/// which rejects the keyword by name.
+fn awaits_else(kind: BlockKind, lines: &[&str], line_idx: usize) -> bool {
+    if kind != BlockKind::If {
+        return false;
+    }
+    lines[line_idx + 1..]
+        .iter()
+        .map(|line| strip_comment(line).trim())
+        .find(|line| !line.is_empty())
+        .is_some_and(|line| strip_leading_keyword(line, "else").is_some())
+}
+
+/// True for an unbraced `if` whose `else` sits on a later line, which has to
+/// buffer so both arms reach the same parse.
+fn opens_split_else(line: &str, lines: &[&str], line_idx: usize) -> bool {
+    strip_leading_keyword(line, "if").is_some()
+        && !line.contains('{')
+        && awaits_else(BlockKind::If, lines, line_idx)
+}
+
+/// Split an unbraced `if` body at its `else`, or return the whole body when it
+/// has none.
+fn split_at_else(s: &str) -> (&str, &str) {
+    let mut depth = 0usize;
+    for (index, _) in s.char_indices() {
+        match s.as_bytes()[index] {
+            b'{' => depth += 1,
+            b'}' => depth = depth.saturating_sub(1),
+            b'e' if depth == 0 && strip_leading_keyword(&s[index..], "else").is_some() => {
+                let preceded_by_word = s[..index]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '_');
+                if !preceded_by_word {
+                    return (&s[..index], &s[index..]);
+                }
+            }
+            _ => {}
+        }
+    }
+    (s, "")
+}
+
+/// True when a buffered block ends on the `else` keyword, so its arm is still
+/// on a later line.
+fn ends_on_bare_else(buf: &str) -> bool {
+    let trimmed = buf.trim_end();
+    let Some(head) = trimmed.strip_suffix("else") else {
+        return false;
+    };
+    !head.ends_with(|c: char| c.is_alphanumeric() || c == '_')
+}
+
+/// Strip `keyword` when it opens `s` as a whole word, returning the rest.
+fn strip_leading_keyword<'a>(s: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = s.trim_start().strip_prefix(keyword)?;
+    if rest.starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(rest.trim_start())
+}
+
+/// Split a leading `{ ... }` off `s`, returning the body and what follows it.
+fn split_braced_body<'a>(s: &'a str, line_num: usize, what: &str) -> Result<(&'a str, &'a str)> {
+    let s = s.trim_start();
+    let open = s.find('{').ok_or_else(|| PrismError::Parse {
+        line: line_num,
+        message: format!("expected `{{` in `{what}` body"),
+    })?;
+    if !s[..open].trim().is_empty() {
+        return Err(PrismError::Parse {
+            line: line_num,
+            message: format!("unexpected `{}` before `{what}` body", s[..open].trim()),
+        });
+    }
+    let after = &s[open + 1..];
+    let close = find_matching_close_brace(after).ok_or_else(|| PrismError::Parse {
+        line: line_num,
+        message: format!("unmatched `{{` in `{what}` body"),
+    })?;
+    Ok((&after[..close], &after[close + 1..]))
+}
+
+/// One `case` or `default` arm of a `switch`; `labels_src` is `None` for
+/// `default`.
+struct SwitchArm<'a> {
+    labels_src: Option<&'a str>,
+    body: &'a str,
+}
+
+fn split_switch_arms<'a>(src: &'a str, line_num: usize) -> Result<Vec<SwitchArm<'a>>> {
+    let mut out = Vec::new();
+    let mut rest = src.trim();
+    while !rest.is_empty() {
+        if let Some(after) = strip_leading_keyword(rest, "case") {
+            let open = after.find('{').ok_or_else(|| PrismError::Parse {
+                line: line_num,
+                message: "expected `{` after `switch` case labels".to_string(),
+            })?;
+            let (body, tail) = split_braced_body(&after[open..], line_num, "case")?;
+            out.push(SwitchArm {
+                labels_src: Some(&after[..open]),
+                body,
+            });
+            rest = tail.trim();
+        } else if let Some(after) = strip_leading_keyword(rest, "default") {
+            let (body, tail) = split_braced_body(after, line_num, "default")?;
+            out.push(SwitchArm {
+                labels_src: None,
+                body,
+            });
+            rest = tail.trim();
+        } else {
+            let word = rest
+                .split(|c: char| c.is_whitespace() || c == '(' || c == '{')
+                .next()
+                .unwrap_or(rest);
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("expected `case` or `default` in `switch` body, got `{word}`"),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Wrap `body` in one negated-equality region per case label, which is how a
+/// conjunction is spelled in a condition language that has no `and`.
+fn nest_default_arm(
+    offset: usize,
+    size: usize,
+    labels: &[u64],
+    body: Vec<Instruction>,
+    region_depth: usize,
+    line_num: usize,
+) -> Result<Vec<Instruction>> {
+    // The nesting the default costs is on top of wherever the `switch` sits, so
+    // the bound is the sum rather than the label count alone.
+    if region_depth + labels.len() > MAX_REGION_DEPTH {
+        return Err(PrismError::Parse {
+            line: line_num,
+            message: format!(
+                "`switch` with a `default` nests one region per case label and would \
+                 pass the depth bound of {MAX_REGION_DEPTH} at {} labels",
+                labels.len()
+            ),
+        });
+    }
+    let mut current = body;
+    for &value in labels.iter().rev() {
+        let condition = ClassicalCondition::RegisterNotEquals {
+            offset,
+            size,
+            value,
+        };
+        current = guarded(condition, current).into_iter().collect();
+    }
+    Ok(current)
 }
 
 fn find_matching_close_brace(s: &str) -> Option<usize> {
@@ -492,14 +665,25 @@ impl<'a> Parser<'a> {
                 state.buf.push(' ');
                 state.buf.push_str(line);
                 state.depth = update_brace_depth(state.depth, line);
-                if state.depth == 0 {
-                    let finished = block.take().unwrap();
-                    instructions.extend(self.dispatch_block(&finished)?);
-                }
-                continue;
+            } else if opens_split_else(line, lines, line_idx) {
+                block = Some(BlockState {
+                    kind: BlockKind::If,
+                    buf: line.to_string(),
+                    start_line: line_num,
+                    depth: 0,
+                });
+            } else {
+                instructions.extend(self.process_top_line(line, line_num, &mut block)?);
             }
 
-            instructions.extend(self.process_top_line(line, line_num, &mut block)?);
+            if let Some(state) = block.as_ref()
+                && state.depth == 0
+                && !awaits_else(state.kind, lines, line_idx)
+                && !ends_on_bare_else(&state.buf)
+            {
+                let finished = block.take().unwrap();
+                instructions.extend(self.dispatch_block(&finished)?);
+            }
         }
 
         if let Some(state) = block {
@@ -528,8 +712,9 @@ impl<'a> Parser<'a> {
 
         // A braced `if` is a guarded region and takes the block path; the
         // one-statement `if (c) x q[0];` form has no brace and falls through to
-        // `parse_if_statement` below.
-        if matches!(first_word, "gate" | "def" | "for")
+        // `parse_if_statement` below. The caller dispatches the block once its
+        // braces balance and no `else` follows.
+        if matches!(first_word, "gate" | "def" | "for" | "switch")
             || (first_word == "if" && line.contains('{'))
         {
             let kind = match first_word {
@@ -537,18 +722,9 @@ impl<'a> Parser<'a> {
                 "def" => BlockKind::Def,
                 "for" => BlockKind::For,
                 "if" => BlockKind::If,
+                "switch" => BlockKind::Switch,
                 _ => unreachable!(),
             };
-            let depth = update_brace_depth(0, line);
-            if line.contains('{') && depth == 0 {
-                let state = BlockState {
-                    kind,
-                    buf: line.to_string(),
-                    start_line: line_num,
-                    depth: 0,
-                };
-                return self.dispatch_block(&state);
-            }
             if !line.contains('{') {
                 return Err(PrismError::Parse {
                     line: line_num,
@@ -559,7 +735,7 @@ impl<'a> Parser<'a> {
                 kind,
                 buf: line.to_string(),
                 start_line: line_num,
-                depth,
+                depth: update_brace_depth(0, line),
             });
             return Ok(Vec::new());
         }
@@ -610,15 +786,24 @@ impl<'a> Parser<'a> {
         }
 
         if line.starts_with("if") {
-            return self.parse_if_statement(line, line_num);
+            if split_at_else(line).1.is_empty() {
+                return self.parse_if_statement(line, line_num);
+            }
+            return self.parse_if_block(line, line_num);
         }
 
+        // Recomputed: the trailing `;` is gone now, so a bare `break;` reports
+        // the keyword rather than falling through to gate parsing.
+        let keyword = line
+            .split(|c: char| c.is_whitespace() || c == '(')
+            .next()
+            .unwrap_or(line);
         if matches!(
-            first_word,
-            "defcal" | "opaque" | "while" | "switch" | "box" | "extern" | "return" | "else"
+            keyword,
+            "defcal" | "opaque" | "while" | "box" | "extern" | "return" | "else" | "break"
         ) {
             return Err(PrismError::UnsupportedConstruct {
-                construct: first_word.to_string(),
+                construct: keyword.to_string(),
                 line: line_num,
             });
         }
@@ -638,6 +823,7 @@ impl<'a> Parser<'a> {
             }
             BlockKind::For => self.expand_for_block(&state.buf, state.start_line),
             BlockKind::If => self.parse_if_block(&state.buf, state.start_line),
+            BlockKind::Switch => self.parse_switch_block(&state.buf, state.start_line),
         }
     }
 
@@ -1243,24 +1429,27 @@ impl<'a> Parser<'a> {
         Ok(out)
     }
 
-    /// Parse `if (cond) { ... }` into a guarded region.
+    /// Parse `if (cond) { ... }`, with an optional `else`, into guarded regions.
     ///
     /// The body reaches [`Parser::parse_lines`], so it admits any statement the
-    /// parser already accepts, nested regions included.
+    /// parser already accepts, nested regions included. An `else` arm becomes a
+    /// second region carrying the negated condition rather than a second span on
+    /// the instruction; see [`Parser::lower_else_arm`] for what that costs.
     fn parse_if_block(&mut self, buf: &str, line_num: usize) -> Result<Vec<Instruction>> {
         let (condition, body_str) = self.split_if_header(buf, line_num)?;
+        let body_str = body_str.trim_start();
+        let (then_src, trailing) = if body_str.starts_with('{') {
+            split_braced_body(body_str, line_num, "if")?
+        } else {
+            split_at_else(body_str)
+        };
+        let then_body = self.parse_region_body(then_src, line_num)?;
 
-        let open = body_str.find('{').ok_or_else(|| PrismError::Parse {
-            line: line_num,
-            message: "expected `{` after `if(...)` condition".to_string(),
-        })?;
-        let after_open = &body_str[open + 1..];
-        let close = find_matching_close_brace(after_open).ok_or_else(|| PrismError::Parse {
-            line: line_num,
-            message: "unmatched `{` in `if` body".to_string(),
-        })?;
-        let trailing = after_open[close + 1..].trim();
-        if !trailing.is_empty() {
+        let trailing = trailing.trim();
+        if trailing.is_empty() {
+            return Ok(guarded(condition, then_body).into_iter().collect());
+        }
+        let Some(after_else) = strip_leading_keyword(trailing, "else") else {
             let word = trailing
                 .split(|c: char| c.is_whitespace() || c == '(' || c == '{')
                 .next()
@@ -1269,8 +1458,82 @@ impl<'a> Parser<'a> {
                 construct: word.to_string(),
                 line: line_num,
             });
+        };
+        self.lower_else_arm(condition, then_body, after_else, line_num)
+    }
+
+    /// Emit the `then` region followed by a region guarded on the negated
+    /// condition.
+    ///
+    /// The negated region re-reads the classical bits after the `then` body has
+    /// run, so a `then` body that measures into its own guard bits could take
+    /// both arms. That case is rejected rather than lowered.
+    fn lower_else_arm(
+        &mut self,
+        condition: ClassicalCondition,
+        then_body: Vec<Instruction>,
+        after_else: &str,
+        line_num: usize,
+    ) -> Result<Vec<Instruction>> {
+        if crate::circuit::body_writes_condition_bits(&then_body, &condition) {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: "`else` needs a condition the `if` body does not overwrite; \
+                          this body measures into a bit the condition reads"
+                    .to_string(),
+            });
         }
 
+        if after_else.trim().is_empty() {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: "expected a statement or block after `else`".to_string(),
+            });
+        }
+        let else_body = if let Some(nested) = strip_leading_keyword(after_else, "if") {
+            self.parse_nested_else_if(nested, line_num)?
+        } else if after_else.starts_with('{') {
+            let (else_src, trailing) = split_braced_body(after_else, line_num, "else")?;
+            if !trailing.trim().is_empty() {
+                return Err(PrismError::Parse {
+                    line: line_num,
+                    message: format!("unexpected `{}` after `else` body", trailing.trim()),
+                });
+            }
+            self.parse_region_body(else_src, line_num)?
+        } else {
+            self.parse_region_body(after_else.trim_end_matches(';'), line_num)?
+        };
+
+        let mut out = Vec::new();
+        out.extend(guarded(condition.clone(), then_body));
+        out.extend(guarded(condition.negate(), else_body));
+        Ok(out)
+    }
+
+    /// Parse the `if` of an `else if` chain, which nests one region deeper.
+    fn parse_nested_else_if(&mut self, nested: &str, line_num: usize) -> Result<Vec<Instruction>> {
+        self.enter_region(line_num)?;
+        let parsed = if nested.contains('{') {
+            self.parse_if_block(&format!("if {nested}"), line_num)
+        } else {
+            self.parse_if_statement(&format!("if {nested}"), line_num)
+        };
+        self.region_depth -= 1;
+        parsed
+    }
+
+    /// Parse a region body's source text one nesting level down.
+    fn parse_region_body(&mut self, src: &str, line_num: usize) -> Result<Vec<Instruction>> {
+        self.enter_region(line_num)?;
+        let body_lines = split_body_into_lines(src.trim());
+        let refs: Vec<&str> = body_lines.iter().map(String::as_str).collect();
+        let body = self.parse_lines(&refs, line_num.saturating_sub(1));
+        self.region_depth -= 1;
+        body
+    }
+
+    fn enter_region(&mut self, line_num: usize) -> Result<()> {
         if self.region_depth >= MAX_REGION_DEPTH {
             return Err(PrismError::Parse {
                 line: line_num,
@@ -1278,12 +1541,135 @@ impl<'a> Parser<'a> {
             });
         }
         self.region_depth += 1;
-        let body_lines = split_body_into_lines(after_open[..close].trim());
-        let refs: Vec<&str> = body_lines.iter().map(String::as_str).collect();
-        let body = self.parse_lines(&refs, line_num.saturating_sub(1));
-        self.region_depth -= 1;
+        Ok(())
+    }
 
-        Ok(guarded(condition, body?).into_iter().collect())
+    /// Parse `switch (creg) { case v { .. } default { .. } }` into a chain of
+    /// guarded regions, one per case label.
+    ///
+    /// The chain is exclusive only because no arm body may write the switched
+    /// register; that is checked rather than assumed. `default` becomes the case
+    /// labels' negations nested, since a conjunction has no flat form in the
+    /// condition language.
+    fn parse_switch_block(&mut self, buf: &str, line_num: usize) -> Result<Vec<Instruction>> {
+        let rest = buf.trim_start().strip_prefix("switch").unwrap().trim();
+        let open = rest.find('(').ok_or_else(|| PrismError::Parse {
+            line: line_num,
+            message: "expected `(` after `switch`".to_string(),
+        })?;
+        let after_open = &rest[open + 1..];
+        let close = find_matching_close_paren(after_open).ok_or_else(|| PrismError::Parse {
+            line: line_num,
+            message: "expected `)` in `switch` operand".to_string(),
+        })?;
+        let (offset, size) = self.resolve_switch_operand(after_open[..close].trim(), line_num)?;
+        let (arms_src, trailing) =
+            split_braced_body(after_open[close + 1..].trim(), line_num, "switch")?;
+        if !trailing.trim().is_empty() {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("unexpected `{}` after `switch` body", trailing.trim()),
+            });
+        }
+
+        let arms = split_switch_arms(arms_src, line_num)?;
+        let mut labels: Vec<u64> = Vec::new();
+        let mut cases: Vec<(Vec<u64>, Vec<Instruction>)> = Vec::new();
+        let mut default: Option<Vec<Instruction>> = None;
+        for arm in arms {
+            let body = self.parse_region_body(arm.body, line_num)?;
+            let Some(labels_src) = arm.labels_src else {
+                if default.replace(body).is_some() {
+                    return Err(PrismError::Parse {
+                        line: line_num,
+                        message: "`switch` has more than one `default` arm".to_string(),
+                    });
+                }
+                continue;
+            };
+            let mut arm_labels = Vec::new();
+            for token in labels_src.split(',') {
+                let value = self.parse_switch_label(token, line_num)?;
+                if labels.contains(&value) {
+                    return Err(PrismError::Parse {
+                        line: line_num,
+                        message: format!("`switch` case label {value} appears twice"),
+                    });
+                }
+                labels.push(value);
+                arm_labels.push(value);
+            }
+            cases.push((arm_labels, body));
+        }
+
+        let probe = ClassicalCondition::RegisterEquals {
+            offset,
+            size,
+            value: 0,
+        };
+        let writes_operand = cases
+            .iter()
+            .map(|(_, body)| body)
+            .chain(default.iter())
+            .any(|body| crate::circuit::body_writes_condition_bits(body, &probe));
+        if writes_operand {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: "`switch` needs an operand no arm overwrites; \
+                          an arm here measures into the switched register"
+                    .to_string(),
+            });
+        }
+
+        let mut out = Vec::new();
+        for (values, body) in &cases {
+            for &value in values {
+                let condition = ClassicalCondition::RegisterEquals {
+                    offset,
+                    size,
+                    value,
+                };
+                out.extend(guarded(condition, body.clone()));
+            }
+        }
+        if let Some(body) = default {
+            out.extend(nest_default_arm(
+                offset,
+                size,
+                &labels,
+                body,
+                self.region_depth,
+                line_num,
+            )?);
+        }
+        Ok(out)
+    }
+
+    fn parse_switch_label(&self, token: &str, line_num: usize) -> Result<u64> {
+        let value = eval_int_expr(token.trim(), line_num, self.int_vars.as_ref())?;
+        u64::try_from(value).map_err(|_| PrismError::Parse {
+            line: line_num,
+            message: format!(
+                "`switch` case label must be non-negative, got `{}`",
+                token.trim()
+            ),
+        })
+    }
+
+    /// Resolve a `switch` operand to the `(offset, size)` of the classical bit
+    /// range it names. A bit reference resolves to size 1.
+    fn resolve_switch_operand(&self, operand: &str, line_num: usize) -> Result<(usize, usize)> {
+        if operand.contains('[') {
+            return Ok((self.resolve_cbit(operand, line_num)?, 1));
+        }
+        let reg = self
+            .cregs
+            .get(operand)
+            .ok_or_else(|| PrismError::UndefinedRegister {
+                name: operand.to_string(),
+                line: line_num,
+            })?;
+        Ok((reg.offset, reg.size))
     }
 
     /// Split `if (cond) rest` into the parsed condition and the trimmed rest,
@@ -1322,6 +1708,62 @@ impl<'a> Parser<'a> {
         Ok(guarded(condition, body).into_iter().collect())
     }
 
+    /// Parse `a ^ b ^ c` or `(a ^ b ^ c) == 0` into a parity condition.
+    ///
+    /// Returns `None` when the expression holds no `^`, which leaves the
+    /// register and bit forms to the caller.
+    fn parse_parity_condition(
+        &self,
+        cond_str: &str,
+        line_num: usize,
+    ) -> Result<Option<ClassicalCondition>> {
+        if !cond_str.contains('^') {
+            return Ok(None);
+        }
+        let malformed = || PrismError::Parse {
+            line: line_num,
+            message: format!("expected `a ^ b` or `(a ^ b) == 0/1`, got: `{cond_str}`"),
+        };
+        let (inner, expected) = match cond_str.strip_prefix('(') {
+            None => (cond_str, true),
+            Some(rest) => {
+                let close = find_matching_close_paren(rest).ok_or_else(malformed)?;
+                let tail = rest[close + 1..].trim();
+                let expected = if tail.is_empty() {
+                    true
+                } else {
+                    let (negate, literal) = match (tail.strip_prefix("=="), tail.strip_prefix("!="))
+                    {
+                        (Some(literal), _) => (false, literal),
+                        (_, Some(literal)) => (true, literal),
+                        _ => return Err(malformed()),
+                    };
+                    match eval_int_expr(literal.trim(), line_num, self.int_vars.as_ref())? {
+                        0 => negate,
+                        1 => !negate,
+                        _ => return Err(malformed()),
+                    }
+                };
+                (&rest[..close], expected)
+            }
+        };
+
+        let mut bits = Vec::new();
+        for token in inner.split('^') {
+            let token = token.trim();
+            // `resolve_cbit` stops at the closing bracket, so a term carrying a
+            // comparison would be silently truncated to its bit reference.
+            if !token.ends_with(']') {
+                return Err(malformed());
+            }
+            bits.push(self.resolve_cbit(token, line_num)?);
+        }
+        Ok(Some(ClassicalCondition::Parity {
+            bits: bits.into(),
+            expected,
+        }))
+    }
+
     /// Parse a classical condition expression for `if (...)`.
     ///
     /// Supported forms:
@@ -1329,12 +1771,17 @@ impl<'a> Parser<'a> {
     /// - `c[i] == 0`, `c[i] == 1`, `c[i] != 0`, `c[i] != 1` (bit vs literal)
     /// - `c[i]` (bit truthy)
     /// - `!c[i]` (bit falsy)
+    /// - `c[i] ^ c[j]`, `(c[i] ^ c[j]) == 0/1` (parity over bits)
     fn parse_classical_condition(
         &self,
         cond_str: &str,
         line_num: usize,
     ) -> Result<ClassicalCondition> {
         let cond_str = cond_str.trim();
+
+        if let Some(parity) = self.parse_parity_condition(cond_str, line_num)? {
+            return Ok(parity);
+        }
 
         if let Some(rest) = cond_str.strip_prefix('!') {
             let inner = rest.trim();

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -97,17 +97,38 @@ fn test_unsupported_def_with_measurement() {
 }
 
 #[test]
-fn test_switch_rejected_by_name() {
+fn test_switch_lowers_to_a_guard_per_label() {
     let qasm = "OPENQASM 3.0;
 qubit[1] q;
 bit[2] c;
 switch (c) { case 0 { x q[0]; } }";
+    let circuit = parse(qasm).expect("parse");
+    assert_eq!(circuit.instructions.len(), 1);
+    assert!(matches!(
+        &circuit.instructions[0],
+        Instruction::Conditional {
+            condition: ClassicalCondition::RegisterEquals {
+                value: 0,
+                size: 2,
+                ..
+            },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_switch_body_must_be_case_or_default() {
+    let qasm = "OPENQASM 3.0;
+qubit[1] q;
+bit[2] c;
+switch (c) { x q[0]; }";
     match parse(qasm).unwrap_err() {
-        PrismError::UnsupportedConstruct { construct, line } => {
-            assert_eq!(construct, "switch");
+        PrismError::Parse { message, line } => {
+            assert!(message.contains("`case` or `default`"), "{message}");
             assert_eq!(line, 4);
         }
-        other => panic!("expected UnsupportedConstruct, got {other:?}"),
+        other => panic!("expected a parse error, got {other:?}"),
     }
 }
 

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -344,10 +344,23 @@ fn cut_register_conditions(
         }
         _ => return Ok(()),
     };
-    let (ClassicalCondition::RegisterEquals { offset, size, .. }
-    | ClassicalCondition::RegisterNotEquals { offset, size, .. }) = condition
-    else {
-        return Ok(());
+    let (offset, size) = match condition {
+        ClassicalCondition::RegisterEquals { offset, size, .. }
+        | ClassicalCondition::RegisterNotEquals { offset, size, .. } => (offset, size),
+        // A parity names bits rather than a range, so it cuts nothing. Its bounds
+        // still need checking here: `CregLayout::bit` panics on a bit past the
+        // declared registers, and export of a hand-built circuit is not API
+        // misuse.
+        ClassicalCondition::Parity { bits, .. } => {
+            if let Some(&bit) = bits.iter().find(|&&bit| bit >= total) {
+                return Err(PrismError::ExportUnsupported {
+                    index,
+                    reason: format!("condition reads bit {bit} but the circuit has {total}"),
+                });
+            }
+            return Ok(());
+        }
+        _ => return Ok(()),
     };
     if offset + size > total {
         return Err(PrismError::ExportUnsupported {
@@ -411,6 +424,31 @@ impl CregLayout {
                 size,
                 value,
             } => format!("{} != {value}", self.register(*offset, *size, index)?),
+            // A parity over one bit is a bit test, and only the bit spelling
+            // reparses: the parser routes an expression to the parity form on
+            // the `^` that a single term does not have.
+            ClassicalCondition::Parity { bits, expected } => match bits.as_ref() {
+                [] => {
+                    return Err(PrismError::ExportUnsupported {
+                        index,
+                        reason: "parity condition over no bits has no OpenQASM form".to_string(),
+                    });
+                }
+                [bit] if *expected => self.bit(*bit),
+                [bit] => format!("!{}", self.bit(*bit)),
+                _ => {
+                    let terms = bits
+                        .iter()
+                        .map(|&bit| self.bit(bit))
+                        .collect::<Vec<_>>()
+                        .join(" ^ ");
+                    if *expected {
+                        terms
+                    } else {
+                        format!("({terms}) == 0")
+                    }
+                }
+            },
         })
     }
 

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -230,6 +230,19 @@ pub enum QecOp {
         records: Vec<QecRecordRef>,
         expected: bool,
     },
+    /// Feed-forward: `body` executes iff the parity over `records` equals
+    /// `expected`.
+    ///
+    /// The predicate has the shape a detector has, because that is what
+    /// adaptive correction reads. `body` admits gates and resets only: the
+    /// record space is a static address space that detectors and observables
+    /// index, so a measurement whose execution depends on a record would make
+    /// those indices depend on the shot.
+    Feedforward {
+        records: Vec<QecRecordRef>,
+        expected: bool,
+        body: Vec<QecOp>,
+    },
     /// Pauli-noise annotation applied at this point in the program. Zero
     /// probability is treated as inactive.
     Noise {
@@ -664,6 +677,23 @@ impl QecProgram {
         })
     }
 
+    /// Append a feed-forward correction: `body` runs iff the parity over
+    /// `records` equals `expected`.
+    ///
+    /// See [`QecOp::Feedforward`] for what the body admits.
+    pub fn feedforward(
+        &mut self,
+        records: &[QecRecordRef],
+        expected: bool,
+        body: Vec<QecOp>,
+    ) -> Result<()> {
+        self.push_op(QecOp::Feedforward {
+            records: records.to_vec(),
+            expected,
+            body,
+        })
+    }
+
     /// Walk the ops with a running count of measurement records emitted so
     /// far. Record-referencing ops resolve relative offsets against that
     /// count; the row-resolver methods below share this walk.
@@ -780,12 +810,57 @@ impl QecProgram {
                     });
                 }
             }
+            QecOp::Feedforward {
+                records,
+                body,
+                expected: _,
+            } => {
+                if records.is_empty() {
+                    return Err(PrismError::InvalidParameter {
+                        message: "feed-forward predicate requires at least one record".to_string(),
+                    });
+                }
+                if body.is_empty() {
+                    return Err(PrismError::InvalidParameter {
+                        message: "feed-forward body requires at least one operation".to_string(),
+                    });
+                }
+                resolve_records(records, next_measurement)?;
+                for inner in body {
+                    if !matches!(inner, QecOp::Gate { .. } | QecOp::Reset { .. }) {
+                        return Err(PrismError::InvalidParameter {
+                            message: format!(
+                                "feed-forward body admits gates and resets only, got `{}`",
+                                qec_op_name(inner)
+                            ),
+                        });
+                    }
+                    self.validate_op(inner, next_measurement)?;
+                }
+            }
             QecOp::Noise { channel, targets } => {
                 validate_noise(*channel, targets, self.num_qubits)?;
             }
             QecOp::Tick => {}
         }
         Ok(())
+    }
+}
+
+/// Short name for an op, used when an error must say which one it found.
+fn qec_op_name(op: &QecOp) -> &'static str {
+    match op {
+        QecOp::Gate { .. } => "gate",
+        QecOp::Measure { .. } => "M",
+        QecOp::MeasurePauliProduct { .. } => "MPP",
+        QecOp::Reset { .. } => "R",
+        QecOp::Detector { .. } => "DETECTOR",
+        QecOp::ObservableInclude { .. } => "OBSERVABLE_INCLUDE",
+        QecOp::ExpectationValue { .. } => "EXP_VAL",
+        QecOp::Postselect { .. } => "POSTSELECT",
+        QecOp::Feedforward { .. } => "FEEDFORWARD",
+        QecOp::Noise { .. } => "noise",
+        QecOp::Tick => "TICK",
     }
 }
 
@@ -836,6 +911,14 @@ pub fn compile_qec_program_rows(program: &QecProgram) -> Result<QecCompiledRows>
                     backend: "QEC row compiler".to_string(),
                     reason: "QEC row compilation has no row representation for `EXP_VAL`; \
                              use `run_qec_program`"
+                        .to_string(),
+                });
+            }
+            QecOp::Feedforward { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC row compiler".to_string(),
+                    reason: "QEC row compilation has no row representation for `FEEDFORWARD`; \
+                             use `run_qec_program_reference`"
                         .to_string(),
                 });
             }
@@ -944,6 +1027,13 @@ pub(crate) fn validate_qec_exp_val_placement(program: &QecProgram) -> Result<()>
                 if seen_exp_val {
                     return Err(terminal_violation(channel.name()));
                 }
+            }
+            QecOp::Feedforward { .. } => {
+                if seen_exp_val {
+                    return Err(terminal_violation("FEEDFORWARD"));
+                }
+                // A conditional reset does not restore liveness: the shots where
+                // the predicate is false leave the qubit collapsed.
             }
             QecOp::Detector { .. }
             | QecOp::ObservableInclude { .. }

--- a/src/qec/noise.rs
+++ b/src/qec/noise.rs
@@ -273,6 +273,14 @@ pub(super) fn lower_qec_program_to_density_matrix(
                         .to_string(),
                 });
             }
+            QecOp::Feedforward { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC density-matrix estimator".to_string(),
+                    reason: "`FEEDFORWARD` reads a measurement record, and the density matrix \
+                             holds none; call `run_qec_program_reference` for such programs"
+                        .to_string(),
+                });
+            }
             QecOp::Noise { .. }
             | QecOp::ExpectationValue { .. }
             | QecOp::Detector { .. }
@@ -418,6 +426,15 @@ fn lower_qec_program_to_deferred_circuit_inner(
                         &mut noise_events,
                     )?;
                 }
+            }
+            QecOp::Feedforward { .. } => {
+                return Err(PrismError::IncompatibleBackend {
+                    backend: "QEC deferred sampler".to_string(),
+                    reason: "deferred measurement sampling evaluates a static map from random \
+                             bits to outcomes, which `FEEDFORWARD` makes depend on the sample; \
+                             `run_qec_program_reference` executes such programs"
+                        .to_string(),
+                });
             }
             QecOp::ExpectationValue { .. }
             | QecOp::Detector { .. }

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -7,11 +7,11 @@ use super::noise::QecCompiledNoiseSampler;
 use super::noise::compile_qec_noisy_sampler;
 use super::{
     QecBasis, QecNoise, QecObservableEstimate, QecOp, QecOptions, QecPauli, QecProgram,
-    QecSampleResult, append_basis_to_z_rotation, append_mpp_parity_rotations,
+    QecRecordRef, QecSampleResult, append_basis_to_z_rotation, append_mpp_parity_rotations,
     append_z_to_basis_rotation, ensure_lowered_record_count, qec_non_clifford_error,
 };
 use crate::backend::{Backend, statevector::StatevectorBackend};
-use crate::circuit::{Circuit, Instruction, SmallVec};
+use crate::circuit::{Circuit, ClassicalCondition, Instruction, SmallVec};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 #[cfg(feature = "bench-internal")]
@@ -498,6 +498,9 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
         })
         .collect::<Result<Vec<_>>>()?;
     let postselection_rows = program.postselection_rows()?;
+    // Record indices are shot-invariant, so the guarded regions are built once
+    // rather than per shot inside the loop below.
+    let feedforward_regions = build_feedforward_regions(program, backend_qubits)?;
     let mut exp_val_sums = vec![0.0f64; exp_val_masks.len()];
     let mut exp_val_sq_sums = vec![0.0f64; exp_val_masks.len()];
     let mut exp_val_accepted = 0usize;
@@ -505,6 +508,7 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
     for shot in 0..shots {
         backend.init(backend_qubits, num_measurements)?;
         let mut next_record = 0;
+        let mut next_feedforward = 0;
 
         for op in program.ops() {
             match op {
@@ -532,6 +536,10 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
                 }
                 QecOp::Noise { channel, targets } => {
                     apply_reference_noise(&mut backend, &mut noise_rng, *channel, targets)?;
+                }
+                QecOp::Feedforward { .. } => {
+                    backend.apply(&feedforward_regions[next_feedforward])?;
+                    next_feedforward += 1;
                 }
                 QecOp::ExpectationValue { .. }
                 | QecOp::Detector { .. }
@@ -607,6 +615,86 @@ pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult
         })
         .collect();
     Ok(result.with_expectation_values(estimates))
+}
+
+/// Lower every feed-forward op in `program` to its guarded instruction, in op
+/// order.
+fn build_feedforward_regions(program: &QecProgram, num_qubits: usize) -> Result<Vec<Instruction>> {
+    let mut regions = Vec::new();
+    let mut next_record = 0usize;
+    for op in program.ops() {
+        match op {
+            QecOp::Measure { .. } | QecOp::MeasurePauliProduct { .. } => next_record += 1,
+            QecOp::Feedforward {
+                records,
+                expected,
+                body,
+            } => regions.push(feedforward_region(
+                records,
+                *expected,
+                body,
+                next_record,
+                num_qubits,
+            )?),
+            _ => {}
+        }
+    }
+    Ok(regions)
+}
+
+/// Build the guarded instruction a feed-forward op executes as.
+///
+/// The QEC record space and the classical bit vector are one address space: the
+/// reference runner writes record `i` to classical bit `i`, so a resolved
+/// record index is the bit the condition reads with no translation. A one-gate
+/// body takes the [`Instruction::Conditional`] lowering [`crate::circuit::guarded`]
+/// picks for it.
+fn feedforward_region(
+    records: &[QecRecordRef],
+    expected: bool,
+    body: &[QecOp],
+    next_record: usize,
+    num_qubits: usize,
+) -> Result<Instruction> {
+    let bits = super::resolve_records(records, next_record)?;
+    let mut lowered = Circuit::new(num_qubits, 0);
+    for op in body {
+        match op {
+            QecOp::Gate { gate, targets } => lowered.add_gate(gate.clone(), targets),
+            QecOp::Reset { basis, qubit } => {
+                lowered.add_reset(*qubit);
+                super::append_z_to_basis_rotation(&mut lowered, *basis, *qubit);
+            }
+            other => {
+                return Err(PrismError::InvalidParameter {
+                    message: format!(
+                        "feed-forward body admits gates and resets only, got `{}`",
+                        super::qec_op_name(other)
+                    ),
+                });
+            }
+        }
+    }
+    let condition = ClassicalCondition::Parity {
+        bits: bits.into(),
+        expected,
+    };
+    crate::circuit::guarded(condition, lowered.instructions).ok_or_else(|| {
+        PrismError::InvalidParameter {
+            message: "feed-forward body is empty".to_string(),
+        }
+    })
+}
+
+/// The compiled sampler's map is fixed before sampling starts, so a
+/// record-conditioned branch cannot route through it.
+fn qec_feedforward_rejection() -> PrismError {
+    PrismError::IncompatibleBackend {
+        backend: "QEC compiled runner".to_string(),
+        reason: "the compiled QEC sampler evaluates a static affine map, which `FEEDFORWARD` \
+                 makes depend on the sample; `run_qec_program_reference` executes such programs"
+            .to_string(),
+    }
 }
 
 fn qec_result_from_measurements(
@@ -1082,6 +1170,9 @@ fn validate_qec_compiled_program(program: &QecProgram) -> Result<bool> {
             QecOp::Noise { channel, .. } => {
                 has_noise |= channel.probability() > 0.0;
             }
+            QecOp::Feedforward { .. } => {
+                return Err(qec_feedforward_rejection());
+            }
             _ => {}
         }
     }
@@ -1153,6 +1244,9 @@ fn lower_qec_program_to_clifford_circuit(program: &QecProgram) -> Result<Circuit
                              reference runners"
                         .to_string(),
                 });
+            }
+            QecOp::Feedforward { .. } => {
+                return Err(qec_feedforward_rejection());
             }
             QecOp::Detector { .. }
             | QecOp::ObservableInclude { .. }

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -791,6 +791,12 @@ pub(super) fn has_temporal_clifford_opportunity(kind: &BackendKind, circuit: &Ci
     if circuit.num_qubits > max_statevector_qubits() {
         return false;
     }
+    // The split pays for itself only when the tail needs a dense state. A
+    // Clifford-only circuit has no such tail, and exporting the tableau to run
+    // measurements or a guarded region densely is strictly a loss.
+    if circuit.is_clifford_only() {
+        return false;
+    }
     let min_gates = min_clifford_prefix_gates(circuit.num_qubits);
     let mut prefix_gates = 0;
     for inst in &circuit.instructions {
@@ -832,6 +838,9 @@ pub(super) fn plan_temporal_clifford(
         return None;
     }
     if circuit.num_qubits > max_statevector_qubits() {
+        return None;
+    }
+    if circuit.is_clifford_only() {
         return None;
     }
     let (prefix, tail) = circuit.clifford_prefix_split()?;

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1618,6 +1618,9 @@ pub(crate) fn run_counts_with(
         return Ok((shots.counts(), shots.metadata));
     }
 
+    let folded = circuit.fold_static_guards();
+    let circuit = folded.as_ref();
+
     let bits = circuit.num_classical_bits;
     let source = prepare_shot_source(&kind, circuit, num_shots, seed)?;
     let Some(metadata) = source.metadata() else {
@@ -2589,6 +2592,12 @@ pub(crate) fn run_shots_with(
     if let BackendKind::StatevectorDistributed { context } = &kind {
         return run_shots_distributed(context.clone(), circuit, num_shots, seed);
     }
+
+    // Once per shots call, not per shot: a guard that cannot depend on a
+    // measurement is resolved here so the sampling predicates below see the
+    // circuit that actually runs. A circuit with no guard borrows through.
+    let folded = circuit.fold_static_guards();
+    let circuit = folded.as_ref();
 
     let bits = circuit.num_classical_bits;
     let source = prepare_shot_source(&kind, circuit, num_shots, seed)?;

--- a/src/sim/terminal_candidate_matrix_tests.rs
+++ b/src/sim/terminal_candidate_matrix_tests.rs
@@ -82,3 +82,49 @@ fn temporal_prefix_circuit_is_not_candidate() {
     ));
     assert!(!auto_terminal_statevector_candidate(&circuit));
 }
+
+// A Clifford-only circuit has no dense tail to accelerate, so exporting the
+// tableau to run its measurements and guards densely is a loss. Deleting the
+// `is_clifford_only` guards in `dispatch.rs` makes both assertions fail.
+#[test]
+fn clifford_only_circuit_is_not_a_temporal_prefix_candidate() {
+    use crate::circuit::{ClassicalCondition, guarded};
+    use crate::circuit::{Instruction, SmallVec};
+
+    let n = 8;
+    let mut circuit = Circuit::new(n, n);
+    circuit.add_gate(Gate::H, &[0]);
+    for _ in 0..4 {
+        for q in 0..n - 1 {
+            circuit.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    circuit.add_measure(0, 0);
+    circuit.instructions.extend(guarded(
+        ClassicalCondition::BitIsOne(0),
+        vec![
+            Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[1]),
+            },
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[2]),
+            },
+        ],
+    ));
+    assert!(circuit.is_clifford_only());
+    assert!(!has_temporal_clifford_opportunity(
+        &BackendKind::Auto,
+        &circuit
+    ));
+    assert!(plan_temporal_clifford(&BackendKind::Auto, &circuit).is_none());
+
+    // The same prefix with a non-Clifford tail still qualifies.
+    let mut mixed = circuit.clone();
+    mixed.add_gate(Gate::Rx(0.3), &[0]);
+    assert!(has_temporal_clifford_opportunity(
+        &BackendKind::Auto,
+        &mixed
+    ));
+}

--- a/tests/common/circuits.rs
+++ b/tests/common/circuits.rs
@@ -422,7 +422,55 @@ pub fn measurement_reset_region() -> Circuit {
     circuit
 }
 
-pub fn measurement_cases() -> [CircuitCase; 5] {
+// The shape `else` and `switch` lower to: sibling guards on a condition and its
+// negation, each re-reading the classical bits after the previous body ran, and
+// each body measuring. The condition is a parity, so every backend's shared
+// `ClassicalCondition::evaluate` carries that variant here too.
+pub fn parity_sibling_regions() -> Circuit {
+    let mut circuit = Circuit::new(4, 4);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_measure(0, 0);
+    circuit.add_measure(1, 1);
+    let parity = ClassicalCondition::Parity {
+        bits: vec![0, 1].into(),
+        expected: true,
+    };
+    circuit.instructions.push(
+        guarded(
+            parity.clone(),
+            vec![
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: SmallVec::from_slice(&[2]),
+                },
+                Instruction::Measure {
+                    qubit: 2,
+                    classical_bit: 2,
+                },
+            ],
+        )
+        .expect("body is not empty"),
+    );
+    circuit.instructions.push(
+        guarded(
+            parity.negate(),
+            vec![
+                Instruction::Gate {
+                    gate: Gate::X,
+                    targets: SmallVec::from_slice(&[3]),
+                },
+                Instruction::Gate {
+                    gate: Gate::Cx,
+                    targets: SmallVec::from_slice(&[3, 2]),
+                },
+            ],
+        )
+        .expect("body is not empty"),
+    );
+    circuit
+}
+
+pub fn measurement_cases() -> [CircuitCase; 6] {
     [
         CircuitCase::new(
             "deterministic_measurement",
@@ -447,6 +495,11 @@ pub fn measurement_cases() -> [CircuitCase; 5] {
         CircuitCase::new(
             "measurement_reset_region",
             measurement_reset_region,
+            CircuitCapabilities::new(),
+        ),
+        CircuitCase::new(
+            "parity_sibling_regions",
+            parity_sibling_regions,
             CircuitCapabilities::new(),
         ),
     ]

--- a/tests/common/conformance.rs
+++ b/tests/common/conformance.rs
@@ -449,6 +449,14 @@ fn describe_condition(condition: &ClassicalCondition) -> String {
             size,
             value,
         } => format!("c[{offset}..{}]!={value}", offset + size),
+        ClassicalCondition::Parity { bits, expected } => {
+            let terms = bits
+                .iter()
+                .map(|bit| format!("c{bit}"))
+                .collect::<Vec<_>>()
+                .join("^");
+            format!("({terms})=={}", u8::from(*expected))
+        }
     }
 }
 

--- a/tests/guarded_regions.rs
+++ b/tests/guarded_regions.rs
@@ -119,22 +119,16 @@ fn nesting_past_the_bound_is_rejected() {
     );
 }
 
-// `else` is stage-3 work. Until then it must reject by name with a line number
-// in every shape, the way `while` and `switch` do: a braced `if` body invites an
-// `else` after it, and falling through to gate parsing reports a register error
-// naming a brace.
+// `else` lowers to a second guard carrying the negated condition, in every
+// shape the source can spell it: same line, own line, and unbraced.
 #[test]
-fn else_rejects_by_name_in_every_shape() {
-    let cases = [
-        (
-            "OPENQASM 3.0;
+fn else_lowers_to_a_negated_sibling_in_every_shape() {
+    let sources = [
+        "OPENQASM 3.0;
 qubit[1] q;
 bit[1] c;
 if (c[0]) { x q[0]; } else { z q[0]; }",
-            4,
-        ),
-        (
-            "OPENQASM 3.0;
+        "OPENQASM 3.0;
 qubit[1] q;
 bit[1] c;
 if (c[0]) {
@@ -143,29 +137,262 @@ if (c[0]) {
 else {
   z q[0];
 }",
-            7,
-        ),
-        (
-            "OPENQASM 3.0;
+        "OPENQASM 3.0;
 qubit[1] q;
 bit[1] c;
 if (c[0]) x q[0];
 else z q[0];",
-            5,
-        ),
+        "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) x q[0]; else z q[0];",
+        "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) { x q[0]; }
+else
+z q[0];",
     ];
-    for (qasm, line) in cases {
-        match openqasm::parse(qasm).expect_err("else is unsupported") {
+    for qasm in sources {
+        let circuit = openqasm::parse(qasm).expect("parse");
+        assert_eq!(circuit.instructions.len(), 2, "in {qasm:?}");
+        let arms: Vec<_> = circuit
+            .instructions
+            .iter()
+            .map(|inst| match inst {
+                Instruction::Conditional {
+                    condition, gate, ..
+                } => (format!("{condition:?}"), gate.name().to_string()),
+                other => panic!("expected a conditional, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(arms[0].1, "x", "in {qasm:?}");
+        assert_eq!(arms[1].1, "z", "in {qasm:?}");
+        assert!(arms[0].0.contains("BitIsOne"), "in {qasm:?}");
+        assert!(arms[1].0.contains("BitIsZero"), "in {qasm:?}");
+    }
+}
+
+#[test]
+fn exactly_one_else_arm_runs() {
+    let qasm = "OPENQASM 3.0;
+qubit[3] q;
+bit[1] c;
+x q[0];
+measure q[0] -> c[0];
+if (c[0]) { x q[1]; } else { x q[2]; }";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let probs = probabilities(&circuit);
+    // q0 and q1 set, q2 clear: index 0b011.
+    assert!(probs[0b011] > 0.999, "{probs:?}");
+}
+
+#[test]
+fn else_if_chains_nest_under_the_negated_arm() {
+    let qasm = "OPENQASM 3.0;
+qubit[4] q;
+bit[2] c;
+x q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+if (c[0]) { x q[2]; } else if (c[1]) { x q[3]; } else { x q[2]; x q[3]; }";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let probs = probabilities(&circuit);
+    // c[0] is 0 and c[1] is 1, so only the middle arm runs: q1 and q3 set.
+    assert!(probs[0b1010] > 0.999, "{probs:?}");
+}
+
+// The negated arm re-reads the bits after the first body ran, so a body that
+// measures into its own guard could take both arms. That is rejected, not
+// lowered.
+#[test]
+fn else_rejects_a_body_that_overwrites_its_own_guard() {
+    let qasm = "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) { measure q[0] -> c[0]; } else { x q[0]; }";
+    match openqasm::parse(qasm).expect_err("unsound lowering") {
+        PrismError::Parse { line, message } => {
+            assert_eq!(line, 4);
+            assert!(message.contains("overwrite"), "{message}");
+        }
+        other => panic!("expected a parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn switch_lowers_to_one_region_per_case_label() {
+    let qasm = "OPENQASM 3.0;
+qubit[4] q;
+bit[2] c;
+switch (c) {
+  case 0 { x q[0]; cx q[0], q[1]; }
+  case 1, 2 { x q[2]; }
+  default { x q[3]; z q[3]; }
+}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    // One guard per case label, so the two-label arm emits two, then the
+    // default nested once per label to spell the conjunction of its negations.
+    assert_eq!(circuit.instructions.len(), 4);
+    assert_eq!(region(&circuit.instructions[0]).body().len(), 2);
+    let default = region(&circuit.instructions[3]);
+    assert_eq!(default.depth(), 3);
+}
+
+#[test]
+fn switch_selects_the_matching_case() {
+    let qasm = "OPENQASM 3.0;
+qubit[5] q;
+bit[2] c;
+x q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+switch (c) {
+  case 0 { x q[2]; }
+  case 2 { x q[3]; }
+  default { x q[4]; }
+}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let probs = probabilities(&circuit);
+    // c reads 0b10, so the `case 2` arm runs and sets q3.
+    assert!(probs[0b01010] > 0.999, "{probs:?}");
+}
+
+#[test]
+fn switch_default_runs_when_no_label_matches() {
+    let qasm = "OPENQASM 3.0;
+qubit[4] q;
+bit[2] c;
+x q[0];
+x q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+switch (c) {
+  case 0 { x q[2]; }
+  case 1 { x q[2]; }
+  default { x q[3]; }
+}";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let probs = probabilities(&circuit);
+    assert!(probs[0b1011] > 0.999, "{probs:?}");
+}
+
+#[test]
+fn switch_rejects_a_duplicate_label_and_a_body_writing_its_operand() {
+    let duplicate = "OPENQASM 3.0;
+qubit[1] q;
+bit[2] c;
+switch (c) {
+  case 1 { x q[0]; }
+  case 1 { z q[0]; }
+}";
+    match openqasm::parse(duplicate).expect_err("duplicate label") {
+        PrismError::Parse { message, .. } => assert!(message.contains("twice"), "{message}"),
+        other => panic!("expected a parse error, got {other:?}"),
+    }
+
+    let writes = "OPENQASM 3.0;
+qubit[1] q;
+bit[2] c;
+switch (c) {
+  case 1 { measure q[0] -> c[0]; }
+  case 2 { x q[0]; }
+}";
+    match openqasm::parse(writes).expect_err("arm writes the operand") {
+        PrismError::Parse { message, .. } => {
+            assert!(message.contains("overwrites"), "{message}")
+        }
+        other => panic!("expected a parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn while_and_break_still_reject_by_name() {
+    for (source, construct, line) in [
+        (
+            "OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\nwhile (c[0]) { x q[0]; }",
+            "while",
+            4,
+        ),
+        ("OPENQASM 3.0;\nqubit[1] q;\nbit[1] c;\nbreak;", "break", 4),
+    ] {
+        match openqasm::parse(source).expect_err("unsupported") {
             PrismError::UnsupportedConstruct {
-                construct,
+                construct: got,
                 line: at,
             } => {
-                assert_eq!(construct, "else", "in {qasm:?}");
-                assert_eq!(at, line, "in {qasm:?}");
+                assert_eq!(got, construct);
+                assert_eq!(at, line);
             }
-            other => panic!("expected UnsupportedConstruct for {qasm:?}, got {other:?}"),
+            other => panic!("expected UnsupportedConstruct for {construct}, got {other:?}"),
         }
     }
+}
+
+#[test]
+fn negation_round_trips_every_condition_variant() {
+    let variants = [
+        ClassicalCondition::BitIsOne(0),
+        ClassicalCondition::BitIsZero(1),
+        ClassicalCondition::RegisterEquals {
+            offset: 0,
+            size: 2,
+            value: 3,
+        },
+        ClassicalCondition::RegisterNotEquals {
+            offset: 1,
+            size: 2,
+            value: 1,
+        },
+        ClassicalCondition::Parity {
+            bits: vec![0, 2].into(),
+            expected: true,
+        },
+    ];
+    let bits = [true, false, true, false];
+    for condition in variants {
+        assert_ne!(
+            condition.evaluate(&bits),
+            condition.negate().evaluate(&bits),
+            "{condition:?}"
+        );
+        assert_eq!(
+            condition.evaluate(&bits),
+            condition.negate().negate().evaluate(&bits),
+            "{condition:?}"
+        );
+    }
+}
+
+#[test]
+fn parity_conditions_round_trip_through_qasm() {
+    for source in [
+        "OPENQASM 3.0;\nqubit[1] q;\nbit[3] c;\nif (c[0] ^ c[2]) { x q[0]; }",
+        "OPENQASM 3.0;\nqubit[1] q;\nbit[3] c;\nif ((c[0] ^ c[2]) == 0) { x q[0]; }",
+    ] {
+        let circuit = openqasm::parse(source).expect("parse");
+        let exported = qasm_export::to_qasm3(&circuit).expect("export");
+        let reparsed = openqasm::parse(&exported).expect("reparse");
+        assert_eq!(
+            format!("{:?}", circuit.instructions),
+            format!("{:?}", reparsed.instructions),
+            "exported: {exported}"
+        );
+    }
+}
+
+#[test]
+fn parity_selects_on_the_measured_bits() {
+    let qasm = "OPENQASM 3.0;
+qubit[3] q;
+bit[3] c;
+x q[0];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+if (c[0] ^ c[1]) { x q[2]; }";
+    let circuit = openqasm::parse(qasm).expect("parse");
+    let probs = probabilities(&circuit);
+    assert!(probs[0b101] > 0.999, "{probs:?}");
 }
 
 // A `def` body can expand to a non-gate instruction. Before regions the parser
@@ -473,4 +700,358 @@ fn a_noise_model_rejects_a_region() {
         matches!(&err, PrismError::IncompatibleBackend { reason, .. } if reason.contains("noise slots")),
         "{err:?}"
     );
+}
+
+// ---- Static-guard folding (the sampling reachability refinement) ----
+
+fn dead_guard_circuit(with_guard: bool) -> Circuit {
+    let mut circuit = Circuit::new(3, 3);
+    if with_guard {
+        let mut body = Circuit::new(3, 3);
+        body.add_gate(Gate::X, &[0]);
+        body.add_gate(Gate::Cx, &[0, 1]);
+        circuit
+            .instructions
+            .extend(guarded(ClassicalCondition::BitIsOne(2), body.instructions));
+    }
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    for q in 0..3 {
+        circuit.add_measure(q, q);
+    }
+    circuit
+}
+
+#[test]
+fn folding_drops_a_dead_guard_and_inlines_a_taken_one() {
+    let dead = dead_guard_circuit(true);
+    assert!(!dead.has_terminal_measurements_only());
+    let folded = dead.fold_static_guards();
+    assert_eq!(
+        folded.instructions.len(),
+        dead_guard_circuit(false).instructions.len()
+    );
+    assert!(folded.has_terminal_measurements_only());
+
+    let mut taken = Circuit::new(2, 2);
+    let mut body = Circuit::new(2, 2);
+    body.add_gate(Gate::X, &[0]);
+    body.add_gate(Gate::Cx, &[0, 1]);
+    taken
+        .instructions
+        .extend(guarded(ClassicalCondition::BitIsZero(0), body.instructions));
+    let folded = taken.fold_static_guards();
+    assert_eq!(folded.instructions.len(), 2);
+    assert!(
+        folded
+            .instructions
+            .iter()
+            .all(|inst| matches!(inst, Instruction::Gate { .. }))
+    );
+}
+
+// The obligation the refinement carries: fold only what is genuinely constant.
+#[test]
+fn folding_keeps_a_guard_a_measurement_can_reach() {
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_measure(0, 0);
+    let mut body = Circuit::new(2, 2);
+    body.add_gate(Gate::X, &[1]);
+    body.add_gate(Gate::Z, &[1]);
+    circuit
+        .instructions
+        .extend(guarded(ClassicalCondition::BitIsOne(0), body.instructions));
+    let folded = circuit.fold_static_guards();
+    assert!(matches!(
+        folded.instructions.last(),
+        Some(Instruction::Region(_))
+    ));
+
+    // A measurement inside a live region writes bits later guards read, so a
+    // guard on those bits stays too.
+    let mut chained = Circuit::new(2, 2);
+    chained.add_gate(Gate::H, &[0]);
+    chained.add_measure(0, 0);
+    let mut body = Circuit::new(2, 2);
+    body.add_gate(Gate::X, &[1]);
+    body.add_measure(1, 1);
+    chained
+        .instructions
+        .extend(guarded(ClassicalCondition::BitIsOne(0), body.instructions));
+    chained.instructions.extend(guarded(
+        ClassicalCondition::BitIsOne(1),
+        vec![
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[0]),
+            },
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[1]),
+            },
+        ],
+    ));
+    let folded = chained.fold_static_guards();
+    assert_eq!(folded.instructions.len(), chained.instructions.len());
+}
+
+#[test]
+fn a_static_circuit_borrows_through_the_fold() {
+    let circuit = dead_guard_circuit(false);
+    let folded = circuit.fold_static_guards();
+    assert!(matches!(folded, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn a_dead_guard_samples_the_same_shots_as_its_absence() {
+    let with_guard = dead_guard_circuit(true);
+    let without = dead_guard_circuit(false);
+    let a = simulate(&with_guard).seed(SEED).shots(512).expect("shots");
+    let b = simulate(&without).seed(SEED).shots(512).expect("shots");
+    assert_eq!(a.counts(), b.counts());
+}
+
+// Obligation (ii) on a distribution the fold cannot make trivially equal: the
+// folded circuit samples through the compiled path, the unfolded one runs
+// per shot on the statevector, and the two must agree.
+#[test]
+fn folding_preserves_a_nontrivial_distribution() {
+    let mut circuit = Circuit::new(3, 3);
+    // Statically taken: bit 2 is unwritten and BitIsZero holds on all-zero.
+    circuit.instructions.extend(guarded(
+        ClassicalCondition::BitIsZero(2),
+        vec![
+            Instruction::Gate {
+                gate: Gate::H,
+                targets: SmallVec::from_slice(&[0]),
+            },
+            Instruction::Gate {
+                gate: Gate::Cx,
+                targets: SmallVec::from_slice(&[0, 1]),
+            },
+        ],
+    ));
+    circuit.add_measure(0, 0);
+    // Live: bit 0 was just written, so this one survives the fold.
+    circuit.instructions.extend(guarded(
+        ClassicalCondition::BitIsOne(0),
+        vec![
+            Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[2]),
+            },
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[2]),
+            },
+        ],
+    ));
+    circuit.add_measure(1, 1);
+    circuit.add_measure(2, 2);
+
+    let folded = circuit.fold_static_guards();
+    assert!(matches!(folded, std::borrow::Cow::Owned(_)));
+    assert!(
+        folded
+            .instructions
+            .iter()
+            .filter(|inst| matches!(inst, Instruction::Region(_)))
+            .count()
+            == 1,
+        "the live guard survives and the taken one inlined"
+    );
+
+    let shots = 4096;
+    let counts = simulate(&circuit).seed(SEED).shots(shots).expect("shots");
+    let reference = simulate(&folded)
+        .seed(SEED + 1)
+        .shots(shots)
+        .expect("shots");
+    let share = |result: &prism_q::ShotsResult, key: &[u64]| {
+        *result.counts().get(key).unwrap_or(&0) as f64 / shots as f64
+    };
+    // q0 and q1 agree; q2 is set only on the 1 branch. So 000 and 111.
+    for key in [vec![0u64], vec![0b111u64]] {
+        let a = share(&counts, &key);
+        let b = share(&reference, &key);
+        assert!((a - b).abs() < 0.05, "{key:?}: {a} against {b}");
+        assert!((a - 0.5).abs() < 0.05, "{key:?} should be about half: {a}");
+    }
+}
+
+// `static_value` must decline a condition it cannot decide: a register
+// straddling a written bit, and a bit past the classical register.
+#[test]
+fn folding_declines_a_partially_written_register_and_an_out_of_range_bit() {
+    let mut straddle = Circuit::new(2, 2);
+    straddle.add_gate(Gate::H, &[0]);
+    straddle.add_measure(0, 0);
+    straddle.instructions.extend(guarded(
+        ClassicalCondition::RegisterEquals {
+            offset: 0,
+            size: 2,
+            value: 0,
+        },
+        vec![
+            Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[1]),
+            },
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[1]),
+            },
+        ],
+    ));
+    assert!(matches!(
+        straddle.fold_static_guards().instructions.last(),
+        Some(Instruction::Region(_))
+    ));
+
+    let mut out_of_range = Circuit::new(1, 1);
+    out_of_range.instructions.extend(guarded(
+        ClassicalCondition::BitIsZero(7),
+        vec![
+            Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[0]),
+            },
+            Instruction::Gate {
+                gate: Gate::Z,
+                targets: SmallVec::from_slice(&[0]),
+            },
+        ],
+    ));
+    let folded = out_of_range.fold_static_guards();
+    assert!(matches!(folded, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn switch_default_nesting_respects_the_enclosing_depth() {
+    let mut qasm = String::from("OPENQASM 3.0;\nqubit[1] q;\nbit[2] c;\n");
+    for _ in 0..MAX_REGION_DEPTH - 1 {
+        qasm.push_str("if (c[0]) {\n");
+    }
+    qasm.push_str("switch (c) { case 0 { x q[0]; } case 1 { z q[0]; } default { h q[0]; } }\n");
+    for _ in 0..MAX_REGION_DEPTH - 1 {
+        qasm.push_str("}\n");
+    }
+    let err = openqasm::parse(&qasm).expect_err("the default would nest past the bound");
+    assert!(
+        matches!(&err, PrismError::Parse { message, .. } if message.contains("depth bound")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
+fn a_single_bit_parity_round_trips_as_a_bit_test() {
+    for (expected, spelling) in [(true, "c[1]"), (false, "!c[1]")] {
+        let mut circuit = Circuit::new(1, 2);
+        circuit.instructions.extend(guarded(
+            ClassicalCondition::Parity {
+                bits: vec![1].into(),
+                expected,
+            },
+            vec![Instruction::Gate {
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[0]),
+            }],
+        ));
+        let exported = qasm_export::to_qasm3(&circuit).expect("export");
+        assert!(exported.contains(spelling), "{exported}");
+        let reparsed = openqasm::parse(&exported).expect("reparse");
+        let bits = [false, true];
+        let condition = match &reparsed.instructions[0] {
+            Instruction::Conditional { condition, .. } => condition,
+            other => panic!("expected a conditional, got {other:?}"),
+        };
+        assert_eq!(condition.evaluate(&bits), expected);
+    }
+}
+
+#[test]
+fn export_rejects_a_parity_past_the_classical_register() {
+    let mut circuit = Circuit::new(1, 1);
+    circuit.instructions.extend(guarded(
+        ClassicalCondition::Parity {
+            bits: vec![0, 5].into(),
+            expected: true,
+        },
+        vec![Instruction::Gate {
+            gate: Gate::X,
+            targets: SmallVec::from_slice(&[0]),
+        }],
+    ));
+    assert!(matches!(
+        qasm_export::to_qasm3(&circuit),
+        Err(PrismError::ExportUnsupported { .. })
+    ));
+}
+
+#[test]
+fn a_parity_term_carrying_a_comparison_is_rejected() {
+    let qasm = "OPENQASM 3.0;\nqubit[1] q;\nbit[2] c;\nif (c[0] == 1 ^ c[1]) x q[0];";
+    assert!(matches!(
+        openqasm::parse(qasm),
+        Err(PrismError::Parse { .. })
+    ));
+}
+
+// An `else` whose arm never arrives keeps the block open rather than dropping
+// the guard and letting a following statement run unconditionally.
+#[test]
+fn an_else_with_no_arm_is_rejected() {
+    for qasm in [
+        "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) { x q[0]; } else",
+        "OPENQASM 3.0;
+qubit[1] q;
+bit[1] c;
+if (c[0]) { x q[0]; }
+else",
+    ] {
+        assert!(
+            matches!(openqasm::parse(qasm), Err(PrismError::Parse { .. })),
+            "dangling else accepted in {qasm:?}"
+        );
+    }
+}
+
+// Both arms are guarded in every spelling, so exactly one body runs and nothing
+// leaks out unguarded.
+#[test]
+fn no_else_spelling_emits_an_unguarded_body() {
+    let sources = [
+        "if (c[0]) x q[1]; else x q[2];",
+        "if (c[0]) { x q[1]; }
+else
+x q[2];",
+        "if (c[0]) { x q[1]; }
+else
+{ x q[2]; }",
+    ];
+    for tail in sources {
+        let qasm = format!(
+            "OPENQASM 3.0;
+qubit[3] q;
+bit[1] c;
+measure q[0] -> c[0];
+{tail}"
+        );
+        let circuit = openqasm::parse(&qasm).expect("parse");
+        assert!(
+            circuit
+                .instructions
+                .iter()
+                .all(|inst| !matches!(inst, Instruction::Gate { .. })),
+            "an arm escaped its guard in {tail:?}: {:?}",
+            circuit.instructions
+        );
+        let probs = probabilities(&circuit);
+        // c[0] reads 0, so only the else arm runs and q2 is set.
+        assert!(probs[0b100] > 0.999, "{tail:?}: {probs:?}");
+    }
 }

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -513,3 +513,111 @@ fn export_round_trips_a_bound_parameter_point() {
     let bound = prepared.bind(&[0.41, 1.27]).expect("bind").clone();
     assert_streams_match(&bound, &round_trip(&bound), "bound_point");
 }
+
+/// Every classical-control construct the parser module header lists, with the
+/// outcome it promises: parse, or reject by name with a line number. The
+/// rejections are the half worth pinning, because a construct that falls
+/// through to gate parsing reports a register error naming a brace.
+#[test]
+fn classical_control_constructs_parse_or_reject_by_name() {
+    const PROLOGUE: &str = "OPENQASM 3.0;\nqubit[3] q;\nbit[2] c;\n";
+
+    let accepted = [
+        ("guarded gate", "if (c[0]) x q[0];"),
+        ("guarded gate, legacy register", "if (c == 1) x q[0];"),
+        (
+            "guarded region",
+            "if (c[0]) { x q[0]; measure q[1] -> c[1]; }",
+        ),
+        ("negated bit", "if (!c[0]) x q[0];"),
+        ("bit literal", "if (c[0] == 1) x q[0];"),
+        ("register inequality", "if (c != 0) x q[0];"),
+        ("parity", "if (c[0] ^ c[1]) x q[0];"),
+        ("parity against zero", "if ((c[0] ^ c[1]) == 0) x q[0];"),
+        ("else, one line", "if (c[0]) x q[0]; else z q[0];"),
+        ("else, braced", "if (c[0]) { x q[0]; } else { z q[0]; }"),
+        (
+            "else on its own line",
+            "if (c[0]) { x q[0]; }\nelse\nz q[0];",
+        ),
+        (
+            "else if",
+            "if (c[0]) { x q[0]; } else if (c[1]) { z q[0]; }",
+        ),
+        (
+            "switch",
+            "switch (c) { case 0 { x q[0]; } case 1 { z q[0]; } }",
+        ),
+        (
+            "switch with default",
+            "switch (c) { case 0 { x q[0]; } default { h q[0]; } }",
+        ),
+        ("bounded for", "for int i in [0:2] { x q[i]; }"),
+    ];
+    for (label, body) in accepted {
+        let qasm = format!("{PROLOGUE}{body}");
+        assert!(
+            openqasm::parse(&qasm).is_ok(),
+            "{label} should parse: {qasm}"
+        );
+    }
+
+    let rejected = [
+        ("while", "while (c[0]) { x q[0]; }", "while"),
+        ("break", "break;", "break"),
+        ("box", "box { x q[0]; }", "box"),
+        ("defcal", "defcal x $0 { }", "defcal"),
+        ("opaque", "opaque foo q;", "opaque"),
+        ("extern", "extern foo(int);", "extern"),
+        ("return", "return;", "return"),
+        ("stray else", "else { x q[0]; }", "else"),
+    ];
+    for (label, body, construct) in rejected {
+        let qasm = format!("{PROLOGUE}{body}");
+        match openqasm::parse(&qasm) {
+            Err(PrismError::UnsupportedConstruct {
+                construct: got,
+                line,
+            }) => {
+                assert_eq!(got, construct, "{label}");
+                assert_eq!(line, 4, "{label} should report its own line");
+            }
+            other => panic!("{label} should reject by name, got {other:?}"),
+        }
+    }
+
+    // Rejected for a reason the construct name does not carry, so these report a
+    // parse error with the line and the reason instead.
+    let explained = [
+        (
+            "else whose body overwrites its guard",
+            "if (c[0]) { measure q[0] -> c[0]; } else { x q[1]; }",
+            "overwrite",
+        ),
+        (
+            "switch arm writing the switched register",
+            "switch (c) { case 1 { measure q[0] -> c[0]; } case 2 { x q[0]; } }",
+            "overwrites",
+        ),
+        (
+            "duplicate case label",
+            "switch (c) { case 1 { x q[0]; } case 1 { z q[0]; } }",
+            "twice",
+        ),
+        (
+            "switch body that is not an arm",
+            "switch (c) { x q[0]; }",
+            "`case` or `default`",
+        ),
+    ];
+    for (label, body, needle) in explained {
+        let qasm = format!("{PROLOGUE}{body}");
+        match openqasm::parse(&qasm) {
+            Err(PrismError::Parse { message, line }) => {
+                assert!(message.contains(needle), "{label}: {message}");
+                assert_eq!(line, 4, "{label} should report its own line");
+            }
+            other => panic!("{label} should be a parse error, got {other:?}"),
+        }
+    }
+}

--- a/tests/qec_feedforward.rs
+++ b/tests/qec_feedforward.rs
@@ -1,0 +1,348 @@
+//! QEC feed-forward: a record-conditioned correction consuming the
+//! guarded-region contract, and the routes that reject it.
+
+use prism_q::{
+    Gate, QecBasis, QecOp, QecOptions, QecPauli, QecProgram, QecRecordRef, run_qec_program,
+    run_qec_program_reference,
+};
+
+fn options(shots: usize) -> QecOptions {
+    QecOptions {
+        shots,
+        seed: 42,
+        keep_measurements: true,
+        ..QecOptions::default()
+    }
+}
+
+/// Teleportation-style correction: measure a qubit prepared in |1>, then flip a
+/// second qubit back to |0> when the record reads 1.
+fn corrected_program(expected: bool) -> QecProgram {
+    let mut program = QecProgram::with_options(2, options(16));
+    program.push_gate(Gate::X, &[0]).unwrap();
+    program.push_gate(Gate::X, &[1]).unwrap();
+    program.measure_z(0).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::lookback(1).unwrap()],
+            expected,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![1],
+            }],
+        )
+        .unwrap();
+    program.measure_z(1).unwrap();
+    program
+}
+
+#[test]
+fn feedforward_fires_on_a_matching_record() {
+    let result = run_qec_program_reference(&corrected_program(true)).unwrap();
+    let measurements = &result.measurements;
+    for shot in 0..16 {
+        assert!(
+            measurements.get_bit(shot, 0),
+            "record 0 is the |1> preparation"
+        );
+        assert!(
+            !measurements.get_bit(shot, 1),
+            "the correction returned q1 to 0"
+        );
+    }
+}
+
+#[test]
+fn feedforward_skips_on_a_mismatching_record() {
+    let result = run_qec_program_reference(&corrected_program(false)).unwrap();
+    let measurements = &result.measurements;
+    for shot in 0..16 {
+        assert!(measurements.get_bit(shot, 1), "the correction did not run");
+    }
+}
+
+// The predicate is a parity over records, which is the shape a detector has and
+// what a register comparison cannot express.
+#[test]
+fn feedforward_reads_the_parity_of_several_records() {
+    let mut program = QecProgram::with_options(3, options(8));
+    program.push_gate(Gate::X, &[0]).unwrap();
+    program.measure_z(0).unwrap();
+    program.measure_z(1).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::absolute(0), QecRecordRef::absolute(1)],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![2],
+            }],
+        )
+        .unwrap();
+    program.measure_z(2).unwrap();
+    let result = run_qec_program_reference(&program).unwrap();
+    let measurements = &result.measurements;
+    // Records read 1 and 0, so the parity is 1 and the correction fires.
+    for shot in 0..8 {
+        assert!(measurements.get_bit(shot, 2));
+    }
+}
+
+// The record space and the classical bit vector are one address space: the
+// runner writes record `i` to classical bit `i`, so an absolute reference and a
+// lookback that resolve to the same index select the same bit.
+#[test]
+fn absolute_and_lookback_references_agree() {
+    let mut absolute = corrected_program(true);
+    absolute.set_options(options(4));
+    let mut lookback = QecProgram::with_options(2, options(4));
+    lookback.push_gate(Gate::X, &[0]).unwrap();
+    lookback.push_gate(Gate::X, &[1]).unwrap();
+    lookback.measure_z(0).unwrap();
+    lookback
+        .feedforward(
+            &[QecRecordRef::absolute(0)],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![1],
+            }],
+        )
+        .unwrap();
+    lookback.measure_z(1).unwrap();
+
+    let a = run_qec_program_reference(&absolute).unwrap();
+    let b = run_qec_program_reference(&lookback).unwrap();
+    for shot in 0..4 {
+        for record in 0..2 {
+            assert_eq!(
+                a.measurements.get_bit(shot, record),
+                b.measurements.get_bit(shot, record),
+                "shot {shot} record {record}"
+            );
+        }
+    }
+}
+
+#[test]
+fn feedforward_body_rejects_a_record_producing_op() {
+    let mut program = QecProgram::with_options(2, options(1));
+    program.measure_z(0).unwrap();
+    let err = program
+        .feedforward(
+            &[QecRecordRef::lookback(1).unwrap()],
+            true,
+            vec![QecOp::Measure {
+                basis: QecBasis::Z,
+                qubit: 1,
+            }],
+        )
+        .expect_err("a conditional record would move every later record index");
+    assert!(
+        format!("{err}").contains("gates and resets only"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn feedforward_predicate_needs_a_record() {
+    let mut program = QecProgram::with_options(1, options(1));
+    program.measure_z(0).unwrap();
+    let err = program
+        .feedforward(
+            &[],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![0],
+            }],
+        )
+        .expect_err("empty predicate");
+    assert!(format!("{err}").contains("at least one record"), "{err}");
+}
+
+#[test]
+fn feedforward_reference_out_of_bounds_is_rejected() {
+    let mut program = QecProgram::with_options(1, options(1));
+    let err = program
+        .feedforward(
+            &[QecRecordRef::absolute(0)],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![0],
+            }],
+        )
+        .expect_err("no records exist yet");
+    assert!(format!("{err}").contains("out of bounds"), "{err}");
+}
+
+// The compiled QEC sampler evaluates a static affine map, which a
+// record-conditioned branch makes depend on the sample. The rejection is
+// explicit, not a silent slow path.
+#[test]
+fn the_compiled_qec_sampler_rejects_feedforward() {
+    let err = run_qec_program(&corrected_program(true)).expect_err("affine sampler");
+    let text = format!("{err}");
+    assert!(text.contains("FEEDFORWARD"), "{text}");
+    assert!(text.contains("run_qec_program_reference"), "{text}");
+}
+
+#[test]
+fn the_detector_error_model_rejects_feedforward() {
+    let mut program = corrected_program(true);
+    program
+        .detector(&[QecRecordRef::lookback(1).unwrap()])
+        .unwrap();
+    let err = program
+        .detector_error_model()
+        .expect_err("a conditional correction is not a linear fault propagation");
+    assert!(format!("{err}").contains("FEEDFORWARD"), "{err}");
+}
+
+#[test]
+fn feedforward_after_an_expectation_value_breaks_terminality() {
+    let mut program = QecProgram::with_options(2, options(1));
+    program.measure_z(0).unwrap();
+    program.expectation_value(&[QecPauli::z(1)], 1.0).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::absolute(0)],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![1],
+            }],
+        )
+        .unwrap();
+    let err = run_qec_program_reference(&program).expect_err("EXP_VAL must stay terminal");
+    assert!(format!("{err}").contains("FEEDFORWARD"), "{err}");
+}
+
+/// A conditional reset in the X basis: the body runs, so q1 lands in |+> and a
+/// following X-basis measurement reads 0 every shot.
+#[test]
+fn feedforward_body_carries_a_basis_reset() {
+    let mut program = QecProgram::with_options(2, options(16));
+    program.push_gate(Gate::X, &[0]).unwrap();
+    program.push_gate(Gate::X, &[1]).unwrap();
+    program.measure_z(0).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::lookback(1).unwrap()],
+            true,
+            vec![QecOp::Reset {
+                basis: QecBasis::X,
+                qubit: 1,
+            }],
+        )
+        .unwrap();
+    program.measure_x(1).unwrap();
+    let result = run_qec_program_reference(&program).unwrap();
+    for shot in 0..16 {
+        assert!(
+            !result.measurements.get_bit(shot, 1),
+            "the reset left q1 in the +1 X eigenstate"
+        );
+    }
+}
+
+// A feed-forward emits no record, so detector rows keep indexing the records
+// the static walk assigned them.
+#[test]
+fn detectors_stay_correct_across_a_feedforward() {
+    let mut program = QecProgram::with_options(2, options(32));
+    program.push_gate(Gate::X, &[0]).unwrap();
+    program.measure_z(0).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::lookback(1).unwrap()],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![0],
+            }],
+        )
+        .unwrap();
+    program.measure_z(0).unwrap();
+    program
+        .detector(&[
+            QecRecordRef::lookback(1).unwrap(),
+            QecRecordRef::lookback(2).unwrap(),
+        ])
+        .unwrap();
+    assert_eq!(program.num_measurements(), 2);
+    let result = run_qec_program_reference(&program).unwrap();
+    let detectors = &result.detectors;
+    for shot in 0..32 {
+        assert!(
+            detectors.get_bit(shot, 0),
+            "record 0 reads 1 and the correction makes record 1 read 0"
+        );
+    }
+}
+
+// The address-space claim, checked against the other executor: the same
+// predicate written directly as a circuit guard produces the same outcomes.
+#[test]
+fn the_equivalent_circuit_guard_agrees() {
+    use prism_q::circuit::{Circuit, ClassicalCondition, guarded};
+
+    let program = corrected_program(true);
+    let qec = run_qec_program_reference(&program).unwrap();
+
+    let mut circuit = Circuit::new(2, 2);
+    circuit.add_gate(Gate::X, &[0]);
+    circuit.add_gate(Gate::X, &[1]);
+    circuit.add_measure(0, 0);
+    circuit.instructions.extend(guarded(
+        ClassicalCondition::Parity {
+            bits: vec![0].into(),
+            expected: true,
+        },
+        vec![prism_q::Instruction::Gate {
+            gate: Gate::X,
+            targets: prism_q::circuit::SmallVec::from_slice(&[1]),
+        }],
+    ));
+    circuit.add_measure(1, 1);
+    let outcome = prism_q::simulate(&circuit).seed(42).run().unwrap();
+
+    for record in 0..2 {
+        assert_eq!(
+            qec.measurements.get_bit(0, record),
+            outcome.classical_bits[record],
+            "record {record}"
+        );
+    }
+}
+
+#[test]
+fn feedforward_body_must_not_be_empty() {
+    let mut program = QecProgram::with_options(1, options(1));
+    program.measure_z(0).unwrap();
+    let err = program
+        .feedforward(&[QecRecordRef::absolute(0)], true, Vec::new())
+        .expect_err("empty body");
+    assert!(format!("{err}").contains("at least one operation"), "{err}");
+}
+
+// No top-level gate, so the row compiler reaches the feed-forward rather than
+// stopping on the gate rejection two arms above it.
+#[test]
+fn the_row_compiler_rejects_feedforward() {
+    let mut program = QecProgram::with_options(1, options(1));
+    program.measure_z(0).unwrap();
+    program
+        .feedforward(
+            &[QecRecordRef::absolute(0)],
+            true,
+            vec![QecOp::Gate {
+                gate: Gate::X,
+                targets: vec![0],
+            }],
+        )
+        .unwrap();
+    let err = prism_q::compile_qec_program_rows(&program).expect_err("no row representation");
+    assert!(format!("{err}").contains("FEEDFORWARD"), "{err}");
+}


### PR DESCRIPTION
## Summary

Completes measurement-conditioned control on the guarded-region contract: `else`,
`else if`, and `switch` in OpenQASM, a pass that resolves guards no measurement can
reach, and a QEC feed-forward op. The expensive decisions were kept out of the IR:
both new constructs lower to guards on the existing condition language, so
`Instruction` stays at 96 bytes by construction rather than by measurement, and the
QEC record space needed no mapping because it was already the classical bit vector.

## Scope

- [x] New feature
- [x] Performance improvement
- [x] Documentation

## What each piece settles

**`else` lowers rather than growing the IR.** The condition language is closed under
negation, so an `else` arm is a second guard carrying `condition.negate()`. The two
candidate shapes both lost on the walkers: a sibling instruction the walker pairs is
unsound under `fusion::reorder` and `strip_measurements`, either of which splits the
pair, and a second span on the instruction adds a descent site to each of roughly
forty places that read `region.body()`, none of which the compiler flags. `switch`
emits one `RegisterEquals` guard per case label, with `default` nested once per label
because nesting is the only conjunction the language has.

Both lowerings carry a side condition worth naming, because it is a real
expressiveness gap rather than a technicality: the chain re-reads the classical bits
after an earlier body has run, so a body that measures into a bit its own guard reads
is rejected with a line number. `if (c[0]) { measure q -> c[0]; } else { ... }` is
unwritable. Buying it back needs either a second span after all or a classical value
that is not a measurement bit.

**The reachability refinement was priced before it was built**, which was the point of
the ordering. `Circuit::fold_static_guards` drops a guard whose condition reads only
bits no preceding measurement writes and inlines one that must be taken, once per
shots or counts call, borrowing through when nothing folds.

**A dispatch defect the guard merely exposed.** Auto split a Clifford-only circuit
into a stabilizer prefix and a dense tail, exporting the tableau to run its
measurements and guards on a statevector. There is no non-Clifford tail to accelerate,
so the split was strictly a loss. Both `has_temporal_clifford_opportunity` and
`plan_temporal_clifford` now decline a Clifford-only circuit.

**QEC feed-forward is a consumer, not a parallel mechanism.** `QecOp::Feedforward`
conditions gates and resets on the parity of a record list, the shape `Detector` and
`Postselect` already have. The open question of whether the record space and the
classical bit vector are one address space or two was answered by reading the runners:
`measure_reference_basis` writes record `i` to classical bit `i`, so the op executes
as an ordinary guarded instruction with no mapping and no translation. Parity
therefore joins the condition language as `ClassicalCondition::Parity`, carrying
`Box<[usize]>` so neither `ClassicalCondition` nor `Instruction` grows. The body
admits gates and resets only, since detectors index the record space absolutely and a
conditional measurement would make every later index depend on the shot.

## Benchmarks

Full Criterion tier, 30 samples, i7-6700K at 4.00GHz, rustc 1.97.0, `parallel`.

### Static-circuit neutrality, adjacent-binary A/B against `df1f81f`

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `statevector/scalability_d5/18` | 78.54 us | 76.38 us | -2.7% | -0.7%, +0.7% | yes, noise |
| `compiled_sampler/noiseless/noiseless_500q_10k` | 18.01 ms | 17.73 ms | -1.6% | -2.7%, -0.1% | yes, noise |
| `stabilizer/scaling/500` | 1.72 ms | 1.72 ms | -0.1% | +0.7%, +0.6% | yes, noise |
| `auto/clifford_d10/18` | 705.04 us | 705.02 us | -0.0% | +0.8%, +1.1% | yes, noise |
| `auto/clifford_d10/20` | 3.73 ms | 3.52 ms | -5.6% | +9.0%, -0.3% | unresolvable, see below |

`stabilizer/scaling/500` is the row a prior change on this file regressed by 7.4%, so
it is the one worth having tight. The `auto/clifford_d10` rows are the rows the
dispatch change can actually reach.

The wide run covered 37 rows. Nineteen of them carried a same-code control spread
above the 5% gate, worst 30.0%, so their change columns are unmeasured rather than
passed; the harness names them in `ab-controls2.md`.

Two rows read as regressions in the wide run and neither survives:

- `compare/clifford_d10/stabilizer/8` at +13.3% is settled by reading the code rather
  than by re-measuring. It runs an explicit `BackendKind::Stabilizer`, and both
  functions this diff changes return early on `!kind.is_auto()`, so the diff cannot
  reach it.
- `auto/clifford_d10/20` at +5.8% is Auto-dispatched and therefore reachable, so it
  was re-measured on its own. The focused run read -5.6%, the opposite direction, with
  a same-code control spread of 9.0%. Two runs disagreeing in sign on a row whose own
  control exceeds the gate is not a result in either direction. Recorded as
  unresolvable, not as a pass. `auto/clifford_d10/18`, which read +3.7% in the wide
  run, resolved at -0.0%.

### Dynamic rows

These are new, so no earlier commit carries them and an A/B cannot compare a row to
its own absence. Each pair is measured adjacently in one process.

| Benchmark | Guarded | Control | Ratio |
| --- | --- | --- | --- |
| `dynamic/dead_region/16` | 119.11 us | 121.16 us (`absent_16`) | at control |
| `dynamic/dead_region/20` | 143.03 us | 135.79 us (`absent_20`) | at control |
| `dynamic/shots/1000` | 19.48 ms | 117.15 us (`terminal_1000`) | 166x |
| `dynamic/shots/10000` | 191.28 ms | 836.09 us (`terminal_10000`) | 229x |
| `dynamic/guarded_region/16` | 15.39 ms | 71.50 us (`unguarded_16`) | 215x |
| `dynamic/guarded_region/20` | 561.57 ms | 88.74 us (`unguarded_20`) | 6330x |
| `dynamic/guarded_region/nofuse_16` | 148.58 us | 74.58 us | 2.0x |
| `dynamic/guarded_region/nofuse_20` | 423.42 us | 91.92 us | 4.6x |

The dead-region rows sit at their guard-free control, against 36.5 ms and 55.1 ms for
the same rows before the refinement. That is the whole claim for the pass.

`dynamic/shots` prices the cliff at roughly 19.5 us of replay per shot against 0.08 us
of sampling from one evolved distribution. The ratio grows with shot count because the
sampling side amortizes and the replay side does not.

`dynamic/guarded_region` does not measure what it was specified to measure, and that
is the more useful finding. The statevector gap is fusion, not the branch: the
unguarded stream collapses from 481 instructions to 41 while the guarded one stays at
21 regions, because no pass fuses inside a region body or across its boundary. The
`nofuse_` pair was added to isolate the branch on a backend that declines fused gates,
and it still reads 2.0x and 4.6x; that residual is the stabilizer's own gate batching,
since a region routes its body through `apply_instructions` separately. Evaluating the
condition is below both. What a guard costs is the optimization window it closes.

**Regression verdict**: PASS. Every reachable row that resolves is at noise. One
reachable row, `auto/clifford_d10/20`, does not resolve on this host and is reported as
unmeasured rather than passed.

## Hotspot notes

Nothing new enters a gate kernel, a per-gate loop, or a fusion pass. `fold_static_guards`
runs once per shots or counts call and its early-out is one discriminant scan over
top-level instructions, on a path that already walks the same list several times.
The `is_clifford_only` call added to dispatch runs once per plan and short-circuits on
the first non-Clifford gate. `feedforward_region` was hoisted out of the QEC reference
runner's per-shot loop after review found it allocating a `Circuit` per shot.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2371 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add information the name and signature do not carry

`parity_sibling_regions` joins the shared corpus, so the sibling-guard shape `else` and
`switch` produce runs on every backend the measurement matrix covers rather than on the
statevector alone. `clifford_only_circuit_is_not_a_temporal_prefix_candidate` is the gate
against reverting the dispatch change, which nothing else in the suite would have caught.
`classical_control_constructs_parse_or_reject_by_name` walks every construct the parser
module header lists.

## Review findings acted on

Four subagent reviews ran against the finished branch, each instructed to refute rather
than confirm. What they found, all fixed and pinned:

- Two silent `else` defects in spellings no test covered. A one-line
  `if (c) x; else y;` dropped the else arm outright, and an `else` alone on its line
  dropped its guard and emitted the arm unconditionally, which turned a conditional
  measurement into an unconditional one.
- Exporting a parity naming a bit past the classical register panicked instead of
  returning `ExportUnsupported`, against the panic policy.
- A single-bit parity exported to text the parser could not read.
- A parity term carrying a comparison, `c[0] == 1 ^ c[1]`, silently dropped the
  comparison and inverted the guard.
- `switch`'s `default` nest counted case labels without the enclosing region depth, so
  it could build past `MAX_REGION_DEPTH`.
- `run_counts_with` never folded, so the counts API kept the slow path.
- A `Circuit` allocated per shot inside the QEC reference runner's shot loop.
- Three error messages pointed at routes that also reject the construct.
- A conditional reset inside a feed-forward body cleared expectation-value liveness,
  which is wrong in the shots where the predicate is false.

They also cleared several things: the "static circuits pay nothing" claim could not be
refuted, no `switch` could be built where two arms run, and `fold_static_guards` could
not be made to fold a guard that is not genuinely constant.

## Architecture or design changes

- [x] `docs/architecture/ir.md` gains the condition language and the folding pass
- [x] `docs/architecture/qec-ir.md` gains feed-forward and its rejections
- [x] `docs/guides/openqasm.md` gains `else`, `switch`, and parity conditions

## Breaking changes

`ClassicalCondition` and `QecOp` are public non-exhaustive-by-convention enums that each
gain a variant, so an external exhaustive match over either stops compiling. `switch`,
`else`, and `break` change error class: the first two now parse, and `break;` reports
`UnsupportedConstruct` rather than a gate-parse error. No behavior change for any circuit
that does not use a guard.

## Risks and rollback

The dispatch change is the only piece that can move a circuit nobody wrote for this
feature, and it is two early returns that can be deleted independently of everything
else; the test named above fails if they are. The folding pass is semantics-preserving
and its call sites are two lines. The parser and QEC additions are reachable only from
new syntax and a new op.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
