### PR TITLE
feat(threading): caller-supplied Rayon pool

### DIFF
--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -74,6 +74,10 @@ feature: `run_shots_compiled_with_gpu`, `DevicePackedShots`
 `DistributedStatevectorBackend`, `DistributedContext`, `RankComm`, `SerialComm`; with
 the `distributed-mpi` feature: `MpiComm`
 
+**Threading:** with the `parallel` feature: `ThreadPool`, a caller-supplied Rayon pool
+that simulation runs inside instead of sizing the process-wide one. See
+[Threading, SIMD, and Memory Layout](./threading-simd.md).
+
 **Accumulators:**
 `ShotAccumulator`, `HistogramAccumulator`, `MarginalsAccumulator`,
 `PauliExpectationAccumulator`, `CorrelatorAccumulator`, `NullAccumulator`,

--- a/docs/architecture/threading-simd.md
+++ b/docs/architecture/threading-simd.md
@@ -24,6 +24,12 @@ Gate kernels have `_par` variants using `par_chunks_mut` for safe Rayon parallel
 
 Thread pool defaults to all logical cores (HT helps at 24q+ by hiding memory latency). Overridable via `RAYON_NUM_THREADS`.
 
+The default is the process-wide Rayon pool, sized on the first simulation call. An
+application that owns that pool can hand PRISM-Q a bounded one instead:
+`ThreadPool::with_threads(n)` builds it and `install` runs a closure on it, leaving the
+global pool unbuilt and unresized. Calls made outside `install` take the global path.
+Pool width is not free of consequences for results; see the determinism contract below.
+
 ## SIMD
 
 `Complex64` maps to 128-bit SIMD naturally. Single-qubit gate kernels use `PreparedGate1q` with runtime CPU detection and tiered dispatch:
@@ -50,6 +56,12 @@ unitary, terminal sampling, reduction, and compiled-sampler claims by running th
 seeded circuits in scoped 1-thread and 4-thread pools; the trajectory, SPD, and
 stabilizer bullets stand on the mechanisms they state.
 
+What every clause below turns on is thread count, not which pool supplied the threads. A
+caller-supplied `ThreadPool` therefore moves exactly the results a different
+`RAYON_NUM_THREADS` would: the bitwise claims survive it, the reduction bound holds
+across it, and compiled shot payloads change with it whenever the pool is narrower or
+wider than the one the comparison run used.
+
 - **Unitary evolution on the dense kernels: bitwise, at any thread count.** Gate kernels
   partition the state into index-derived disjoint ranges (fixed chunk boundaries, index
   bijections for the `SendPtr` kernels) and write elementwise, so the schedule cannot
@@ -71,8 +83,9 @@ stabilizer bullets stand on the mechanisms they state.
 - **Compiled (BTS) sampling: reproducible at a fixed thread count only.** The batched
   sampler derives one RNG stream per worker and splits shots by
   `rayon::current_num_threads()`, so a different pool width yields a different, equally
-  distributed shot set. Pin `RAYON_NUM_THREADS` when byte-identical shot payloads matter
-  across machines. The GPU analogue is documented in the [GPU guide](../guides/gpu.md).
+  distributed shot set. Pin the width when byte-identical shot payloads matter across
+  machines, through `RAYON_NUM_THREADS` on the global path or through the width passed to
+  `ThreadPool::with_threads` on the scoped one. The GPU analogue is documented in the [GPU guide](../guides/gpu.md).
 - **SPD analytic estimates: stable to about 1e-12 between runs.** Hash-order term
   accumulation moves the last ulp even at a fixed thread count; tests carry that
   tolerance.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -23,6 +23,10 @@ dominates), with `MIN_PAR_ELEMS = 4096` per task. The pool defaults to all logic
 ```admonish tip title="Control the thread pool"
 Set `RAYON_NUM_THREADS` to cap parallelism. Hyperthreading helps at 24+ qubits by hiding
 memory latency, but on a contended host it adds noise to benchmarks.
+
+An application that already owns the process-wide Rayon pool can keep it: build a
+`ThreadPool::with_threads(n)` and run simulations inside `install`. The global pool is
+left unbuilt on that path.
 ```
 
 ## Determinism

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -237,9 +237,19 @@ pub(crate) fn init_classical_bits(bits: &mut Vec<bool>, num: usize) {
 /// latency. Benchmarks show 17% improvement with logical cores at 24q.
 /// The user can override via `RAYON_NUM_THREADS`.
 ///
+/// Does nothing when the caller already runs inside a Rayon pool, as under
+/// [`ThreadPool::install`](crate::ThreadPool::install): that pool serves the
+/// work, and the global one stays as the caller left it. The `Once` is not
+/// consumed on that path, so a later call from outside a pool still installs
+/// the global pool.
+///
 /// Safe to call multiple times. Only the first call takes effect.
 #[cfg(feature = "parallel")]
 pub(crate) fn init_thread_pool() {
+    if rayon::current_thread_index().is_some() {
+        return;
+    }
+
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
@@ -251,6 +261,24 @@ pub(crate) fn init_thread_pool() {
                 .ok();
         }
     });
