### PR TITLE
refactor(statevector): share the tiered 1q sweep with factored

### DIFF
--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -53,6 +53,8 @@ use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 #[cfg(feature = "parallel")]
 use crate::backend::statevector::SendPtr;
 #[cfg(feature = "parallel")]
+use crate::backend::statevector::kernels::{apply_multi_1q_par, apply_single_gate_par};
+#[cfg(feature = "parallel")]
 use crate::backend::{
     MIN_PAR_ELEMS, MIN_PAR_ITERS, PARALLEL_THRESHOLD_QUBITS, chunk_min_len as par_chunk_min_len,
 };
@@ -471,7 +473,7 @@ impl FactoredBackend {
                     seq_or_par!(
                         simd::PreparedGate1q::new(&mat)
                             .apply_full_sequential(&mut sub.state, local),
-                        par_apply_1q(&mut sub.state, local, &mat)
+                        apply_single_gate_par(&mut sub.state, local, &mat)
                     );
                 }
             }
@@ -500,7 +502,7 @@ impl FactoredBackend {
 
             #[cfg(feature = "parallel")]
             if sub.qubits.len() >= PARALLEL_THRESHOLD_QUBITS {
-                par_apply_multi_1q(&mut sub.state, &gate_list);
+                apply_multi_1q_par(&mut sub.state, &gate_list);
                 continue;
             }
 
@@ -734,7 +736,7 @@ impl Backend for FactoredBackend {
         } else {
             #[cfg(feature = "parallel")]
             if par {
-                par_apply_1q(&mut sub.state, local, matrix);
+                apply_single_gate_par(&mut sub.state, local, matrix);
                 return Ok(());
             }
             simd::PreparedGate1q::new(matrix).apply_full_sequential(&mut sub.state, local);
@@ -1241,39 +1243,6 @@ fn apply_batch_phase_seq(
 
 #[cfg(feature = "parallel")]
 #[inline(always)]
-fn par_apply_1q(state: &mut [Complex64], target: usize, mat: &[[Complex64; 2]; 2]) {
-    let half = 1usize << target;
-    let block_size = half << 1;
-    let prepared = simd::PreparedGate1q::new(mat);
-
-    const MIN_TILE: usize = 8192;
-    let tile_size = MIN_TILE.max(block_size);
-    let num_tiles = state.len() / tile_size;
-
-    if block_size <= MIN_TILE && num_tiles >= 4 {
-        state.par_chunks_mut(MIN_TILE).for_each(|tile| {
-            prepared.apply_full_sequential(tile, target);
-        });
-    } else if num_tiles >= 4 {
-        state.par_chunks_mut(block_size).for_each(|chunk| {
-            let (lo, hi) = chunk.split_at_mut(half);
-            prepared.apply(lo, hi);
-        });
-    } else {
-        let sub_tile = MIN_TILE.min(half);
-        for block in state.chunks_mut(block_size) {
-            let (lo, hi) = block.split_at_mut(half);
-            lo.par_chunks_mut(sub_tile)
-                .zip(hi.par_chunks_mut(sub_tile))
-                .for_each(|(lo_t, hi_t)| {
-                    prepared.apply(lo_t, hi_t);
-                });
-        }
-    }
-}
-
-#[cfg(feature = "parallel")]
-#[inline(always)]
 fn par_apply_diagonal(
     state: &mut [Complex64],
     target: usize,
@@ -1608,73 +1577,4 @@ fn par_apply_fused2q(
                 prepared.apply_group_ptr(ptr.as_f64_ptr(), i);
             }
         });
-}
-
-#[cfg(feature = "parallel")]
-fn par_apply_multi_1q(state: &mut [Complex64], gates: &[(usize, [[Complex64; 2]; 2])]) {
-    if gates.is_empty() {
-        return;
-    }
-    if gates.len() == 1 {
-        par_apply_1q(state, gates[0].0, &gates[0].1);
-        return;
-    }
-
-    const MULTI_TILE: usize = 16384;
-    const L3_TILE: usize = 131072;
-
-    const fn max_target_for_tile(tile_size: usize) -> usize {
-        let mut t = 0usize;
-        while (1usize << (t + 1)) <= tile_size {
-            t += 1;
-        }
-        t - 1
-    }
-
-    let max_l2_target = max_target_for_tile(MULTI_TILE);
-    let max_l3_target = max_target_for_tile(L3_TILE);
-
-    let mut small_gates: SmallVec<[(usize, simd::PreparedGate1q); 16]> = SmallVec::new();
-    let mut medium_gates: SmallVec<[(usize, simd::PreparedGate1q); 4]> = SmallVec::new();
-    let mut large_gates: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = SmallVec::new();
-
-    for &(target, mat) in gates {
-        if target <= max_l2_target {
-            small_gates.push((target, simd::PreparedGate1q::new(&mat)));
-        } else if target <= max_l3_target {
-            medium_gates.push((target, simd::PreparedGate1q::new(&mat)));
-        } else {
-            large_gates.push((target, mat));
-        }
-    }
-
-    if !small_gates.is_empty() {
-        let outer_block = 1usize << (max_l2_target + 1);
-        let tile_size = MULTI_TILE.max(outer_block);
-        state
-            .par_chunks_mut(tile_size)
-            .with_min_len(par_chunk_min_len(tile_size))
-            .for_each(|tile| {
-                for &(target, ref prepared) in &small_gates {
-                    prepared.apply_tiled(tile, target);
-                }
-            });
-    }
-
-    if !medium_gates.is_empty() {
-        let outer_block = 1usize << (max_l3_target + 1);
-        let tile_size = L3_TILE.max(outer_block);
-        state
-            .par_chunks_mut(tile_size)
-            .with_min_len(par_chunk_min_len(tile_size))
-            .for_each(|tile| {
-                for &(target, ref prepared) in &medium_gates {
-                    prepared.apply_tiled(tile, target);
-                }
-            });
-    }
-
-    for (target, mat) in large_gates {
-        par_apply_1q(state, target, &mat);
-    }
 }

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -1584,52 +1584,190 @@ fn pauli_rot_pair_halves(
     }
 }
 
