### PR TITLE
feat(qasm): parse input and output declarations

### DIFF
--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -53,6 +53,47 @@ c[0] = measure q[0]; // OQ3 measurement
 OpenQASM 2.0 syntax also works: `qreg q[3];` / `creg c[3];` declarations and
 `measure q[0] -> c[0];` measurement.
 
+`output bit[3] c;` declares the register and marks it as the program's result.
+Every classical bit is reported either way, so the marking costs nothing and
+changes nothing.
+
+## Input parameters
+
+An `input` declaration names a parameter slot. `openqasm::parse_parametric`
+returns the template circuit alongside the `Parameters` that binds it, in
+declaration order and under the declared names:
+
+```qasm
+OPENQASM 3.0;
+input float[64] theta;
+input float[64] phi;
+qubit[2] q;
+h q[0];
+rx(theta) q[0];
+cx q[0], q[1];
+rz(phi) q[1];
+```
+
+```rust
+let (template, params) = openqasm::parse_parametric(qasm)?;
+let bound = params.bind(&template, &[0.41, 1.27])?;
+let text = to_qasm3(&bound)?;   // angles written out, no `input` line
+```
+
+Several gates may read one input, which is the weight sharing `Parameters`
+already models: `rx(theta) q;` over a register links every gate it produces to
+the same slot, and binding writes one angle to each.
+
+`parse` itself rejects a program that declares an input, because it has nowhere
+to take the value and a zero would be a quiet wrong answer. Feed those through
+`parse_parametric`, or through `PreparedCircuit` for a sweep.
+
+An input binds an angle whole, so it may only be the entire angle argument of a
+directly named parametric gate at the top level. `rx(2 * theta)`, an input on a
+gate carrying no rotation angle, one reaching a `gate`, `def`, `for`, or guarded
+body, and one on a modified gate all return `UnsupportedConstruct` naming the
+reason rather than binding something the source did not mean.
+
 ## Supported gates
 
 - **Standard / aliases**: x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot,

--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -99,9 +99,20 @@ reason rather than binding something the source did not mean.
 - **Standard / aliases**: x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot,
   cy, cz, cp/cphase, crx, cry, crz, ch, swap, ccx/toffoli, cswap/fredkin, cu, u1, u2,
   u3/u/U.
-- **Qiskit / exporter**: sxdg, cs, csdg, csx, ccz, r, rzz, rxx, ryy, xx_plus_yy,
+- **Qiskit / exporter**: sxdg, cs, csdg, csx, ccz, r, xx_plus_yy,
   xx_minus_yy, ecr, iswap, dcx, c3x, c4x, mcx, rccx, rc3x/rcccx.
 - **Hardware-native**: gpi, gpi2, ms, syc, sqrt_iswap, sqrt_iswap_inv.
+- **Pauli rotations**: `r` followed by one Pauli letter per qubit argument.
+  `rxx`, `ryy`, and `rzz` are the two-letter cases; `rxyz(0.7) q[0], q[1], q[2];`
+  is `exp(-i * 0.7 * (X⊗Y⊗Z) / 2)` with `x` on `q[0]`. `rzz` resolves to the
+  native two-qubit rotation and a one-letter name to `rx`/`ry`/`rz`; wider
+  strings build the native multi-qubit gate, which the statevector applies in
+  one pass and every other backend receives as its CNOT-ladder lowering.
+
+  The wider spelling is a PRISM-Q extension rather than standard OpenQASM, and
+  `to_qasm3` emits it so a round trip preserves the gate instead of a lowering
+  of it. For output another toolchain reads, run
+  `circuit::expand_pauli_rotations` before exporting.
 
 ## Other supported constructs
 

--- a/src/circuit/expr.rs
+++ b/src/circuit/expr.rs
@@ -364,6 +364,22 @@ fn utf8_char_width(lead: u8) -> usize {
     }
 }
 