+}
+
+#[cfg(all(test, feature = "parallel"))]
+mod thread_pool_tests {
+    // The global pool is process state, so this is the only case in the lib
+    // test binary that may configure it. The scoped half lives in
+    // `tests/thread_pool.rs`.
+    #[test]
+    fn init_thread_pool_sizes_the_global_pool() {
+        let expected: usize = match std::env::var("RAYON_NUM_THREADS") {
+            Ok(requested) => requested.parse().expect("RAYON_NUM_THREADS is a count"),
+            Err(_) => num_cpus::get(),
+        };
+
+        super::init_thread_pool();
+
+        assert_eq!(rayon::current_num_threads(), expected);
+    }
 }
 
 /// Buffer width for [`sorted_mcu_qubits`]. A dense state indexes amplitudes with a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ pub mod gpu;
 mod hash;
 pub mod qec;
 pub mod sim;
+#[cfg(feature = "parallel")]
+pub mod threading;
 
 #[cfg(feature = "distributed")]
 pub use backend::distributed_statevector::DistributedStatevectorBackend;
@@ -124,6 +126,8 @@ pub use sim::{
     RunOutcome, Seeded, ShotsResult, Simulate, Unseeded, bitstring, run_expectation_values,
     run_observable_expectation, run_on, run_on_state, run_qasm, simulate,
 };
+#[cfg(feature = "parallel")]
+pub use threading::ThreadPool;
 
 #[cfg(feature = "gpu")]
 pub use sim::compiled::{DevicePackedShots, run_shots_compiled_with_gpu};

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,0 +1,77 @@
+//! Caller-supplied Rayon pool, for embedding PRISM-Q in an application that
+//! owns the process-wide pool.
+
+use crate::error::{PrismError, Result};
+
+/// A bounded Rayon pool that PRISM-Q runs inside, leaving the process-wide pool
+/// untouched.
+///
+/// Simulation entry points size the global Rayon pool on first use, which an
+/// embedding application may not want. Work run through [`ThreadPool::install`]
+/// uses this pool instead, and the global pool is neither built nor resized, so
+/// an application that installed its own keeps it.
+///
+/// Pool width is part of what a result depends on. Dense unitary evolution,
+/// seeded terminal sampling, and the stabilizer tableau are bitwise at any
+/// width, parallel reductions move by about 1e-12, and compiled (BTS) shot
+/// payloads differ between widths because the batched sampler splits shots by
+/// pool width. A narrower pool is therefore not a slower route to the same
+/// bytes for every result; the per-path contract is the determinism section of
+/// the threading architecture page.
+///
+/// # Examples
+///
+/// ```
+/// use prism_q::{ThreadPool, run_qasm};
+///
+/// let qasm = r#"
+///     OPENQASM 3.0;
+///     include "stdgates.inc";
+///     qubit[2] q;
+///     h q[0];
+///     cx q[0], q[1];
+/// "#;
+///
+/// let pool = ThreadPool::with_threads(2).expect("build pool");
+/// let result = pool.install(|| run_qasm(qasm, 42)).expect("simulation");
+/// let probs = result.probabilities.expect("no probabilities").to_vec();
+/// assert!((probs[0] - 0.5).abs() < 1e-10);
+/// ```
+pub struct ThreadPool {
+    inner: rayon::ThreadPool,
+}
+
+impl ThreadPool {
+    /// Build a pool of `threads` workers, or of the Rayon default width when
+    /// `threads` is 0.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrismError::InvalidParameter`] when the operating system
+    /// refuses to spawn the workers.
+    pub fn with_threads(threads: usize) -> Result<Self> {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .map(|inner| Self { inner })
+            .map_err(|e| PrismError::InvalidParameter {
+                message: format!("could not build a Rayon pool of {threads} threads: {e}"),
+            })
+    }
+
+    /// Run `op` on this pool, blocking the calling thread until it returns.
+    ///
+    /// Every Rayon kernel PRISM-Q reaches from `op` runs on these workers. Work
+    /// that escapes `op`, such as a simulation handed to another thread, falls
+    /// back to the global pool.
+    pub fn install<T: Send>(&self, op: impl FnOnce() -> T + Send) -> T {
+        self.inner.install(op)
+    }
+
+    /// Worker count, which is what `rayon::current_num_threads` reports inside
+    /// [`install`](Self::install). Resolves the default width taken by
+    /// `with_threads(0)`.
+    pub fn num_threads(&self) -> usize {
+        self.inner.current_num_threads()
+    }
+}

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -10,8 +10,8 @@ use common::SEED;
 use num_complex::Complex64;
 use prism_q::circuits::qft_circuit;
 use prism_q::{
-    BackendKind, Circuit, Gate, McuData, PauliTerm, StatevectorBackend, run_on, run_on_state,
-    run_shots_compiled, simulate,
+    BackendKind, Circuit, Gate, McuData, PauliTerm, StatevectorBackend, ThreadPool, run_on,
+    run_on_state, run_shots_compiled, simulate,
 };
 
 #[cfg(not(miri))]
