### PR TITLE
fix(bench): measure the backend each row names

### DIFF
--- a/benches/bench_driver.rs
+++ b/benches/bench_driver.rs
@@ -3,7 +3,10 @@
 //! Use `--features bench-fast` for a quick run that reduces warmup and
 //! measurement time. Omit for the full suite with default Criterion timing.
 
-use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::measurement::WallTime;
+use criterion::{
+    BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
+};
 use prism_q::backend::Backend;
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
@@ -15,34 +18,52 @@ use common::{configure_group, run_with};
 
 const QUBIT_COUNTS: [usize; 5] = [4, 8, 12, 16, 20];
 
+/// Time one gate's kernel over a full-superposition `n_qubits` state.
+///
+/// Two deliberate choices, both of which a row gets wrong by default.
+///
+/// Applies through [`StatevectorBackend`] rather than `simulate()`. A circuit
+/// holding a few gates on a wide register has a largest connected block far
+/// narrower than the register, and independent-subsystem decomposition claims
+/// such a circuit before a backend is resolved, so the `simulate()` route
+/// reports `Decomposed` and never reaches the dense kernel.
+///
+/// Holds one backend for the whole row rather than rebuilding per iteration.
+/// Every gate benched here is unitary, so repeated application walks the same
+/// amplitudes and cannot drift the norm, and at 20 qubits a per-iteration
+/// rebuild puts a 16 MB allocate-and-zero pass beside every measured one. The
+/// state is prepared in full superposition so no amplitude is zero.
+fn bench_kernel_row(
+    group: &mut BenchmarkGroup<WallTime>,
+    name: &str,
+    n_qubits: usize,
+    gate: Gate,
+    targets: &[usize],
+) {
+    let mut circuit = Circuit::new(n_qubits, 0);
+    circuit.add_gate(gate, targets);
+    group.bench_function(BenchmarkId::new(name, n_qubits), |b| {
+        let mut backend = StatevectorBackend::new(42);
+        backend.init(n_qubits, 0).unwrap();
+        let mut prep = Circuit::new(n_qubits, 0);
+        for q in 0..n_qubits {
+            prep.add_gate(Gate::H, &[q]);
+        }
+        for inst in &prep.instructions {
+            backend.apply(inst).unwrap();
+        }
+        b.iter(|| backend.apply(&circuit.instructions[0]).unwrap());
+    });
+}
+
 fn bench_single_qubit_gates(c: &mut Criterion) {
     let mut group = c.benchmark_group("single_qubit_gates");
     configure_group(&mut group);
 
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(BenchmarkId::new("h_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::H, &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("rx_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Rx(1.234), &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("t_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::T, &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
+        bench_kernel_row(&mut group, "h_gate", n_qubits, Gate::H, &[0]);
+        bench_kernel_row(&mut group, "rx_gate", n_qubits, Gate::Rx(1.234), &[0]);
+        bench_kernel_row(&mut group, "t_gate", n_qubits, Gate::T, &[0]);
     }
 
     group.finish();
@@ -52,101 +73,36 @@ fn bench_two_qubit_gates(c: &mut Criterion) {
     let mut group = c.benchmark_group("two_qubit_gates");
     configure_group(&mut group);
 
+    let cx_4x4 = Gate::Cx.matrix_4x4();
+
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(BenchmarkId::new("cx_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Cx, &[0, 1]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(
-            BenchmarkId::new("cx_ctrl_gt_adjacent", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Cx, &[1, 0]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
+        let hi = n_qubits - 1;
+        bench_kernel_row(&mut group, "cx_gate", n_qubits, Gate::Cx, &[0, 1]);
+        bench_kernel_row(
+            &mut group,
+            "cx_ctrl_gt_adjacent",
+            n_qubits,
+            Gate::Cx,
+            &[1, 0],
         );
-
-        group.bench_with_input(
-            BenchmarkId::new("cx_ctrl_lt_high", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Cx, &[0, n - 1]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
+        bench_kernel_row(&mut group, "cx_ctrl_lt_high", n_qubits, Gate::Cx, &[0, hi]);
+        bench_kernel_row(&mut group, "cx_ctrl_gt_high", n_qubits, Gate::Cx, &[hi, 0]);
+        bench_kernel_row(&mut group, "cz_gate", n_qubits, Gate::Cz, &[0, 1]);
+        bench_kernel_row(&mut group, "cz_high", n_qubits, Gate::Cz, &[0, hi]);
+        bench_kernel_row(&mut group, "swap_gate", n_qubits, Gate::Swap, &[0, 1]);
+        bench_kernel_row(
+            &mut group,
+            "fused2q_adjacent",
+            n_qubits,
+            Gate::Fused2q(Box::new(cx_4x4)),
+            &[0, 1],
         );
-
-        group.bench_with_input(
-            BenchmarkId::new("cx_ctrl_gt_high", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Cx, &[n - 1, 0]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
-        );
-
-        group.bench_with_input(BenchmarkId::new("cz_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Cz, &[0, 1]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("cz_high", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Cz, &[0, n - 1]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(
-            BenchmarkId::new("swap_gate", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Swap, &[0, 1]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("fused2q_adjacent", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, 1]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("fused2q_high", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())), &[0, n - 1]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
+        bench_kernel_row(
+            &mut group,
+            "fused2q_high",
+            n_qubits,
+            Gate::Fused2q(Box::new(cx_4x4)),
+            &[0, hi],
         );
     }
 
@@ -394,14 +350,13 @@ fn bench_high_target_qubit(c: &mut Criterion) {
     configure_group(&mut group);
 
     for &(n_qubits, target) in &[(16, 13), (20, 15), (20, 17)] {
-        let label = format!("h_q{}_n{}", target, n_qubits);
-        group.bench_function(&label, |b| {
-            let mut circuit = Circuit::new(n_qubits, 0);
-            circuit.add_gate(Gate::H, &[target]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
+        bench_kernel_row(
+            &mut group,
+            &format!("h_q{}", target),
+            n_qubits,
+            Gate::H,
+            &[target],
+        );
     }
 
     // Diagonal counterpart of the rows above. The diagonal pass tiles by
@@ -422,43 +377,39 @@ fn bench_high_target_qubit(c: &mut Criterion) {
     group.finish();
 }
 
+// Driven through `StatevectorBackend::apply` rather than `simulate()`, like
+// `two_qubit_gate_kernels` above. A single controlled gate leaves every other
+// qubit isolated, so the largest connected block is far narrower than the
+// register and independent-subsystem decomposition claims the circuit before
+// any backend is chosen: routed through `simulate()` these rows resolve to
+// `Decomposed` and never reach the kernel they are named for.
 fn bench_controlled_gates(c: &mut Criterion) {
     let mut group = c.benchmark_group("controlled_gates");
     configure_group(&mut group);
 
     let h_mat = Gate::H.matrix_2x2();
+    let x_mat = Gate::X.matrix_2x2();
 
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(BenchmarkId::new("cu_h", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::cu(h_mat), &[0, 1]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-    }
+        bench_kernel_row(&mut group, "cu_h", n_qubits, Gate::cu(h_mat), &[0, 1]);
 
-    let x_mat = Gate::X.matrix_2x2();
-    for &n_qubits in &[4, 8, 12, 16, 20] {
-        if n_qubits < 3 {
-            continue;
+        if n_qubits >= 3 {
+            bench_kernel_row(
+                &mut group,
+                "toffoli",
+                n_qubits,
+                Gate::mcu(x_mat, 2),
+                &[0, 1, 2],
+            );
         }
-        group.bench_with_input(BenchmarkId::new("toffoli", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::mcu(x_mat, 2), &[0, 1, 2]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
         if n_qubits >= 4 {
-            group.bench_with_input(BenchmarkId::new("cccx", n_qubits), &n_qubits, |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::mcu(x_mat, 3), &[0, 1, 2, 3]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            });
+            bench_kernel_row(
+                &mut group,
+                "cccx",
+                n_qubits,
+                Gate::mcu(x_mat, 3),
+                &[0, 1, 2, 3],
+            );
         }
     }
 
@@ -470,29 +421,9 @@ fn bench_diagonal_parametric_gates(c: &mut Criterion) {
     configure_group(&mut group);
 
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(BenchmarkId::new("rz_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Rz(1.234), &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("ry_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::Ry(1.234), &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(BenchmarkId::new("p_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::P(1.234), &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
+        bench_kernel_row(&mut group, "rz_gate", n_qubits, Gate::Rz(1.234), &[0]);
+        bench_kernel_row(&mut group, "ry_gate", n_qubits, Gate::Ry(1.234), &[0]);
+        bench_kernel_row(&mut group, "p_gate", n_qubits, Gate::P(1.234), &[0]);
     }
 
     group.finish();
@@ -505,28 +436,19 @@ fn bench_cphase_kernel(c: &mut Criterion) {
     let theta = std::f64::consts::FRAC_PI_4;
 
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(
-            BenchmarkId::new("ctrl_lt_target", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::cphase(theta), &[0, 1]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
+        bench_kernel_row(
+            &mut group,
+            "ctrl_lt_target",
+            n_qubits,
+            Gate::cphase(theta),
+            &[0, 1],
         );
-
-        group.bench_with_input(
-            BenchmarkId::new("ctrl_gt_target", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::cphase(theta), &[1, 0]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
+        bench_kernel_row(
+            &mut group,
+            "ctrl_gt_target",
+            n_qubits,
+            Gate::cphase(theta),
+            &[1, 0],
         );
     }
 
@@ -538,25 +460,8 @@ fn bench_new_gate_types(c: &mut Criterion) {
     configure_group(&mut group);
 
     for &n_qubits in &QUBIT_COUNTS {
-        group.bench_with_input(BenchmarkId::new("sx_gate", n_qubits), &n_qubits, |b, &n| {
-            let mut circuit = Circuit::new(n, 0);
-            circuit.add_gate(Gate::SX, &[0]);
-            b.iter(|| {
-                run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-            });
-        });
-
-        group.bench_with_input(
-            BenchmarkId::new("sxdg_gate", n_qubits),
-            &n_qubits,
-            |b, &n| {
-                let mut circuit = Circuit::new(n, 0);
-                circuit.add_gate(Gate::SXdg, &[0]);
-                b.iter(|| {
-                    run_with(BackendKind::Statevector, &circuit, 42).unwrap();
-                });
-            },
-        );
+        bench_kernel_row(&mut group, "sx_gate", n_qubits, Gate::SX, &[0]);
+        bench_kernel_row(&mut group, "sxdg_gate", n_qubits, Gate::SXdg, &[0]);
     }
 
     group.finish();

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -32,6 +32,12 @@ pub fn qft_circuit(n: usize) -> Circuit {
 }
 
 /// Build a random circuit with `n` qubits, `depth` layers of 1q + brick-layer CX.
+///
+/// The interaction graph is connected at `depth >= 2`: the first two layers lay
+/// down both halves of the brick pattern unconditionally, and later layers keep
+/// each bond at random. Without that guarantee a dropped bond can split the
+/// register into independent blocks, which routes the circuit to the decomposed
+/// path instead of the backend a caller selected.
 pub fn random_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut c = Circuit::new(n, 0);
@@ -42,7 +48,8 @@ pub fn random_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
         }
         let offset = layer % 2;
         for q in (offset..n - 1).step_by(2) {
-            if rng.random_bool(0.5) {
+            let keep = rng.random_bool(0.5);
+            if layer < 2 || keep {
                 c.add_gate(Gate::Cx, &[q, q + 1]);
             }
         }
@@ -249,6 +256,12 @@ pub fn qaoa_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
 /// blocks, so the runs collapse into `DiagonalBatch` instructions at 16 qubits
 /// and above.
 ///
+/// Pairs sweep the register modulo `n`, which is what keeps the interaction
+/// graph connected at `layers >= 2` for any `n`. Anchoring them to the low half
+/// instead leaves every qubit above `n / 2 + layers` untouched by any 2q gate,
+/// splitting the register once that tail is wide enough for the decomposed
+/// route to claim the circuit.
+///
 /// # Panics
 /// Panics if `n < 2` (stride selection divides by `n / 2`).
 pub fn diagonal_mixed_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
@@ -268,12 +281,13 @@ pub fn diagonal_mixed_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
         }
         let stride = 1 + layer % (n / 2);
         for q in 0..n / 2 {
-            let q1 = q + stride;
+            let q0 = 2 * q;
+            let q1 = (q0 + stride) % n;
             let theta = rng.random::<f64>() * std::f64::consts::TAU;
             match rng.random_range(0..3) {
-                0 => c.add_gate(Gate::Cz, &[q, q1]),
-                1 => c.add_gate(Gate::cphase(theta), &[q, q1]),
-                _ => c.add_gate(Gate::Rzz(theta), &[q, q1]),
+                0 => c.add_gate(Gate::Cz, &[q0, q1]),
+                1 => c.add_gate(Gate::cphase(theta), &[q0, q1]),
+                _ => c.add_gate(Gate::Rzz(theta), &[q0, q1]),
             }
         }
     }

--- a/tests/bench_fixture_routing.rs
+++ b/tests/bench_fixture_routing.rs
@@ -1,0 +1,115 @@
+//! Bench fixtures reach the backend their row names.
+//!
+//! Independent-subsystem decomposition is chosen before a backend family is
+//! resolved and does not consult an explicit [`BackendKind`], so a fixture whose
+//! interaction graph splits runs on per-block backends no matter what a caller
+//! asked for. That is correct routing and a silently wrong measurement: the
+//! affected rows stayed green, kept reporting, and went non-monotonic in qubit
+//! count. Nothing else in the suite checks the engine a run actually used.
+
+use prism_q::sim::ResolvedBackend;
+use prism_q::{BackendKind, circuits, sim};
+
+const SEED: u64 = 0xDEAD_BEEF;
+
+#[track_caller]
+fn assert_resolves(label: &str, kind: BackendKind, circuit: &prism_q::circuit::Circuit) {
+    let outcome = sim::simulate(circuit)
+        .backend(kind.clone())
+        .seed(42)
+        .run()
+        .unwrap();
+    assert!(
+        !matches!(outcome.metadata.backend, ResolvedBackend::Decomposed),
+        "{label}: asked for {kind:?}, ran on {:?}. The fixture's interaction \
+         graph splits, so this row measures the decomposed route rather than \
+         the backend it names.",
+        outcome.metadata.backend
+    );
+}
+
+// Widths 18 and 20 are the ones that regressed: the brick layer dropped a bond
+// often enough that roughly half of all (n, seed) pairs split the register, and
+// 22 and 24 happened to survive while 18 and 20 did not.
+#[test]
+fn random_circuit_rows_reach_their_backend() {
+    for n in [12usize, 14, 16, 18, 20, 22, 24] {
+        let circuit = circuits::random_circuit(n, 10, SEED);
+        assert_resolves(
+            &format!("random_d10/{n}"),
+            BackendKind::Statevector,
+            &circuit,
+        );
+    }
+
+    // The `factored/random_d10` group compares two arms on one circuit, so a
+    // split sends both to the same route and the comparison measures nothing.
+    for n in [16usize, 20, 24] {
+        let circuit = circuits::random_circuit(n, 10, SEED);
+        for kind in [
+            BackendKind::Statevector,
+            BackendKind::Factored,
+            BackendKind::Sparse,
+            BackendKind::Mps { max_bond_dim: 64 },
+        ] {
+            assert_resolves(&format!("random_d10/{n}"), kind, &circuit);
+        }
+    }
+}
+
+// `scalability_d5` sweeps 2 to 26 at depth 5, so it is the row set most exposed
+// to a fixture that connects only at higher depth.
+#[test]
+fn scalability_sweep_rows_reach_their_backend() {
+    for n in (4..=26).step_by(2) {
+        let circuit = circuits::random_circuit(n, 5, SEED);
+        assert_resolves(
+            &format!("scalability_d5/{n}"),
+            BackendKind::Statevector,
+            &circuit,
+        );
+    }
+}
+
+#[test]
+fn diagonal_mixed_rows_reach_their_backend() {
+    for n in [16usize, 20, 22, 24, 26] {
+        let circuit = circuits::diagonal_mixed_circuit(n, 6, SEED);
+        assert_resolves(
+            &format!("diag_mixed_l6/{n}"),
+            BackendKind::Statevector,
+            &circuit,
+        );
+    }
+}
+
+#[test]
+fn statevector_corpus_rows_reach_the_statevector() {
+    for n in [16usize, 20] {
+        assert_resolves(
+            &format!("clifford_d10/{n}"),
+            BackendKind::Statevector,
+            &circuits::clifford_heavy_circuit(n, 10, SEED),
+        );
+        assert_resolves(
+            &format!("qaoa_l3/{n}"),
+            BackendKind::Statevector,
+            &circuits::qaoa_circuit(n, 3, SEED),
+        );
+        assert_resolves(
+            &format!("hea_l5/{n}"),
+            BackendKind::Statevector,
+            &circuits::hardware_efficient_ansatz(n, 5, SEED),
+        );
+        assert_resolves(
+            &format!("qv/{n}"),
+            BackendKind::Statevector,
+            &circuits::quantum_volume_circuit(n, n, SEED),
+        );
+        assert_resolves(
+            &format!("qpe_t_gate/{n}"),
+            BackendKind::Statevector,
+            &circuits::phase_estimation_circuit(n),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Independent-subsystem decomposition is chosen before a backend family is resolved and
does not consult an explicit `BackendKind`, so a circuit whose register splits runs on
per-block backends whatever the caller selected. That is correct routing and a silently
wrong measurement, and a large part of the benchmark corpus was shaped to trigger it:
rows stayed green, kept reporting, and went non-monotonic in qubit count. This makes the
affected rows execute the engine their group names, and adds the assertion that was
missing to catch it.

Nothing in the simulation path changes. The router is right; the rows were wrong.

## Scope

- [x] Bug fix
- [x] Build, CI, or tooling

## What was wrong

Two independent causes, found by reading `metadata.backend` off each row's own run.

**Microbenchmark rows put one or two gates on a wide register.** The largest connected
block is then far narrower than the register, so every row in `single_qubit_gates`,
`two_qubit_gates`, `cphase_kernel`, `controlled_gates`, `diagonal_parametric_gates`,
`new_gate_types`, and the `h_*` rows of `high_target_qubit` resolved to the decomposed
route at every width from 8 up. None reached the kernel it is named for. They now drive
`StatevectorBackend::apply`, which is the idiom `two_qubit_gate_kernels` and the
measurement rows in the same file already use for this reason.

**Two circuit generators split their own register.** `random_circuit` dropped each
brick-layer CX at probability one half, so a bond could fail to form across the whole
depth; roughly half of all width and seed pairs split, which is why `random_d10` is clean
at 16, decomposed at 18 and 20, and clean again at 22 and 24. `diagonal_mixed_circuit`
anchored its pairs to the low half of the register with an unwrapped stride, so at 20
qubits and 6 layers nothing above qubit 15 received a two-qubit gate at all.

The second one also degraded a comparison: both arms of `factored/random_d10/20` resolved
to the same decomposed route, so that row compared a route against itself.

## Benchmarks

Adjacent-binary A/B against `main`, `--features parallel`, 30 samples, i7-6700K. The
first three rows are the control group: they are built by generators this diff does not
touch and already resolved to the statevector, so they carry the host and layout term.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | ---: | ---: | ---: | --- | --- |
| `statevector/clifford_d10/20` | 67.78 ms | 68.08 ms | +0.4% | -0.4%, +0.7% | yes, noise |
| `statevector/hea_l5/20` | 60.08 ms | 60.24 ms | +0.3% | -0.1%, -0.3% | yes, noise |
| `statevector/qaoa_l3/20` | 32.56 ms | 33.05 ms | +1.5% | -0.3%, +1.1% | yes, noise |
| `statevector/random_d10/16` | 1.90 ms | 2.15 ms | +13.0% | -3.3%, -3.7% | no, expected |
| `statevector/diag_mixed_l6/20` | 2.74 ms | 61.19 ms | +2134% | +0.3%, -2.3% | no, expected |
| `statevector/random_d10/20` | 2.00 ms | 47.00 ms | +2251% | -5.3%, -1.5% | no, expected |
| `statevector/scalability_d5/20` | 44.80 us | 32.76 ms | +73019% | -6.2%, -0.4% | no, expected |

Regression verdict: WAIVER.

Every row past the gate is a row that previously measured the decomposed route and now
measures the statevector. The increase is the defect being removed, not a slowdown: the
before column is the cost of simulating several small blocks, and the after column is the
cost of the 20-qubit circuit the row claims to run. The control group holds flat across
the same two binaries, which is what separates this from host drift, and an earlier
attempt to size the same effect by comparing against numbers taken in a previous session
put those controls 18% to 23% high, so the flat control column here is doing real work.

Two of the four are formally unmeasurable rather than measured: `random_d10/20` and
`scalability_d5/20` carry same-code control spreads of 5.3% and 6.2%, above the gate. The
direction is not in doubt at three and four orders of magnitude, but the precise figures
are not claimable, and `scalability_d5` runs at `sample_size(10)`, which is triage tier
rather than a measurement.

`random_d10/16` is the one row that changed without having been broken. It already
resolved to the statevector; it costs 13.0% more because the generator now lays down the
brick pattern unconditionally on the first two layers, so the circuit carries more CX. A
fixture that got denser, not a kernel that got slower.

No hot path is touched, so there is nothing here to profile.

## Correctness

- [x] `cargo nextest run --features parallel` passes locally (2174 tests)
- [x] `cargo test --doc --features parallel` passes (18 doctests)
- [x] `cargo clippy --all-targets --features parallel -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on the two changed generators state the connectivity invariant, which is
      the fact a caller cannot read off the signature

`tests/bench_fixture_routing.rs` asserts the resolved engine rather than a result,
because a result was never the thing that broke: these rows were green throughout. It
fails on three of its four cases against the generators as they were, which was checked
by reverting them.

Feature-gated arms are untouched, so the wider feature sets were not run.

## Breaking changes

`circuits::random_circuit` and `circuits::diagonal_mixed_circuit` return different
circuits for the same seed. Both are public. Determinism per seed is preserved, and no
test asserted their exact output, but any stored baseline keyed on a row built from
either one no longer describes the same circuit.

Row ids in `high_target_qubit` gain the standard parameter suffix, so baselines will not
match them by name either.

## Risks and rollback

Confined to benchmark definitions, two fixture generators, and one new test. No
simulation path, dispatch rule, or kernel is touched, so a revert restores the previous
numbers exactly and costs nothing else.

The judgement worth reviewing is the fix direction. Decomposition is the correct route
for a circuit that genuinely splits, so this changes the fixtures and the harness rather
than the router. The alternative, making an explicit backend request suppress
decomposition, would trade a measurement bug for a routing bug.

## Follow-ups not in this PR

`two_qubit_gate_kernels` drives the backend directly and is correct on that axis, but it
rebuilds a backend per iteration through `iter_batched` with `BatchSize::SmallInput` at
up to 22 qubits. The first version of this change copied that shape and every 20-qubit
row read the same time regardless of gate, because batching many 16 MB backends swamps
the kernel. Holding one backend per row fixes it here; that group still carries the
original shape and its current numbers should be treated as suspect until it is checked.

`measurement/measure_superposition` still decomposes. It is end-to-end by shape and the
group already carries direct-backend measure rows, so it was left alone deliberately.
