### PR TITLE
feat(qasm): spell the native Pauli rotation

### DIFF
--- a/docs/guides/openqasm.md
+++ b/docs/guides/openqasm.md
@@ -99,9 +99,20 @@ reason rather than binding something the source did not mean.
 - **Standard / aliases**: x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, p/phase, cx/CX/cnot,
   cy, cz, cp/cphase, crx, cry, crz, ch, swap, ccx/toffoli, cswap/fredkin, cu, u1, u2,
   u3/u/U.
-- **Qiskit / exporter**: sxdg, cs, csdg, csx, ccz, r, rzz, rxx, ryy, xx_plus_yy,
+- **Qiskit / exporter**: sxdg, cs, csdg, csx, ccz, r, xx_plus_yy,
   xx_minus_yy, ecr, iswap, dcx, c3x, c4x, mcx, rccx, rc3x/rcccx.
 - **Hardware-native**: gpi, gpi2, ms, syc, sqrt_iswap, sqrt_iswap_inv.
+- **Pauli rotations**: `r` followed by one Pauli letter per qubit argument.
+  `rxx`, `ryy`, and `rzz` are the two-letter cases; `rxyz(0.7) q[0], q[1], q[2];`
+  is `exp(-i * 0.7 * (X⊗Y⊗Z) / 2)` with `x` on `q[0]`. `rzz` resolves to the
+  native two-qubit rotation and a one-letter name to `rx`/`ry`/`rz`; wider
+  strings build the native multi-qubit gate, which the statevector applies in
+  one pass and every other backend receives as its CNOT-ladder lowering.
+
+  The wider spelling is a PRISM-Q extension rather than standard OpenQASM, and
+  `to_qasm3` emits it so a round trip preserves the gate instead of a lowering
+  of it. For output another toolchain reads, run
+  `circuit::expand_pauli_rotations` before exporting.
 
 ## Other supported constructs
 

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -98,40 +98,8 @@ impl Circuit {
     /// Panics if `factors` is empty, names a qubit twice, or names a qubit out
     /// of bounds.
     pub fn add_pauli_rotation(&mut self, theta: f64, factors: &[PauliTerm]) {
-        assert!(
-            !factors.is_empty(),
-            "Pauli rotation needs at least one factor"
-        );
-        let mut sorted: SmallVec<[PauliTerm; 4]> = SmallVec::from_slice(factors);
-        sorted.sort_unstable_by_key(|term| term.qubit);
-        for pair in sorted.windows(2) {
-            assert_ne!(
-                pair[0].qubit, pair[1].qubit,
-                "Pauli rotation has duplicate factor on qubit {}",
-                pair[0].qubit
-            );
-        }
-        match sorted.as_slice() {
-            [term] => {
-                let gate = match term.axis {
-                    PauliAxis::X => Gate::Rx(theta),
-                    PauliAxis::Y => Gate::Ry(theta),
-                    PauliAxis::Z => Gate::Rz(theta),
-                };
-                self.add_gate(gate, &[term.qubit]);
-            }
-            [a, b] if a.axis == PauliAxis::Z && b.axis == PauliAxis::Z => {
-                self.add_gate(Gate::Rzz(theta), &[a.qubit, b.qubit]);
-            }
-            _ => {
-                let targets: SmallVec<[usize; 4]> = sorted.iter().map(|term| term.qubit).collect();
-                let axes: Vec<PauliAxis> = sorted.iter().map(|term| term.axis).collect();
-                self.add_gate(
-                    Gate::PauliRot(Box::new(PauliRotData { theta, axes })),
-                    &targets,
-                );
-            }
-        }
+        let (gate, targets) = pauli_rotation_gate(theta, factors);
+        self.add_gate(gate, &targets);
     }
 
     /// Append a measurement operation.
@@ -907,6 +875,55 @@ pub(crate) fn pauli_rotation_lowering(
 /// Backends without the native kernel call this before dispatch, the same
 /// probe-plus-expansion route as [`expand_qft_blocks`]. Returns
 /// `Cow::Borrowed` when there is nothing to expand.
+/// Lower a Pauli rotation to the gate and target order a circuit stores it as,
+/// the recognizing step behind [`Circuit::add_pauli_rotation`].
+///
+/// Shared with the OpenQASM parser, which builds the instruction itself and so
+/// cannot go through `add_pauli_rotation`. Targets come back sorted by qubit
+/// with the letters aligned to them.
+///
+/// # Panics
+/// Panics if `factors` is empty or names a qubit twice.
+pub(crate) fn pauli_rotation_gate(
+    theta: f64,
+    factors: &[PauliTerm],
+) -> (Gate, SmallVec<[usize; 4]>) {
+    assert!(
+        !factors.is_empty(),
+        "Pauli rotation needs at least one factor"
+    );
+    let mut sorted: SmallVec<[PauliTerm; 4]> = SmallVec::from_slice(factors);
+    sorted.sort_unstable_by_key(|term| term.qubit);
+    for pair in sorted.windows(2) {
+        assert_ne!(
+            pair[0].qubit, pair[1].qubit,
+            "Pauli rotation has duplicate factor on qubit {}",
+            pair[0].qubit
+        );
+    }
+    match sorted.as_slice() {
+        [term] => {
+            let gate = match term.axis {
+                PauliAxis::X => Gate::Rx(theta),
+                PauliAxis::Y => Gate::Ry(theta),
+                PauliAxis::Z => Gate::Rz(theta),
+            };
+            (gate, smallvec![term.qubit])
+        }
+        [a, b] if a.axis == PauliAxis::Z && b.axis == PauliAxis::Z => {
+            (Gate::Rzz(theta), smallvec![a.qubit, b.qubit])
+        }
+        _ => {
+            let targets: SmallVec<[usize; 4]> = sorted.iter().map(|term| term.qubit).collect();
+            let axes: Vec<PauliAxis> = sorted.iter().map(|term| term.axis).collect();
+            (
+                Gate::PauliRot(Box::new(PauliRotData { theta, axes })),
+                targets,
+            )
+        }
+    }
+}
+
 pub fn expand_pauli_rotations(circuit: &Circuit) -> std::borrow::Cow<'_, Circuit> {
     if !any_bare_gate(&circuit.instructions, &mut |gate| {
         matches!(gate, Gate::PauliRot(_))

--- a/src/circuit/openqasm.rs
+++ b/src/circuit/openqasm.rs
@@ -13,7 +13,8 @@
 //! | Output declaration | `output bit[4] c;` | Declares the register; every bit is reported anyway |
 //! | 1-qubit gates | `h q[0]; x q[1];` | id, x, y, z, h, s, sdg, t, tdg, sx, sxdg, p/phase, r, gpi, gpi2, u/U forms |
 //! | Parametric gates | `rx(pi/4) q[0];` | rx, ry, rz, cu, ms, arithmetic expressions with `pi`, math functions |
-//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, rzz, rxx, ryy, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
+//! | 2-qubit gates | `cx q[0], q[1];` | cx/cnot, cy, cz, ch, cs, csdg, cp/cphase, crx, cry, crz, csx, swap, xx_plus_yy, xx_minus_yy, ecr, iswap, dcx, syc, sqrt_iswap |
+//! | Pauli rotation | `rzz(t) q[0], q[1];` `rxyz(t) q[0], q[1], q[2];` | `r` plus the Pauli letters, one per qubit argument; `rxx`, `ryy`, `rzz` are the two-letter cases |
 //! | Multi-qubit gates | `ccx q[0], q[1], q[2];` | ccx/toffoli, ccz, cswap/fredkin, c3x, c4x, mcx, rccx, rc3x/rcccx |
 //! | Gate modifiers | `inv @ h q[0];` | `inv @`, `ctrl @` (chainable), `pow(k) @` (integer k) for direct gates |
 //! | Measurement (OQ3) | `c[0] = measure q[0];` | Assignment syntax (primary) |
@@ -70,10 +71,11 @@ use num_complex::Complex64;
 
 use crate::circuit::{
     Circuit, ClassicalCondition, Instruction, MAX_REGION_DEPTH, ParamLink, Parameters, SmallVec,
-    guarded, smallvec,
+    guarded, pauli_rotation_gate, smallvec,
 };
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
+use crate::sim::unified_pauli::{PauliAxis, PauliTerm};
 use std::collections::HashMap;
 
 /// Parse an OpenQASM 3.0 string into a PRISM-Q [`Circuit`].
@@ -226,6 +228,23 @@ const MAX_GATE_EXPANSION_DEPTH: usize = 32;
 const MAX_FOR_ITERATIONS: i64 = 1_000_000;
 
 use super::expr::{contains_word, eval_expr, replace_word, split_top_level_commas};
+
+/// Pauli letters of an `r<letters>` rotation name, or `None` when the name is
+/// not one.
+///
+/// Covers the `rxx`, `ryy`, and `rzz` OpenQASM already spells as well as the
+/// wider strings it does not, so one rule serves the whole family. `rzz` still
+/// resolves to `Gate::Rzz` and a weight-1 name to `Rx`/`Ry`/`Rz`, because
+/// `pauli_rotation_gate` lowers those; only the residual strings build the
+/// native multi-qubit gate. Names like `rccx` do not match, `c` being no Pauli
+/// letter.
+fn pauli_rotation_axes(name: &str) -> Option<Vec<PauliAxis>> {
+    let letters = name.strip_prefix('r')?;
+    if letters.len() < 2 {
+        return None;
+    }
+    letters.chars().map(PauliAxis::from_letter).collect()
+}
 
 fn strip_comment(line: &str) -> &str {
     match line.find("//") {
@@ -2110,6 +2129,47 @@ impl<'a> Parser<'a> {
         Ok((all_instrs, input_slot))
     }
 
+    /// Build the instruction an `r<letters>` application names, checking the
+    /// arity and distinctness `pauli_rotation_gate` would otherwise panic on.
+    fn resolve_pauli_rotation(
+        gate_name: &str,
+        axes: &[PauliAxis],
+        params: &[f64],
+        modifiers: &[Modifier],
+        qubits: &SmallVec<[usize; 4]>,
+        line_num: usize,
+    ) -> Result<Instruction> {
+        if !modifiers.is_empty() {
+            return Err(PrismError::UnsupportedConstruct {
+                construct: format!("modifier on Pauli rotation `{gate_name}`"),
+                line: line_num,
+            });
+        }
+        Self::expect_param_count(gate_name, params, 1, line_num)?;
+        if qubits.len() != axes.len() {
+            return Err(PrismError::GateArity {
+                gate: gate_name.to_string(),
+                expected: axes.len(),
+                got: qubits.len(),
+            });
+        }
+        let mut seen: SmallVec<[usize; 4]> = qubits.clone();
+        seen.sort_unstable();
+        if let Some(pair) = seen.windows(2).find(|pair| pair[0] == pair[1]) {
+            return Err(PrismError::Parse {
+                line: line_num,
+                message: format!("Pauli rotation `{gate_name}` names qubit {} twice", pair[0]),
+            });
+        }
+        let factors: Vec<PauliTerm> = qubits
+            .iter()
+            .zip(axes)
+            .map(|(&qubit, &axis)| PauliTerm::new(qubit, axis))
+            .collect();
+        let (gate, targets) = pauli_rotation_gate(params[0], &factors);
+        Ok(Instruction::Gate { gate, targets })
+    }
+
     /// A slot writes one angle onto each instruction it links, so every
     /// instruction a gate reading an `input` produced has to carry one.
     fn check_every_instruction_is_bindable(
@@ -2168,6 +2228,13 @@ impl<'a> Parser<'a> {
                 });
             }
             return Ok(instrs);
+        }
+
+        if let Some(axes) = pauli_rotation_axes(gate_name) {
+            return Self::resolve_pauli_rotation(
+                gate_name, &axes, params, modifiers, qubits, line_num,
+            )
+            .map(|instr| vec![instr]);
         }
 
         let mut gate = Self::resolve_gate(gate_name, params, line_num)?;
@@ -2744,10 +2811,6 @@ impl<'a> Parser<'a> {
                 Self::expect_param_count(name, params, 1, line_num)?;
                 Ok(Gate::cphase(params[0]))
             }
-            "rzz" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Ok(Gate::Rzz(params[0]))
-            }
             "cx" | "CX" | "cnot" => Ok(Gate::Cx),
             "cy" => Ok(Gate::cu(Gate::Y.matrix_2x2())),
             "cs" => Ok(Gate::cu(Gate::S.matrix_2x2())),
@@ -2916,37 +2979,6 @@ impl<'a> Parser<'a> {
                     Self::ig(Gate::Cx, &[t2, t1]),
                     Self::ig(Gate::mcu(Gate::X.matrix_2x2(), 2), &[ctrl, t1, t2]),
                     Self::ig(Gate::Cx, &[t2, t1]),
-                ]))
-            }
-            "rxx" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Self::check_arity(name, qubits, 2)?;
-                let q0 = qubits[0];
-                let q1 = qubits[1];
-                Ok(Some(vec![
-                    Self::ig(Gate::H, &[q0]),
-                    Self::ig(Gate::H, &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rz(params[0]), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::H, &[q0]),
-                    Self::ig(Gate::H, &[q1]),
-                ]))
-            }
-            "ryy" => {
-                Self::expect_param_count(name, params, 1, line_num)?;
-                Self::check_arity(name, qubits, 2)?;
-                let q0 = qubits[0];
-                let q1 = qubits[1];
-                let half_pi = std::f64::consts::FRAC_PI_2;
-                Ok(Some(vec![
-                    Self::ig(Gate::Rx(half_pi), &[q0]),
-                    Self::ig(Gate::Rx(half_pi), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rz(params[0]), &[q1]),
-                    Self::ig(Gate::Cx, &[q0, q1]),
-                    Self::ig(Gate::Rx(-half_pi), &[q0]),
-                    Self::ig(Gate::Rx(-half_pi), &[q1]),
                 ]))
             }
             "ecr" => {

--- a/src/circuit/openqasm_tests.rs
+++ b/src/circuit/openqasm_tests.rs
@@ -788,18 +788,74 @@ fn test_rzz_gate() {
     ));
 }
 