+/// Apply one gate over the whole state, tiling or splitting by block size.
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) fn apply_single_gate_par(
+    state: &mut [Complex64],
+    target: usize,
+    mat: &[[Complex64; 2]; 2],
+) {
+    let half = 1usize << target;
+    let block_size = half << 1;
+    let prepared = simd::PreparedGate1q::new(mat);
+
+    const MIN_TILE: usize = 8192;
+
+    let tile_size = MIN_TILE.max(block_size);
+    let num_tiles = state.len() / tile_size;
+
+    if block_size <= MIN_TILE && num_tiles >= 4 {
+        state.par_chunks_mut(MIN_TILE).for_each(|tile| {
+            prepared.apply_full_sequential(tile, target);
+        });
+    } else if num_tiles >= 4 {
+        state.par_chunks_mut(block_size).for_each(|chunk| {
+            let (lo, hi) = chunk.split_at_mut(half);
+            prepared.apply(lo, hi);
+        });
+    } else {
+        let sub_tile = MIN_TILE.min(half);
+        for block in state.chunks_mut(block_size) {
+            let (lo, hi) = block.split_at_mut(half);
+            lo.par_chunks_mut(sub_tile)
+                .zip(hi.par_chunks_mut(sub_tile))
+                .for_each(|(lo_t, hi_t)| {
+                    prepared.apply(lo_t, hi_t);
+                });
+        }
+    }
+}
+
+/// Apply gates on `k` distinct targets in one traversal instead of `k`.
+///
+/// Gates on disjoint qubits commute, so the stages run in target order.
+/// For targets above the L3 tier only: below it the tiered passes keep a
+/// tile cache resident across gates, which this shape cannot.
+#[cfg(feature = "parallel")]
+fn apply_multi_1q_shared(state: &mut [Complex64], gates: &[(usize, [[Complex64; 2]; 2])]) {
+    let mut sorted: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = gates.into();
+    sorted.sort_unstable_by_key(|&(target, _)| target);
+    let k = sorted.len();
+    let lanes = 1usize << k;
+    let low_target = sorted[0].0;
+
+    let prepared: SmallVec<[simd::PreparedGate1q; 4]> = sorted
+        .iter()
+        .map(|(_, mat)| simd::PreparedGate1q::new(mat))
+        .collect();
+
+    let mut offsets: SmallVec<[usize; 16]> = SmallVec::with_capacity(lanes);
+    for j in 0..lanes {
+        let mut offset = 0usize;
+        for (axis, &(target, _)) in sorted.iter().enumerate() {
+            if (j >> axis) & 1 == 1 {
+                offset |= 1usize << target;
+            }
+        }
+        offsets.push(offset);
+    }
+
+    let run = 1usize << low_target;
+    let tile_len = (MULTI_GATE_L2_TILE / lanes).max(1);
+    let tiles_per_run = run / tile_len;
+    let blocks = (state.len() >> k) >> low_target;
+
+    let base_of = |block: usize| {
+        let mut base = block << low_target;
+        for &(target, _) in sorted.iter() {
+            base = insert_zero_bit(base, target);
+        }
+        base
+    };
+
+    let start_of = |unit: usize| base_of(unit / tiles_per_run) + (unit % tiles_per_run) * tile_len;
+    let units = blocks * tiles_per_run;
+
+    let ptr = SendPtr(state.as_mut_ptr());
+    (0..units).into_par_iter().for_each(|unit| {
+        let start = start_of(unit);
+        for (axis, prep) in prepared.iter().enumerate() {
+            let stride = 1usize << axis;
+            for j in 0..lanes {
+                if j & stride != 0 {
+                    continue;
+                }
+                // SAFETY: the target weights are super-increasing, so
+                // the target bits and tile index partition the buffer
+                // into disjoint `tile_len` runs; no two lanes or units
+                // alias.
+                unsafe {
+                    let base = ptr.as_complex_ptr();
+                    let lo = std::slice::from_raw_parts_mut(base.add(start + offsets[j]), tile_len);
+                    let hi = std::slice::from_raw_parts_mut(
+                        base.add(start + offsets[j | stride]),
+                        tile_len,
+                    );
+                    prep.apply(lo, hi);
+                }
+            }
+        }
+    });
+}
+
+/// Apply a `MultiFused` batch in the tiered tiled pass. Shared with the factored
+/// backend, whose blocks are bare statevector slices.
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) fn apply_multi_1q_par(state: &mut [Complex64], gates: &[(usize, [[Complex64; 2]; 2])]) {
+    if gates.is_empty() {
+        return;
+    }
+    if gates.len() == 1 {
+        apply_single_gate_par(state, gates[0].0, &gates[0].1);
+        return;
+    }
+
+    let mut small_gates: SmallVec<[(usize, simd::PreparedGate1q); 16]> = SmallVec::new();
+    let mut medium_gates: SmallVec<[(usize, simd::PreparedGate1q); 4]> = SmallVec::new();
+    let mut large_gates: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = SmallVec::new();
+
+    for &(target, mat) in gates {
+        if target <= MULTI_GATE_MAX_L2_TARGET {
+            small_gates.push((target, simd::PreparedGate1q::new(&mat)));
+        } else if target <= MULTI_GATE_MAX_L3_TARGET {
+            medium_gates.push((target, simd::PreparedGate1q::new(&mat)));
+        } else {
+            large_gates.push((target, mat));
+        }
+    }
+
+    if !small_gates.is_empty() {
+        let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
+        let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
+        state
+            .par_chunks_mut(tile_size)
+            .with_min_len(chunk_min_len(tile_size))
+            .for_each(|tile| {
+                for &(target, ref prepared) in &small_gates {
+                    prepared.apply_tiled(tile, target);
+                }
+            });
+    }
+
+    if !medium_gates.is_empty() {
+        let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
+        let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
+        state
+            .par_chunks_mut(tile_size)
+            .with_min_len(chunk_min_len(tile_size))
+            .for_each(|tile| {
+                for &(target, ref prepared) in &medium_gates {
+                    prepared.apply_tiled(tile, target);
+                }
+            });
+    }
+
+    for chunk in large_gates.chunks(MAX_SHARED_1Q_TARGETS) {
+        if chunk.len() > 1 {
+            apply_multi_1q_shared(state, chunk);
+        } else {
+            apply_single_gate_par(state, chunk[0].0, &chunk[0].1);
+        }
+    }
+}
+
 impl StatevectorBackend {
     #[inline(always)]
     pub(super) fn apply_single_gate(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
         #[cfg(feature = "parallel")]
         if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
-            self.apply_single_gate_par(target, mat);
+            apply_single_gate_par(&mut self.state, target, &mat);
             return;
         }
 
         let prepared = simd::PreparedGate1q::new(&mat);
         prepared.apply_full_sequential(&mut self.state, target);
-    }
-
-    #[cfg(feature = "parallel")]
-    #[inline(always)]
-    fn apply_single_gate_par(&mut self, target: usize, mat: [[Complex64; 2]; 2]) {
-        let half = 1usize << target;
-        let block_size = half << 1;
-        let prepared = simd::PreparedGate1q::new(&mat);
-        let state_len = self.state.len();
-
-        const MIN_TILE: usize = 8192;
-
-        let tile_size = MIN_TILE.max(block_size);
-        let num_tiles = state_len / tile_size;
-
-        if block_size <= MIN_TILE && num_tiles >= 4 {
-            self.state.par_chunks_mut(MIN_TILE).for_each(|tile| {
-                prepared.apply_full_sequential(tile, target);
-            });
-        } else if num_tiles >= 4 {
-            self.state.par_chunks_mut(block_size).for_each(|chunk| {
-                let (lo, hi) = chunk.split_at_mut(half);
-                prepared.apply(lo, hi);
-            });
-        } else {
-            let sub_tile = MIN_TILE.min(half);
-            for block in self.state.chunks_mut(block_size) {
-                let (lo, hi) = block.split_at_mut(half);
-                lo.par_chunks_mut(sub_tile)
-                    .zip(hi.par_chunks_mut(sub_tile))
-                    .for_each(|(lo_t, hi_t)| {
-                        prepared.apply(lo_t, hi_t);
-                    });
-            }
-        }
     }
 
     #[inline(always)]