+/// True when `needle` occurs in `haystack` at identifier boundaries, the same
+/// rule [`replace_word`] substitutes on.
+pub(super) fn contains_word(haystack: &str, needle: &str) -> bool {
+    let hb = haystack.as_bytes();
+    let nb = needle.as_bytes();
+    let nlen = nb.len();
+    if nlen == 0 || nlen > hb.len() {
+        return false;
+    }
+    (0..=hb.len() - nlen).any(|i| {
+        &hb[i..i + nlen] == nb
+            && (i == 0 || !is_ident_char(hb[i - 1]))
+            && (i + nlen >= hb.len() || !is_ident_char(hb[i + nlen]))
+    })
+}
+
 pub(super) fn replace_word(haystack: &str, needle: &str, replacement: &str) -> String {
     let hb = haystack.as_bytes();
     let nb = needle.as_bytes();

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -98,40 +98,8 @@ impl Circuit {
     /// Panics if `factors` is empty, names a qubit twice, or names a qubit out
     /// of bounds.
     pub fn add_pauli_rotation(&mut self, theta: f64, factors: &[PauliTerm]) {
-        assert!(
-            !factors.is_empty(),
-            "Pauli rotation needs at least one factor"
-        );
-        let mut sorted: SmallVec<[PauliTerm; 4]> = SmallVec::from_slice(factors);
-        sorted.sort_unstable_by_key(|term| term.qubit);
-        for pair in sorted.windows(2) {
-            assert_ne!(
-                pair[0].qubit, pair[1].qubit,
-                "Pauli rotation has duplicate factor on qubit {}",
-                pair[0].qubit
-            );
-        }
-        match sorted.as_slice() {
-            [term] => {
-                let gate = match term.axis {
-                    PauliAxis::X => Gate::Rx(theta),
-                    PauliAxis::Y => Gate::Ry(theta),
-                    PauliAxis::Z => Gate::Rz(theta),
-                };
-                self.add_gate(gate, &[term.qubit]);
-            }
-            [a, b] if a.axis == PauliAxis::Z && b.axis == PauliAxis::Z => {
-                self.add_gate(Gate::Rzz(theta), &[a.qubit, b.qubit]);
-            }
-            _ => {
-                let targets: SmallVec<[usize; 4]> = sorted.iter().map(|term| term.qubit).collect();
-                let axes: Vec<PauliAxis> = sorted.iter().map(|term| term.axis).collect();
-                self.add_gate(
-                    Gate::PauliRot(Box::new(PauliRotData { theta, axes })),
-                    &targets,
-                );
-            }
-        }
+        let (gate, targets) = pauli_rotation_gate(theta, factors);
+        self.add_gate(gate, &targets);
     }
 
     /// Append a measurement operation.
@@ -907,6 +875,55 @@ pub(crate) fn pauli_rotation_lowering(
 /// Backends without the native kernel call this before dispatch, the same
 /// probe-plus-expansion route as [`expand_qft_blocks`]. Returns
 /// `Cow::Borrowed` when there is nothing to expand.
+/// Lower a Pauli rotation to the gate and target order a circuit stores it as,
+/// the recognizing step behind [`Circuit::add_pauli_rotation`].
+///
+/// Shared with the OpenQASM parser, which builds the instruction itself and so
+/// cannot go through `add_pauli_rotation`. Targets come back sorted by qubit
+/// with the letters aligned to them.
+///
+/// # Panics
+/// Panics if `factors` is empty or names a qubit twice.
+pub(crate) fn pauli_rotation_gate(
+    theta: f64,
+    factors: &[PauliTerm],
+) -> (Gate, SmallVec<[usize; 4]>) {
+    assert!(
+        !factors.is_empty(),
+        "Pauli rotation needs at least one factor"
+    );
+    let mut sorted: SmallVec<[PauliTerm; 4]> = SmallVec::from_slice(factors);
+    sorted.sort_unstable_by_key(|term| term.qubit);
+    for pair in sorted.windows(2) {
+        assert_ne!(
+            pair[0].qubit, pair[1].qubit,
+            "Pauli rotation has duplicate factor on qubit {}",
+            pair[0].qubit
+        );
+    }
+    match sorted.as_slice() {
+        [term] => {
+            let gate = match term.axis {
+                PauliAxis::X => Gate::Rx(theta),
+                PauliAxis::Y => Gate::Ry(theta),
+                PauliAxis::Z => Gate::Rz(theta),
+            };
+            (gate, smallvec![term.qubit])
+        }
+        [a, b] if a.axis == PauliAxis::Z && b.axis == PauliAxis::Z => {
+            (Gate::Rzz(theta), smallvec![a.qubit, b.qubit])
+        }
+        _ => {
+            let targets: SmallVec<[usize; 4]> = sorted.iter().map(|term| term.qubit).collect();
+            let axes: Vec<PauliAxis> = sorted.iter().map(|term| term.axis).collect();
+            (
+                Gate::PauliRot(Box::new(PauliRotData { theta, axes })),
+                targets,
+            )
+        }
+    }
+}
+
 pub fn expand_pauli_rotations(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
     if !any_bare_gate(&circuit.instructions, &mut |gate| {
         matches!(gate, Gate::PauliRot(_))

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -9,6 +9,8 @@
 //! | Qubit declaration | `qubit[4] q;` | OQ3 syntax (primary) |
 //! | Bit declaration | `bit[4] c;` | OQ3 syntax (primary) |
 //! | Legacy qreg/creg | `qreg q[4]; creg c[4];` | OQ2 compat |
+//! | Input parameter | `input float[64] theta;` | One named slot; [`parse_parametric`] returns them |
+//! | Output declaration | `output bit[4] c;` | Declares the register; every bit is reported anyway |
 //! | 1-qubit gates | `h q[0]; x q[1];` | id, x, y, z, h, s, sdg, t, tdg, sx, sxdg, p/phase, r, gpi, gpi2, u/U forms |
 //! | Parametric gates | `rx(pi/4) q[0];` | rx, ry, rz, cu, ms, arithmetic expressions with `pi`, math functions |
 //! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
@@ -50,6 +52,12 @@
 //!   re-read the bits after an earlier body ran
 //! - `switch` with a `default` and more case labels than the region depth bound
 //! - `duration`, `stretch` outside `def` parameter lists
+//! - `input` of any type but `float` and `angle`, and `output` of any type but
+//!   `bit`
+//! - an `input` anywhere but as the whole angle argument of a top-level
+//!   parametric gate: an expression over one, two on one gate, a modified gate,
+//!   a gate carrying no rotation angle, and a use inside a `gate`, `def`,
+//!   `for`, or guarded-region body all reject
 //!
 //! # Error behaviour
 //!
@@ -61,7 +69,8 @@
 use num_complex::Complex64;
 
 use crate::circuit::{
-    Circuit, ClassicalCondition, Instruction, MAX_REGION_DEPTH, SmallVec, guarded, smallvec,
+    Circuit, ClassicalCondition, Instruction, MAX_REGION_DEPTH, ParamLink, Parameters, SmallVec,
+    guarded, smallvec,
 };
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
@@ -74,8 +83,40 @@ use std::collections::HashMap;
 ///
 /// # Errors
 ///
-/// Returns structured [`PrismError`] for any parse failure or unsupported construct.
+/// Returns structured [`PrismError`] for any parse failure or unsupported
+/// construct, and [`PrismError::InvalidParameter`] when the program declares an
+/// `input`, whose value this entry point has nowhere to take. Use
+/// [`parse_parametric`] for those.
 pub fn parse(input: &str) -> Result<Circuit> {
+    let (circuit, params) = Parser::new(input).parse()?;
+    if params.num_slots() > 0 {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "program declares {} `input` parameter(s); parse it with `parse_parametric` and bind them",
+                params.num_slots()
+            ),
+        });
+    }
+    Ok(circuit)
+}
+
+/// Parse an OpenQASM 3.0 string into a [`Circuit`] plus the [`Parameters`] its
+/// `input` declarations name.
+///
+/// Slots are ordered by declaration and carry the declared names, so
+/// [`Parameters::slot_of`] resolves an angle by the name the source used. The
+/// returned circuit is a template holding zero for every input; bind it before
+/// running, since dispatch reads the angles it is given.
+///
+/// An `input` may only be the whole angle argument of a directly named
+/// parametric gate at the top level. An expression over one, a use inside a
+/// gate, `def`, `for`, or guarded-region body, and a use on a gate carrying no
+/// rotation angle all return [`PrismError::UnsupportedConstruct`].
+///
+/// # Errors
+///
+/// Same conditions as [`parse`], less the `input` rejection.
+pub fn parse_parametric(input: &str) -> Result<(Circuit, Parameters)> {
     Parser::new(input).parse()
 }
 
@@ -168,12 +209,23 @@ pub(crate) struct Parser<'a> {
     region_depth: usize,
     param_vars: Option<HashMap<String, f64>>,
     int_vars: Option<HashMap<String, i64>>,
+    /// `input` slot per declared name, and the names in slot order.
+    inputs: HashMap<String, usize>,
+    input_names: Vec<String>,
+    links: Vec<ParamLink>,
+    /// Slot the statement just parsed reads, handed from `process_top_line` up
+    /// to `parse_lines`, which is the only place that knows the instruction
+    /// index the link needs.
+    pending_input_slot: Option<usize>,
+    /// True while parsing a block body, whose instruction indices are local to
+    /// that body and so cannot carry a top-level parameter link.
+    nested: bool,
 }
 
 const MAX_GATE_EXPANSION_DEPTH: usize = 32;
 const MAX_FOR_ITERATIONS: i64 = 1_000_000;
 
-use super::expr::{eval_expr, replace_word, split_top_level_commas};
+use super::expr::{contains_word, eval_expr, replace_word, split_top_level_commas};
 
 fn strip_comment(line: &str) -> &str {
     match line.find("//") {
@@ -635,18 +687,27 @@ impl<'a> Parser<'a> {
             region_depth: 0,
             param_vars: None,
             int_vars: None,
+            inputs: HashMap::new(),
+            input_names: Vec::new(),
+            links: Vec::new(),
+            pending_input_slot: None,
+            nested: false,
         }
     }
 
-    fn parse(mut self) -> Result<Circuit> {
+    fn parse(mut self) -> Result<(Circuit, Parameters)> {
         let lines: Vec<&str> = self.input.lines().collect();
         let instructions = self.parse_lines(&lines, 0)?;
 
-        Ok(Circuit {
+        let circuit = Circuit {
             num_qubits: self.total_qubits,
             num_classical_bits: self.total_cbits,
             instructions,
-        })
+        };
+        let params = Parameters::from_links(self.links, self.input_names.len())
+            .with_names(self.input_names)
+            .pinned_to(&circuit);
+        Ok((circuit, params))
     }
 
     fn parse_lines(&mut self, lines: &[&str], line_offset: usize) -> Result<Vec<Instruction>> {
@@ -673,7 +734,17 @@ impl<'a> Parser<'a> {
                     depth: 0,
                 });
             } else {
-                instructions.extend(self.process_top_line(line, line_num, &mut block)?);
+                let base = instructions.len();
+                let produced = self.process_top_line(line, line_num, &mut block)?;
+                if let Some(slot) = self.pending_input_slot.take() {
+                    for offset in 0..produced.len() {
+                        self.links.push(ParamLink {
+                            instruction: base + offset,
+                            slot,
+                        });
+                    }
+                }
+                instructions.extend(produced);
             }
 
             if let Some(state) = block.as_ref()
@@ -705,6 +776,7 @@ impl<'a> Parser<'a> {
         line_num: usize,
         block: &mut Option<BlockState>,
     ) -> Result<Vec<Instruction>> {
+        self.pending_input_slot = None;
         let first_word = line
             .split(|c: char| c.is_whitespace() || c == '(')
             .next()
@@ -760,6 +832,14 @@ impl<'a> Parser<'a> {
             self.parse_bit_decl(line, line_num)?;
             return Ok(Vec::new());
         }
+        if first_word == "input" {
+            self.parse_input_decl(line, line_num)?;
+            return Ok(Vec::new());
+        }
+        if first_word == "output" {
+            self.parse_output_decl(line, line_num)?;
+            return Ok(Vec::new());
+        }
         if line.starts_with("qreg") {
             self.parse_qreg_legacy(line, line_num)?;
             return Ok(Vec::new());
@@ -808,7 +888,9 @@ impl<'a> Parser<'a> {
             });
         }
 
-        self.parse_gate_application(line, line_num)
+        let (instrs, slot) = self.parse_gate_application(line, line_num)?;
+        self.pending_input_slot = slot;
+        Ok(instrs)
     }
 
     fn dispatch_block(&mut self, state: &BlockState) -> Result<Vec<Instruction>> {
@@ -835,6 +917,94 @@ impl<'a> Parser<'a> {
         self.total_qubits += size;
         self.qregs.insert(name, Register { offset, size });
         Ok(())
+    }
+
+    /// `input float[64] theta` declares one parameter slot, named and ordered
+    /// by declaration. The template holds zero until a binding writes it.
+    fn parse_input_decl(&mut self, line: &str, line_num: usize) -> Result<()> {
+        let rest = line.strip_prefix("input").unwrap().trim();
+        let (ty, name) = Self::split_declared_type(rest, "input", line_num)?;
+        if !matches!(Self::type_keyword(ty), "float" | "angle") {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("`input {ty}` (only float and angle inputs bind to an angle)"),
+                line: line_num,
+            });
+        }
+        if self.inputs.contains_key(&name) {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("input `{name}` declared twice"),
+            });
+        }
+        self.inputs.insert(name.clone(), self.input_names.len());
+        self.input_names.push(name);
+        Ok(())
+    }
+
+    /// `output bit[4] c` declares the register and marks it as the program's
+    /// result. Every classical bit is already reported, so the marking is
+    /// carried by the declaration alone.
+    fn parse_output_decl(&mut self, line: &str, line_num: usize) -> Result<()> {
+        let rest = line.strip_prefix("output").unwrap().trim();
+        let (ty, _) = Self::split_declared_type(rest, "output", line_num)?;
+        if Self::type_keyword(ty) != "bit" {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("`output {ty}` (only bit outputs are reported)"),
+                line: line_num,
+            });
+        }
+        self.parse_bit_decl(rest, line_num)
+    }
+
+    /// Split `float[64] theta` into its type and its name.
+    fn split_declared_type<'s>(
+        rest: &'s str,
+        keyword: &str,
+        line_num: usize,
+    ) -> Result<(&'s str, String)> {
+        let split = rest
+            .rfind(|c: char| c.is_whitespace())
+            .ok_or_else(|| PrismError::Parse {
+                line: line_num,
+                message: format!("expected `{keyword} <type> <name>`, got `{keyword} {rest}`"),
+            })?;
+        let (ty, name) = (rest[..split].trim(), rest[split..].trim());
+        if ty.is_empty() || name.is_empty() {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("expected `{keyword} <type> <name>`, got `{keyword} {rest}`"),
+            });
+        }
+        Ok((ty, name.to_string()))
+    }
+
+    /// Type name with any width suffix dropped: `float[64]` reads as `float`.
+    fn type_keyword(ty: &str) -> &str {
+        ty.split('[').next().unwrap_or(ty).trim()
+    }
+
+    /// Evaluate one gate argument, reporting the slot when it is exactly an
+    /// `input` name.
+    fn resolve_param(&self, expr: &str, line_num: usize) -> Result<(f64, Option<usize>)> {
+        let expr = expr.trim();
+        if let Some(&slot) = self.inputs.get(expr) {
+            if self.nested {
+                return Err(PrismError::UnsupportedConstruct {
+                    construct: format!("input `{expr}` inside a block body"),
+                    line: line_num,
+                });
+            }
+            return Ok((0.0, Some(slot)));
+        }
+        if let Some(name) = self.input_names.iter().find(|n| contains_word(expr, n)) {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!(
+                    "expression `{expr}` over input `{name}`; an input binds an angle whole"
+                ),
+                line: line_num,
+            });
+        }
+        Ok((eval_expr(expr, line_num, self.param_vars.as_ref())?, None))
     }
 
     /// OQ3 syntax: `bit[4] c` or `bit c` (single bit).