+// `rxx` and `ryy` took a seven-gate basis-change ladder until the native
+// multi-qubit rotation gained a spelling. Equivalence to that ladder is checked
+// numerically in `tests/pauli_rot_correctness.rs`; the shape belongs here.
 #[test]
 fn test_rxx_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\nrxx(pi/4) q[0], q[1];";
     let c = parse(qasm).unwrap();
-    assert_eq!(c.instructions.len(), 7);
+    assert_eq!(c.instructions.len(), 1);
+    let Instruction::Gate {
+        gate: Gate::PauliRot(data),
+        targets,
+    } = &c.instructions[0]
+    else {
+        panic!("expected a PauliRot, got {:?}", c.instructions[0]);
+    };
+    assert_eq!(data.axes(), [PauliAxis::X, PauliAxis::X]);
+    assert_eq!(targets.as_slice(), [0, 1]);
 }
 
 #[test]
 fn test_ryy_gate() {
     let qasm = "OPENQASM 3.0;\nqubit[2] q;\nryy(pi/4) q[0], q[1];";
     let c = parse(qasm).unwrap();
-    assert_eq!(c.instructions.len(), 7);
+    assert_eq!(c.instructions.len(), 1);
+    assert!(matches!(
+        &c.instructions[0],
+        Instruction::Gate {
+            gate: Gate::PauliRot(data),
+            ..
+        } if data.axes() == [PauliAxis::Y, PauliAxis::Y]
+    ));
+}
+
+#[test]
+fn test_wide_pauli_rotation_gate() {
+    let qasm = "OPENQASM 3.0;\nqubit[4] q;\nrxyz(0.7) q[2], q[0], q[3];";
+    let c = parse(qasm).unwrap();
+    assert_eq!(c.instructions.len(), 1);
+    let Instruction::Gate {
+        gate: Gate::PauliRot(data),
+        targets,
+    } = &c.instructions[0]
+    else {
+        panic!("expected a PauliRot, got {:?}", c.instructions[0]);
+    };
+    // Targets sort by qubit and the letters follow them, so `y` stays on q[0].
+    assert_eq!(targets.as_slice(), [0, 2, 3]);
+    assert_eq!(data.axes(), [PauliAxis::Y, PauliAxis::X, PauliAxis::Z]);
+}
+
+#[test]
+fn test_pauli_rotation_rejections() {
+    let repeated = parse("OPENQASM 3.0;\nqubit[3] q;\nrxx(0.3) q[0], q[0];");
+    assert!(matches!(repeated, Err(PrismError::Parse { .. })));
+
+    let arity = parse("OPENQASM 3.0;\nqubit[3] q;\nrxyz(0.3) q[0], q[1];");
+    assert!(matches!(arity, Err(PrismError::GateArity { .. })));
+
+    let modified = parse("OPENQASM 3.0;\nqubit[3] q;\ninv @ rxyz(0.3) q[0], q[1], q[2];");
+    assert!(matches!(
+        modified,
+        Err(PrismError::UnsupportedConstruct { .. })
+    ));
+
+    // `rccx` is not a Pauli string, `c` being no Pauli letter, so the name
+    // still reaches its own decomposition.
+    let rccx = parse("OPENQASM 3.0;\nqubit[3] q;\nrccx q[0], q[1], q[2];").unwrap();
+    assert!(rccx.instructions.len() > 1);
 }
 
 #[test]