@@ -45,9 +45,7 @@ const SAMPLING_SHOTS: usize = 256;
 const REDUCTION_EPS: f64 = 1e-12;
 
 fn in_pool<T: Send>(threads: usize, op: impl FnOnce() -> T + Send) -> T {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(threads)
-        .build()
+    ThreadPool::with_threads(threads)
         .expect("scoped Rayon pool")
         .install(op)
 }

--- a/tests/thread_pool.rs
+++ b/tests/thread_pool.rs
@@ -1,0 +1,53 @@
+//! Pool-ownership contract for [`prism_q::ThreadPool`]: a scoped run serves the
+//! work from the caller's pool and leaves the process-wide pool as it found it.
+//!
+//! One test function, in order: the global-pool assertion needs the global pool
+//! still unbuilt, and a second case in this binary would build it first.
+
+#![cfg(feature = "parallel")]
+
+mod common;
+
+use common::SEED;
+use num_complex::Complex64;
+use prism_q::circuits::qft_circuit;
+use prism_q::{StatevectorBackend, ThreadPool, run_on};
+
+const QUBITS: usize = 16;
+const SCOPED_THREADS: usize = 2;
+const OUTER_THREADS: usize = 3;
+
+fn amplitudes() -> Vec<(u64, u64)> {
+    let mut backend = StatevectorBackend::new(SEED);
+    run_on(&mut backend, &qft_circuit(QUBITS)).expect("qft run");
+    backend
+        .state_vector()
+        .iter()
+        .map(|a: &Complex64| (a.re.to_bits(), a.im.to_bits()))
+        .collect()
+}
+
+#[test]
+fn scoped_pool_serves_the_work_and_leaves_the_global_pool_alone() {
+    let pool = ThreadPool::with_threads(SCOPED_THREADS).expect("scoped pool");
+    assert_eq!(pool.num_threads(), SCOPED_THREADS);
+
+    let (width, scoped) = pool.install(|| (rayon::current_num_threads(), amplitudes()));
+    assert_eq!(width, SCOPED_THREADS);
+
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(OUTER_THREADS)
+        .build_global()
+        .expect("the scoped run left the global pool unbuilt");
+    let outer = rayon::current_num_threads();
+    assert_eq!(outer, OUTER_THREADS);
+
+    let global = amplitudes();
+    let rescoped = pool.install(amplitudes);
+    assert_eq!(rayon::current_num_threads(), outer);
+
+    // Dense unitary evolution is bitwise at any width, so pool width is the only
+    // difference between the three runs and none of them may show it.
+    assert_eq!(scoped, global);
+    assert_eq!(scoped, rescoped);
+}


### PR DESCRIPTION
## Summary

`init_thread_pool` sized the process-wide Rayon pool through `build_global` on first
use, so an application embedding the crate either had its process pool sized here or
silently inherited whatever another library installed, with `RAYON_NUM_THREADS` the only
lever. `ThreadPool::with_threads(n)` now builds a bounded pool and `install` runs a
closure on it; `init_thread_pool` returns early when the caller is already inside a
Rayon pool, so the global one is neither built nor resized. The global path is unchanged
and stays the default.

```rust
let pool = prism_q::ThreadPool::with_threads(4)?;
let result = pool.install(|| prism_q::run_qasm(src, 42))?;
```