@@ -1392,7 +1562,9 @@ impl<'a> Parser<'a> {
             self.int_vars = Some(new_vars);
 
             let lines: Vec<&str> = substituted.iter().map(String::as_str).collect();
+            let was_nested = std::mem::replace(&mut self.nested, true);
             let result = self.parse_lines(&lines, line_num.saturating_sub(1));
+            self.nested = was_nested;
 
             self.int_vars = saved;
             all_instrs.extend(result?);
@@ -1528,7 +1700,9 @@ impl<'a> Parser<'a> {
         self.enter_region(line_num)?;
         let body_lines = split_body_into_lines(src.trim());
         let refs: Vec<&str> = body_lines.iter().map(String::as_str).collect();
+        let was_nested = std::mem::replace(&mut self.nested, true);
         let body = self.parse_lines(&refs, line_num.saturating_sub(1));
+        self.nested = was_nested;
         self.region_depth -= 1;
         body
     }
@@ -1704,7 +1878,13 @@ impl<'a> Parser<'a> {
                 message: "expected gate after `if(...)` condition".to_string(),
             });
         }
-        let body = self.parse_gate_application(body_str, line_num)?;
+        let (body, input_slot) = self.parse_gate_application(body_str, line_num)?;
+        if input_slot.is_some() {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: "`input` inside a guarded statement".to_string(),
+                line: line_num,
+            });
+        }
         Ok(guarded(condition, body).into_iter().collect())
     }
 
@@ -1870,16 +2050,30 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_gate_application(&self, line: &str, line_num: usize) -> Result<Vec<Instruction>> {
+    /// Parse one gate application, reporting the `input` slot every instruction
+    /// it produced reads. A register broadcast produces several, and they share
+    /// the slot, which is the weight sharing [`Parameters`] already models.
+    fn parse_gate_application(
+        &self,
+        line: &str,
+        line_num: usize,
+    ) -> Result<(Vec<Instruction>, Option<usize>)> {
         let (modifiers, gate_line) = Self::strip_modifiers(line, line_num)?;
 
         if modifiers.is_empty() {
             if let Some(instrs) = self.try_expand_def_call(gate_line, line_num)? {
-                return Ok(instrs);
+                return Ok((instrs, None));
             }
         }
 
-        let (gate_name, params, args_str) = self.split_gate_line(gate_line, line_num)?;
+        let (gate_name, params, input_slot, args_str) =
+            self.split_gate_line(gate_line, line_num)?;
+        if input_slot.is_some() && !modifiers.is_empty() {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("modifier on `{gate_name}` reading an `input`"),
+                line: line_num,
+            });
+        }
 
         let qubit_tokens: Vec<&str> = args_str
             .split(',')