@@ -3050,85 +3188,6 @@ impl StatevectorBackend {
         self.pending_norm *= inv_norm;
     }
 
-    /// Apply gates on `k` distinct targets in one traversal instead of `k`.
-    ///
-    /// Gates on disjoint qubits commute, so the stages run in target order.
-    /// For targets above the L3 tier only: below it the tiered passes keep a
-    /// tile cache resident across gates, which this shape cannot.
-    #[cfg(feature = "parallel")]
-    fn apply_multi_1q_shared(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
-        let mut sorted: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = gates.into();
-        sorted.sort_unstable_by_key(|&(target, _)| target);
-        let k = sorted.len();
-        let lanes = 1usize << k;
-        let low_target = sorted[0].0;
-
-        let prepared: SmallVec<[simd::PreparedGate1q; 4]> = sorted
-            .iter()
-            .map(|(_, mat)| simd::PreparedGate1q::new(mat))
-            .collect();
-
-        let mut offsets: SmallVec<[usize; 16]> = SmallVec::with_capacity(lanes);
-        for j in 0..lanes {
-            let mut offset = 0usize;
-            for (axis, &(target, _)) in sorted.iter().enumerate() {
-                if (j >> axis) & 1 == 1 {
-                    offset |= 1usize << target;
-                }
-            }
-            offsets.push(offset);
-        }
-
-        let run = 1usize << low_target;
-        let tile_len = (MULTI_GATE_L2_TILE / lanes).max(1);
-        let tiles_per_run = run / tile_len;
-        let blocks = (self.state.len() >> k) >> low_target;
-
-        let base_of = |block: usize| {
-            let mut base = block << low_target;
-            for &(target, _) in sorted.iter() {
-                base = insert_zero_bit(base, target);
-            }
-            base
-        };
-
-        let start_of =
-            |unit: usize| base_of(unit / tiles_per_run) + (unit % tiles_per_run) * tile_len;
-        let units = blocks * tiles_per_run;
-
-        #[cfg(feature = "parallel")]
-        {
-            let ptr = SendPtr(self.state.as_mut_ptr());
-            (0..units).into_par_iter().for_each(|unit| {
-                let start = start_of(unit);
-                for (axis, prep) in prepared.iter().enumerate() {
-                    let stride = 1usize << axis;
-                    for j in 0..lanes {
-                        if j & stride != 0 {
-                            continue;
-                        }
-                        // SAFETY: the target weights are super-increasing, so
-                        // the target bits and tile index partition the buffer
-                        // into disjoint `tile_len` runs; no two lanes or units
-                        // alias.
-                        unsafe {
-                            let base = ptr.as_complex_ptr();
-                            let lo = std::slice::from_raw_parts_mut(
-                                base.add(start + offsets[j]),
-                                tile_len,
-                            );
-                            let hi = std::slice::from_raw_parts_mut(
-                                base.add(start + offsets[j | stride]),
-                                tile_len,
-                            );
-                            prep.apply(lo, hi);
-                        }
-                    }
-                }
-            });
-        }
-    }
-
     /// Apply multiple single-qubit gates in a multi-tier tiled pass.
     ///
     /// Three tiers based on gate target qubit:
