### PR TITLE
feat(pauli): arbitrary-angle Z rotations in the Pauli engines

### DIFF
--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -51,8 +51,10 @@ probability extraction failures propagate as errors. `marginals()` requires
 either a direct Pauli marginal route or backend probability output; it returns
 `BackendUnsupported` instead of fabricating uniform marginals when neither path
 is available. Stochastic and deterministic Pauli marginal backends accept only
-unitary Clifford+T circuits without measurement, reset, or conditional
-instructions.
+unitary circuits of Clifford gates and Z-axis rotations (`T`, `Tdg`, `Rz`, `P`)
+without measurement, reset, or conditional instructions. Automatic dispatch
+still routes only Clifford+T circuits to SPD; a circuit carrying arbitrary
+rotation angles reaches the Pauli engines by explicit backend selection.
 
 ## Noise across the terminals
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1741,13 +1741,9 @@ fn supports_pauli_marginal_backend(circuit: &Circuit) -> bool {
     circuit.is_clifford_plus_t() && !has_nonunitary_or_classical_ops(circuit)
 }
 
+/// Gate-set support is left to the engines, which accept Clifford gates and
+/// Z-axis rotations and report the offending gate by name.
 fn validate_pauli_marginal_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
-    if !circuit.is_clifford_plus_t() {
-        return Err(PrismError::IncompatibleBackend {
-            backend: format!("{kind:?}"),
-            reason: "Pauli marginal backends require Clifford+T gates".into(),
-        });
-    }
     if has_nonunitary_or_classical_ops(circuit) {
         return Err(PrismError::IncompatibleBackend {
             backend: format!("{kind:?}"),

--- a/src/sim/tests.rs
+++ b/src/sim/tests.rs
@@ -184,23 +184,23 @@ impl Backend for ProbabilityFailureBackend {
     }
 }
 
-fn assert_pauli_marginals_reject(circuit: &Circuit) {
-    for backend in [
+fn pauli_marginal_errors(circuit: &Circuit) -> Vec<PrismError> {
+    [
         BackendKind::StochasticPauli { num_samples: 100 },
         BackendKind::DeterministicPauli {
             epsilon: 0.0,
             max_terms: 0,
         },
-    ] {
-        assert!(matches!(
-            simulate(circuit)
-                .backend(backend)
-                .seed(42)
-                .marginals()
-                .unwrap_err(),
-            PrismError::IncompatibleBackend { .. }
-        ));
-    }
+    ]
+    .into_iter()
+    .map(|backend| {
+        simulate(circuit)
+            .backend(backend)
+            .seed(42)
+            .marginals()
+            .unwrap_err()
+    })
+    .collect()
 }
 
 #[test]
@@ -1657,11 +1657,33 @@ fn test_pauli_backends_return_marginals_through_builder() {
 }
 
 #[test]
-fn test_pauli_marginals_reject_non_clifford_t_gates() {
+fn test_pauli_marginals_reject_gates_off_the_z_axis() {
     let mut c = Circuit::new(1, 0);
     c.add_gate(Gate::Rx(0.25), &[0]);
 
-    assert_pauli_marginals_reject(&c);
+    for err in pauli_marginal_errors(&c) {
+        assert!(
+            matches!(err, PrismError::BackendUnsupported { .. }),
+            "{err:?}"
+        );
+    }
+
+    let mut supported = Circuit::new(1, 0);
+    supported.add_gate(Gate::H, &[0]);
+    supported.add_gate(Gate::Rz(0.25), &[0]);
+    assert_eq!(
+        simulate(&supported)
+            .backend(BackendKind::DeterministicPauli {
+                epsilon: 0.0,
+                max_terms: 0,
+            })
+            .seed(42)
+            .marginals()
+            .unwrap()
+            .marginals
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -1684,7 +1706,12 @@ fn test_pauli_marginals_reject_measurements_resets_and_conditionals() {
     });
 
     for circuit in [&measured, &reset, &conditional] {
-        assert_pauli_marginals_reject(circuit);
+        for err in pauli_marginal_errors(circuit) {
+            assert!(
+                matches!(err, PrismError::IncompatibleBackend { .. }),
+                "{err:?}"
+            );
+        }
     }
 }
 

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -1,6 +1,7 @@
-//! Pauli propagation engines for Clifford+T circuits: SPP samples backward
-//! Heisenberg propagation stochastically, SPD carries the full weighted Pauli
-//! sum with optional truncation. Neither materializes a state vector.
+//! Pauli propagation engines for circuits of Clifford gates and Z-axis
+//! rotations: SPP samples backward Heisenberg propagation stochastically, SPD
+//! carries the full weighted Pauli sum with optional truncation. Neither
+//! materializes a state vector.
 
 use num_complex::Complex64;
 use rand::SeedableRng;
@@ -12,14 +13,12 @@ use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 use crate::sim::compiled::{PauliVec, flip_bit, propagate_backward};
 
-const SQRT_2: f64 = std::f64::consts::SQRT_2;
-
 /// Absolute ceiling on the weighted-Pauli term count, enforced even in exact
 /// mode (`max_terms == 0`). Without a per-step truncation budget the term set
-/// grows as `2^(in-cone T count)`; this caps transient memory the same way the
-/// stabilizer-rank backend does. Exceeding it is an error, not a silent
-/// truncation: callers wanting bounded approximate evaluation pass a nonzero
-/// `max_terms` instead.
+/// grows as `2^(in-cone branching rotations)`; this caps transient memory the
+/// same way the stabilizer-rank backend does. Exceeding it is an error, not a
+/// silent truncation: callers wanting bounded approximate evaluation pass a
+/// nonzero `max_terms` instead.
 const SPD_MAX_TERMS_CEILING: usize = 1 << 20;
 
 #[inline]
@@ -36,14 +35,33 @@ fn check_spd_term_ceiling(len: usize) -> Result<()> {
     Ok(())
 }
 
-fn validate_clifford_t_unitary(circuit: &Circuit, backend: &'static str) -> Result<()> {
+/// Rotation angle of the Z-axis rotation a gate lowers to, if any.
+///
+/// `P(λ)` and `Rz(λ)` differ by the global phase `e^{-iλ/2}`, which conjugation
+/// discards, so both report `λ`. Clifford Z rotations (`Z`, `S`, `Sdg`) are
+/// deliberately absent: they conjugate exactly through the Clifford path and
+/// would otherwise branch into a term with a rounding-noise coefficient.
+#[inline]
+fn z_rotation_angle(gate: &Gate) -> Option<f64> {
+    match gate {
+        Gate::T => Some(std::f64::consts::FRAC_PI_4),
+        Gate::Tdg => Some(-std::f64::consts::FRAC_PI_4),
+        Gate::Rz(theta) | Gate::P(theta) => Some(*theta),
+        _ => None,
+    }
+}
+
+fn validate_pauli_unitary(circuit: &Circuit, backend: &'static str) -> Result<()> {
     for inst in &circuit.instructions {
         match inst {
             Instruction::Gate { gate, .. } => {
-                if !(gate.is_clifford() || matches!(gate, Gate::T | Gate::Tdg)) {
+                if !(gate.is_clifford() || z_rotation_angle(gate).is_some()) {
                     return Err(PrismError::BackendUnsupported {
                         backend: backend.to_string(),
-                        operation: format!("non-Clifford+T gate `{}`", gate.name()),
+                        operation: format!(
+                            "gate `{}` is neither Clifford nor a Z-axis rotation",
+                            gate.name()
+                        ),
                     });
                 }
             }
@@ -54,7 +72,8 @@ fn validate_clifford_t_unitary(circuit: &Circuit, backend: &'static str) -> Resu
             | Instruction::Region(_) => {
                 return Err(PrismError::IncompatibleBackend {
                     backend: backend.to_string(),
-                    reason: "Pauli propagation requires a unitary Clifford+T circuit without measurements, resets, or conditionals"
+                    reason: "Pauli propagation requires a unitary circuit without measurements, \
+                         resets, or conditionals"
                         .to_string(),
                 });
             }
@@ -67,7 +86,7 @@ fn validate_clifford_t_unitary(circuit: &Circuit, backend: &'static str) -> Resu
 
 enum CoalescedOp {
     SmallCliff(Vec<(Gate, SmallVec<[usize; 4]>)>),
-    T { qubit: usize, is_dagger: bool },
+    ZRot { qubit: usize, branch: RotBranch },
 }
 
 fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
@@ -76,24 +95,14 @@ fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
 
     for inst in &circuit.instructions {
         if let Instruction::Gate { gate, targets } = inst {
-            match gate {
-                Gate::T => {
-                    flush_cliff_buf(&mut cliff_buf, &mut ops);
-                    ops.push(CoalescedOp::T {
-                        qubit: targets[0],
-                        is_dagger: false,
-                    });
-                }
-                Gate::Tdg => {
-                    flush_cliff_buf(&mut cliff_buf, &mut ops);
-                    ops.push(CoalescedOp::T {
-                        qubit: targets[0],
-                        is_dagger: true,
-                    });
-                }
-                _ => {
-                    cliff_buf.push((gate.clone(), SmallVec::from_slice(targets)));
-                }
+            if let Some(theta) = z_rotation_angle(gate) {
+                flush_cliff_buf(&mut cliff_buf, &mut ops);
+                ops.push(CoalescedOp::ZRot {
+                    qubit: targets[0],
+                    branch: RotBranch::new(theta),
+                });
+            } else {
+                cliff_buf.push((gate.clone(), SmallVec::from_slice(targets)));
             }
         } else {
             flush_cliff_buf(&mut cliff_buf, &mut ops);
@@ -112,33 +121,52 @@ fn flush_cliff_buf(buf: &mut Vec<(Gate, SmallVec<[usize; 4]>)>, ops: &mut Vec<Co
 
 // ---- SPP (Stochastic Pauli Propagation) ----
 
+/// Sampling data for one Z-axis rotation, built once per gate so the per-sample
+/// loop stays free of trigonometry.
+#[derive(Clone, Copy)]
+struct RotBranch {
+    p_keep: f64,
+    keep_weight: f64,
+    flip_weight_im: f64,
+}
+
+impl RotBranch {
+    /// Branch probability and importance weights for `Rz(theta)`.
+    ///
+    /// Backward conjugation sends an in-support Pauli `P` to
+    /// `cos(theta) P + (-i sin(theta)) P Z_q`. PauliVec stores the Y letter as
+    /// the ordered product XZ and actual `Y = i XZ`, which is where the flip
+    /// branch picks up its imaginary unit. Branch selection is proportional to
+    /// coefficient magnitude, so the per-sample weight magnitude is
+    /// `|cos| + |sin|`: 1 at the Clifford angles, `sqrt(2)` at `theta = pi/4`.
+    fn new(theta: f64) -> Self {
+        let (sin, cos) = theta.sin_cos();
+        let norm1 = cos.abs() + sin.abs();
+        Self {
+            p_keep: cos.abs() / norm1,
+            keep_weight: norm1 * cos.signum(),
+            flip_weight_im: -norm1 * sin.signum(),
+        }
+    }
+}
+
 #[inline(always)]
-fn branch_t_gate(
+fn branch_z_rotation(
     pauli: &mut PauliVec,
     qubit: usize,
-    is_dagger: bool,
+    branch: &RotBranch,
     rng: &mut impl Rng,
 ) -> Complex64 {
-    // PauliVec stores the Y letter as the ordered product XZ. Since
-    // actual Y = i XZ, the T flip branch is imaginary in this basis:
-    // T contributes -i/sqrt(2), and Tdg contributes +i/sqrt(2).
-    // SPP samples one branch with probability 1/2, so the per-shot
-    // flip weight is +/-i*sqrt(2).
     if !pauli.has_x_or_y(qubit) {
         return Complex64::new(1.0, 0.0);
     }
 
-    let keep = rng.random_bool(0.5);
-    if keep {
-        return Complex64::new(SQRT_2, 0.0);
+    if rng.random_bool(branch.p_keep) {
+        return Complex64::new(branch.keep_weight, 0.0);
     }
 
     flip_bit(&mut pauli.z, qubit);
-    if is_dagger {
-        Complex64::new(0.0, SQRT_2)
-    } else {
-        Complex64::new(0.0, -SQRT_2)
-    }
+    Complex64::new(0.0, branch.flip_weight_im)
 }
 
 fn backward_propagate_coalesced(
@@ -164,8 +192,8 @@ fn backward_propagate_coalesced(
                     propagate_backward(&mut pauli, gate, targets);
                 }
             }
-            CoalescedOp::T { qubit, is_dagger } => {
-                weight *= branch_t_gate(&mut pauli, *qubit, *is_dagger, rng);
+            CoalescedOp::ZRot { qubit, branch } => {
+                weight *= branch_z_rotation(&mut pauli, *qubit, branch, rng);
             }
         }
     }
@@ -173,18 +201,13 @@ fn backward_propagate_coalesced(
     (pauli, weight)
 }
 
-fn count_t_gates(circuit: &Circuit) -> usize {
+fn count_branching_gates(circuit: &Circuit) -> usize {
     circuit
         .instructions
         .iter()
-        .filter(|inst| {
-            matches!(
-                inst,
-                Instruction::Gate {
-                    gate: Gate::T | Gate::Tdg,
-                    ..
-                }
-            )
+        .filter(|inst| match inst {
+            Instruction::Gate { gate, .. } => z_rotation_angle(gate).is_some(),
+            _ => false,
         })
         .count()
 }
@@ -195,7 +218,7 @@ pub struct SppResult {
     pub std_errors: Vec<f64>,
     /// Samples drawn per qubit, not in total.
     pub num_samples: usize,
-    /// T plus Tdg gates in the circuit.
+    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, and `P`.
     pub t_count: usize,
     /// Fraction of samples whose propagated Pauli was diagonal (contributed a
     /// nonzero value).
@@ -341,23 +364,28 @@ fn pauli_vec_from_terms(
     Ok((pv, coeff))
 }
 
-/// Estimate `⟨0^n| U† P U |0^n⟩` for joint Pauli observable `P` on a
-/// Clifford+T circuit `U` via stochastic Pauli propagation.
+/// Estimate `⟨0^n| U† P U |0^n⟩` for joint Pauli observable `P` on a circuit
+/// `U` of Clifford gates and Z-axis rotations, via stochastic Pauli
+/// propagation.
 ///
 /// Each sample backward-propagates the observable through the circuit
-/// (Clifford segments as coalesced gate runs, T gates via a stochastic
-/// Pauli branch that records a complex weight). The
+/// (Clifford segments as coalesced gate runs, `Rz(theta)` and its `T` special
+/// case via a stochastic Pauli branch that records a complex weight). The
 /// contribution is `Re(weight)` when the final Pauli is diagonal in
 /// `{I, Z}` (i.e. evaluates trivially on `|0^n⟩`), else zero.
+///
+/// Sample variance grows with the product of `|cos θ| + |sin θ|` over the
+/// in-support rotations, so it is largest at `θ = π/4` and vanishes as the
+/// angles approach a Clifford multiple of `π/2`.
 pub fn run_spp_observable(
     circuit: &Circuit,
     observable: &[PauliTerm],
     num_samples: usize,
     seed: u64,
 ) -> Result<SppObservableResult> {
-    validate_clifford_t_unitary(circuit, "SPP observable")?;
+    validate_pauli_unitary(circuit, "SPP observable")?;
     let n = circuit.num_qubits;
-    let t_count = count_t_gates(circuit);
+    let t_count = count_branching_gates(circuit);
     let ops = coalesce_cliffords(circuit);
     let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
 
@@ -398,8 +426,8 @@ pub fn run_spp_observable(
     })
 }
 
-/// Estimate `⟨Z_q⟩` for every qubit of a unitary Clifford+T circuit via
-/// stochastic Pauli propagation.
+/// Estimate `⟨Z_q⟩` for every qubit of a unitary circuit of Clifford gates and
+/// Z-axis rotations, via stochastic Pauli propagation.
 ///
 /// Draws `num_samples` backward propagations per qubit; the cost scales with
 /// samples and gate count, not `2^n`. See [`run_spp_observable`] for a single
@@ -423,10 +451,10 @@ pub fn run_spp_observable(
 /// # Ok::<(), prism_q::PrismError>(())
 /// ```
 pub fn run_spp(circuit: &Circuit, num_samples: usize, seed: u64) -> Result<SppResult> {
-    validate_clifford_t_unitary(circuit, "SPP")?;
+    validate_pauli_unitary(circuit, "SPP")?;
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
-    let t_count = count_t_gates(circuit);
+    let t_count = count_branching_gates(circuit);
     let ops = coalesce_cliffords(circuit);
 
     #[cfg(feature = "parallel")]
@@ -607,15 +635,14 @@ impl WeightedPauliSum {
         }
     }
 
-    fn branch_t_deterministic(&mut self, qubit: usize, is_dagger: bool) {
+    /// Split every in-support term under backward conjugation by a Z rotation,
+    /// which sends `P` to `cos(theta) P + (-i sin(theta)) P Z_q`. Takes the
+    /// evaluated `(sin, cos)` because `run_spd` replays the circuit once per
+    /// qubit and the trigonometry is per gate, not per replay. A branch whose
+    /// coefficient is exactly zero is not inserted, so `Rz(0)` and `P(0)` leave
+    /// the term count alone.
+    fn branch_z_rotation(&mut self, qubit: usize, sin: f64, cos: f64) {
         let old_terms: Vec<(PauliVec, Complex64)> = self.terms.drain().collect();
-        let inv_sqrt2 = 1.0 / SQRT_2;
-        let keep_coeff = Complex64::new(inv_sqrt2, 0.0);
-        let flip_coeff = if is_dagger {
-            Complex64::new(0.0, inv_sqrt2)
-        } else {
-            Complex64::new(0.0, -inv_sqrt2)
-        };
 
         for (pauli, coeff) in old_terms {
             if !pauli.has_x_or_y(qubit) {
@@ -623,12 +650,14 @@ impl WeightedPauliSum {
                 continue;
             }
 
-            let pauli_keep = pauli.clone();
-            let mut pauli_flip = pauli;
-            flip_bit(&mut pauli_flip.z, qubit);
-
-            self.insert(pauli_keep, coeff * keep_coeff);
-            self.insert(pauli_flip, coeff * flip_coeff);
+            if cos != 0.0 {
+                self.insert(pauli.clone(), coeff * cos);
+            }
+            if sin != 0.0 {
+                let mut pauli_flip = pauli;
+                flip_bit(&mut pauli_flip.z, qubit);
+                self.insert(pauli_flip, Complex64::new(coeff.im * sin, -coeff.re * sin));
+            }
         }
     }
 
@@ -660,7 +689,7 @@ impl WeightedPauliSum {
 pub struct SpdResult {
     /// `⟨Z_q⟩` per qubit; exact when nothing was truncated.
     pub expectations: Vec<f64>,
-    /// T plus Tdg gates in the circuit.
+    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, and `P`.
     pub t_count: usize,
     /// Peak size of the weighted Pauli sum across all per-qubit runs, not the
     /// truncation budget passed in.
@@ -672,20 +701,32 @@ pub struct SpdResult {
 /// Deterministic SPD on a joint Pauli observable.
 ///
 /// Starts with the single weighted term `(observable, 1.0)`, backward-
-/// propagates through every gate, branches each T into two terms with
-/// `α / β` coefficients, and truncates terms whose magnitude falls below
-/// `epsilon` whenever the sum exceeds `max_terms`. Returns
-/// `⟨0^n| U† P U |0^n⟩` as the sum of remaining diagonal-term
+/// propagates through every gate, splits each in-support term at an `Rz(theta)`
+/// into `cos(theta)` and `-i sin(theta)` branches, and truncates terms whose
+/// magnitude falls below `epsilon` whenever the sum exceeds `max_terms`.
+/// Returns `⟨0^n| U† P U |0^n⟩` as the sum of remaining diagonal-term
 /// coefficients.
+///
+/// # Truncation
+///
+/// Every rotation with a non-Clifford angle branches, so a variational circuit
+/// branches on each of its rotations rather than only on its `T` gates, and the
+/// term count is bounded by `2^(in-support rotations)`. With `max_terms == 0`
+/// the run is exact and errors once the sum passes an internal ceiling. With
+/// `max_terms > 0`, sub-`epsilon` terms are dropped whenever the sum exceeds
+/// the budget and `total_discarded` bounds the resulting error, per the
+/// 1-norm bound `|error| ≤ Σ |discarded|`. An `epsilon` too small to prune the
+/// growth still reaches the ceiling and errors there: the run never returns a
+/// silently over-truncated value.
 pub fn run_spd_observable(
     circuit: &Circuit,
     observable: &[PauliTerm],
     epsilon: f64,
     max_terms: usize,
 ) -> Result<SpdObservableResult> {
-    validate_clifford_t_unitary(circuit, "SPD observable")?;
+    validate_pauli_unitary(circuit, "SPD observable")?;
     let n = circuit.num_qubits;
-    let t_count = count_t_gates(circuit);
+    let t_count = count_branching_gates(circuit);
     let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
 
     let mut sum = WeightedPauliSum::new();
@@ -695,10 +736,10 @@ pub fn run_spd_observable(
 
     for inst in circuit.instructions.iter().rev() {
         if let Instruction::Gate { gate, targets } = inst {
-            match gate {
-                Gate::T => sum.branch_t_deterministic(targets[0], false),
-                Gate::Tdg => sum.branch_t_deterministic(targets[0], true),
-                _ => sum.conjugate_all_backward_phased(gate, targets),
+            if let Some((sin, cos)) = z_rotation_angle(gate).map(f64::sin_cos) {
+                sum.branch_z_rotation(targets[0], sin, cos);
+            } else {
+                sum.conjugate_all_backward_phased(gate, targets);
             }
         }
         if max_terms > 0 && sum.terms.len() > max_terms {
@@ -722,34 +763,44 @@ pub fn run_spd_observable(
     })
 }
 
-/// Compute `⟨Z_q⟩` for every qubit of a unitary Clifford+T circuit via
-/// deterministic sparse Pauli dynamics.
+/// Compute `⟨Z_q⟩` for every qubit of a unitary circuit of Clifford gates and
+/// Z-axis rotations, via deterministic sparse Pauli dynamics.
 ///
-/// Each qubit's `Z_q` propagates backward as a weighted Pauli sum; T gates
-/// double the in-support terms. When the sum exceeds `max_terms`, terms with
-/// coefficient magnitude below `epsilon` are dropped. `max_terms == 0`
-/// disables truncation: exact, but the sum must stay under a hard term
-/// ceiling. See [`run_spd_observable`] for a single joint observable.
+/// Each qubit's `Z_q` propagates backward as a weighted Pauli sum; every
+/// rotation with a non-Clifford angle doubles the in-support terms. When the
+/// sum exceeds `max_terms`, terms with coefficient magnitude below `epsilon`
+/// are dropped. `max_terms == 0` disables truncation: exact, but the sum must
+/// stay under a hard term ceiling. See [`run_spd_observable`] for a single
+/// joint observable and for the truncation contract.
 pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdResult> {
-    validate_clifford_t_unitary(circuit, "SPD")?;
+    validate_pauli_unitary(circuit, "SPD")?;
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
-    let t_count = count_t_gates(circuit);
+    let t_count = count_branching_gates(circuit);
 
     let mut expectations = Vec::with_capacity(n);
     let mut peak_terms = 0usize;
     let mut total_discarded = 0.0;
 
+    let rotations: Vec<Option<(f64, f64)>> = circuit
+        .instructions
+        .iter()
+        .map(|inst| match inst {
+            Instruction::Gate { gate, .. } => z_rotation_angle(gate).map(f64::sin_cos),
+            _ => None,
+        })
+        .collect();
+
     for q in 0..n {
         let mut sum = WeightedPauliSum::new();
         sum.insert(PauliVec::z_on_qubit(num_words, q), Complex64::new(1.0, 0.0));
 
-        for inst in circuit.instructions.iter().rev() {
+        for (idx, inst) in circuit.instructions.iter().enumerate().rev() {
             if let Instruction::Gate { gate, targets } = inst {
-                match gate {
-                    Gate::T => sum.branch_t_deterministic(targets[0], false),
-                    Gate::Tdg => sum.branch_t_deterministic(targets[0], true),
-                    _ => sum.conjugate_all_backward_phased(gate, targets),
+                if let Some((sin, cos)) = rotations[idx] {
+                    sum.branch_z_rotation(targets[0], sin, cos);
+                } else {
+                    sum.conjugate_all_backward_phased(gate, targets);
                 }
             }
 
@@ -814,20 +865,20 @@ pub fn inverse_light_cone(circuit: &Circuit, observable: &[PauliTerm]) -> Vec<bo
 
 /// SPD on a joint Pauli observable, restricted to the inverse light cone.
 ///
-/// Identical in result to `run_spd_observable` for any Clifford+T circuit, but
-/// skips gates whose support is disjoint from the propagated observable's
-/// causal cone. For QEC syndrome and detector observables with bounded
-/// spatial support, this turns the SPD cliff from a function of total T-count
-/// into a function of in-cone T-count.
+/// Identical in result to `run_spd_observable`, but skips gates whose support
+/// is disjoint from the propagated observable's causal cone. For QEC syndrome
+/// and detector observables with bounded spatial support, this turns the SPD
+/// cliff from a function of the total branching-gate count into a function of
+/// the in-cone count.
 pub fn run_spd_observable_light_cone(
     circuit: &Circuit,
     observable: &[PauliTerm],
     epsilon: f64,
     max_terms: usize,
 ) -> Result<SpdObservableResult> {
-    validate_clifford_t_unitary(circuit, "light-cone SPD observable")?;
+    validate_pauli_unitary(circuit, "light-cone SPD observable")?;
     let n = circuit.num_qubits;
-    let t_count = count_t_gates(circuit);
+    let t_count = count_branching_gates(circuit);
     let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
     let keep = inverse_light_cone(circuit, observable);
 
@@ -841,10 +892,10 @@ pub fn run_spd_observable_light_cone(
             continue;
         }
         if let Instruction::Gate { gate, targets } = inst {
-            match gate {
-                Gate::T => sum.branch_t_deterministic(targets[0], false),
-                Gate::Tdg => sum.branch_t_deterministic(targets[0], true),
-                _ => sum.conjugate_all_backward_phased(gate, targets),
+            if let Some((sin, cos)) = z_rotation_angle(gate).map(f64::sin_cos) {
+                sum.branch_z_rotation(targets[0], sin, cos);
+            } else {
+                sum.conjugate_all_backward_phased(gate, targets);
             }
         }
         if max_terms > 0 && sum.terms.len() > max_terms {

--- a/src/sim/unified_pauli_tests.rs
+++ b/src/sim/unified_pauli_tests.rs
@@ -1,6 +1,11 @@
 use super::*;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use std::f64::consts::{FRAC_PI_4, SQRT_2};
+
+fn t_branch() -> RotBranch {
+    RotBranch::new(FRAC_PI_4)
+}
 
 #[test]
 fn test_no_t_gates_matches_propagate_backward() {
@@ -59,11 +64,11 @@ fn test_branch_t_gate_passthrough_iz() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
     let mut pauli_i = PauliVec::new(1);
-    let w = branch_t_gate(&mut pauli_i, 0, false, &mut rng);
+    let w = branch_z_rotation(&mut pauli_i, 0, &t_branch(), &mut rng);
     assert!((w - Complex64::new(1.0, 0.0)).norm() < 1e-14);
 
     let mut pauli_z = PauliVec::z_on_qubit(1, 0);
-    let w = branch_t_gate(&mut pauli_z, 0, false, &mut rng);
+    let w = branch_z_rotation(&mut pauli_z, 0, &t_branch(), &mut rng);
     assert!((w - Complex64::new(1.0, 0.0)).norm() < 1e-14);
 }
 
@@ -77,7 +82,7 @@ fn test_branch_t_gate_x_branches() {
     for _ in 0..num_samples {
         let mut pauli = PauliVec::new(1);
         pauli.x[0] = 1;
-        let w = branch_t_gate(&mut pauli, 0, false, &mut rng);
+        let w = branch_z_rotation(&mut pauli, 0, &t_branch(), &mut rng);
         assert!((w.norm() - SQRT_2).abs() < 1e-14);
         if pauli.z[0] == 0 {
             x_count += 1;

--- a/tests/pauli_joint_observable.rs
+++ b/tests/pauli_joint_observable.rs
@@ -5,7 +5,9 @@ mod common;
 use common::SEED;
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
-use prism_q::{PauliAxis, PauliTerm, run_spd_observable, run_spp_observable};
+use prism_q::{
+    BackendKind, PauliAxis, PauliTerm, run_spd_observable, run_spp_observable, simulate,
+};
 
 #[test]
 fn spp_recovers_single_qubit_z_expectation_on_h_t_h_circuit() {
@@ -155,15 +157,185 @@ fn duplicate_pauli_factors_are_rejected() {
 }
 
 #[test]
-fn spd_rejects_non_clifford_non_t_gates() {
+fn spd_rejects_gates_off_the_z_axis() {
     let mut circuit = Circuit::new(1, 0);
     circuit.add_gate(Gate::Rx(0.37), &[0]);
 
     let err = run_spd_observable(&circuit, &[PauliTerm::z(0)], 0.0, 0)
-        .expect_err("SPD must reject gates outside Clifford+T");
+        .expect_err("SPD must reject rotations off the Z axis");
     let msg = format!("{err:?}");
     assert!(
-        msg.contains("non-Clifford+T"),
-        "expected non-Clifford+T rejection, got {msg}"
+        msg.contains("rx"),
+        "rejection should name the gate, got {msg}"
     );
+
+    let mut supported = Circuit::new(1, 0);
+    supported.add_gate(Gate::Rz(0.37), &[0]);
+    run_spd_observable(&supported, &[PauliTerm::z(0)], 0.0, 0)
+        .expect("SPD must accept a Z-axis rotation");
+}
+
+/// The generalized rotation branch must reduce to the T rule exactly, not
+/// approximately: both engines take the same code path at `theta = pi/4`, so a
+/// last-ulp difference would mean the generalization, not the rounding, is off.
+#[test]
+fn rz_at_quarter_pi_is_bit_identical_to_t() {
+    let observable = [PauliTerm::z(0), PauliTerm::y(1)];
+    for (angle, t_gate) in [
+        (std::f64::consts::FRAC_PI_4, Gate::T),
+        (-std::f64::consts::FRAC_PI_4, Gate::Tdg),
+    ] {
+        let build = |rot: &Gate| {
+            let mut c = Circuit::new(2, 0);
+            c.add_gate(Gate::H, &[0]);
+            c.add_gate(Gate::H, &[1]);
+            c.add_gate(rot.clone(), &[0]);
+            c.add_gate(Gate::Cx, &[0, 1]);
+            c.add_gate(rot.clone(), &[1]);
+            c.add_gate(Gate::H, &[0]);
+            c
+        };
+        let with_t = build(&t_gate);
+        let with_rz = build(&Gate::Rz(angle));
+
+        let spd_t = run_spd_observable(&with_t, &observable, 0.0, 0).unwrap();
+        let spd_rz = run_spd_observable(&with_rz, &observable, 0.0, 0).unwrap();
+        assert_eq!(spd_t.mean.to_bits(), spd_rz.mean.to_bits());
+        assert_eq!(spd_t.peak_terms, spd_rz.peak_terms);
+
+        let spp_t = run_spp_observable(&with_t, &observable, 4_000, SEED).unwrap();
+        let spp_rz = run_spp_observable(&with_rz, &observable, 4_000, SEED).unwrap();
+        assert_eq!(spp_t.mean.to_bits(), spp_rz.mean.to_bits());
+        assert_eq!(spp_t.variance.to_bits(), spp_rz.variance.to_bits());
+    }
+}
+
+#[test]
+fn phase_gate_matches_rz_of_the_same_angle() {
+    let theta = 0.731;
+    let build = |rot: Gate| {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(rot, &[1]);
+        c.add_gate(Gate::H, &[1]);
+        c
+    };
+    let observable = [PauliTerm::z(1)];
+    let with_p = run_spd_observable(&build(Gate::P(theta)), &observable, 0.0, 0).unwrap();
+    let with_rz = run_spd_observable(&build(Gate::Rz(theta)), &observable, 0.0, 0).unwrap();
+    assert_eq!(with_p.mean.to_bits(), with_rz.mean.to_bits());
+}
+
+/// QAOA-shaped layers: a `Cx`-`Rz`-`Cx` cost term plus a single-qubit rotation,
+/// one rotation angle per layer.
+fn variational_circuit(angles: &[f64]) -> Circuit {
+    let mut c = Circuit::new(3, 0);
+    for q in 0..3 {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for (layer, &theta) in angles.iter().enumerate() {
+        let q = layer % 3;
+        c.add_gate(Gate::Cx, &[q, (q + 1) % 3]);
+        c.add_gate(Gate::Rz(theta), &[(q + 1) % 3]);
+        c.add_gate(Gate::Cx, &[q, (q + 1) % 3]);
+        c.add_gate(Gate::Rz(theta), &[q]);
+        c.add_gate(Gate::H, &[q]);
+    }
+    c
+}
+
+#[test]
+fn spd_arbitrary_angles_match_the_statevector() {
+    let circuit = variational_circuit(&[0.37, 1.94, -0.62, 2.71]);
+    let observables = [
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::x(1)],
+        vec![PauliTerm::y(0), PauliTerm::y(2)],
+        vec![PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)],
+    ];
+
+    let exact = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+
+    for (obs, expected) in observables.iter().zip(exact) {
+        let spd = run_spd_observable(&circuit, obs, 0.0, 0).unwrap();
+        assert!(
+            (spd.mean - expected).abs() < 1e-12,
+            "SPD {:.15} vs statevector {expected:.15} for {obs:?}",
+            spd.mean
+        );
+    }
+}
+
+#[test]
+fn spp_arbitrary_angles_match_the_statevector() {
+    let circuit = variational_circuit(&[0.37, 1.94, -0.62]);
+    let observables = [
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::z(1), PauliTerm::x(2)],
+    ];
+
+    let exact = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+
+    for (obs, expected) in observables.iter().zip(exact) {
+        let spp = run_spp_observable(&circuit, obs, 200_000, SEED).unwrap();
+        assert!(
+            (spp.mean - expected).abs() < 3.0 * spp.std_error + 0.01,
+            "SPP {:.6} +/- {:.6} vs statevector {expected:.6}",
+            spp.mean,
+            spp.std_error
+        );
+    }
+}
+
+/// Sampling variance is set by the product of `|cos| + |sin|` over the
+/// branching rotations, so it peaks at the T angle and collapses toward the
+/// Clifford angles. That gradient is the reason the capability is worth having:
+/// near-Clifford angles cost far fewer samples for the same error.
+#[test]
+fn spp_variance_peaks_at_the_t_angle() {
+    let quarter = std::f64::consts::FRAC_PI_4;
+    let sweep: Vec<f64> = [0.02, 0.4, quarter, 1.1, std::f64::consts::FRAC_PI_2 - 0.02]
+        .into_iter()
+        .map(|theta| {
+            let circuit = variational_circuit(&[theta; 4]);
+            run_spp_observable(&circuit, &[PauliTerm::z(0)], 20_000, SEED)
+                .unwrap()
+                .variance
+        })
+        .collect();
+
+    let peak = sweep[2];
+    assert!(
+        sweep.iter().all(|v| *v <= peak),
+        "T angle should hold the maximum variance: {sweep:?}"
+    );
+    for near_clifford in [sweep[0], sweep[4]] {
+        assert!(
+            near_clifford < 0.2 * peak,
+            "near-Clifford variance {near_clifford:.4} should sit far under the peak {peak:.4}"
+        );
+    }
+}
+
+#[test]
+fn zero_angle_rotations_do_not_branch() {
+    let mut circuit = Circuit::new(2, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    circuit.add_gate(Gate::Rz(0.0), &[0]);
+    circuit.add_gate(Gate::P(0.0), &[0]);
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+
+    let spd = run_spd_observable(&circuit, &[PauliTerm::x(0), PauliTerm::x(1)], 0.0, 0).unwrap();
+    assert_eq!(spd.peak_terms, 1);
+    assert_eq!(spd.t_count, 2);
+    assert!((spd.mean - 1.0).abs() < 1e-15, "got {}", spd.mean);
 }

--- a/tests/qec_t_correctness.rs
+++ b/tests/qec_t_correctness.rs
@@ -543,7 +543,7 @@ fn auto_routes_non_clifford_non_t_gate_to_tensor_network() {
         .expect_err("SPD must reject gates outside Clifford+T");
     let spd_msg = format!("{spd_err:?}");
     assert!(
-        spd_msg.contains("non-Clifford+T"),
+        spd_msg.contains("rx"),
         "unexpected SPD rejection: {spd_msg}"
     );
 


### PR DESCRIPTION
## Summary

The Pauli propagation engines rejected every gate outside Clifford+T, so a QAOA or VQE
circuit could not reach SPP or SPD at all. Backward conjugation through a Z rotation
splits a Pauli into `cos(theta) P` and `-i sin(theta) P Z_q`, and the T rule already
implemented in both engines is the `theta = pi/4` case of exactly that, so both branch
functions now take the angle and `T`/`Tdg` route through them. `Rz` and `P` join the
accepted gate set; measurement, reset, conditional, and region rejections are unchanged,
and automatic dispatch still routes only Clifford+T circuits to SPD, so arbitrary angles
arrive by explicit backend selection.

SPP selects a branch with probability proportional to coefficient magnitude rather than
uniformly. Both rules are unbiased and both give `p = 1/2` at `pi/4`, so the T path is
unchanged, but the 1-norm rule bounds the per-sample weight by `|cos| + |sin|`, which is
what makes a near-Clifford angle cheap instead of merely rare.

## Scope

- [x] New feature

## Benchmarks

This adds a capability rather than speeding up an existing path, so the deliverable is
the variance sweep below and the A/B is a control against slowing the existing
Clifford+T route. Full Criterion tier, 30 samples, i7-6700K at 4.00GHz,
rustc 1.97.0, `--features parallel`, `lto = "fat"`, reference `main` (b49fcb0).

### Variance against angle

6 qubits, 8 QAOA-shaped layers (16 `Rz` rotations), observable `Z_0`, 200k SPP samples,
seed 42. `xi^R` is the analytic weight bound `(|cos| + |sin|)^16`. SPD ran exact
(`max_terms = 0`) at every angle and agreed with the statevector to better than 1e-9,
which the harness asserts rather than reports.

| theta | xi^R | exact | SPP mean | variance | std err | nonzero frac | SPD peak terms |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0.0000 | 1.00 | 0.00000 | 0.00000 | 0.0000 | 0.00000 | 0.0000 | 1 |
| 0.0982 | 4.16 | 0.01898 | 0.01905 | 0.0308 | 0.00039 | 0.0117 | 42 |
| 0.1963 | 13.36 | 0.07252 | 0.07435 | 0.1762 | 0.00094 | 0.0306 | 42 |
| 0.2945 | 34.29 | 0.15101 | 0.15312 | 0.4970 | 0.00158 | 0.0456 | 42 |
| 0.3927 | 72.12 | 0.24048 | 0.24100 | 1.0052 | 0.00224 | 0.0556 | 42 |
| 0.4909 | 126.59 | 0.32526 | 0.32278 | 1.6341 | 0.00286 | 0.0613 | 42 |
| 0.5890 | 187.68 | 0.39081 | 0.38963 | 2.2702 | 0.00337 | 0.0644 | 42 |
| 0.6872 | 236.97 | 0.42638 | 0.43250 | 2.7541 | 0.00371 | 0.0654 | 42 |
| 0.7854 | 256.00 | 0.42678 | 0.42824 | 2.8251 | 0.00376 | 0.0628 | 42 |
| 0.8836 | 236.97 | 0.39305 | 0.39287 | 2.5538 | 0.00357 | 0.0586 | 42 |
| 0.9817 | 187.68 | 0.33194 | 0.32952 | 2.0015 | 0.00316 | 0.0527 | 42 |
| 1.0799 | 126.59 | 0.25431 | 0.25478 | 1.3661 | 0.00261 | 0.0463 | 42 |
| 1.1781 | 72.12 | 0.17284 | 0.17280 | 0.7716 | 0.00196 | 0.0378 | 42 |
| 1.2763 | 34.29 | 0.09956 | 0.10131 | 0.3544 | 0.00133 | 0.0284 | 42 |
| 1.3744 | 13.36 | 0.04375 | 0.04425 | 0.1122 | 0.00075 | 0.0172 | 42 |
| 1.4726 | 4.16 | 0.01045 | 0.01067 | 0.0180 | 0.00030 | 0.0063 | 42 |
| 1.5708 | 1.00 | -0.00000 | 0.00000 | 0.0000 | 0.00000 | 0.0000 | 42 |

Row 9 is `theta = pi/4`, the T angle; the last row is `pi/2`, a Clifford angle. Sample
variance peaks at the T angle and vanishes at both Clifford endpoints, tracking the
analytic bound. Converted to a sample budget for a fixed error of 1e-3: 2.83M samples at
`pi/4` against 30.8k at `theta = 0.098`, a factor of 92. Near-Clifford angles are the
regime where the capability pays, which is the question the sweep was run to settle.

### Clifford+T control

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- | --- |
| `clifford_t/spd/5q_4t` | 14.23 us | 14.54 us | +2.1% | +1.7% / -2.1% | yes, noise |
| `clifford_t/spd/10q_1t` | 44.32 us | 43.99 us | -0.7% | +0.3% / -0.5% | yes |
| `clifford_t/spd/10q_2t` | 51.19 us | 51.17 us | -0.0% | +0.4% / -1.8% | yes, noise |
| `clifford_t/spd/10q_4t` | 54.80 us | 55.01 us | +0.4% | -2.2% / -2.7% | yes, noise |
| `clifford_t/spd/10q_8t` | 62.35 us | 62.20 us | -0.2% | -3.7% / -3.8% | yes, noise |
| `clifford_t/spd/10q_12t` | 60.85 us | 61.93 us | +1.8% | +1.8% / -3.8% | yes, noise |
| `clifford_t/spd/15q_4t` | 107.25 us | 108.48 us | +1.1% | +1.8% / -4.6% | yes, noise |
| `clifford_t/spd/20q_4t` | 186.51 us | 183.01 us | -1.9% | +1.1% / +0.8% | yes |
| `spp/spd/10q_2t` | 50.96 us | 51.16 us | +0.4% | -1.8% / -1.2% | yes, noise |
| `spp/spd/10q_4t` | 54.46 us | 54.42 us | -0.1% | +0.8% / -1.5% | yes, noise |
| `spp/spd/10q_8t` | 61.84 us | 62.90 us | +1.7% | -4.6% / -0.6% | yes, noise |
| `spp/spd/10q_12t` | 60.52 us | 60.24 us | -0.5% | -0.6% / +0.8% | yes, noise |
| `spp/spp_10k/10q_2t` | 17.29 ms | 17.41 ms | +0.7% | -1.0% / -0.6% | yes, noise |
| `spp/spp_10k/10q_4t` | 17.23 ms | 17.34 ms | +0.7% | +0.5% / -0.0% | yes |
| `spp/spp_10k/10q_8t` | 17.47 ms | 17.40 ms | -0.4% | +0.8% / -0.4% | yes, noise |
| `spp/spp_10k/10q_12t` | 17.70 ms | 17.71 ms | +0.0% | -1.7% / +0.1% | yes, noise |

16 rows, worst same-code control spread 4.6%, every row resolvable at the gate.

Large SPP rows, separate run on an idle host, worst same-code control spread 1.8%:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- | --- |
| `spp/spp_10k/20q_8t` | 47.72 ms | 47.56 ms | -0.3% | -0.1% / +0.1% | yes |
| `spp/spp_10k/50q_8t` | 272.55 ms | 263.85 ms | -3.2% | -1.8% / +0.5% | yes |
| `spp/spp_10k/100q_8t` | 1.064 s | 1.081 s | +1.5% | -0.2% / -0.1% | yes |
| `spp/spp_10k/20q_100t` | 58.95 ms | 60.05 ms | +1.9% | +0.3% / -0.1% | yes |

`20q_100t` and `100q_8t` are small real slowdowns rather than noise, since their controls
sit at 0.3% or below. The rotation-dense row showing it is the expected shape: SPP's
branch loads a probability and two weights from the coalesced op where the T path used
immediates, because the weights now depend on an angle. Both are well inside the gate.

`spp/spp_10k/50q_1000t` is omitted rather than covered. At roughly 12 minutes per pass it
would have dominated the run, and `20q_100t` exercises the same per-rotation overhead.

An earlier revision of this branch did regress SPD: `spp/spd/10q_12t` +5.6% against
controls of -0.4% and -0.2%, and `clifford_t/spd/10q_8t` +5.4%. `run_spd` replays the
circuit once per qubit, so evaluating `sin_cos` inside the branch function ran it
`qubits x rotations` times instead of once per gate. It is now evaluated once per
instruction before the replay loop, and the branch coefficients multiply through as
scalars rather than as complex values with a known-zero component, which is what the T
path got for free while its coefficients were constants. Both rows read -0.5% and -0.2%
after the fix.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (2163 tests)
- [x] `cargo test --doc --features parallel` passes
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on changed `pub` items carry the new gate set and the truncation contract

Feature-gated arms are untouched, so the gate ran at `parallel`. The GPU and distributed
paths do not reach these engines.

New coverage in `tests/pauli_joint_observable.rs`:

- `rz_at_quarter_pi_is_bit_identical_to_t` asserts `Rz(pi/4)` and `Gate::T` agree on the
  raw bits of the SPD mean and the SPP mean and variance, and the same for `Rz(-pi/4)`
  against `Tdg`. Both engines take one code path at that angle, so the test is a guard
  against a future special case reintroducing a second rule.
- `spd_arbitrary_angles_match_the_statevector` and its SPP sibling check four observables
  mixing all three axes against the statevector on a variational circuit.
- `spp_variance_peaks_at_the_t_angle` pins the gradient the sweep measured.
- `phase_gate_matches_rz_of_the_same_angle` pins that conjugation discards the global
  phase between the two.
- `zero_angle_rotations_do_not_branch` pins that a zero-coefficient branch is not
  inserted, so `Rz(0)` leaves the term count alone.

## Hotspot notes

`branch_z_rotation` in both engines and `run_spd`'s per-qubit replay loop. SPP builds
each rotation's branch data once at coalesce time, so the sampling loop stays free of
trigonometry; SPD evaluates it once per instruction for the same reason.

## Architecture or design changes

- [x] `docs/architecture/engine.md` records the widened gate set and that automatic
      dispatch is unchanged

## Truncation

Every rotation with a non-Clifford angle branches, so a variational circuit branches on
each of its rotations rather than only on its `T` gates. The contract is unchanged in
kind and now documented on `run_spd_observable`: `max_terms == 0` is exact and errors at
the term ceiling, `max_terms > 0` drops sub-`epsilon` terms once the sum passes the
budget with `total_discarded` bounding the error, and an `epsilon` too small to prune the
growth reaches the ceiling and errors there rather than returning a silently
over-truncated value. Making `max_terms` a hard budget by dropping the smallest terms was
considered and rejected: the QEC sampler passes a bounded `max_terms` with a small
`epsilon` and would start discarding more without asking.

## Breaking changes

A gate outside the supported set now returns `BackendUnsupported` from the Pauli marginal
route rather than `IncompatibleBackend`, and names the gate. Non-unitary circuits still
return `IncompatibleBackend`. `SppResult::t_count` and `SpdResult::t_count` count every
branching rotation, not only `T` and `Tdg`; for a Clifford+T circuit the value is
unchanged.

## Risks and rollback

Confined to `src/sim/unified_pauli.rs` and the two guards that let a circuit reach it.
Automatic dispatch is untouched, so a Clifford+T circuit takes the same route it did
before and the new gate set is reachable only by explicit backend selection. `Rzz` and
multi-axis `PauliRot` are still rejected; a QAOA cost layer compiled as `Cx`-`Rz`-`Cx`
runs today, a native `Rzz` one does not.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