@@ -1893,12 +2087,6 @@ impl<'a> Parser<'a> {
 
         let broadcast_len = self.broadcast_length(&resolved, &gate_name, line_num)?;
 
-        if broadcast_len <= 1 {
-            let qubits: SmallVec<[usize; 4]> = resolved.iter().map(|v| v[0]).collect();
-            return self
-                .resolve_gate_application_once(&gate_name, &params, &modifiers, &qubits, line_num);
-        }
-
         let mut all_instrs = Vec::with_capacity(broadcast_len);
         for i in 0..broadcast_len {
             let qubits: SmallVec<[usize; 4]> = resolved
@@ -1907,10 +2095,40 @@ impl<'a> Parser<'a> {
                 .collect();
 
             all_instrs.append(&mut self.resolve_gate_application_once(
-                &gate_name, &params, &modifiers, &qubits, line_num,
+                &gate_name,
+                &params,
+                &modifiers,
+                &qubits,
+                input_slot.is_some(),
+                line_num,
             )?);
         }
-        Ok(all_instrs)
+
+        if input_slot.is_some() {
+            Self::check_every_instruction_is_bindable(&all_instrs, &gate_name, line_num)?;
+        }
+        Ok((all_instrs, input_slot))
+    }
+
+    /// A slot writes one angle onto each instruction it links, so every
+    /// instruction a gate reading an `input` produced has to carry one.
+    fn check_every_instruction_is_bindable(
+        instrs: &[Instruction],
+        gate_name: &str,
+        line_num: usize,
+    ) -> Result<()> {
+        let bindable = instrs.iter().all(|instr| {
+            matches!(instr, Instruction::Gate { gate, .. } if gate.pauli_generator().is_some())
+        });
+        if !bindable {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!(
+                    "`input` on `{gate_name}`, which carries no rotation angle to bind"
+                ),
+                line: line_num,
+            });
+        }
+        Ok(())
     }
 
     fn resolve_gate_application_once(
@@ -1919,9 +2137,18 @@ impl<'a> Parser<'a> {
         params: &[f64],
         modifiers: &[Modifier],
         qubits: &SmallVec<[usize; 4]>,
+        has_input: bool,
         line_num: usize,
     ) -> Result<Vec<Instruction>> {
         if let Some(instrs) = Self::resolve_decomposed_gate(gate_name, params, qubits, line_num)? {
+            // A lowering folds the angle into its own arithmetic, so binding a
+            // slot afterwards would write the raw value over a derived one.
+            if has_input {
+                return Err(PrismError::UnsupportedConstruct {
+                    construct: format!("`input` on `{gate_name}`, which lowers to a gate sequence"),
+                    line: line_num,
+                });
+            }
             if !modifiers.is_empty() {
                 return Err(PrismError::UnsupportedConstruct {
                     construct: format!("modifier on decomposed gate `{gate_name}`"),
@@ -1932,6 +2159,14 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(instrs) = self.expand_user_gate(gate_name, params, qubits, line_num)? {
+            // Expansion substitutes the numeric value into the body, so a body
+            // writing `rx(2 * a)` would take a bound angle whole.
+            if has_input {
+                return Err(PrismError::UnsupportedConstruct {
+                    construct: format!("`input` on user-defined gate `{gate_name}`"),
+                    line: line_num,
+                });
+            }
             return Ok(instrs);
         }
 
@@ -2041,6 +2276,11 @@ impl<'a> Parser<'a> {
             region_depth: self.region_depth,
             param_vars: Some(var_map),
             int_vars: self.int_vars.clone(),
+            inputs: HashMap::new(),
+            input_names: Vec::new(),
+            links: Vec::new(),
+            pending_input_slot: None,
+            nested: true,
         };
         sub_parser.qregs.insert(
             "__q__".to_string(),
@@ -2087,7 +2327,8 @@ impl<'a> Parser<'a> {
                     replace_word(&expanded, qubit_name, &format!("__q__[{}]", call_qubits[i]));
             }
 
-            let instrs = sub_parser.parse_gate_application(expanded.trim(), line_num)?;
+            // The sub-parser declares no inputs, so the slot is always `None`.
+            let (instrs, _) = sub_parser.parse_gate_application(expanded.trim(), line_num)?;
             all_instrs.extend(instrs);
         }
 
@@ -2175,6 +2416,21 @@ impl<'a> Parser<'a> {
             });
         }
 
+        // The body is inlined with the argument's numeric value substituted in,
+        // so a slot recorded here would bind an angle the body derives from.
+        // Rejecting by name beats the unknown-identifier error the substitution
+        // would otherwise raise on a name that is declared.
+        if let Some(input) = self
+            .input_names
+            .iter()
+            .find(|input| raw_args.iter().any(|arg| contains_word(arg, input)))
+        {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("input `{input}` as an argument to `def {name}`"),
+                line: line_num,
+            });
+        }
+
         let mut qubit_substs: Vec<(String, usize)> = Vec::new();
         let mut float_vars: HashMap<String, f64> = self.param_vars.clone().unwrap_or_default();
         let mut int_vars: HashMap<String, i64> = self.int_vars.clone().unwrap_or_default();
@@ -2229,6 +2485,11 @@ impl<'a> Parser<'a> {
             region_depth: self.region_depth,
             param_vars: Some(float_vars),
             int_vars: Some(int_vars),
+            inputs: HashMap::new(),
+            input_names: Vec::new(),
+            links: Vec::new(),
+            pending_input_slot: None,
+            nested: true,
         };
         sub_parser.qregs.insert(
             "__q__".to_string(),
@@ -2382,7 +2643,11 @@ impl<'a> Parser<'a> {
         Gate::cu(mat)
     }
 
-    fn split_gate_line(&self, line: &str, line_num: usize) -> Result<(String, Vec<f64>, String)> {
+    fn split_gate_line(
+        &self,
+        line: &str,
+        line_num: usize,
+    ) -> Result<(String, Vec<f64>, Option<usize>, String)> {
         if let Some(paren_start) = line.find('(') {
             let mut depth = 0usize;
             let mut paren_end = None;
@@ -2405,10 +2670,9 @@ impl<'a> Parser<'a> {
             })?;
             let gate_name = line[..paren_start].trim().to_string();
             let params_str = &line[paren_start + 1..paren_end];
-            let params =
-                Self::parse_params_with_vars(params_str, line_num, self.param_vars.as_ref())?;
+            let (params, input_slot) = self.parse_params(params_str, line_num)?;
             let args_str = line[paren_end + 1..].trim().to_string();
-            Ok((gate_name, params, args_str))
+            Ok((gate_name, params, input_slot, args_str))
         } else {
             let first_space = line
                 .find(char::is_whitespace)
@@ -2418,19 +2682,29 @@ impl<'a> Parser<'a> {
                 })?;
             let gate_name = line[..first_space].trim().to_string();
             let args_str = line[first_space..].trim().to_string();
-            Ok((gate_name, vec![], args_str))
+            Ok((gate_name, vec![], None, args_str))
         }
     }
 
-    fn parse_params_with_vars(
-        params_str: &str,
-        line_num: usize,
-        vars: Option<&HashMap<String, f64>>,
-    ) -> Result<Vec<f64>> {
-        split_top_level_commas(params_str)
-            .iter()
-            .map(|p| eval_expr(p.trim(), line_num, vars))
-            .collect()
+    /// Evaluate a gate's argument list, reporting the one `input` slot it reads.
+    ///
+    /// Two inputs on one gate are rejected: a slot is written onto the single
+    /// angle a bindable gate carries, so a second one would have nowhere to go.
+    fn parse_params(&self, params_str: &str, line_num: usize) -> Result<(Vec<f64>, Option<usize>)> {
+        let mut values = Vec::new();
+        let mut input_slot = None;
+        for part in split_top_level_commas(params_str) {
+            let (value, slot) = self.resolve_param(part, line_num)?;
+            if slot.is_some() && input_slot.is_some() {
+                return Err(PrismError::UnsupportedConstruct {
+                    construct: "two `input` parameters on one gate".to_string(),
+                    line: line_num,
+                });
+            }
+            input_slot = input_slot.or(slot);
+            values.push(value);
+        }
+        Ok((values, input_slot))
     }
 
     fn resolve_gate(name: &str, params: &[f64], line_num: usize) -> Result<Gate> {

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -13,7 +13,8 @@
 //! | Output declaration | `output bit[4] c;` | Declares the register; every bit is reported anyway |
 //! | 1-qubit gates | `h q[0]; x q[1];` | id, x, y, z, h, s, sdg, t, tdg, sx, sxdg, p/phase, r, gpi, gpi2, u/U forms |
 //! | Parametric gates | `rx(pi/4) q[0];` | rx, ry, rz, cu, ms, arithmetic expressions with `pi`, math functions |
-//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
+//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
+//! | Pauli rotation | `rzz(t) q[0], q[1];` `rxyz(t) q[0], q[1], q[2];` | `r` plus the Pauli letters, one per qubit argument; `rxx`, `ryy`, `rzz` are the two-letter cases |
 //! | Multi-qubit gates | `ccx q[0], q[1], q[2];` | ccx/toffoli, ccz, cswap/fredkin, c3x, c4x, mcx, rccx, rc3x/rcccx |
 //! | Gate modifiers | `inv @ h q[0];` | `inv @`, `ctrl @` (chainable), `pow(k) @` (integer k) for direct gates |
 //! | Measurement (OQ3) | `c[0] = measure q[0];` | Assignment syntax (primary) |
@@ -70,10 +71,11 @@ use num_complex::Complex64;
 
 use crate::circuit::{
     Circuit, ClassicalCondition, Instruction, MAX_REGION_DEPTH, ParamLink, Parameters, SmallVec,
-    guarded, smallvec,
+    guarded, pauli_rotation_gate, smallvec,
 };
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 use std::collections::HashMap;
 
 /// Parse an OpenQASM 3.0 string into a PRISM-Q [`Circuit`].
@@ -226,6 +228,23 @@ const MAX_GATE_EXPANSION_DEPTH: usize = 32;
 const MAX_FOR_ITERATIONS: i64 = 1_000_000;
 
 use super::expr::{contains_word, eval_expr, replace_word, split_top_level_commas};
+
+/// Pauli letters of an `r<letters>` rotation name, or `None` when the name is
+/// not one.
+///
+/// Covers the `rxx`, `ryy`, and `rzz` OpenQASM already spells as well as the
+/// wider strings it does not, so one rule serves the whole family. `rzz` still
+/// resolves to `Gate::Rzz` and a weight-1 name to `Rx`/`Ry`/`Rz`, because
+/// `pauli_rotation_gate` lowers those; only the residual strings build the
+/// native multi-qubit gate. Names like `rccx` do not match, `c` being no Pauli
+/// letter.
+fn pauli_rotation_axes(name: &str) -> Option<Vec<PauliAxis>> {
+    let letters = name.strip_prefix('r')?;
+    if letters.len() < 2 {
+        return None;
+    }
+    letters.chars().map(PauliAxis::from_letter).collect()
+}
 
 fn strip_comment(line: &str) -> &str {
     match line.find("//") {
@@ -2110,6 +2129,47 @@ impl<'a> Parser<'a> {
         Ok((all_instrs, input_slot))
     }
 
+    /// Build the instruction an `r<letters>` application names, checking the
+    /// arity and distinctness `pauli_rotation_gate` would otherwise panic on.
+    fn resolve_pauli_rotation(
+        gate_name: &str,
+        axes: &[PauliAxis],
+        params: &[f64],
+        modifiers: &[Modifier],
+        qubits: &SmallVec<[usize; 4]>,
+        line_num: usize,
+    ) -> Result<Instruction> {
+        if !modifiers.is_empty() {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("modifier on Pauli rotation `{gate_name}`"),
+                line: line_num,
+            });
+        }
+        Self::expect_param_count(gate_name, params, 1, line_num)?;
+        if qubits.len() != axes.len() {
+            return Err(PrismError::GateArity {
+                gate: gate_name.to_string(),
+                expected: axes.len(),
+                got: qubits.len(),
+            });
+        }
+        let mut seen: SmallVec<[usize; 4]> = qubits.clone();
+        seen.sort_unstable();
+        if let Some(pair) = seen.windows(2).find(|pair| pair[0] == pair[1]) {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("Pauli rotation `{gate_name}` names qubit {} twice", pair[0]),
+            });
+        }
+        let factors: Vec<PauliTerm> = qubits
+            .iter()
+            .zip(axes)
+            .map(|(&qubit, &axis)| PauliTerm::new(qubit, axis))
+            .collect();
+        let (gate, targets) = pauli_rotation_gate(params[0], &factors);
+        Ok(Instruction::Gate { gate, targets })
+    }
+
     /// A slot writes one angle onto each instruction it links, so every
     /// instruction a gate reading an `input` produced has to carry one.
     fn check_every_instruction_is_bindable(
@@ -2168,6 +2228,13 @@ impl<'a> Parser<'a> {
                 });
             }
             return Ok(instrs);
+        }
+
+        if let Some(axes) = pauli_rotation_axes(gate_name) {
+            return Self::resolve_pauli_rotation(
+                gate_name, &axes, params, modifiers, qubits, line_num,
+            )
+            .map(|instr| vec![instr]);
         }
 
         let mut gate = Self::resolve_gate(gate_name, params, line_num)?;