@@ -3148,7 +3207,7 @@ impl StatevectorBackend {
 
         #[cfg(feature = "parallel")]
         if self.num_qubits >= PARALLEL_THRESHOLD_QUBITS {
-            self.apply_multi_1q_par(gates);
+            apply_multi_1q_par(&mut self.state, gates);
             return;
         }
 
@@ -3188,58 +3247,6 @@ impl StatevectorBackend {
 
         for (target, mat) in large_gates {
             self.apply_single_gate(target, mat);
-        }
-    }
-
-    #[cfg(feature = "parallel")]
-    #[inline(always)]
-    fn apply_multi_1q_par(&mut self, gates: &[(usize, [[Complex64; 2]; 2])]) {
-        let mut small_gates: SmallVec<[(usize, simd::PreparedGate1q); 16]> = SmallVec::new();
-        let mut medium_gates: SmallVec<[(usize, simd::PreparedGate1q); 4]> = SmallVec::new();
-        let mut large_gates: SmallVec<[(usize, [[Complex64; 2]; 2]); 4]> = SmallVec::new();
-
-        for &(target, mat) in gates {
-            if target <= MULTI_GATE_MAX_L2_TARGET {
-                small_gates.push((target, simd::PreparedGate1q::new(&mat)));
-            } else if target <= MULTI_GATE_MAX_L3_TARGET {
-                medium_gates.push((target, simd::PreparedGate1q::new(&mat)));
-            } else {
-                large_gates.push((target, mat));
-            }
-        }
-
-        if !small_gates.is_empty() {
-            let outer_block = 1usize << (MULTI_GATE_MAX_L2_TARGET + 1);
-            let tile_size = MULTI_GATE_L2_TILE.max(outer_block);
-            self.state
-                .par_chunks_mut(tile_size)
-                .with_min_len(chunk_min_len(tile_size))
-                .for_each(|tile| {
-                    for &(target, ref prepared) in &small_gates {
-                        prepared.apply_tiled(tile, target);
-                    }
-                });
-        }
-
-        if !medium_gates.is_empty() {
-            let outer_block = 1usize << (MULTI_GATE_MAX_L3_TARGET + 1);
-            let tile_size = MULTI_GATE_L3_TILE.max(outer_block);
-            self.state
-                .par_chunks_mut(tile_size)
-                .with_min_len(chunk_min_len(tile_size))
-                .for_each(|tile| {
-                    for &(target, ref prepared) in &medium_gates {
-                        prepared.apply_tiled(tile, target);
-                    }
-                });
-        }
-
-        for chunk in large_gates.chunks(MAX_SHARED_1Q_TARGETS) {
-            if chunk.len() > 1 {
-                self.apply_multi_1q_shared(chunk);
-            } else {
-                self.apply_single_gate(chunk[0].0, chunk[0].1);
-            }
         }
     }
 

--- a/tests/factored_correctness.rs
+++ b/tests/factored_correctness.rs
@@ -19,6 +19,19 @@ fn check_fused_vs_unfused(label: &str, circuit: &Circuit) {
     assert_fused_matches_unfused(|| FactoredBackend::new(SEED), circuit, FACTORED_EPS, label);
 }
 
+fn has_multi_fused(circuit: &Circuit) -> bool {
+    let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
+    fused.instructions.iter().any(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::MultiFused(_),
+                ..
+            }
+        )
+    })
+}
+
 fn has_batch_phase(circuit: &Circuit) -> bool {
     let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
     fused.instructions.iter().any(|inst| {
@@ -181,6 +194,40 @@ fn factored_random_blocks_12q_fused() {
         "random_blocks 4x3 d5 fused",
         &circuits::independent_random_blocks(4, 3, 5, SEED),
     );
+}
+
+// The factored MultiFused path shares the statevector's tiered kernel, so it
+// needs a block wide enough to reach every tier: local targets 0-13 land in L2,
+// 14-16 in L3, and 17 above both. A 4-qubit block would exercise none of them.
+#[test]
+fn factored_multi_fused_spans_every_tier_20q_sv() {
+    const WIDE: usize = 18;
+    let mut c = Circuit::new(20, 0);
+    for q in 0..WIDE {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for q in 0..WIDE - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c.add_gate(Gate::H, &[18]);
+    c.add_gate(Gate::Cx, &[18, 19]);
+    for q in 0..WIDE {
+        c.add_gate(Gate::Ry(0.19 + q as f64 * 0.07), &[q]);
+    }
+
+    assert_eq!(
+        c.independent_subsystems().len(),
+        2,
+        "the wide block and the trailing pair must stay separate or nothing is factored"
+    );
+    assert!(
+        has_multi_fused(&c),
+        "the trailing rotation layer should batch into MultiFused"
+    );
+    // The SV cross alone cannot see a broken tiered kernel: both backends share
+    // it. The unfused arm applies each rotation on its own, so it can.
+    check_fused_vs_unfused("multi_fused all tiers 20q fused", &c);
+    check_sv_cross("multi_fused all tiers 20q sv", &c);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The factored backend carried a verbatim copy of the statevector's tiered single-qubit
sweep, down to its own tile constants and a redeclared `max_target_for_tile`. The copy had
already drifted: when the high-target gates were folded into one shared traversal, the copy
kept applying them one full-state pass each. Sharing the code leaves one implementation to
keep correct instead of two that have already proven they diverge.

## Scope

- [x] Refactor or cleanup

## Benchmarks

N/A, no behavioral change to measure. `apply_single_gate_par`, `apply_multi_1q_shared`, and
`apply_multi_1q_par` move from methods on `StatevectorBackend` to free functions over a
state slice, which is all a factored block is. The bodies are unchanged and the
`inline(always)` attributes are preserved, 59 occurrences in the file before and after, so
no statevector call site changes shape.

The factored path does change: it picks up the high-target fold it had missed. No bench row
reaches it on either backend, which is why the drift went unnoticed for as long as it did,
so there is no row to put in a table. `hardware_efficient_ansatz` lays single-qubit gates
then an unconditional chain of CX, so `fuse_2q_gates` absorbs every one of them and
`fuse_multi_1q_gates` returns early. Instrumenting the fused stream confirms this holds on
the statevector rows too.

Regression verdict: N/A, no hot-path behavior changed.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2373 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed items add information the name and signature do not carry
- [x] `cargo check --no-default-features --all-targets` passes, covering the sequential arms

`factored_multi_fused_spans_every_tier_20q_sv` covers the rewired call site. It drives an
18-qubit block so local targets land in all three tiers, and it checks against unfused
execution rather than against the statevector: the two backends now share this kernel, so a
cross-backend comparison cannot witness it breaking. An earlier draft of the test used the
statevector as the oracle and stayed green with the entire high-target branch deleted.

The shared fold itself is covered through the statevector, which exercises it on every
MultiFused batch carrying more than one high target. Reaching the multi-target case through
the factored call site specifically would need a 19-qubit block, and is not covered here.

## Hotspot notes

The moved functions sit on the statevector single-qubit and MultiFused paths. Attribute
parity is the thing that matters for a move like this, since an inlining change is
invisible to the row it slows down, and it is verified above rather than assumed.

## Breaking changes

None. Every moved item is crate-internal.

## Risks and rollback

Small. The statevector half is a move with attributes and bodies preserved. The factored
half changes traversal shape for targets above the L3 tier, reaching the same amplitudes in
a different order, and is a single commit to revert if it turns out wrong.
