### PR TITLE
perf(backend): evaluate a batch of observables in one traversal

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1540,6 +1540,87 @@ fn bench_expectation_factored(c: &mut Criterion) {
     group.finish();
 }
 
+/// Observable evaluation on the backends that answer from their own
+/// representation instead of a dense amplitude buffer. Same circuit family and
+/// observable shape as `expectation/pauli_sum_factored`, with the same
+/// `statevector` control arm; sparse stops at 16 qubits because its state is
+/// dense here and the per-observable walk is a hash lookup per stored
+/// amplitude.
+fn bench_expectation_native(c: &mut Criterion) {
+    for &(group_name, ref kind, ref sizes) in &[
+        (
+            "expectation/pauli_sum_sparse",
+            BackendKind::Sparse,
+            vec![12usize, 16],
+        ),
+        (
+            "expectation/pauli_sum_mps",
+            BackendKind::Mps { max_bond_dim: 64 },
+            vec![16usize, 20],
+        ),
+    ] {
+        let mut group = c.benchmark_group(group_name);
+        configure_group(&mut group);
+
+        for &n in sizes {
+            let circuit = circuits::hardware_efficient_ansatz(n, 2, SEED);
+            let observables: Vec<Vec<PauliTerm>> = (0..n - 1)
+                .map(|q| vec![PauliTerm::z(q), PauliTerm::z(q + 1)])
+                .collect();
+
+            for &(name, ref arm) in &[
+                ("native", kind.clone()),
+                ("statevector", BackendKind::Statevector),
+            ] {
+                group.bench_with_input(BenchmarkId::new(name, n), &circuit, |b, circ| {
+                    b.iter(|| {
+                        black_box(
+                            sim::simulate(circ)
+                                .backend(arm.clone())
+                                .seed(42)
+                                .expectation_values(&observables)
+                                .unwrap(),
+                        )
+                    });
+                });
+            }
+        }
+
+        group.finish();
+    }
+}
+
+/// Observable evaluation on a prepared density matrix.
+///
+/// Evolution is outside the timed section here, unlike the groups above. A
+/// `4^n` buffer costs seconds to evolve and microseconds to read observables
+/// off, so a whole-pipeline row cannot resolve a change to the reduction.
+/// No in-group control arm: the statevector answers observables through the
+/// simulation helper rather than the trait method, so it cannot be timed on
+/// the same footing. The statevector arms of the groups above serve instead.
+fn bench_expectation_density_matrix(c: &mut Criterion) {
+    use prism_q::backend::Backend;
+    use prism_q::backend::density_matrix::DensityMatrixBackend;
+
+    let mut group = c.benchmark_group("expectation/pauli_sum_density_matrix");
+    configure_group(&mut group);
+
+    for &n in &[8usize, 10] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 2, SEED);
+        let observables: Vec<Vec<PauliTerm>> = (0..n - 1)
+            .map(|q| vec![PauliTerm::z(q), PauliTerm::z(q + 1)])
+            .collect();
+
+        let mut dm = DensityMatrixBackend::new(SEED);
+        sim::run_on(&mut dm, &circuit).unwrap();
+        group.bench_with_input(BenchmarkId::new("native", n), &dm, |b, backend| {
+            b.iter(|| black_box(backend.pauli_expectations(&observables).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
 /// Weighted-observable evaluation at a molecular-Hamiltonian term count:
 /// 2000 Jordan-Wigner strings per size. The `grouped` arm is the
 /// qubit-wise-commuting route with variance; the `ungrouped` control is the
@@ -2613,6 +2694,8 @@ criterion_group! {
     // Forward Pauli-sum expectation (parallel-sandwich neutrality)
     bench_expectation,
     bench_expectation_factored,
+    bench_expectation_native,
+    bench_expectation_density_matrix,
     bench_expectation_grouped,
     // Factored backend
     bench_factored_random,

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -641,17 +641,34 @@ impl DensityMatrixBackend {
     /// trace collapses to a single diagonal-offset sweep:
     /// `Tr(rho P) = i^{num_y} sum_j (-1)^{popcount(j & zmask)} rho[j][j ^ xmask]`.
     pub fn expectation_pauli(&self, xmask: usize, zmask: usize, num_y: u32) -> f64 {
+        self.expectations_pauli(&[(xmask, zmask, num_y)])[0]
+    }
+
+    /// [`DensityMatrixBackend::expectation_pauli`] for every mask triple in one
+    /// sweep of the `4^n` buffer.
+    ///
+    /// Each row is visited once and contributes one entry per observable, so
+    /// the strided sweep is paid once instead of once per observable. Values
+    /// match the single-observable form exactly: the accumulation order within
+    /// an observable is unchanged.
+    pub fn expectations_pauli(&self, masks: &[(usize, usize, u32)]) -> Vec<f64> {
         let d = self.dim();
-        let mut acc = Complex64::new(0.0, 0.0);
+        let mut acc = vec![Complex64::new(0.0, 0.0); masks.len()];
         for j in 0..d {
-            let sign = if (j & zmask).count_ones() & 1 == 1 {
-                -1.0
-            } else {
-                1.0
-            };
-            acc += self.sv.state[j * d + (j ^ xmask)] * sign;
+            let row = &self.sv.state[j * d..(j + 1) * d];
+            for (slot, &(xmask, zmask, _)) in acc.iter_mut().zip(masks) {
+                let sign = if (j & zmask).count_ones() & 1 == 1 {
+                    -1.0
+                } else {
+                    1.0
+                };
+                *slot += row[j ^ xmask] * sign;
+            }
         }
-        (acc * i_pow(num_y)).re
+        acc.iter()
+            .zip(masks)
+            .map(|(value, &(_, _, num_y))| (value * i_pow(num_y)).re)
+            .collect()
     }
 }
 
@@ -765,13 +782,11 @@ impl Backend for DensityMatrixBackend {
     /// `<psi|P_k|psi>`. `rho` is trace-one by construction, so no
     /// normalization divide is needed.
     fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
-        observables
+        let masks = observables
             .iter()
-            .map(|observable| {
-                let (xmask, zmask, num_y) = crate::sim::pauli_masks(observable, self.num_qubits)?;
-                Ok(self.expectation_pauli(xmask, zmask, num_y))
-            })
-            .collect()
+            .map(|observable| crate::sim::pauli_masks(observable, self.num_qubits))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(self.expectations_pauli(&masks))
     }
 
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {

--- a/src/backend/factored/mod.rs
+++ b/src/backend/factored/mod.rs
@@ -901,34 +901,41 @@ impl Backend for FactoredBackend {
     /// A joint Pauli factorizes across independent sub-states, so the value is
     /// the product of the per-block expectations. Blocks the observable does
     /// not touch contribute one and are skipped.
+    ///
+    /// Every observable that touches a given sub-state is evaluated in one
+    /// traversal of it, so the block is read once rather than once per
+    /// observable. The cross-block product stays per observable.
     fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
-        let norms: Vec<f64> = self
-            .substates
+        let masks: Vec<Vec<(usize, usize, u32)>> = observables
             .iter()
-            .map(|slot| {
-                slot.as_ref()
-                    .map_or(0.0, |sub| crate::backend::state_norm_sqr(&sub.state))
-            })
-            .collect();
+            .map(|observable| self.substate_pauli_masks(observable))
+            .collect::<Result<_>>()?;
 
-        observables
-            .iter()
-            .map(|observable| {
-                let masks = self.substate_pauli_masks(observable)?;
-                let mut product = 1.0f64;
-                for (ss, slot) in self.substates.iter().enumerate() {
-                    let Some(sub) = slot else { continue };
-                    let (xmask, zmask, num_y) = masks[ss];
-                    if xmask == 0 && zmask == 0 {
-                        continue;
-                    }
-                    product *= crate::sim::pauli_expectation_from_masks(
-                        &sub.state, xmask, zmask, num_y, norms[ss],
-                    );
+        let mut products = vec![1.0f64; observables.len()];
+        let mut rows: Vec<usize> = Vec::new();
+        let mut group: Vec<(usize, usize, u32)> = Vec::new();
+        for (ss, slot) in self.substates.iter().enumerate() {
+            let Some(sub) = slot else { continue };
+            rows.clear();
+            group.clear();
+            for (index, observable_masks) in masks.iter().enumerate() {
+                let entry = observable_masks[ss];
+                if entry.0 == 0 && entry.1 == 0 {
+                    continue;
                 }
-                Ok(product)
-            })
-            .collect()
+                rows.push(index);
+                group.push(entry);
+            }
+            if group.is_empty() {
+                continue;
+            }
+            let norm = crate::backend::state_norm_sqr(&sub.state);
+            let values = crate::sim::pauli_expectations_from_masks(&sub.state, &group, norm);
+            for (&index, value) in rows.iter().zip(values) {
+                products[index] *= value;
+            }
+        }
+        Ok(products)
     }
 }
 

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -478,6 +478,20 @@ pub enum MpsPauliAxis {
     Z,
 }
 
+fn mps_pauli_factors(observable: &[PauliTerm]) -> Vec<(usize, MpsPauliAxis)> {
+    observable
+        .iter()
+        .map(|term| {
+            let axis = match term.axis {
+                PauliAxis::X => MpsPauliAxis::X,
+                PauliAxis::Y => MpsPauliAxis::Y,
+                PauliAxis::Z => MpsPauliAxis::Z,
+            };
+            (term.qubit, axis)
+        })
+        .collect()
+}
+
 #[inline]
 fn pauli_matrix_entry(axis: Option<MpsPauliAxis>, j: usize, k: usize) -> Complex64 {
     match (axis, j, k) {
@@ -682,6 +696,25 @@ impl MpsBackend {
             return Ok(ONE);
         }
 
+        let site_axis = self.pauli_site_axes(pauli_factors)?;
+
+        let mut env: Vec<Complex64> = vec![ONE; 1];
+        let mut env_cols: usize = 1;
+
+        for (i, a) in self.sites.iter().enumerate().take(self.num_qubits) {
+            env = self.contract_pauli_env(i, &env, env_cols, site_axis[i]);
+            env_cols = a.bond_right;
+        }
+
+        Ok(env[0])
+    }
+
+    /// Site index of each requested Pauli factor, `None` where the string acts
+    /// as identity. Rejects out-of-range qubits and duplicate factors.
+    fn pauli_site_axes(
+        &self,
+        pauli_factors: &[(usize, MpsPauliAxis)],
+    ) -> Result<Vec<Option<MpsPauliAxis>>> {
         let mut site_axis: Vec<Option<MpsPauliAxis>> = vec![None; self.num_qubits];
         for &(qubit, axis) in pauli_factors {
             if qubit >= self.num_qubits {
@@ -700,62 +733,86 @@ impl MpsBackend {
             }
             site_axis[site] = Some(axis);
         }
+        Ok(site_axis)
+    }
 
-        let mut env: Vec<Complex64> = vec![ONE; 1];
-        let mut env_cols: usize = 1;
+    /// Absorb one site into the `⟨ψ|P|ψ⟩` environment, applying `axis` as the
+    /// site's Pauli matrix (identity when `None`).
+    ///
+    /// `env` is indexed `[bra bond, ket bond]` with `env_cols` columns; the
+    /// result is indexed the same way with `bond_right` columns.
+    fn contract_pauli_env(
+        &self,
+        site: usize,
+        env: &[Complex64],
+        env_cols: usize,
+        axis: Option<MpsPauliAxis>,
+    ) -> Vec<Complex64> {
+        let a = &self.sites[site];
+        let bl = a.bond_left;
+        let br = a.bond_right;
 
-        for (i, a) in self.sites.iter().enumerate().take(self.num_qubits) {
-            let bl = a.bond_left;
-            let br = a.bond_right;
-
-            // Step 1: tmp[β, j, α'] = Σ_α env[α, β] · conj(A[α, j, α'])
-            let mut tmp = vec![ZERO; bl * 2 * br];
-            for alpha in 0..bl {
-                for j in 0..2 {
-                    for alpha_p in 0..br {
-                        let a_val = a.data[a.idx(alpha, j, alpha_p)].conj();
-                        if a_val == ZERO {
-                            continue;
-                        }
-                        for beta in 0..bl {
-                            let e_ab = env[alpha * env_cols + beta];
-                            tmp[beta * (2 * br) + j * br + alpha_p] += a_val * e_ab;
-                        }
+        // Step 1: tmp[β, j, α'] = Σ_α env[α, β] · conj(A[α, j, α'])
+        let mut tmp = vec![ZERO; bl * 2 * br];
+        for alpha in 0..bl {
+            for j in 0..2 {
+                for alpha_p in 0..br {
+                    let a_val = a.data[a.idx(alpha, j, alpha_p)].conj();
+                    if a_val == ZERO {
+                        continue;
+                    }
+                    for beta in 0..bl {
+                        let e_ab = env[alpha * env_cols + beta];
+                        tmp[beta * (2 * br) + j * br + alpha_p] += a_val * e_ab;
                     }
                 }
             }
-
-            // Step 2: new_env[α', β'] = Σ_{β, j, k} tmp[β, j, α'] · M[j,k] · A[β, k, β']
-            // with M = local Pauli matrix at site i (or identity if no factor).
-            let mut new_env = vec![ZERO; br * br];
-            let axis = site_axis[i];
-            for beta in 0..bl {
-                for j in 0..2 {
-                    for k in 0..2 {
-                        let m_jk = pauli_matrix_entry(axis, j, k);
-                        if m_jk == ZERO {
-                            continue;
-                        }
-                        for beta_p in 0..br {
-                            let a_bk = a.data[a.idx(beta, k, beta_p)];
-                            if a_bk == ZERO {
-                                continue;
-                            }
-                            let ma_val = m_jk * a_bk;
-                            for alpha_p in 0..br {
-                                let t = tmp[beta * (2 * br) + j * br + alpha_p];
-                                new_env[alpha_p * br + beta_p] += t * ma_val;
-                            }
-                        }
-                    }
-                }
-            }
-
-            env = new_env;
-            env_cols = br;
         }
 
-        Ok(env[0])
+        // Step 2: new_env[α', β'] = Σ_{β, j, k} tmp[β, j, α'] · M[j,k] · A[β, k, β']
+        // with M = local Pauli matrix at this site (or identity if no factor).
+        let mut new_env = vec![ZERO; br * br];
+        for beta in 0..bl {
+            for j in 0..2 {
+                for k in 0..2 {
+                    let m_jk = pauli_matrix_entry(axis, j, k);
+                    if m_jk == ZERO {
+                        continue;
+                    }
+                    for beta_p in 0..br {
+                        let a_bk = a.data[a.idx(beta, k, beta_p)];
+                        if a_bk == ZERO {
+                            continue;
+                        }
+                        let ma_val = m_jk * a_bk;
+                        for alpha_p in 0..br {
+                            let t = tmp[beta * (2 * br) + j * br + alpha_p];
+                            new_env[alpha_p * br + beta_p] += t * ma_val;
+                        }
+                    }
+                }
+            }
+        }
+
+        new_env
+    }
+
+    /// Identity environments left of every site, plus `⟨ψ|ψ⟩` as the last
+    /// entry, in the `[bra bond, ket bond]` convention of
+    /// [`MpsBackend::contract_pauli_env`].
+    ///
+    /// Entry `s` is the contraction of sites `0..s`, so it has `bond_left(s)`
+    /// columns and entry `num_qubits` is the `1x1` norm.
+    fn pauli_env_prefixes(&self) -> Vec<Vec<Complex64>> {
+        let mut prefixes = Vec::with_capacity(self.num_qubits + 1);
+        prefixes.push(vec![ONE; 1]);
+        let mut env_cols = 1usize;
+        for site in 0..self.num_qubits {
+            let next = self.contract_pauli_env(site, prefixes.last().unwrap(), env_cols, None);
+            env_cols = self.sites[site].bond_right;
+            prefixes.push(next);
+        }
+        prefixes
     }
 
     /// MPS site index currently hosting logical qubit `q`. SWAP-routing
@@ -2285,27 +2342,67 @@ impl Backend for MpsBackend {
         true
     }
 
-    /// Routes each observable through [`MpsBackend::pauli_expectation`], which
-    /// contracts the chain once per observable. Divided by `⟨ψ|ψ⟩` because a
-    /// truncated chain is not exactly normalized.
+    /// Identity environments are swept once and shared, so an observable
+    /// contracts only the sites between its first and last non-identity
+    /// factor: a single-qubit observable costs one site instead of a full
+    /// chain walk. Divided by `⟨ψ|ψ⟩` because a truncated chain is not
+    /// exactly normalized.
     fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
-        let norm = self.pauli_expectation(&[])?.re;
+        if self.num_qubits == 0 {
+            return Ok(vec![1.0; observables.len()]);
+        }
+        if observables.len() < 2 {
+            // One observable costs the same two sweeps either way, and keeping
+            // the plain contraction here leaves a route that shares no code
+            // with the windowed one for a test to compare against.
+            let norm = self.pauli_expectation(&[])?.re;
+            return observables
+                .iter()
+                .map(|observable| {
+                    let value = self.pauli_expectation(&mps_pauli_factors(observable))?;
+                    Ok(if norm == 0.0 { 0.0 } else { value.re / norm })
+                })
+                .collect();
+        }
+
+        let prefixes = self.pauli_env_prefixes();
+        let rights = self.right_environments();
+        let norm = prefixes[self.num_qubits][0].re;
+
         observables
             .iter()
             .map(|observable| {
-                let factors: Vec<(usize, MpsPauliAxis)> = observable
-                    .iter()
-                    .map(|term| {
-                        let axis = match term.axis {
-                            PauliAxis::X => MpsPauliAxis::X,
-                            PauliAxis::Y => MpsPauliAxis::Y,
-                            PauliAxis::Z => MpsPauliAxis::Z,
-                        };
-                        (term.qubit, axis)
-                    })
-                    .collect();
-                let value = self.pauli_expectation(&factors)?;
-                Ok(if norm == 0.0 { 0.0 } else { value.re / norm })
+                let site_axis = self.pauli_site_axes(&mps_pauli_factors(observable))?;
+                if norm == 0.0 {
+                    return Ok(0.0);
+                }
+                let Some(first) = site_axis.iter().position(Option::is_some) else {
+                    return Ok(1.0);
+                };
+                let last = site_axis.iter().rposition(Option::is_some).unwrap();
+
+                let mut env = self.contract_pauli_env(
+                    first,
+                    &prefixes[first],
+                    self.sites[first].bond_left,
+                    site_axis[first],
+                );
+                let mut cols = self.sites[first].bond_right;
+                for (site, axis) in site_axis.iter().enumerate().take(last + 1).skip(first + 1) {
+                    env = self.contract_pauli_env(site, &env, cols, *axis);
+                    cols = self.sites[site].bond_right;
+                }
+
+                // The identity cap right of `last` carries the ket bond first,
+                // so closing the two chains is a trace of the two matrices.
+                let right = &rights[last];
+                let mut value = ZERO;
+                for bra in 0..cols {
+                    for ket in 0..cols {
+                        value += env[bra * cols + ket] * right[ket * cols + bra];
+                    }
+                }
+                Ok(value.re / norm)
             })
             .collect()
     }

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -612,30 +612,57 @@ impl Backend for SparseBackend {
         true
     }
 
+    /// Every observable is accumulated in one walk of the stored amplitudes.
+    /// A Z-only observable has `xmask == 0`, so its partner is the entry
+    /// itself and it costs a popcount instead of a hash lookup; the two
+    /// families are accumulated separately for that reason.
     fn pauli_expectations(&self, observables: &[Vec<PauliTerm>]) -> Result<Vec<f64>> {
-        let norm: f64 = self.state.values().map(|amp| amp.norm_sqr()).sum();
-        observables
+        let masks = observables
             .iter()
-            .map(|observable| {
-                let (xmask, zmask, num_y) = crate::sim::pauli_masks(observable, self.num_qubits)?;
-                if norm == 0.0 {
-                    return Ok(0.0);
+            .map(|observable| crate::sim::pauli_masks(observable, self.num_qubits))
+            .collect::<Result<Vec<_>>>()?;
+
+        let norm: f64 = self.state.values().map(|amp| amp.norm_sqr()).sum();
+        if norm == 0.0 {
+            return Ok(vec![0.0; masks.len()]);
+        }
+
+        let z_only: Vec<usize> = masks
+            .iter()
+            .filter(|&&(xmask, _, _)| xmask == 0)
+            .map(|&(_, zmask, _)| zmask)
+            .collect();
+        let general: Vec<(usize, usize)> = masks
+            .iter()
+            .filter(|&&(xmask, _, _)| xmask != 0)
+            .map(|&(xmask, zmask, _)| (xmask, zmask))
+            .collect();
+
+        let mut z_sum = vec![0.0f64; z_only.len()];
+        let mut g_sum = vec![Complex64::new(0.0, 0.0); general.len()];
+        for (&idx, &amp) in &self.state {
+            let parity_sign = |mask: usize| {
+                if (idx & mask).count_ones() & 1 == 1 {
+                    -1.0
+                } else {
+                    1.0
                 }
-                let mut acc = Complex64::new(0.0, 0.0);
-                for (&idx, &amp) in &self.state {
-                    let Some(&partner) = self.state.get(&(idx ^ xmask)) else {
-                        continue;
-                    };
-                    let sign = if (idx & zmask).count_ones() & 1 == 1 {
-                        -1.0
-                    } else {
-                        1.0
-                    };
-                    acc += partner.conj() * amp * sign;
-                }
-                Ok((acc * crate::sim::i_pow(num_y)).re / norm)
-            })
-            .collect()
+            };
+            let norm_sqr = amp.norm_sqr();
+            for (slot, &zmask) in z_sum.iter_mut().zip(&z_only) {
+                *slot += norm_sqr * parity_sign(zmask);
+            }
+            for (slot, &(xmask, zmask)) in g_sum.iter_mut().zip(&general) {
+                let Some(&partner) = self.state.get(&(idx ^ xmask)) else {
+                    continue;
+                };
+                *slot += partner.conj() * amp * parity_sign(zmask);
+            }
+        }
+
+        Ok(crate::sim::finish_expectations(
+            &masks, &z_sum, &g_sum, norm,
+        ))
     }
 
     fn export_statevector(&self) -> Result<Vec<Complex64>> {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -2500,7 +2500,11 @@ pub(crate) fn pauli_expectations_from_masks(
 }
 
 /// Interleave the two accumulator families back into observable order.
-fn finish_expectations(
+///
+/// Entries of `z_sum` and `g_sum` are in `masks` order within their family:
+/// the `i`-th `xmask == 0` entry of `masks` reads `z_sum[i]`, and the `i`-th
+/// `xmask != 0` entry reads `g_sum[i]`.
+pub(crate) fn finish_expectations(
     masks: &[(usize, usize, u32)],
     z_sum: &[f64],
     g_sum: &[Complex64],

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -2810,13 +2810,11 @@ pub(crate) fn dm_expectation_values(
     seed: u64,
 ) -> Result<Vec<f64>> {
     let dm = evolve_density_matrix(circuit, noise, initial_state, seed)?;
-    observables
+    let masks = observables
         .iter()
-        .map(|obs| {
-            let (xmask, zmask, num_y) = crate::sim::pauli_masks(obs, circuit.num_qubits)?;
-            Ok(dm.expectation_pauli(xmask, zmask, num_y))
-        })
-        .collect()
+        .map(|obs| crate::sim::pauli_masks(obs, circuit.num_qubits))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(dm.expectations_pauli(&masks))
 }
 
 #[path = "noise_builder.rs"]

--- a/tests/expectation_values.rs
+++ b/tests/expectation_values.rs
@@ -358,6 +358,154 @@ fn tensor_network_expectation_values_match_statevector() {
     );
 }
 
+// ---- batched traversal vs the per-observable loop ----
+
+// Each of these backends evaluates a batch of observables in one pass over its
+// state and a batch of one with the single-observable reduction. Batching
+// reassociates the sum across observables and never within one, so the two must
+// agree. The list alternates between the Z-only family and the family carrying
+// an X or Y factor, since the batched pass splits on exactly that and has to
+// interleave the halves back into request order; the empty observable is the
+// identity, which touches no site at all. Comparing against the same backend
+// one observable at a time rather than against the statevector, because a
+// cross-backend check cannot witness a shared batched helper breaking.
+fn batch_observables() -> [Vec<PauliTerm>; 6] {
+    [
+        vec![PauliTerm::x(0), PauliTerm::y(1)],
+        vec![PauliTerm::z(2), PauliTerm::z(5)],
+        vec![PauliTerm::y(4)],
+        vec![PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(3)],
+        vec![],
+        vec![PauliTerm::x(3), PauliTerm::z(5)],
+    ]
+}
+
+fn assert_batch_matches_per_observable_loop(label: &str, backend: BackendKind, circuit: &Circuit) {
+    let observables = batch_observables();
+    let batched = simulate(circuit)
+        .backend(backend.clone())
+        .seed(42)
+        .expectation_values(&observables)
+        .unwrap();
+    let one_at_a_time: Vec<f64> = observables
+        .iter()
+        .map(|obs| {
+            simulate(circuit)
+                .backend(backend.clone())
+                .seed(42)
+                .expectation_values(std::slice::from_ref(obs))
+                .unwrap()[0]
+        })
+        .collect();
+    common::assert_probs_close(&batched, &one_at_a_time, 1e-12, label);
+}
+
+#[test]
+fn factored_batch_matches_the_per_observable_loop() {
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Ry(0.4 + 0.1 * q as f64), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cx, &[2, 3]);
+    c.add_gate(Gate::Cx, &[4, 5]);
+    assert_batch_matches_per_observable_loop("factored batch blocks", BackendKind::Factored, &c);
+    assert_batch_matches_per_observable_loop(
+        "factored batch merged",
+        BackendKind::Factored,
+        &entangled_non_clifford(6),
+    );
+}
+
+#[test]
+fn sparse_batch_matches_the_per_observable_loop() {
+    assert_batch_matches_per_observable_loop(
+        "sparse batch",
+        BackendKind::Sparse,
+        &entangled_non_clifford(6),
+    );
+}
+
+// The identity environment right of an observable's last site is closed against
+// the swept environment as a trace, so it enters transposed. A chain of real
+// site tensors makes both matrices real symmetric and hides a wrong transpose;
+// the diagonal T alone does not help, because its phase cancels in the
+// environment contraction. Rx after T is what puts an imaginary part in the
+// environments, and the statevector value is the independent authority for it.
+fn complex_environment_chain(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::Ry(0.3 + 0.15 * q as f64), &[q]);
+    }
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..n {
+        c.add_gate(Gate::T, &[q]);
+        c.add_gate(Gate::Rx(0.2 + 0.1 * q as f64), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, n - 1]);
+    c.add_gate(Gate::Cx, &[2, 4]);
+    c
+}
+
+#[test]
+fn mps_batch_matches_the_per_observable_loop() {
+    let mps = BackendKind::Mps {
+        max_bond_dim: 1 << 8,
+    };
+    assert_batch_matches_per_observable_loop("mps batch", mps.clone(), &entangled_non_clifford(6));
+    assert_batch_matches_per_observable_loop(
+        "mps batch complex environments",
+        mps.clone(),
+        &complex_environment_chain(6),
+    );
+    assert_matches_statevector(
+        "mps expectation complex environments",
+        mps,
+        &complex_environment_chain(6),
+    );
+}
+
+// SWAP routing permutes the site layout, so the first and last site an
+// observable touches are not its first and last logical qubit, and the shared
+// identity environments are read at the routed positions.
+#[test]
+fn mps_batch_matches_the_per_observable_loop_under_swap_routing() {
+    let mut c = Circuit::new(6, 0);
+    for q in 0..6 {
+        c.add_gate(Gate::Ry(0.25 * (q + 1) as f64), &[q]);
+    }
+    c.add_gate(Gate::Cx, &[0, 5]);
+    c.add_gate(Gate::T, &[2]);
+    c.add_gate(Gate::Cx, &[1, 4]);
+    assert_batch_matches_per_observable_loop(
+        "mps batch swap routed",
+        BackendKind::Mps {
+            max_bond_dim: 1 << 8,
+        },
+        &c,
+    );
+}
+
+#[test]
+fn density_matrix_batch_matches_the_per_observable_loop() {
+    let circuit = entangled_non_clifford(6);
+    let observables = batch_observables();
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+    let batched =
+        density_matrix_expectation_values(&circuit, &observables, Some(&noise), 42).unwrap();
+    let one_at_a_time: Vec<f64> = observables
+        .iter()
+        .map(|obs| {
+            density_matrix_expectation_values(&circuit, std::slice::from_ref(obs), Some(&noise), 42)
+                .unwrap()[0]
+        })
+        .collect();
+    common::assert_probs_close(&batched, &one_at_a_time, 1e-12, "density matrix batch");
+}
+
 // The native path validates observables before it runs, so a bad qubit index
 // costs nothing on a circuit the statevector could not hold.
 #[test]


### PR DESCRIPTION
## Summary

The density matrix, sparse, factored, and MPS backends each walked their whole state once
per observable. Every marginal query builds one observable per qubit, so an n-qubit
marginal walked the state n times where one walk would do. Each backend now accumulates
every observable in a single pass, following the shape the dense route already uses:
split the Z-only masks from the general ones and fold both families per element.

MPS carries the same redundancy through a different mechanism, so it gets a different
fix. Identity environments are swept once for the whole batch, and an observable
contracts only the sites between its first and last non-identity factor. A single-qubit
observable drops from a full chain walk to one site contraction.

`product.rs` is already O(1) per term and is untouched. `tensornetwork.rs` and
`distributed_statevector` are untouched: the same shape did not fall out for free in
either.

## Benchmark summary

Adjacent-binary A/B, `--features parallel`, 30 samples, i7-6700K, rustc 1.97.0.
Three clean runs; the change rows below are from the run carrying all of them, with a
second run confirming each.

| Benchmark | Before | After | Change | Confirming run | Control (ref) | Control (new) |
|-----------|--------|-------|--------|----------------|---------------|---------------|
| `expectation/pauli_sum_mps/native/20` | 422.51 us | 258.68 us | -38.8% | -39.5% | +0.2% | +9.0% |
| `expectation/pauli_sum_mps/native/16` | 294.18 us | 195.78 us | -33.4% | -32.3% | +1.6% | +1.7% |
| `expectation/pauli_sum_factored/factored/16` | 3.59 ms | 2.91 ms | -18.9% | -19.2% | -1.2% | -0.7% |
| `expectation/pauli_sum_sparse/native/12` | 1.89 ms | 1.66 ms | -12.4% | -10.5% | -0.3% | -0.1% |
| `expectation/pauli_sum_density_matrix/native/10` | 18.58 us | 16.48 us | -11.3% | -12.2% | +0.2% | +0.7% |
| `expectation/pauli_sum_factored/factored/20` | 64.20 ms | 58.20 ms | -9.3% | -9.4% | -0.1% | +0.5% |
| `expectation/pauli_sum_sparse/native/16` | 63.52 ms | 57.94 ms | -8.8% | -9.1% | +0.5% | -0.7% |
| `expectation/pauli_sum_density_matrix/native/8` | 4.03 us | 3.94 us | -2.0% | -2.1% | +0.0% | -0.3% |

Controls, none of which the diff can reach:

| Benchmark | Change | Control (ref) | Control (new) |
|-----------|--------|---------------|---------------|
| `expectation/pauli_sum/14` | +4.3% | +0.7% | +5.5% |
| `expectation/pauli_sum/16` | +1.3% | -2.7% | +2.0% |
| `expectation/pauli_sum/18` | -0.7% | +1.1% | +0.8% |
| `expectation/pauli_sum/20` | -0.4% | -0.2% | +0.5% |
| `expectation/pauli_sum_factored/statevector/16` | -0.8% | -2.2% | -1.6% |
| `expectation/pauli_sum_factored/statevector/20` | -0.1% | +0.1% | -0.3% |
| `expectation/pauli_sum_mps/statevector/16` | +0.2% | -1.8% | +2.3% |
| `expectation/pauli_sum_mps/statevector/20` | +0.0% | +0.2% | +0.2% |
| `expectation/pauli_sum_sparse/statevector/12` | +1.0% | -1.2% | +0.9% |
| `expectation/pauli_sum_sparse/statevector/16` | -0.4% | -0.9% | +3.5% |
| `gradient/prefix_local/adjoint/18` | +1.7% | -0.0% | +1.5% |
| `gradient/prefix_local/adjoint/20` | -0.2% | -0.3% | -0.4% |

`gradient/prefix_local/adjoint/{18,20}` were watched deliberately: an earlier observable
change regressed them 13.8% by altering what LTO inlined rather than by changing their
code. They read +1.7% and -0.2% here, and +0.5%/+1.3% and +1.4%/-0.2% on the other two
runs, so that failure did not recur.

`expectation/pauli_sum/14` at +4.3% sits against a +5.5% control on this run and is
unresolvable there; it read +1.7% against a +3.4% control on another. Noise either way.

The density-matrix pair is a result rather than a shortfall at 8 qubits. `4^8` is 1 MB
and cache resident on this host, `4^10` is 16 MB and past the 8 MB L3, so the batch pays
off exactly where the repeated traversal stops being free.

### Rows that did not exist

Sparse, MPS, and the density matrix had no observable bench row, so this PR adds them.
Sparse and MPS mirror the factored group, circuit run included. The density-matrix row
prepares the state outside the timed section: a `4^n` buffer costs seconds to evolve and
microseconds to read observables off, so a whole-pipeline row would report circuit-run
noise and nothing else. It carries no in-group statevector arm, because the statevector
answers observables through the simulation helper rather than the trait method and cannot
be timed on the same footing; the statevector arms of the other three groups serve.

### Discarded runs

Two earlier A/B runs are not reported above because they measured nothing: another
`bench_ab.sh` shared the host and produced same-code control spreads of 1041% and 1009%.
Sampling load before starting did not catch it, because the collision began after the
clear check passed. What does catch it: the script runs exactly one bench binary at a
time, so two concurrent `exe-ref`/`exe-new` processes are provably a foreign run. The
three runs reported here were verified clean by that check.

## Regression verdict

PASS. No row regressed beyond 5%, and no row regressed beyond its own control spread.

## Tests

`tests/expectation_values.rs` gains a batch-against-per-observable-loop case per backend.
Batching reassociates the sum across observables and never within one, so the two must
agree; the assertion is a 1e-12 tolerance rather than equality, because parallel
reductions pair partial sums differently.

The oracle is the same backend one observable at a time, not a sibling backend, since a
cross-backend comparison cannot witness a shared batched helper breaking. For MPS that
required a further step: a batch of one deliberately keeps the plain contraction, so the
loop side shares no code with the windowed side. Without it both sides go through the
same environment cap and the comparison is blind to it.

The MPS environment cap enters transposed, and the first version of that test passed
under a deliberately wrong transpose. A chain of real site tensors makes both matrices
real symmetric and hides it, and the diagonal `T` does not help because its phase cancels
in the environment contraction. `Rx` after `T` is what puts an imaginary part in the
environments; the test now uses that circuit and fails under the mutation.

## Documentation

Docstrings on the changed and new items. No architecture change.