@@ -2744,10 +2811,6 @@ impl<'a> Parser<'a> {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Ok(Gate::cphase(params[0]))
             }
-            "rzz" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Ok(Gate::Rzz(params[0]))
-            }
             "cx" | "CX" | "cnot" => Ok(Gate::Cx),
             "cy" => Ok(Gate::cu(Gate::Y.matrix_2x2())),
             "cs" => Ok(Gate::cu(Gate::S.matrix_2x2())),
@@ -2916,37 +2979,6 @@ impl<'a> Parser<'a> {
                     Self::ig(Gate::Cx, &[t2, t1]),
                     Self::ig(Gate::mcu(Gate::X.matrix_2x2(), 2), &[ctrl, t1, t2]),
                     Self::ig(Gate::Cx, &[t2, t1]),
-                ]))
-            }
-            "rxx" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Self::check_arity(name, qubits, 2)?;
-                let q0 = qubits[0];
-                let q1 = qubits[1];
-                Ok(Some(vec![
-                    Self::ig(Gate::H, &[q0]),
-                    Self::ig(Gate::H, &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rz(params[0]), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::H, &[q0]),
-                    Self::ig(Gate::H, &[q1]),
-                ]))
-            }
-            "ryy" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Self::check_arity(name, qubits, 2)?;
-                let q0 = qubits[0];
-                let q1 = qubits[1];
-                let half_pi = std::f64::consts::FRAC_PI_2;
-                Ok(Some(vec![
-                    Self::ig(Gate::Rx(half_pi), &[q0]),
-                    Self::ig(Gate::Rx(half_pi), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rz(params[0]), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rx(-half_pi), &[q0]),
-                    Self::ig(Gate::Rx(-half_pi), &[q1]),
                 ]))
             }
             "ecr" => {

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -788,18 +788,74 @@ fn test_rzz_gate() {
     ));
 }
 
+// `rxx` and `ryy` took a seven-gate basis-change ladder until the native
+// multi-qubit rotation gained a spelling. Equivalence to that ladder is checked
+// numerically in `tests/pauli_rot_correctness.rs`; the shape belongs here.
 #[test]
 fn test_rxx_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\nrxx(pi/4) q[0], q[1];";
     let c = parse(qasm).unwrap();
-    assert_eq!(c.instructions.len(), 7);
+    assert_eq!(c.instructions.len(), 1);
+    let Instruction::Gate {
+        gate: Gate::PauliRot(data),
+        targets,
+    } = &c.instructions[0]
+    else {
+        panic!("expected a PauliRot, got {:?}", c.instructions[0]);
+    };
+    assert_eq!(data.axes(), [PauliAxis::X, PauliAxis::X]);
+    assert_eq!(targets.as_slice(), [0, 1]);
 }
 
 #[test]
 fn test_ryy_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\nryy(pi/4) q[0], q[1];";
     let c = parse(qasm).unwrap();
