### PR TITLE
perf(circuit): fuse guarded region bodies

### DIFF
--- a/docs/architecture/fusion.md
+++ b/docs/architecture/fusion.md
@@ -4,7 +4,8 @@ Gate optimizations before execution, gated by qubit count thresholds. Every pass
 
 ```mermaid
 flowchart TD
-    IN[Input Circuit] --> P0["cancel_self_inverse_pairs (always)"]
+    IN[Input Circuit] --> PR["fuse_region_bodies (always): each guarded body through this same pipeline"]
+    PR --> P0["cancel_self_inverse_pairs (always)"]
     P0 --> P0r["fuse_rzz (always): CX&middot;Rz&middot;CX to Rzz"]
     P0r --> P0b["fuse_batch_rzz (>=16q): N&times;Rzz to BatchRzz"]
     P0b --> G{"qubits >= MIN_QUBITS_FOR_FUSION (10)?"}

--- a/docs/architecture/ir.md
+++ b/docs/architecture/ir.md
@@ -38,6 +38,12 @@ flushes exactly those qubits at the region boundary and is transparent
 elsewhere, and no pass fuses across the boundary because a region is not an
 `Instruction::Gate`.
 
+The body itself is fused, by `fuse_region_bodies` running the same pipeline over
+it as an ordinary instruction list on the same register, nested bodies included.
+That is body-local only and does not weaken the boundary above: a body is fused
+as a unit, which is sound because it executes as a unit. Leaving it unfused cost
+73.5% of `dynamic/guarded_region/20`.
+
 `Conditional` is the single-gate lowering of the same construct. `if (c) x q[0];`
 keeps that form, so the common guarded gate costs no allocation; anything else
 becomes a `Region`. Build either through `circuit::guarded`, which picks the

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -23,7 +23,7 @@ use std::borrow::Cow;
 
 use num_complex::Complex64;
 
-use super::{Circuit, Instruction, SmallVec, smallvec};
+use super::{Circuit, GuardedRegion, Instruction, SmallVec, smallvec};
 use crate::gates::{
     DiagEntry, DiagonalBatchData, Gate, Multi2qData, MultiFusedData, is_diagonal_2x2,
     is_diagonal_4x4, kron_2x2, mat_mul_2x2, mat_mul_4x4,
@@ -1347,6 +1347,52 @@ where
     }
 }
 
+/// Fuse each guarded region's body in isolation.
+///
+/// Every other pass treats a region as one opaque instruction spanning its
+/// qubit union, so a body would otherwise run entirely unfused. A body is an
+/// ordinary instruction list over the same register, so the pipeline applies to
+/// it unchanged. Nothing moves across the boundary here, and nesting is handled
+/// by the recursive call rather than by descending twice.
+///
+/// The tracer is left alone deliberately: this pass rewrites region payloads in
+/// place, and a region carries no provenance of its own, so the input mapping
+/// still describes the output exactly.
+pub(super) fn fuse_region_bodies<'a>(circuit: &'a Circuit) -> Cow<'a, Circuit> {
+    let insts = &circuit.instructions;
+    let mut out: Option<Vec<Instruction>> = None;
+
+    for (i, inst) in insts.iter().enumerate() {
+        let fused_region = match inst {
+            Instruction::Region(region) => {
+                let body = circuit.with_instructions(region.body().to_vec());
+                match fuse_traced(&body, &mut Tracer::off()) {
+                    Cow::Owned(fused) => Some(Instruction::Region(Box::new(GuardedRegion::new(
+                        region.condition().clone(),
+                        fused.instructions,
+                    )))),
+                    Cow::Borrowed(_) => None,
+                }
+            }
+            _ => None,
+        };
+
+        match fused_region {
+            Some(region) => out.get_or_insert_with(|| insts[..i].to_vec()).push(region),
+            None => {
+                if let Some(buf) = out.as_mut() {
+                    buf.push(inst.clone());
+                }
+            }
+        }
+    }
+
+    match out {
+        Some(buf) => Cow::Owned(circuit.with_instructions(buf)),
+        None => Cow::Borrowed(circuit),
+    }
+}
+
 /// Returns `Cow::Borrowed` when no fusion is profitable (zero overhead).
 /// Set `supports_fused` to `false` for backends that cannot handle fused gates
 /// (e.g., stabilizer).
@@ -1360,7 +1406,8 @@ pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, C
 /// The pass pipeline, recording provenance into `t` when it is tracking.
 pub(super) fn fuse_traced<'a>(circuit: &'a Circuit, t: &mut Tracer) -> Cow<'a, Circuit> {
     let n = circuit.num_qubits;
-    let pass0 = cancel_self_inverse_pairs(circuit, t);
+    let pass_r = fuse_region_bodies(circuit);
+    let pass0 = apply_pass(pass_r, t, cancel_self_inverse_pairs);
     let pass0r = apply_pass(pass0, t, fuse_rzz);
     let pass0b = gated(pass0r, n, MIN_QUBITS_FOR_DIAG_BATCH, |c| {
         apply_pass(c, t, fuse_batch_rzz)

--- a/tests/guarded_regions.rs
+++ b/tests/guarded_regions.rs
@@ -468,6 +468,101 @@ fn nested_region_runs_only_when_both_conditions_hold() {
     assert!((inner_then_outer(false)[0] - 1.0).abs() < 1e-12);
 }
 
+// A region is opaque to every other pass, so its body is fused on its own or
+// not at all. Pin both halves: that the body really does fuse, and that fusing
+// it changes nothing observable on either branch of the guard.
+#[test]
+fn a_fused_region_body_agrees_with_the_bare_layers_on_both_branches() {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Body {
+        Guarded,
+        Bare,
+        Absent,
+    }
+
+    fn layers() -> Vec<Instruction> {
+        let mut body = Vec::new();
+        for q in 1..16u32 {
+            for gate in [Gate::H, Gate::T] {
+                body.push(Instruction::Gate {
+                    gate,
+                    targets: SmallVec::from_slice(&[q as usize]),
+                });
+            }
+        }
+        for q in 1..15usize {
+            body.push(Instruction::Gate {
+                gate: Gate::Cx,
+                targets: SmallVec::from_slice(&[q, q + 1]),
+            });
+        }
+        body
+    }
+
+    // BitIsZero(0) holds after measuring |0> and fails after the flip, so the
+    // same guard drives both branches without touching the body.
+    fn build(flip: bool, body: Body) -> Circuit {
+        let mut circuit = Circuit::new(16, 1);
+        if flip {
+            circuit.add_gate(Gate::X, &[0]);
+        }
+        circuit.add_measure(0, 0);
+        match body {
+            Body::Guarded => circuit.instructions.push(
+                guarded(ClassicalCondition::BitIsZero(0), layers()).expect("body is not empty"),
+            ),
+            Body::Bare => circuit.instructions.extend(layers()),
+            Body::Absent => {}
+        }
+        circuit
+    }
+
+    let guarded_circuit = build(false, Body::Guarded);
+    let fused = fuse_circuit(&guarded_circuit, true);
+    let body = fused
+        .instructions
+        .iter()
+        .find_map(|inst| match inst {
+            Instruction::Region(region) => Some(region.body()),
+            _ => None,
+        })
+        .expect("the region must survive fusion");
+    assert!(
+        body.len() < layers().len(),
+        "fusion must shorten the body, got {} of {}",
+        body.len(),
+        layers().len()
+    );
+    assert!(
+        body.iter().any(|inst| matches!(
+            inst,
+            Instruction::Gate {
+                gate: Gate::Fused(_) | Gate::Fused2q(_) | Gate::MultiFused(_) | Gate::Multi2q(_),
+                ..
+            }
+        )),
+        "a fused body must carry at least one fused gate"
+    );
+
+    let taken = probabilities(&guarded_circuit);
+    let bare = probabilities(&build(false, Body::Bare));
+    for (i, (a, b)) in taken.iter().zip(&bare).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-12,
+            "taken branch differs at {i}: {a} vs {b}"
+        );
+    }
+
+    let skipped = probabilities(&build(true, Body::Guarded));
+    let absent = probabilities(&build(true, Body::Absent));
+    for (i, (a, b)) in skipped.iter().zip(&absent).enumerate() {
+        assert!(
+            (a - b).abs() < 1e-12,
+            "skipped branch differs at {i}: {a} vs {b}"
+        );
+    }
+}
+
 #[test]
 fn fusion_never_absorbs_a_region_and_flushes_only_its_qubits() {
     let mut circuit = Circuit::new(16, 1);


### PR DESCRIPTION
## Summary

Every fusion pass treats a guarded region as one opaque instruction spanning its qubit
union, so a region body ran gate by gate however long it was. A body is an ordinary
instruction list over the same register and it executes as a unit, so the pipeline applies
to it unchanged. `fuse_region_bodies` runs it, recursing into nested bodies through the
pipeline itself rather than descending twice. Feed-forward correction circuits are exactly
this shape, so the cost fell on the construct that motivated regions in the first place.

## Scope

- [x] Performance improvement

## Benchmarks

Two adjacent-binary runs against two independently built references, one from the branch
point and one from `main`. Full sample count, not a reduced-sample triage run. Table below
is the run against `main`, with the first run quoted beside it, because a single run on this
host is not a result.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `dynamic/guarded_region/20` | 553.03 ms | 141.45 ms | -74.4% (first run -73.5%) | -10.2%, +0.6% (first run +1.1%, +0.2%) | PASS, improvement |
| `dynamic/guarded_region/16` | 12.93 ms | 7.09 ms | -45.2% (first run -44.1%) | +0.0%, -1.8% | PASS, improvement |
| `dynamic/guarded_region/unguarded_20` | 90.63 us | 90.77 us | +0.2% (first run +1.6%) | -1.5%, -0.1% | PASS, unmoved |
| `dynamic/guarded_region/unguarded_16` | 66.93 us | 69.85 us | +4.4% | +8.0%, -1.5% | Unresolvable, control exceeds the change |
| `dynamic/guarded_region/nofuse_20` | 365.09 us | 369.09 us | +1.1% (first run -0.3%) | -0.3%, -1.9% | PASS, unmoved |
| `dynamic/guarded_region/nofuse_16` | 127.80 us | 93.49 us | -26.9% | +1.0%, -13.6% | Unresolvable |
| `dynamic/guarded_region/nofuse_unguarded_20` | 97.19 us | 96.64 us | -0.6% | +4.1%, +2.6% | PASS, unmoved |
| `dynamic/guarded_region/nofuse_unguarded_16` | 73.16 us | 72.92 us | -0.3% | +8.3%, -0.8% | Unresolvable |

`unguarded_20` and `unguarded_16` are the in-group controls: the same layers emitted without
a guard, which this diff cannot reach because there is no region to descend into. The
`nofuse_` rows run on the stabilizer backend, which declines fused gates, so `fuse_circuit`
returns its input borrowed and the new pass never executes. All four are expected to sit
still, and the four that resolve do.

The three sub-130 microsecond rows flagged unresolvable came back with same-code control
spreads of 13.6%, 8.3%, and 8.0%. They are unmeasured on this host, not flat, and are
reported that way rather than folded into the result. The `/20` row in this run carries a
-10.2% reference control; the first run measured the same row at -73.5% against controls of
+1.1% and +0.2%, and the two runs agree within one point on an effect seven times the wider
control.

What is left on these rows is fusion across the boundary, which this PR deliberately does
not attempt. The benchmark wraps each layer in its own region, so cancellation between
adjacent layers cannot be seen from inside any one body. Crossing the boundary needs the
per-qubit barrier argument recorded in the dynamic-circuits design note and is a separate
change.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2373 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] New fusion pass has a test against the unfused form
- [x] `cargo check --no-default-features --all-targets` passes

`a_fused_region_body_agrees_with_the_bare_layers_on_both_branches` pins both halves: that
the body genuinely fuses, shorter and carrying a fused gate form, and that fusing it changes
nothing observable. The taken branch is checked against the same layers emitted bare and the
skipped branch against the body omitted entirely, so neither side depends on a second
simulator. Neutering the pass to a no-op fails it.

Two properties were checked before writing the pass, either of which would have made it
unsound:

- Region bodies sit outside the parameter surface. `Parameters::all_rotations` walks only
  top-level instructions and a region carries no provenance, so rewriting a body cannot
  desync a prepared circuit's replay. The top-level instruction count is unchanged, so the
  mapping the tracer holds still describes the output exactly. The pass leaves the tracer
  alone deliberately and says so.
- The passes are state-agnostic local rewrites, so fusing a body in isolation is valid even
  though the body executes conditionally.

## Hotspot notes

The pass runs once per fusion, not per gate, and only walks top-level instructions looking
for regions. Building a fused circuit is off the hot path by roughly three orders of
magnitude against apply cost, and a circuit with no regions returns its input borrowed.

## Architecture or design changes

- [x] `docs/architecture/` updated

`docs/architecture/ir.md` previously stated that no pass fuses across a region boundary, in
a sentence that read as covering inside the body as well. It now says both things
separately. The pass is added to the pipeline diagram in `docs/architecture/fusion.md`.

## Breaking changes

None. A fused body computes the same amplitudes, and a backend that declines fused gates
never sees one.

## Risks and rollback

Contained. The pass is one function at the head of the pipeline; a circuit with no regions
takes the borrowed path and is untouched. Reverting the commit restores the previous
behavior with no migration. The blast radius if the fusion of a body were wrong is any
circuit with a guarded region, which is why the test checks both branches against forms
built without a region rather than against another simulator.