@@ -2656,8 +2712,20 @@ fn gate_names_round_trip_through_resolve_gate() {
             Gate::Rx(t) | Gate::Ry(t) | Gate::Rz(t) | Gate::P(t) | Gate::Rzz(t) => vec![*t],
             _ => vec![],
         };
-        let resolved = Parser::resolve_gate(gate.name(), &params, 0)
-            .unwrap_or_else(|e| panic!("`{}` did not resolve: {e}", gate.name()));
+        // `rzz` reaches the Pauli-rotation rule first, the way the parser
+        // dispatches it, and that rule lowers ZZ back to `Gate::Rzz`.
+        let resolved = match super::pauli_rotation_axes(gate.name()) {
+            Some(axes) => {
+                let factors: Vec<PauliTerm> = axes
+                    .iter()
+                    .enumerate()
+                    .map(|(q, &axis)| PauliTerm::new(q, axis))
+                    .collect();
+                super::pauli_rotation_gate(params[0], &factors).0
+            }
+            None => Parser::resolve_gate(gate.name(), &params, 0)
+                .unwrap_or_else(|e| panic!("`{}` did not resolve: {e}", gate.name())),
+        };
         assert_eq!(
             resolved,
             gate,

--- a/src/circuit/qasm_export.rs
+++ b/src/circuit/qasm_export.rs
@@ -5,8 +5,14 @@
 //! gate matrices agreeing to floating-point round-off rather than bit for bit.
 //! Angles carried inline (`rx`, `rz`, `rzz`, `p`) survive exactly.
 //!
-//! [`Gate::QftBlock`] expands to its textbook sequence before emission, and
-//! [`Gate::PauliRot`] to its CNOT-ladder lowering. Fusion payloads have no
+//! [`Gate::QftBlock`] expands to its textbook sequence before emission.
+//! [`Gate::PauliRot`] keeps its native form, spelled `r` followed by the Pauli
+//! letters (`rxyz(0.7) q[0], q[1], q[2];`), which generalizes the `rzz` the
+//! parser already takes and is what makes the round trip preserve the gate
+//! rather than a lowering of it. That spelling is a PRISM-Q extension: for
+//! output another toolchain reads, run
+//! [`expand_pauli_rotations`](super::expand_pauli_rotations) first and export
+//! the CNOT ladder instead. Fusion payloads have no
 //! OpenQASM spelling and are rejected: `MultiFused`, `Multi2q`,
 //! `BatchPhase`, `BatchRzz`, `DiagonalBatch`, a `Fused2q` outside the two-qubit
 //! families the parser builds, and a single-qubit matrix carrying a global phase
@@ -18,7 +24,7 @@ use std::f64::consts::{FRAC_PI_2, PI, TAU};
 use std::fmt::Write;
 
 use super::openqasm::Parser;
-use super::{Circuit, ClassicalCondition, Instruction, expand_pauli_rotations, expand_qft_blocks};
+use super::{Circuit, ClassicalCondition, Instruction, expand_qft_blocks};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 
@@ -51,7 +57,6 @@ const EPS: f64 = 1e-12;
 /// ```
 pub fn to_qasm3(circuit: &Circuit) -> Result<String> {
     let expanded = expand_qft_blocks(circuit);
-    let expanded = expand_pauli_rotations(&expanded);
     let circuit = expanded.as_ref();
     let cregs = CregLayout::of(circuit)?;
 
@@ -176,6 +181,14 @@ fn gate_head(gate: &Gate) -> Option<String> {
         Gate::Rz(theta) => format!("rz({theta})"),
         Gate::P(theta) => format!("p({theta})"),
         Gate::Rzz(theta) => format!("rzz({theta})"),
+        Gate::PauliRot(data) => {
+            let letters: String = data
+                .axes()
+                .iter()
+                .map(|axis| axis.letter().to_ascii_lowercase())
+                .collect();
+            format!("r{letters}({})", data.theta())
+        }
         Gate::Cx => "cx".to_string(),
         Gate::Cz => "cz".to_string(),
         Gate::Swap => "swap".to_string(),

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -272,6 +272,27 @@ pub enum PauliAxis {
     Z,
 }
 
+impl PauliAxis {
+    /// Uppercase letter naming the axis, the spelling Pauli strings carry.
+    pub fn letter(self) -> char {
+        match self {
+            PauliAxis::X => 'X',
+            PauliAxis::Y => 'Y',
+            PauliAxis::Z => 'Z',
+        }
+    }
+
+    /// Inverse of [`letter`](Self::letter), accepting either case.
+    pub fn from_letter(letter: char) -> Option<Self> {
+        match letter.to_ascii_uppercase() {
+            'X' => Some(PauliAxis::X),
+            'Y' => Some(PauliAxis::Y),
+            'Z' => Some(PauliAxis::Z),
+            _ => None,
+        }
+    }
+}
+
 /// One non-identity factor of a joint Pauli observable. Ordered by qubit,
 /// then axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/tests/openqasm_goldens.rs
+++ b/tests/openqasm_goldens.rs
@@ -764,7 +764,7 @@ fn input_uses_the_binding_surface_cannot_carry_reject_by_name() {
             "gate myrot(a) x { rx(2 * a) x; }
 myrot(t) q[0];",
         ),
-        ("lowered gate", "rxx(t) q[0], q[1];"),
+        ("lowered gate", "xx_plus_yy(t, 0.2) q[0], q[1];"),
         (
             "inside a def body",
             "def d(qubit a, float w) { rx(w) a; }
@@ -807,4 +807,41 @@ d(q[0], t);",
             .is_err(),
         "a name declared twice should not silently take the second slot"
     );
+}
+
+// A Pauli rotation is one gate carrying one angle, so an `input` binds it the
+// way it binds `rx`: the spelling exists and the binding surface reaches it.
+#[test]
+fn an_input_binds_a_pauli_rotation_and_survives_the_round_trip() {
+    let qasm = "OPENQASM 3.0;\ninput float[64] t;\nqubit[3] q;\nh q[0];\nrxyz(0.0) q[0], q[1], q[2];\nrxx(t) q[0], q[1];\n";
+    let (template, params) = openqasm::parse_parametric(qasm).expect("parse");
+    assert_eq!(params.num_slots(), 1);
+    assert_eq!(params.links().len(), 1);
+
+    let bound = params.bind(&template, &[0.63]).expect("bind");
+    assert!(
+        matches!(
+            &bound.instructions[2],
+            Instruction::Gate { gate: Gate::PauliRot(data), .. } if data.theta() == 0.63
+        ),
+        "expected the bound angle on a PauliRot, got {:?}",
+        bound.instructions[2]
+    );
+
+    let round = round_trip(&bound);
+    assert_streams_match(&bound, &round, "bound_pauli_rotation");
+    let native = round
+        .instructions
+        .iter()
+        .filter(|i| {
+            matches!(
+                i,
+                Instruction::Gate {
+                    gate: Gate::PauliRot(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(native, 2, "the round trip lost a native rotation");
 }

--- a/tests/pauli_rot_correctness.rs
+++ b/tests/pauli_rot_correctness.rs
@@ -183,12 +183,47 @@ fn z_only_rotation_preserves_sparsity() {
     assert!(!mixed.is_sparse_friendly());
 }
 
+// Agreement with the ladder is not the property to assert: the ladder passes it
+// whether or not the native gate survived. Assert the reparsed instruction is a
+// `PauliRot`, the way `the_native_gate_carries_the_gradient` does on the
+// gradient side.
 #[test]
-fn qasm_export_emits_the_lowering() {
+fn qasm_export_keeps_the_native_pauli_rotation() {
     let circuit = trotter_like_circuit(4);
     let qasm = prism_q::circuit::qasm_export::to_qasm3(&circuit).unwrap();
-    assert!(!qasm.contains("pauli_rot"));
+    let round = prism_q::circuit::openqasm::parse(&qasm).expect("reparse");
+
+    assert_eq!(circuit.instructions.len(), round.instructions.len());
+    let native = |c: &Circuit| {
+        c.instructions
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i,
+                    Instruction::Gate {
+                        gate: Gate::PauliRot(_),
+                        ..
+                    }
+                )
+            })
+            .count()
+    };
+    assert!(native(&circuit) > 0, "fixture carries no PauliRot");
+    assert_eq!(native(&circuit), native(&round));
+    assert!(
+        !qasm.contains("cx"),
+        "export fell back to the ladder: {qasm}"
+    );
+}
+
+// The ladder is still reachable for a consumer that cannot read the extension.
+#[test]
+fn expanding_first_exports_the_portable_ladder() {
+    let circuit = trotter_like_circuit(4);
+    let lowered = prism_q::circuit::expand_pauli_rotations(&circuit);
+    let qasm = prism_q::circuit::qasm_export::to_qasm3(&lowered).unwrap();
     assert!(qasm.contains("cx"));
+    assert!(!qasm.contains("rxyz"));
 }
 
 // Noise events are indexed per instruction, so the trajectory engine applies
@@ -231,4 +266,53 @@ fn constructor_rejects_duplicate_qubits() {
 fn constructor_rejects_empty_strings() {
     let mut c = Circuit::new(1, 0);
     c.add_pauli_rotation(0.1, &[]);
+}
+
+// `rxx` and `ryy` parsed to a seven-gate basis-change ladder before the native
+// rotation gained a spelling. Both forms are the same unitary, so pin that
+// rather than trusting the change: the ladder is written out here so the
+// comparison does not run through the code that replaced it.
+#[test]
+fn parsed_rxx_and_ryy_agree_with_the_ladder_they_replaced() {
+    use prism_q::circuit::openqasm;
+
+    let cases = [
+        (
+            "rxx",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\nrxx(0.7) q[0], q[1];",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n\
+             h q[0];\nh q[1];\ncx q[0], q[1];\nrz(0.7) q[1];\ncx q[0], q[1];\nh q[0];\nh q[1];",
+        ),
+        (
+            "ryy",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\nryy(0.7) q[0], q[1];",
+            "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\n\
+             rx(pi/2) q[0];\nrx(pi/2) q[1];\ncx q[0], q[1];\nrz(0.7) q[1];\ncx q[0], q[1];\n\
+             rx(-pi/2) q[0];\nrx(-pi/2) q[1];",
+        ),
+    ];
+
+    for (label, native_src, ladder_src) in cases {
+        let native = openqasm::parse(native_src).expect("parse native");
+        assert_eq!(
+            native.instructions.len(),
+            2,
+            "{label}: expected one rotation"
+        );
+
+        let ladder = openqasm::parse(ladder_src).expect("parse ladder");
+        let mut a = StatevectorBackend::new(SEED);
+        let mut b = StatevectorBackend::new(SEED);
+        let native_probs = sim::run_on(&mut a, &native)
+            .expect("run native")
+            .probabilities
+            .expect("probs")
+            .to_vec();
+        let ladder_probs = sim::run_on(&mut b, &ladder)
+            .expect("run ladder")
+            .probabilities
+            .expect("probs")
+            .to_vec();
+        assert_probs_close(&native_probs, &ladder_probs, SV_EPS, label);
+    }
 }


### PR DESCRIPTION
## Summary

Export lowered `Gate::PauliRot` to its CNOT ladder because the parser had no
name for it, so a round trip returned a correct circuit that was no longer the
gate it started as. `r` followed by one Pauli letter per qubit argument spells
it, generalizing the `rzz` the parser already took, and export emits that form.

Stacked on the `input` and `output` declarations branch, which the round-trip
test binds through.

## Scope

- [x] New feature
- [x] Documentation

## What landed

`rxyz(0.7) q[0], q[1], q[2];` is `exp(-i * 0.7 * (X⊗Y⊗Z) / 2)` with `x` on
`q[0]`. Targets sort by qubit and the letters follow them, matching how a
circuit stores the gate.

The two-letter names join the same rule rather than sitting beside it. `rzz`
still resolves to `Gate::Rzz`, because the recognizing lowering produces it, and
a one-letter name would still give `rx`, `ry`, or `rz`. Only the residual
strings build the native multi-qubit gate.

The recognizing lowering moved to `circuit::pauli_rotation_gate` so the parser,
which builds the instruction itself and cannot go through
`Circuit::add_pauli_rotation`, shares the sort and the recognition rather than
reimplementing them.

## The behavior change, and how it is pinned

`rxx` and `ryy` parsed to a seven-gate basis-change ladder and now produce the
native gate. Two things make that safe rather than merely intended:

- Backends that decline the gate are unaffected. The sim layer already expands
  every `PauliRot` before dispatch, so those routes see the same instruction
  stream they saw before. The statevector gets its one-pass kernel instead.
- `parsed_rxx_and_ryy_agree_with_the_ladder_they_replaced` writes the old ladder
  out by hand and simulates both forms, so the equivalence is measured rather
  than asserted, and the comparison does not run through the code that replaced
  it.

## The spelling is an extension

`r` plus a wider Pauli string is not standard OpenQASM. That is the cost of a
round trip that preserves the gate, and it is stated in the module header and
the guide. For output another toolchain reads,
`circuit::expand_pauli_rotations` before export still produces the portable
ladder, pinned by `expanding_first_exports_the_portable_ladder`.

## Benchmarks

N/A, no hot-path changes. Both the native kernel and its ladder expansion
already existed and neither changed; what moved is which one a given piece of
source text resolves to.

## Correctness

- [x] `cargo nextest run --features parallel` passes (2185 tests)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo test --doc --features parallel` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with rustdoc warnings denied

`qasm_export_keeps_the_native_pauli_rotation` asserts the reparsed instruction
is a `PauliRot`, which is the property that matters: a test asserting agreement
with the ladder passes whether or not the native gate survived, so it would not
have caught this. Rejections are pinned by name for a repeated qubit, a wrong
arity, and a modifier, and `rccx` still reaches its own decomposition, `c` being
no Pauli letter.

## Breaking changes

`rxx` and `ryy` produce one instruction where they produced seven. Results are
unchanged on every backend, and the instruction count is the visible difference
for anyone reading a parsed circuit. `to_qasm3` output changes for a circuit
holding a `PauliRot`: it now carries the extension spelling rather than the
ladder.

## Risks and rollback

The reachable surface is the `r`-prefixed names. A user gate defined with one of
those names still wins, since the recognition sits after user-gate expansion,
and a name carrying a non-Pauli letter never matches. Reverting restores the
ladder on both sides.