-    assert_eq!(c.instructions.len(), 7);
+    assert_eq!(c.instructions.len(), 1);
+    assert!(matches!(
+        &c.instructions[0],
+        Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            ..
+        } if data.axes() == [PauliAxis::Y, PauliAxis::Y]
+    ));
+}
+
+#[test]
+fn test_wide_pauli_rotation_gate() {
+    let qasm = "OPENQASM 3.0;\nqubit[4] q;\nrxyz(0.7) q[2], q[0], q[3];";
+    let c = parse(qasm).unwrap();
+    assert_eq!(c.instructions.len(), 1);
+    let Instruction::Gate {
+        gate: Gate::PauliRot(data),
+        targets,
+    } = &c.instructions[0]
+    else {
+        panic!("expected a PauliRot, got {:?}", c.instructions[0]);
+    };
+    // Targets sort by qubit and the letters follow them, so `y` stays on q[0].
+    assert_eq!(targets.as_slice(), [0, 2, 3]);
+    assert_eq!(data.axes(), [PauliAxis::Y, PauliAxis::X, PauliAxis::Z]);
+}
+
+#[test]
+fn test_pauli_rotation_rejections() {
+    let repeated = parse("OPENQASM 3.0;\nqubit[3] q;\nrxx(0.3) q[0], q[0];");
+    assert!(matches!(repeated, Err(PrismError::Parse { .. })));
+
+    let arity = parse("OPENQASM 3.0;\nqubit[3] q;\nrxyz(0.3) q[0], q[1];");
+    assert!(matches!(arity, Err(PrismError::GateArity { .. })));
+
+    let modified = parse("OPENQASM 3.0;\nqubit[3] q;\ninv @ rxyz(0.3) q[0], q[1], q[2];");
+    assert!(matches!(
+        modified,
+        Err(PrismError::UnsupportedConstruct { .. })
+    ));
+
+    // `rccx` is not a Pauli string, `c` being no Pauli letter, so the name
+    // still reaches its own decomposition.
+    let rccx = parse("OPENQASM 3.0;\nqubit[3] q;\nrccx q[0], q[1], q[2];").unwrap();
+    assert!(rccx.instructions.len() > 1);
 }
 
 #[test]
@@ -2656,8 +2712,20 @@ fn gate_names_round_trip_through_resolve_gate() {
             Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::P(t) | Gate::Rzz(t) => vec![*t],
             _ => vec![],
         };