`with_threads(0)` takes the Rayon default width, and `num_threads()` reports the
resolved width, which is what the determinism contract turns on. The guard is
`rayon::current_thread_index().is_some()`, so a caller who installs their own Rayon pool
directly gets the same treatment without going through this type. The `Once` is not
consumed on the guarded path, so a later call from outside a pool still installs the
global pool.

## Determinism

`docs/architecture/threading-simd.md` now states that every clause in its contract turns
on thread count, not on which pool supplied the threads. A caller-supplied pool moves
exactly the results a different `RAYON_NUM_THREADS` would: the bitwise claims (dense
unitary evolution, seeded terminal sampling, the stabilizer tableau) survive it, the
1e-12 reduction bound holds across it, and compiled (BTS) shot payloads change with the
width, because the batched sampler splits shots by `rayon::current_num_threads`. The
compiled-sampling bullet names both ways to pin the width.

## Benchmark summary

The claim under test is that the default path did not move. Adjacent-binary A/B against
`main` (b49fcb0), `--features parallel`, 30 samples, i7-6700K, rustc 1.97.0. Five runs;
three are thrown out on same-code control spreads of 88%, 540%, and 65%, measured while
other work held the host. The two usable runs:

| Benchmark | Run A change | Run A controls | Run B change | Run B controls |
|-----------|-------------|----------------|-------------|----------------|
| `stabilizer/scaling/1000` | -3.2% | +3.3% / +1.6% | +0.7% | -2.8% / +3.6% |
| `statevector/random_d10/20` | -1.5% | +2.0% / -1.3% | -5.8% | -7.7% / -0.1% |
| `statevector/qaoa_l3/20` | +2.7% | -0.2% / +6.2% | +4.0% | +1.7% / +3.3% |

`stabilizer/scaling/1000` resolves in both runs and reads a null: opposite signs, each
magnitude inside its own control. Each statevector row resolves in exactly one of the
two runs and is unresolvable in the other, so each carries one measurement rather than
two: `random_d10/20` at -1.5% in run A, `qaoa_l3/20` at +4.0% in run B.

The `qaoa_l3/20` positive appears in both runs (+2.7%, +4.0%) and is under the 5% gate
in both, so it is reported rather than buried. It is not attributed to this change: the
added work is one thread-local read per `Backend::init`, once per 38 ms iteration, which
cannot produce 4%. Treat it as host drift pending a quiet-host repeat.

No scoped-pool row was added. A new row has no before side, so it would be a standalone
number rather than a comparison, and the scoped path's cost is pool width, which is the
caller's choice.

## Regression verdict

PASS at 5.0%. No row moved beyond its own control spread in a run that could resolve it.
Three of the five rows measured are reported as unresolvable on this host rather than as
passes: `stabilizer/scaling/1000` resolved twice, the two statevector rows once each.

## Tests

- `tests/thread_pool.rs::scoped_pool_serves_the_work_and_leaves_the_global_pool_alone`
  runs a 16q QFT in a 2-thread pool, then asserts `build_global` still succeeds, which
  holds only if nothing in the scoped run configured it. The assertion is sharp: with
  the guard removed it fails with `GlobalPoolAlreadyInitialized`. It then builds a
  3-thread global pool, checks a second scoped run leaves the outer
  `current_num_threads` unchanged, and compares the scoped, global, and rescoped
  amplitudes bitwise. One test function per file, because a second case would build the
  global pool the first one asserts is absent.
- `backend::thread_pool_tests::init_thread_pool_sizes_the_global_pool` pins the default
  path at `num_cpus::get()`, or at `RAYON_NUM_THREADS` when set, so the change cannot
  quietly become opt-out.
- `tests/determinism.rs` now scopes its pools through the public `ThreadPool`, so the
  whole thread-count contract is pinned through the shipped API. Its six cases pass
  unchanged.

Gate on 9c3391f: `cargo fmt --check`, `cargo clippy --all-targets --features parallel -D
warnings -D clippy::undocumented_unsafe_blocks`, 2159 tests, 18 doctests, `cargo doc
--no-deps --features "parallel gpu distributed"` under `RUSTDOCFLAGS=-D warnings`, and a
`--no-default-features` build, all clean.

## Documentation

`docs/architecture/threading-simd.md` (threading and determinism sections),
`docs/architecture/api-surface.md` (new threading entry), `docs/guides/performance.md`
(thread-pool tip). Docstrings on `ThreadPool`, `with_threads`, `install`, and
`num_threads`, plus the guard's contract on `init_thread_pool`.