-        let resolved = Parser::resolve_gate(gate.name(), &params, 0)
-            .unwrap_or_else(|e| panic!("`{}` did not resolve: {e}", gate.name()));
+        // `rzz` reaches the Pauli-rotation rule first, the way the parser
+        // dispatches it, and that rule lowers ZZ back to `Gate::Rzz`.
+        let resolved = match super::pauli_rotation_axes(gate.name()) {
+            Some(axes) => {
+                let factors: Vec<PauliTerm> = axes
+                    .iter()
+                    .enumerate()
+                    .map(|(q, &axis)| PauliTerm::new(q, axis))
+                    .collect();
+                super::pauli_rotation_gate(params[0], &factors).0
+            }
+            None => Parser::resolve_gate(gate.name(), &params, 0)
+                .unwrap_or_else(|e| panic!("`{}` did not resolve: {e}", gate.name())),
+        };
         assert_eq!(
             resolved,
             gate,

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -5,8 +5,14 @@
 //! gate matrices agreeing to floating-point round-off rather than bit for bit.
 //! Angles carried inline (`rx`, `rz`, `rzz`, `p`) survive exactly.
 //!
-//! [`Gate::QftBlock`] expands to its textbook sequence before emission, and
-//! [`Gate::PauliRot`] to its CNOT-ladder lowering. Fusion payloads have no
+//! [`Gate::QftBlock`] expands to its textbook sequence before emission.
+//! [`Gate::PauliRot`] keeps its native form, spelled `r` followed by the Pauli
+//! letters (`rxyz(0.7) q[0], q[1], q[2];`), which generalizes the `rzz` the
+//! parser already takes and is what makes the round trip preserve the gate
+//! rather than a lowering of it. That spelling is a PRISM-Q extension: for
+//! output another toolchain reads, run
+//! [`expand_pauli_rotations`](super::expand_pauli_rotations) first and export
+//! the CNOT ladder instead. Fusion payloads have no
 //! OpenQASM spelling and are rejected: `MultiFused`, `Multi2q`,
 //! `BatchPhase`, `BatchRzz`, `DiagonalBatch`, a `Fused2q` outside the two-qubit
 //! families the parser builds, and a single-qubit matrix carrying a global phase
@@ -18,7 +24,7 @@ use std::f64::consts::{FRAC_PI_2, PI, TAU};
 use std::fmt::Write;
 
 use super::openqasm::Parser;
-use super::{Circuit, ClassicalCondition, Instruction, expand_pauli_rotations, expand_qft_blocks};
+use super::{Circuit, ClassicalCondition, Instruction, expand_qft_blocks};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
@@ -51,7 +57,6 @@ const EPS: f64 = 1e-12;
 /// ```
 pub fn to_qasm3(circuit: &Circuit) -> Result<String> {
     let expanded = expand_qft_blocks(circuit);
-    let expanded = expand_pauli_rotations(&expanded);
     let circuit = expanded.as_ref();
     let cregs = CregLayout::of(circuit)?;
 
@@ -176,6 +181,14 @@ fn gate_head(gate: &Gate) -> Option<String> {
         Gate::Rz(theta) => format!("rz({theta})"),
         Gate::P(theta) => format!("p({theta})"),
         Gate::Rzz(theta) => format!("rzz({theta})"),
+        Gate::PauliRot(data) => {
+            let letters: String = data
+                .axes()
+                .iter()
+                .map(|axis| axis.letter().to_ascii_lowercase())
+                .collect();
+            format!("r{letters}({})", data.theta())
+        }
         Gate::Cx => "cx".to_string(),
         Gate::Cz => "cz".to_string(),
         Gate::Swap => "swap".to_string(),

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -272,6 +272,27 @@ pub enum PauliAxis {
     Z,
 }
 
+impl PauliAxis {
+    /// Uppercase letter naming the axis, the spelling Pauli strings carry.
+    pub fn letter(self) -> char {
+        match self {
+            PauliAxis::X => 'X',
+            PauliAxis::Y => 'Y',
+            PauliAxis::Z => 'Z',
+        }
+    }
+
+    /// Inverse of [`letter`](Self::letter), accepting either case.
+    pub fn from_letter(letter: char) -> Option<Self> {
+        match letter.to_ascii_uppercase() {
+            'X' => Some(PauliAxis::X),
+            'Y' => Some(PauliAxis::Y),
+            'Z' => Some(PauliAxis::Z),
+            _ => None,
+        }
+    }
+}
+
 /// One non-identity factor of a joint Pauli observable. Ordered by qubit,
 /// then axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -764,7 +764,7 @@ fn input_uses_the_binding_surface_cannot_carry_reject_by_name() {
             "gate myrot(a) x { rx(2 * a) x; }
 myrot(t) q[0];",
         ),
-        ("lowered gate", "rxx(t) q[0], q[1];"),
+        ("lowered gate", "xx_plus_yy(t, 0.2) q[0], q[1];"),
         (
             "inside a def body",
             "def d(qubit a, float w) { rx(w) a; }
@@ -807,4 +807,41 @@ d(q[0], t);",
             .is_err(),
         "a name declared twice should not silently take the second slot"
     );
+}
+
+// A Pauli rotation is one gate carrying one angle, so an `input` binds it the
+// way it binds `rx`: the spelling exists and the binding surface reaches it.
+#[test]
+fn an_input_binds_a_pauli_rotation_and_survives_the_round_trip() {
+    let qasm = "OPENQASM 3.0;\ninput float[64] t;\nqubit[3] q;\nh q[0];\nrxyz(0.0) q[0], q[1], q[2];\nrxx(t) q[0], q[1];\n";
+    let (template, params) = openqasm::parse_parametric(qasm).expect("parse");
+    assert_eq!(params.num_slots(), 1);
+    assert_eq!(params.links().len(), 1);
+
+    let bound = params.bind(&template, &[0.63]).expect("bind");
+    assert!(
+        matches!(
+            &bound.instructions[2],
+            Instruction::Gate { gate: Gate::PauliRot(data), .. } if data.theta() == 0.63
+        ),
+        "expected the bound angle on a PauliRot, got {:?}",
+        bound.instructions[2]
+    );
+
+    let round = round_trip(&bound);
+    assert_streams_match(&bound, &round, "bound_pauli_rotation");
+    let native = round
+        .instructions
+        .iter()
+        .filter(|i| {
+            matches!(
+                i,
+                Instruction::Gate {
+                    gate: Gate::PauliRot(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(native, 2, "the round trip lost a native rotation");
 }

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -621,3 +621,190 @@ fn classical_control_constructs_parse_or_reject_by_name() {
         }
     }
 }
+
+const PARAMETRIC: &str = r#"
+OPENQASM 3.0;
+include "stdgates.inc";
+input float[64] theta;
+input angle phi;
+qubit[3] q;
+output bit[3] c;
+h q[0];
+rx(theta) q[0];
+cx q[0], q[1];
+rz(phi) q[1];
+rzz(theta) q[1], q[2];
+"#;
+
+// The deliverable is a round trip rather than a parse: an `input` declaration
+// becomes a named slot, a value vector binds through it, and the bound point
+// exports and re-imports as the same instruction stream.
+#[test]
+fn an_input_declaration_round_trips_through_a_bound_point() {
+    let (template, params) = openqasm::parse_parametric(PARAMETRIC).expect("parse");
+    assert_eq!(template.num_qubits, 3);
+    assert_eq!(template.num_classical_bits, 3);
+    assert_eq!(params.num_slots(), 2);
+
+    let bound = params.bind(&template, &[0.41, 1.27]).expect("bind");
+    assert_eq!(params.values(&bound).expect("values"), vec![0.41, 1.27]);
+
+    let round = round_trip(&bound);
+    assert_streams_match(&bound, &round, "input_bound_point");
+
+    // The exported text carries the bound angles, not the declarations, so the
+    // reparse needs no parameter surface of its own.
+    let qasm = to_qasm3(&bound).expect("export");
+    assert!(!qasm.contains("input"), "export emitted an input: {qasm}");
+    assert_probs_close(
+        &sv_reference_probs(&round),
+        &sv_reference_probs(&bound),
+        SV_EPS,
+        "input_bound_point",
+    );
+}
+
+#[test]
+fn input_slots_are_named_and_ordered_by_declaration() {
+    let (template, params) = openqasm::parse_parametric(PARAMETRIC).expect("parse");
+    assert_eq!(params.name_of(0), Some("theta"));
+    assert_eq!(params.name_of(1), Some("phi"));
+    assert_eq!(params.slot_of("phi"), Some(1));
+    assert_eq!(params.slot_of("psi"), None);
+    assert!(params.unread_slots().is_empty());
+
+    // `theta` drives two gates and `phi` one, which is the weight sharing the
+    // parameter surface already models.
+    let mut per_slot = [0usize; 2];
+    for link in params.links() {
+        per_slot[link.slot] += 1;
+    }
+    assert_eq!(per_slot, [2, 1]);
+    params.validate(&template).expect("links validate");
+}
+
+#[test]
+fn a_bound_program_agrees_with_the_same_angles_written_out() {
+    let (template, params) = openqasm::parse_parametric(PARAMETRIC).expect("parse");
+    let bound = params.bind(&template, &[0.41, 1.27]).expect("bind");
+
+    let literal = openqasm::parse(
+        r#"
+        OPENQASM 3.0;
+        qubit[3] q;
+        bit[3] c;
+        h q[0];
+        rx(0.41) q[0];
+        cx q[0], q[1];
+        rz(1.27) q[1];
+        rzz(0.41) q[1], q[2];
+        "#,
+    )
+    .expect("parse literal");
+    assert_probs_close(
+        &sv_reference_probs(&bound),
+        &sv_reference_probs(&literal),
+        SV_EPS,
+        "bound_vs_literal",
+    );
+}
+
+#[test]
+fn parse_rejects_a_program_that_leaves_inputs_unbound() {
+    let err = openqasm::parse(PARAMETRIC).expect_err("unbound inputs");
+    assert!(
+        matches!(err, PrismError::InvalidParameter { .. }),
+        "expected InvalidParameter, got {err:?}"
+    );
+}
+
+#[test]
+fn an_input_broadcast_over_a_register_shares_one_slot() {
+    let qasm = "OPENQASM 3.0;\ninput float[64] t;\nqubit[3] q;\nrx(t) q;\n";
+    let (template, params) = openqasm::parse_parametric(qasm).expect("parse");
+    assert_eq!(params.num_slots(), 1);
+    assert_eq!(params.links().len(), 3);
+    assert!(params.links().iter().all(|l| l.slot == 0));
+
+    let bound = params.bind(&template, &[0.9]).expect("bind");
+    let literal = openqasm::parse(
+        "OPENQASM 3.0;\nqubit[3] q;\nrx(0.9) q[0];\nrx(0.9) q[1];\nrx(0.9) q[2];\n",
+    )
+    .expect("parse literal");
+    assert_probs_close(
+        &sv_reference_probs(&bound),
+        &sv_reference_probs(&literal),
+        SV_EPS,
+        "broadcast_vs_literal",
+    );
+}
+
+// Every way an `input` can be written that the binding surface cannot carry.
+// One angle is written per link, so an input reaching anything but a whole
+// top-level rotation angle has nowhere to land, and a silent wrong angle is the
+// failure worth pinning against.
+#[test]
+fn input_uses_the_binding_surface_cannot_carry_reject_by_name() {
+    const PROLOGUE: &str = "OPENQASM 3.0;\ninput float[64] t;\nqubit[3] q;\nbit[3] c;\n";
+
+    let rejected = [
+        ("expression over an input", "rx(2 * t) q[0];"),
+        ("expression with a function", "rx(sin(t)) q[0];"),
+        (
+            "two inputs on one gate",
+            "input float[64] u;\nr(t, u) q[0];",
+        ),
+        ("gate carrying no angle", "cu(t, 0, 0, 0) q[0], q[1];"),
+        ("modified gate", "ctrl @ rx(t) q[0], q[1];"),
+        ("inside a for body", "for int i in [0:1] { rx(t) q[i]; }"),
+        ("inside a guarded region", "if (c[0]) { rx(t) q[0]; }"),
+        ("inside a guarded statement", "if (c[0]) rx(t) q[0];"),
+        (
+            "user-defined gate",
+            "gate myrot(a) x { rx(2 * a) x; }
+myrot(t) q[0];",
+        ),
+        ("lowered gate", "rxx(t) q[0], q[1];"),
+        (
+            "inside a def body",
+            "def d(qubit a, float w) { rx(w) a; }
+d(q[0], t);",
+        ),
+    ];
+    for (label, body) in rejected {
+        let qasm = format!("{PROLOGUE}{body}");
+        let err = openqasm::parse_parametric(&qasm)
+            .err()
+            .unwrap_or_else(|| panic!("{label}: expected a rejection, parsed"));
+        assert!(
+            matches!(err, PrismError::UnsupportedConstruct { .. }),
+            "{label}: expected UnsupportedConstruct, got {err:?}"
+        );
+    }
+
+    let bad_types = [
+        (
+            "integer input",
+            "OPENQASM 3.0;\ninput int[32] n;\nqubit[1] q;\n",
+        ),
+        (
+            "qubit output",
+            "OPENQASM 3.0;\nqubit[1] q;\noutput float[64] x;\n",
+        ),
+    ];
+    for (label, qasm) in bad_types {
+        assert!(
+            matches!(
+                openqasm::parse_parametric(qasm),
+                Err(PrismError::UnsupportedConstruct { .. })
+            ),
+            "{label}: expected UnsupportedConstruct"
+        );
+    }
+
+    assert!(
+        openqasm::parse_parametric("OPENQASM 3.0;\ninput float[64] t;\ninput float[64] t;\n")
+            .is_err(),
+        "a name declared twice should not silently take the second slot"
+    );
+}

--- a/tests/pauli_rot_correctness.rs
+++ b/tests/pauli_rot_correctness.rs
@@ -183,12 +183,47 @@ fn z_only_rotation_preserves_sparsity() {
     assert!(!mixed.is_sparse_friendly());
 }
 
+// Agreement with the ladder is not the property to assert: the ladder passes it
+// whether or not the native gate survived. Assert the reparsed instruction is a
+// `PauliRot`, the way `the_native_gate_carries_the_gradient` does on the
+// gradient side.
 #[test]
-fn qasm_export_emits_the_lowering() {
+fn qasm_export_keeps_the_native_pauli_rotation() {
     let circuit = trotter_like_circuit(4);
     let qasm = prism_q::circuit::qasm_export::to_qasm3(&circuit).unwrap();
-    assert!(!qasm.contains("pauli_rot"));
+    let round = prism_q::circuit::openqasm::parse(&qasm).expect("reparse");
+
+    assert_eq!(circuit.instructions.len(), round.instructions.len());
+    let native = |c: &Circuit| {
+        c.instructions
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i,
+                    Instruction::Gate {
+                        gate: Gate::PauliRot(_),
+                        ..
+                    }
+                )
+            })
+            .count()
+    };
+    assert!(native(&circuit) > 0, "fixture carries no PauliRot");
+    assert_eq!(native(&circuit), native(&round));
+    assert!(
+        !qasm.contains("cx"),
+        "export fell back to the ladder: {qasm}"
+    );
+}
+
+// The ladder is still reachable for a consumer that cannot read the extension.
+#[test]
+fn expanding_first_exports_the_portable_ladder() {
+    let circuit = trotter_like_circuit(4);
+    let lowered = prism_q::circuit::expand_pauli_rotations(&circuit);
+    let qasm = prism_q::circuit::qasm_export::to_qasm3(&lowered).unwrap();
     assert!(qasm.contains("cx"));
+    assert!(!qasm.contains("rxyz"));
 }
 
 // Noise events are indexed per instruction, so the trajectory engine applies
@@ -231,4 +266,53 @@ fn constructor_rejects_duplicate_qubits() {
 fn constructor_rejects_empty_strings() {
     let mut c = Circuit::new(1, 0);
     c.add_pauli_rotation(0.1, &[]);
+}
+
+// `rxx` and `ryy` parsed to a seven-gate basis-change ladder before the native
+// rotation gained a spelling. Both forms are the same unitary, so pin that
+// rather than trusting the change: the ladder is written out here so the
+// comparison does not run through the code that replaced it.
+#[test]
+fn parsed_rxx_and_ryy_agree_with_the_ladder_they_replaced() {
+    use prism_q::circuit::openqasm;
+
+    let cases = [
+        (
+            "rxx",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\nrxx(0.7) q[0], q[1];",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n\
+             h q[0];\nh q[1];\ncx q[0], q[1];\nrz(0.7) q[1];\ncx q[0], q[1];\nh q[0];\nh q[1];",
+        ),
+        (
+            "ryy",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\nryy(0.7) q[0], q[1];",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n\
+             rx(pi/2) q[0];\nrx(pi/2) q[1];\ncx q[0], q[1];\nrz(0.7) q[1];\ncx q[0], q[1];\n\
+             rx(-pi/2) q[0];\nrx(-pi/2) q[1];",
+        ),
+    ];
+
+    for (label, native_src, ladder_src) in cases {
+        let native = openqasm::parse(native_src).expect("parse native");
+        assert_eq!(
+            native.instructions.len(),
+            2,
+            "{label}: expected one rotation"
+        );
+
+        let ladder = openqasm::parse(ladder_src).expect("parse ladder");
+        let mut a = StatevectorBackend::new(SEED);
+        let mut b = StatevectorBackend::new(SEED);
+        let native_probs = sim::run_on(&mut a, &native)
+            .expect("run native")
+            .probabilities
+            .expect("probs")
+            .to_vec();
+        let ladder_probs = sim::run_on(&mut b, &ladder)
+            .expect("run ladder")
+            .probabilities
+            .expect("probs")
+            .to_vec();
+        assert_probs_close(&native_probs, &ladder_probs, SV_EPS, label);
+    }
 }


### PR DESCRIPTION
## Summary

Without `input` there is no parameterized OpenQASM: an angle had to be written
out, so a sweep could not be expressed in the source language at all.
`openqasm::parse_parametric` now returns the template circuit beside the
`Parameters` its declarations name, in declaration order and under the declared
names, which is the surface `Parameters::bind` and `PreparedCircuit` already
take.

Export needed no change, which is what building it against the Rust parameter
surface first bought: a bound point is an ordinary circuit.

## Scope

- [x] New feature
- [x] Documentation

## What landed

- `input float[64] theta;` and `input angle phi;` declare one named slot each.
  `output bit[n] c;` declares the register and marks it; every classical bit is
  reported either way, so the marking is carried by the declaration alone.
- `parse` rejects a program that declares an input rather than defaulting it to
  zero, naming `parse_parametric` in the error. A quiet wrong angle is worse
  than no answer.
- A register broadcast links every instruction it produced to the one slot,
  which is the weight sharing `Parameters` already models.

## The restriction, and why four of the rejections are load-bearing

An input binds an angle whole, so it is admitted only as the entire angle
argument of a directly named parametric gate at the top level. Eleven other
positions reject by name with a line number. Most are conservative, but four
close paths that would otherwise record a link onto an angle the source derives
rather than supplies:

- A decomposed gate folds the argument into its own lowering arithmetic.
- A user-defined `gate` is expanded with the numeric value substituted into the
  body, so a body writing `rx(2 * a)` would take a bound angle whole.
- A `def` call inlines the same way. Rejecting by name also beats the
  unknown-identifier error the substitution would otherwise raise on a name that
  is in fact declared.
- A `gate`, `for`, or guarded-region body has instruction indices local to that
  body, and a parameter link is an index into the top-level stream.

`input_uses_the_binding_surface_cannot_carry_reject_by_name` walks all eleven.

## Benchmarks

N/A, no hot-path changes. This is parser and API surface; `fuse_circuit` is
already on record at roughly 200 microseconds worst case against a 130
millisecond apply, and nothing here is in that path either.

## Correctness

- [x] `cargo nextest run --features parallel` passes (2180 tests)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo test --doc --features parallel` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with rustdoc warnings denied

The deliverable is a round trip rather than a parse, so
`an_input_declaration_round_trips_through_a_bound_point` binds a value vector,
exports through `to_qasm3`, re-imports, and compares instruction streams and
probabilities. `a_bound_program_agrees_with_the_same_angles_written_out` checks
the bound circuit against the literal-angle program it should equal.
`an_input_broadcast_over_a_register_shares_one_slot` pins the shared-slot case
against three separate gates.

## Breaking changes

`parse` now returns `InvalidParameter` for a program declaring an `input`, where
it previously failed on the unknown declaration keyword. Both are errors; the
message is better and names the entry point that accepts them.

## Risks and rollback

Small. The parser gains two declaration keywords and one recognition step in
front of the existing gate resolution, both reached only when a program declares
an input. `parse` keeps its signature and every existing program takes the same
path it did.
