### PR TITLE
fix: budget two growth allocations and pin QEC measurement conventions

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -51,11 +51,17 @@ through dispatch.
 | Sparse entry count | `PRISM_MAX_SPARSE_QUBITS` (the map holds at most `2^q` entries) | Same budget at 64 bytes per entry across the double-buffered maps |
 | Factored merged-block width | `PRISM_MAX_FACTORED_MERGE_QUBITS` | Same budget over `Complex64` |
 | MPS gate workspace | `PRISM_MAX_MPS_WORKSPACE_QUBITS` (at most `2^q` amplitudes of live contraction buffers) | Same budget over `Complex64` |
+| Factored stabilizer merged-cluster width | `PRISM_MAX_STABILIZER_CLUSTER_QUBITS` | Widest joint tableau fitting the same budget, counted as `2n + 1` rows of `2 * ceil(n / 64)` words and halved to cover the peak while both source tableaux are still live |
 
-The three growth caps are deliberately independent of `PRISM_MAX_SV_QUBITS`: the sparse,
-factored, and MPS backends exist to run above the statevector cap, so lowering that cap
-to steer routing must not shrink what they may hold. Their defaults come from the same
-detected-memory budget.
+The four growth caps are deliberately independent of `PRISM_MAX_SV_QUBITS`: the sparse,
+factored, MPS, and factored stabilizer backends exist to run above the statevector cap,
+so lowering that cap to steer routing must not shrink what they may hold. Their defaults
+come from the same detected-memory budget.
+
+The factored stabilizer cap is the one that is not a `2^n` amplitude count. A stabilizer
+cluster costs `O(n^2 / 64)` words, so a dense cap is the wrong scale here: it would hold
+a cluster to the dense backends' qubit ceiling, far below the widths reached by the
+Clifford circuits at 128 qubits and above that dispatch selects that backend for.
 
 The density-matrix cap is the tighter of its own override and half the statevector cap,
 computed in one place so dispatch-time validation and the backend's `init` guard cannot

--- a/docs/architecture/qec-programs.md
+++ b/docs/architecture/qec-programs.md
@@ -24,8 +24,8 @@ scope, duplicate qubits in a Pauli product, and `DEPOLARIZE2` target pairing.
 | `QecOp` variant | Payload | Semantics |
 | --- | --- | --- |
 | `Gate` | `gate`, `targets` | Standard gate. The compiled runner requires Clifford gates; the reference runner accepts any gate the statevector backend supports. |
-| `Measure` | `basis`, `qubit` | Single-qubit measurement in the requested basis. One record. |
-| `MeasurePauliProduct` | `terms` | One record equal to the parity of the listed Pauli terms. |
+| `Measure` | `basis`, `qubit` | Single-qubit measurement in the requested basis. One record. The qubit is left in the Z frame: the basis rotation is not undone. Reset it before a later operation reuses it. |
+| `MeasurePauliProduct` | `terms` | One record equal to the parity of the listed Pauli terms. Unlike `Measure`, the per-term basis rotations are undone before the record is taken. |
 | `Reset` | `basis`, `qubit` | Reset to the `+1` eigenstate of the requested basis. |
 | `Detector` | `records`, `coords` | Parity over the listed records. `coords` is passthrough metadata with no effect on sampling. |
 | `ObservableInclude` | `observable`, `records` | Includes for the same observable index XOR into a single row. |

--- a/docs/architecture/qec-programs.md
+++ b/docs/architecture/qec-programs.md
@@ -24,7 +24,7 @@ scope, duplicate qubits in a Pauli product, and `DEPOLARIZE2` target pairing.
 | `QecOp` variant | Payload | Semantics |
 | --- | --- | --- |
 | `Gate` | `gate`, `targets` | Standard gate. The compiled runner requires Clifford gates; the reference runner accepts any gate the statevector backend supports. |
-| `Measure` | `basis`, `qubit` | Single-qubit measurement in the requested basis. One record. The qubit is left in the Z frame: the basis rotation is not undone. Reset it before a later operation reuses it. |
+| `Measure` | `basis`, `qubit` | Single-qubit measurement in the requested basis. One record. The qubit is left in the Z frame: the basis rotation is not undone. After a non-Z basis, reusing the qubit before a `Reset` is rejected, so the frame it is left in is never observable. |
 | `MeasurePauliProduct` | `terms` | One record equal to the parity of the listed Pauli terms. Unlike `Measure`, the per-term basis rotations are undone before the record is taken. |
 | `Reset` | `basis`, `qubit` | Reset to the `+1` eigenstate of the requested basis. |
 | `Detector` | `records`, `coords` | Parity over the listed records. `coords` is passthrough metadata with no effect on sampling. |

--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -484,12 +484,17 @@ pub struct FactoredStabilizerBackend {
     subs: Vec<Option<SubTableau>>,
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
+    /// Merged-cluster qubit cap from
+    /// [`crate::backend::max_stabilizer_cluster_qubits`], read once at
+    /// construction so the per-merge check is a field compare.
+    cluster_cap: usize,
 }
 
 impl FactoredStabilizerBackend {
     pub fn new(seed: u64) -> Self {
         Self {
             num_qubits: 0,
+            cluster_cap: crate::backend::max_stabilizer_cluster_qubits(),
             qubit_to_sub: Vec::new(),
             subs: Vec::new(),
             classical_bits: Vec::new(),
@@ -497,7 +502,7 @@ impl FactoredStabilizerBackend {
         }
     }
 
-    fn ensure_same_sub(&mut self, targets: &[usize]) -> usize {
+    fn ensure_same_sub(&mut self, targets: &[usize]) -> Result<usize> {
         let first = self.qubit_to_sub[targets[0]];
         let mut need_merge: SmallVec<[usize; 4]> = SmallVec::new();
         for &q in &targets[1..] {
@@ -507,18 +512,26 @@ impl FactoredStabilizerBackend {
             }
         }
         for other in need_merge {
-            self.merge_subs(first, other);
+            self.merge_subs(first, other)?;
         }
-        first
+        Ok(first)
     }
 
-    fn merge_subs(&mut self, dst_idx: usize, src_idx: usize) {
+    fn merge_subs(&mut self, dst_idx: usize, src_idx: usize) -> Result<()> {
+        let total_n =
+            self.subs[dst_idx].as_ref().unwrap().n + self.subs[src_idx].as_ref().unwrap().n;
+        if total_n > self.cluster_cap {
+            return Err(crate::backend::stabilizer_cluster_error(
+                total_n,
+                self.cluster_cap,
+            ));
+        }
+
         let src = self.subs[src_idx].take().unwrap();
         let dst = self.subs[dst_idx].as_ref().unwrap();
 
         let a = dst.n;
         let b = src.n;
-        let total_n = a + b;
         let new_nw = total_n.div_ceil(64);
         let new_stride = 2 * new_nw;
         let total_rows = 2 * total_n + 1;
@@ -612,6 +625,7 @@ impl FactoredStabilizerBackend {
         for &q in &src.qubits {
             self.qubit_to_sub[q] = dst_idx;
         }
+        Ok(())
     }
 
     fn try_split(&mut self, sub_idx: usize) -> bool {
@@ -835,7 +849,7 @@ impl Backend for FactoredStabilizerBackend {
     fn apply(&mut self, instruction: &Instruction) -> Result<()> {
         match instruction {
             Instruction::Gate { gate, targets } => {
-                let ss = self.ensure_same_sub(targets);
+                let ss = self.ensure_same_sub(targets)?;
                 let sub = self.subs[ss].as_mut().unwrap();
                 let mut local = SmallVec::<[usize; 4]>::new();
                 for &t in targets.iter() {
@@ -868,7 +882,7 @@ impl Backend for FactoredStabilizerBackend {
                 targets,
             } => {
                 if condition.evaluate(&self.classical_bits) {
-                    let ss = self.ensure_same_sub(targets);
+                    let ss = self.ensure_same_sub(targets)?;
                     let sub = self.subs[ss].as_mut().unwrap();
                     let mut local = SmallVec::<[usize; 4]>::new();
                     for &t in targets.iter() {

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -139,10 +139,10 @@ fn stabilizer_tableau_words(n: u128) -> u128 {
 ///
 /// Separate from [`max_factored_merge_qubits`] because the resources differ in
 /// kind: a factored merge allocates `2^n` amplitudes, while a stabilizer merge
-/// allocates a tableau of `O(n^2 / 64)` words. Reusing the dense cap here would
-/// reject the first merge of a 128-qubit Clifford circuit, which is the shape
-/// dispatch selects this backend for. `PRISM_MAX_STABILIZER_CLUSTER_QUBITS`
-/// overrides it.
+/// allocates a tableau of `O(n^2 / 64)` words. Reusing a dense cap would hold a
+/// cluster to the dense backends' qubit ceiling, far below the widths reached by
+/// the Clifford circuits at 128 qubits and above that dispatch selects this
+/// backend for. `PRISM_MAX_STABILIZER_CLUSTER_QUBITS` overrides it.
 pub(crate) fn max_stabilizer_cluster_qubits() -> usize {
     static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -128,6 +128,74 @@ pub(crate) fn max_factored_merge_qubits() -> usize {
     })
 }
 
+/// Words a stabilizer tableau of `n` qubits occupies: `2n + 1` rows of
+/// `2 * ceil(n / 64)` words each.
+fn stabilizer_tableau_words(n: u128) -> u128 {
+    (2 * n + 1) * 2 * n.div_ceil(64)
+}
+
+/// Merged-cluster qubit cap for the factored stabilizer backend, checked at
+/// merge time.
+///
+/// Separate from [`max_factored_merge_qubits`] because the resources differ in
+/// kind: a factored merge allocates `2^n` amplitudes, while a stabilizer merge
+/// allocates a tableau of `O(n^2 / 64)` words. Reusing the dense cap here would
+/// reject the first merge of a 128-qubit Clifford circuit, which is the shape
+/// dispatch selects this backend for. `PRISM_MAX_STABILIZER_CLUSTER_QUBITS`
+/// overrides it.
+pub(crate) fn max_stabilizer_cluster_qubits() -> usize {
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        if let Some(n) = env_qubit_override("PRISM_MAX_STABILIZER_CLUSTER_QUBITS") {
+            return n;
+        }
+        match detect_physical_memory_bytes() {
+            Some(bytes) => {
+                // The old pair is still live when the joint tableau allocates,
+                // and is strictly smaller than it, so peak is under twice the
+                // merged size.
+                let budget_words = u128::from(bytes / MEMORY_BUDGET_DIVISOR) / 8 / 2;
+                let mut n: u128 = 1;
+                while stabilizer_tableau_words(2 * n) <= budget_words
+                    && 2 * n < u128::from(u32::MAX)
+                {
+                    n *= 2;
+                }
+                let mut step = n / 2;
+                while step > 0 {
+                    if stabilizer_tableau_words(n + step) <= budget_words {
+                        n += step;
+                    }
+                    step /= 2;
+                }
+                usize::try_from(n).unwrap_or(usize::MAX)
+            }
+            None => {
+                eprintln!(
+                    "warning: could not detect system memory; stabilizer cluster cap is \
+                     disabled. Large merges may abort on allocation. Set \
+                     PRISM_MAX_STABILIZER_CLUSTER_QUBITS to suppress."
+                );
+                usize::MAX
+            }
+        }
+    })
+}
+
+/// Error for a stabilizer cluster merge of `total_n` qubits over the cluster
+/// budget, raised before the joint tableau allocates.
+#[cold]
+pub(crate) fn stabilizer_cluster_error(total_n: usize, cap: usize) -> PrismError {
+    PrismError::IncompatibleBackend {
+        backend: "factored-stabilizer".to_string(),
+        reason: format!(
+            "merging entangled clusters needs a {total_n}-qubit joint tableau, exceeding \
+             the cap of {cap} on this machine \
+             (set PRISM_MAX_STABILIZER_CLUSTER_QUBITS to override)"
+        ),
+    }
+}
+
 /// Workspace cap for MPS gate application, as `2^q` amplitudes of live
 /// contraction buffers. Independent of the statevector override for the same
 /// reason as the factored merge cap: MPS exists to run above that cap.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -204,7 +204,8 @@ pub(crate) const PHASE_IS_ONE_EPS: f64 = 1e-15;
 pub(crate) use memory::{
     DM_QUBIT_CAP_ENV, check_state_allocation, dense_probability_len, dense_statevector_len,
     max_dense_outcome_bits, max_density_matrix_qubits, max_factored_merge_qubits,
-    max_sparse_entries, max_statevector_qubits, mps_workspace_cap_elements, reserve_dense_output,
+    max_sparse_entries, max_stabilizer_cluster_qubits, max_statevector_qubits,
+    mps_workspace_cap_elements, reserve_dense_output, stabilizer_cluster_error,
     tensor_probability_len, workspace_allocation_error,
 };
 

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -1437,6 +1437,35 @@ impl MpsBackend {
         }
     }
 
+    /// Reject a dense `2^n x 2^n` gate matrix over the workspace budget before
+    /// it is built.
+    ///
+    /// The N-site path holds two of them at peak, the assembled matrix and the
+    /// role-reordered copy, and both are allocated before
+    /// [`Self::apply_adjacent_n_qubit`] reaches its own theta check.
+    fn check_n_qubit_gate_matrix(&self, n: usize) -> Result<()> {
+        // Rejected outright rather than by comparison: `2^(2n + 1)` is not
+        // representable here, and the cap is itself `u128::MAX` when memory
+        // detection is unavailable, so a comparison would pass and leave the
+        // caller to shift `1usize` by more than its width.
+        if n >= 63 {
+            return Err(crate::backend::workspace_allocation_error(
+                "mps",
+                "multi-qubit gate matrix",
+                u128::MAX,
+            ));
+        }
+        let elements = 2u128 << (2 * n);
+        if elements > self.workspace_cap {
+            return Err(crate::backend::workspace_allocation_error(
+                "mps",
+                "multi-qubit gate matrix",
+                elements,
+            ));
+        }
+        Ok(())
+    }
+
     fn apply_adjacent_n_qubit(
         &mut self,
         gate: &[Complex64],
@@ -2140,11 +2169,12 @@ impl MpsBackend {
             }
             Gate::Mcu(data) => {
                 let num_ctrl = data.num_controls as usize;
+                let n = num_ctrl + 1;
+                self.check_n_qubit_gate_matrix(n)?;
                 let all_qubits: Vec<usize> = targets
                     .iter()
                     .map(|&qubit| self.site_for_logical(qubit))
                     .collect();
-                let n = num_ctrl + 1;
                 let dim = 1usize << n;
                 let role_order: Vec<usize> = (0..n).collect();
                 let gate_mat = mcu_matrix(num_ctrl, &data.mat, &role_order);

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -973,6 +973,52 @@ pub(crate) fn qec_terms_to_pauli(terms: &[QecPauli]) -> Vec<crate::sim::unified_
         .collect()
 }
 
+/// Reject reuse of a qubit measured in a non-Z basis before its next reset.
+///
+/// A basis measurement leaves the qubit in the Z frame rather than in the basis
+/// it named, so a later operation on that qubit reads a state the program did
+/// not ask for. Both lowerings take that convention, and it is only unobservable
+/// while the qubit is reset before reuse, which is the contract
+/// [`run_qec_program`] already documents. This makes it an error rather than a
+/// silent difference.
+///
+/// Z-basis measurements are unaffected: they rotate nothing, so nothing is left
+/// behind to observe. `MPP` is unaffected for the same reason, since it undoes
+/// each term's rotation before taking the record.
+pub(crate) fn validate_measured_qubit_reuse(program: &QecProgram) -> Result<()> {
+    let reuse = |qubit: usize| PrismError::InvalidParameter {
+        message: format!(
+            "qubit {qubit} was measured in a non-Z basis and must be reset before it is used \
+             again: a basis measurement leaves the qubit in the Z frame, not in the basis it \
+             named"
+        ),
+    };
+    let mut rotated = vec![false; program.num_qubits()];
+    for op in program.ops() {
+        match op {
+            QecOp::Gate { targets, .. } => {
+                if let Some(&qubit) = targets.iter().find(|&&q| rotated[q]) {
+                    return Err(reuse(qubit));
+                }
+            }
+            QecOp::Measure { basis, qubit } => {
+                if rotated[*qubit] {
+                    return Err(reuse(*qubit));
+                }
+                rotated[*qubit] = *basis != QecBasis::Z;
+            }
+            QecOp::MeasurePauliProduct { terms } => {
+                if let Some(term) = terms.iter().find(|t| rotated[t.qubit]) {
+                    return Err(reuse(term.qubit));
+                }
+            }
+            QecOp::Reset { qubit, .. } => rotated[*qubit] = false,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Validate `EXP_VAL` placement for execution.
 ///
 /// Terminality: no gate, measurement, reset, or active noise may follow an

--- a/src/qec/mod.rs
+++ b/src/qec/mod.rs
@@ -255,6 +255,12 @@ pub enum QecOp {
 }
 
 /// Packed Pauli row for one QEC measurement record.
+///
+/// The row names the Hermitian operator measured, with `Y` carried as both the
+/// `x` and `z` bit of its qubit. A consumer that rebuilds the operator as a
+/// per-qubit product of `X` and `Z` recovers `(-i)^k` times it, for `k` the
+/// number of `Y` letters, since `XZ = -iY`. The row carries no sign of its own;
+/// the measured eigenvalue comes from the state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QecMeasurementRow {
     num_qubits: usize,

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -48,7 +48,9 @@ use rand_chacha::ChaCha8Rng;
 ///   route accepts them via the analytical strategies).
 /// - A measured qubit must be `Reset` before any later gate reuses it; the
 ///   compiled lowering defers measurements to the terminal records of an
-///   internal circuit.
+///   internal circuit. Reuse after a non-Z basis measurement is rejected
+///   rather than left to the caller, since that case also leaves the qubit in
+///   the Z frame.
 /// - [`QecOptions::chunk_size`] bounds the per-batch shot count. Setting
 ///   `chunk_size` together with `keep_measurements: false` keeps peak memory
 ///   at one chunk worth of measurement records.
@@ -80,6 +82,7 @@ use rand_chacha::ChaCha8Rng;
 /// # Ok::<(), prism_q::PrismError>(())
 /// ```
 pub fn run_qec_program(program: &QecProgram) -> Result<QecSampleResult> {
+    super::validate_measured_qubit_reuse(program)?;
     if program.num_expectation_values() > 0 {
         super::validate_qec_exp_val_placement(program)?;
         let has_active_noise = program
@@ -464,6 +467,7 @@ impl QecProfiledSampler {
 /// [`QecOptions::chunk_size`] is validated for shape but not used to bound
 /// execution batches.
 pub fn run_qec_program_reference(program: &QecProgram) -> Result<QecSampleResult> {
+    super::validate_measured_qubit_reuse(program)?;
     qec_runner_chunk_size(program.options())?;
     super::validate_qec_exp_val_placement(program)?;
     let shots = program.options().shots;

--- a/src/qec/runner.rs
+++ b/src/qec/runner.rs
@@ -1279,6 +1279,15 @@ fn reset_reference_basis(
     rotate_reference_z_to_basis(backend, basis, qubit)
 }
 
+/// Measure `qubit` in `basis`, leaving it in the Z frame.
+///
+/// The basis rotation is not undone, matching what
+/// [`lower_qec_program_to_clifford_circuit`] emits and what the deferred noisy
+/// lowering in [`crate::qec::noise`] emits. Restoring here instead would append
+/// a gate after every basis measurement, which costs
+/// [`Circuit::has_terminal_measurements_only`] and the terminal sampling paths
+/// it gates. A program that reuses the qubit resets it first, which is what
+/// makes the convention unobservable in well-formed programs.
 fn measure_reference_basis(
     backend: &mut StatevectorBackend,
     basis: QecBasis,
@@ -1290,9 +1299,7 @@ fn measure_reference_basis(
         qubit,
         classical_bit: record,
     })?;
-    let outcome = backend.classical_results()[record];
-    rotate_reference_z_to_basis(backend, basis, qubit)?;
-    Ok(outcome)
+    Ok(backend.classical_results()[record])
 }
 
 fn measure_reference_mpp(

--- a/tests/golden_small_circuits.rs
+++ b/tests/golden_small_circuits.rs
@@ -19,6 +19,7 @@ use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::circuit::Circuit;
 use prism_q::gates::{Gate, McuData};
 use prism_q::sim;
+use prism_q::{QecOptions, QecPauli, QecProgram, run_qec_program, run_qec_program_reference};
 
 const EPS: f64 = 1e-12;
 
@@ -1212,4 +1213,48 @@ fn pauli_rot_matches_ladder_lowering() {
     for (i, (a, e)) in sv.iter().zip(&lowered).enumerate() {
         assert_amplitude(*a, *e, &format!("index {i}"));
     }
+}
+
+// Y (x) Y on a Bell pair, by hand.
+//
+// H then CX prepares |Phi+> = (|00> + |11>)/sqrt(2). With Y|0> = i|1> and
+// Y|1> = -i|0>:
+//   (Y (x) Y)|00> = (i|1>)(x)(i|1>) = -|11>
+//   (Y (x) Y)|11> = (-i|0>)(x)(-i|0>) = -|00>
+// so (Y (x) Y)|Phi+> = -|Phi+>, eigenvalue -1. A record bit is 1 for
+// eigenvalue -1, as measuring Z on |1> shows, so every shot reads true.
+//
+// Cross-check on the sign, which is the whole point of the case: Y = i XZ, so
+// Y (x) Y = -(X (x) X)(Z (x) Z), and |Phi+> is a +1 eigenstate of both
+// factors, giving -1. An implementation that packs Y as X and Z without the
+// i^2 would read false here.
+#[test]
+fn y_tensor_y_on_a_bell_pair_measures_minus_one() {
+    let options = QecOptions {
+        shots: 32,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(2, options);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.push_gate(Gate::Cx, &[0, 1]).unwrap();
+    program
+        .measure_pauli_product(&[QecPauli::y(0), QecPauli::y(1)])
+        .unwrap();
+
+    let expected = vec![vec![true]; 32];
+    assert_eq!(
+        run_qec_program(&program).unwrap().measurements.to_shots(),
+        expected,
+        "compiled runner disagrees with the hand-computed -1 eigenvalue"
+    );
+    assert_eq!(
+        run_qec_program_reference(&program)
+            .unwrap()
+            .measurements
+            .to_shots(),
+        expected,
+        "reference runner disagrees with the hand-computed -1 eigenvalue"
+    );
 }

--- a/tests/growth_budget_oversize.rs
+++ b/tests/growth_budget_oversize.rs
@@ -12,9 +12,10 @@ use prism_q::{
     run_on,
 };
 
-// Merge cap 8: a factored merge past 8 qubits rejects. MPS workspace cap
-// 2^8 = 256 amplitudes. Sparse cap 6: the map may hold at most 64 entries.
-// The statevector cap stays untouched: these ceilings must bind on their own.
+// Merge cap 8: a factored merge past 8 qubits rejects, and so does a stabilizer
+// cluster merge past 8. MPS workspace cap 2^8 = 256 amplitudes. Sparse cap 6:
+// the map may hold at most 64 entries. The statevector cap stays untouched:
+// these ceilings must bind on their own.
 const MERGE_CAP: usize = 8;
 const SPARSE_ENTRY_CAP: usize = 1 << 6;
 
@@ -140,7 +141,8 @@ fn mps_workspace_over_the_cap_is_rejected() {
 }
 
 // The N-site path holds the assembled 4^n gate matrix and its reordered copy
-// at peak, so a 4-control MCU needs 512 amplitudes against the cap's 256.
+// at peak, which is 2^(2n + 1) amplitudes for n = controls + 1. Four controls
+// needs 2048 against the cap's 256; two controls needs 128 and fits.
 fn wide_mcu(n: usize, num_controls: u8) -> Circuit {
     let mut c = Circuit::new(n, 0);
     let x = [
@@ -166,7 +168,7 @@ fn mps_narrow_mcu_still_runs() {
     small_caps();
     let circuit = wide_mcu(8, 2);
     let mut backend = MpsBackend::new(42, 1 << 20);
-    run_on(&mut backend, &circuit).expect("an at-cap MCU must run");
+    run_on(&mut backend, &circuit).expect("an MCU within the cap must run");
 }
 
 #[test]

--- a/tests/growth_budget_oversize.rs
+++ b/tests/growth_budget_oversize.rs
@@ -6,7 +6,10 @@
 use std::sync::Once;
 
 use prism_q::gates::Gate;
-use prism_q::{Circuit, FactoredBackend, MpsBackend, PrismError, SparseBackend, run_on};
+use prism_q::{
+    Circuit, FactoredBackend, FactoredStabilizerBackend, MpsBackend, PrismError, SparseBackend,
+    run_on,
+};
 
 // Merge cap 8: a factored merge past 8 qubits rejects. MPS workspace cap
 // 2^8 = 256 amplitudes. Sparse cap 6: the map may hold at most 64 entries.
@@ -23,6 +26,7 @@ fn small_caps() {
             std::env::set_var("PRISM_MAX_FACTORED_MERGE_QUBITS", "8");
             std::env::set_var("PRISM_MAX_MPS_WORKSPACE_QUBITS", "8");
             std::env::set_var("PRISM_MAX_SPARSE_QUBITS", "6");
+            std::env::set_var("PRISM_MAX_STABILIZER_CLUSTER_QUBITS", "8");
         }
     });
 }
@@ -132,6 +136,23 @@ fn mps_workspace_over_the_cap_is_rejected() {
     let mut backend = MpsBackend::new(42, 1 << 20);
     let err = run_on(&mut backend, &circuit).unwrap_err();
     assert_cap_error(err, "mps");
+}
+
+#[test]
+fn stabilizer_cluster_merge_over_the_cap_is_rejected() {
+    small_caps();
+    let circuit = bridged_blocks(5, 5);
+    let mut backend = FactoredStabilizerBackend::new(42);
+    let err = run_on(&mut backend, &circuit).unwrap_err();
+    assert_cap_error(err, "factored-stabilizer");
+}
+
+#[test]
+fn stabilizer_cluster_merge_at_the_cap_still_runs() {
+    small_caps();
+    let circuit = bridged_blocks(MERGE_CAP / 2, MERGE_CAP / 2);
+    let mut backend = FactoredStabilizerBackend::new(42);
+    run_on(&mut backend, &circuit).expect("an at-cap cluster merge must run");
 }
 
 #[test]

--- a/tests/growth_budget_oversize.rs
+++ b/tests/growth_budget_oversize.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Once;
 
+use num_complex::Complex64;
 use prism_q::gates::Gate;
 use prism_q::{
     Circuit, FactoredBackend, FactoredStabilizerBackend, MpsBackend, PrismError, SparseBackend,
@@ -136,6 +137,36 @@ fn mps_workspace_over_the_cap_is_rejected() {
     let mut backend = MpsBackend::new(42, 1 << 20);
     let err = run_on(&mut backend, &circuit).unwrap_err();
     assert_cap_error(err, "mps");
+}
+
+// The N-site path holds the assembled 4^n gate matrix and its reordered copy
+// at peak, so a 4-control MCU needs 512 amplitudes against the cap's 256.
+fn wide_mcu(n: usize, num_controls: u8) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    let x = [
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let targets: Vec<usize> = (0..=num_controls as usize).collect();
+    c.add_gate(Gate::mcu(x, num_controls), &targets);
+    c
+}
+
+#[test]
+fn mps_mcu_gate_matrix_over_the_cap_is_rejected() {
+    small_caps();
+    let circuit = wide_mcu(8, 4);
+    let mut backend = MpsBackend::new(42, 1 << 20);
+    let err = run_on(&mut backend, &circuit).unwrap_err();
+    assert_cap_error(err, "mps");
+}
+
+#[test]
+fn mps_narrow_mcu_still_runs() {
+    small_caps();
+    let circuit = wide_mcu(8, 2);
+    let mut backend = MpsBackend::new(42, 1 << 20);
+    run_on(&mut backend, &circuit).expect("an at-cap MCU must run");
 }
 
 #[test]

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -246,10 +246,11 @@ fn qec_reference_runner_executes_gates_and_postselection() {
     assert_eq!(result.observables.to_shots(), vec![vec![true]; 4]);
 }
 
-// Measuring X on |+> is deterministic and leaves the qubit in |+>, so a Z
-// measurement of the same qubit with no intervening reset is deterministic too.
-// The two runners must agree on both records and on the post-measurement state
-// the second one reads.
+// Measuring X on |+> is deterministic, and the qubit is left in the Z frame
+// rather than rotated back, so it sits in |0> and the following Z measurement
+// reads 0 deterministically. Under the restoring convention the qubit would
+// return to |+> and that second record would be random, which is how the two
+// runners used to differ.
 #[test]
 fn qec_basis_measurement_leaves_the_same_state_in_both_runners() {
     let options = QecOptions {

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -246,6 +246,36 @@ fn qec_reference_runner_executes_gates_and_postselection() {
     assert_eq!(result.observables.to_shots(), vec![vec![true]; 4]);
 }
 
+// Measuring X on |+> is deterministic and leaves the qubit in |+>, so a Z
+// measurement of the same qubit with no intervening reset is deterministic too.
+// The two runners must agree on both records and on the post-measurement state
+// the second one reads.
+#[test]
+fn qec_basis_measurement_leaves_the_same_state_in_both_runners() {
+    let options = QecOptions {
+        shots: 64,
+        seed: 42,
+        chunk_size: None,
+        keep_measurements: true,
+    };
+    let mut program = QecProgram::with_options(1, options);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.measure_x(0).unwrap();
+    program.measure_z(0).unwrap();
+
+    let compiled = run_qec_program(&program).unwrap().measurements.to_shots();
+    let reference = run_qec_program_reference(&program)
+        .unwrap()
+        .measurements
+        .to_shots();
+
+    assert_eq!(
+        compiled, reference,
+        "compiled and reference runners disagree on the post-measurement state"
+    );
+    assert_eq!(compiled, vec![vec![false, false]; 64]);
+}
+
 #[test]
 fn qec_compiled_runner_executes_clifford_programs_without_statevector_fallback() {
     let options = QecOptions {

--- a/tests/qec_ir.rs
+++ b/tests/qec_ir.rs
@@ -1,7 +1,7 @@
 use prism_q::circuit::openqasm;
 use prism_q::{
-    Gate, PackedShots, QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram, QecRecordRef,
-    QecSampleResult, compile_qec_program_rows, parse_qec_program, run_qec_program,
+    Gate, PackedShots, PrismError, QecBasis, QecNoise, QecOp, QecOptions, QecPauli, QecProgram,
+    QecRecordRef, QecSampleResult, compile_qec_program_rows, parse_qec_program, run_qec_program,
     run_qec_program_reference,
 };
 
@@ -246,13 +246,36 @@ fn qec_reference_runner_executes_gates_and_postselection() {
     assert_eq!(result.observables.to_shots(), vec![vec![true]; 4]);
 }
 
-// Measuring X on |+> is deterministic, and the qubit is left in the Z frame
-// rather than rotated back, so it sits in |0> and the following Z measurement
-// reads 0 deterministically. Under the restoring convention the qubit would
-// return to |+> and that second record would be random, which is how the two
-// runners used to differ.
+// A non-Z basis measurement leaves the qubit in the Z frame rather than in the
+// basis it named, so reusing it without a reset would read a state the program
+// never asked for. Both runners reject instead of quietly disagreeing, which is
+// what keeps the convention unobservable rather than merely documented.
 #[test]
-fn qec_basis_measurement_leaves_the_same_state_in_both_runners() {
+fn qec_rejects_reuse_of_a_basis_measured_qubit() {
+    let mut program = QecProgram::new(1);
+    program.push_gate(Gate::H, &[0]).unwrap();
+    program.measure_x(0).unwrap();
+    program.measure_z(0).unwrap();
+
+    for err in [
+        run_qec_program(&program).unwrap_err(),
+        run_qec_program_reference(&program).unwrap_err(),
+    ] {
+        match err {
+            PrismError::InvalidParameter { message } => assert!(
+                message.contains("must be reset before it is used again"),
+                "expected a reuse rejection, got {message}"
+            ),
+            other => panic!("expected a reuse rejection, got {other:?}"),
+        }
+    }
+}
+
+// The same shape with the reset the contract requires. Measuring X on |+> is
+// deterministic, the reset returns the qubit to |0>, and the Z measurement that
+// follows reads 0 on both runners.
+#[test]
+fn qec_basis_measurement_then_reset_agrees_across_runners() {
     let options = QecOptions {
         shots: 64,
         seed: 42,
@@ -262,6 +285,7 @@ fn qec_basis_measurement_leaves_the_same_state_in_both_runners() {
     let mut program = QecProgram::with_options(1, options);
     program.push_gate(Gate::H, &[0]).unwrap();
     program.measure_x(0).unwrap();
+    program.reset(QecBasis::Z, 0).unwrap();
     program.measure_z(0).unwrap();
 
     let compiled = run_qec_program(&program).unwrap().measurements.to_shots();
@@ -270,10 +294,7 @@ fn qec_basis_measurement_leaves_the_same_state_in_both_runners() {
         .measurements
         .to_shots();
 
-    assert_eq!(
-        compiled, reference,
-        "compiled and reference runners disagree on the post-measurement state"
-    );
+    assert_eq!(compiled, reference, "runners disagree after a legal reuse");
     assert_eq!(compiled, vec![vec![false, false]; 64]);
 }
 


### PR DESCRIPTION
## Summary

Two allocations sized by the workload had nothing checking them, so an oversize
input aborted the process on allocation instead of returning the memory-budget
error the other growth paths return. A library that aborts its host is a
production defect whatever its throughput.

Alongside them, two QEC measurement conventions that were never written down:
the reference runner and the compiled lowering left different post-measurement
states after a basis measurement, and no test in the suite measured a Pauli
product containing a Y, so the sign convention both runners depend on was
unpinned.

The two areas are unrelated and are separate commits. They travel together
because the QEC pair are prerequisites for widening the measurement surface and
were found while auditing the same rejection contract.

## Scope

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Build, CI, or tooling

## Decision needing sign-off

The factored stabilizer cap is a **fourth** cap environment variable,
`PRISM_MAX_STABILIZER_CLUSTER_QUBITS`, where the intent had been to reuse an
existing one. Reviewers should accept or reject this explicitly rather than read
past it.

All three existing growth caps are `2^n` dense-amplitude budgets, roughly 27
qubits on a 16 GiB host. A stabilizer cluster costs `O(n^2 / 64)` words, and
dispatch selects the factored stabilizer backend for Clifford circuits at 128
qubits and above. Reusing the factored merge cap would therefore hold a cluster
to the dense qubit ceiling, far below the widths those circuits reach. The scale
gap also makes the ceiling untestable without an override: a merge large enough
to bind a detected-memory ceiling is around 180,000 qubits, which no test can
construct.

The alternative, if this is rejected, is to leave the merge unbudgeted and
accept the abort.

## Benchmarks

N/A, no hot-path changes.

Nothing here touches a shared hot path: no `Instruction` variant, no gate
kernel, no fusion threshold, and no new arm in the per-gate dispatch loop. Both
new guards are integer compares against a field read once at construction, on
paths that already allocate, and both sit at the allocation owner rather than in
a gate loop. The QEC change removes two gate applications from the reference
runner's per-measurement path and adds none.

Regression verdict: PASS, on the grounds that no measured row is reachable from
this diff. If a reviewer disputes that, the falsifier is a single
`scripts/bench_ab.sh --features parallel` run over the gate-heavy rows in
`benches/circuits.rs`, which should read noise-level on every row.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
      (2411 tests, 0 skipped, run with `--no-fail-fast` so nothing is hidden
      behind an early cancel; GPU device present so `golden_gpu` ran rather
      than skipped)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (18)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" --
      -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with
      `RUSTDOCFLAGS=-D warnings`
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry

Six tests are added, and each was confirmed to fail against the unguarded code
rather than merely to pass, since a rejection test that passes does not show
that the rejection precedes the allocation.

Two of them are worth reading. `mps_mcu_gate_matrix_over_the_cap_is_rejected`
fails without its guard because the pre-existing workspace check measures the
contracted theta, which is bounded by the bond dimension, and a one-gate circuit
on a product state has bond dimension 1: that check computes 128 against a cap
of 256 and passes, while the gate matrix it never looks at is what aborts.
`qec_rejects_reuse_of_a_basis_measured_qubit` builds the program that used to
expose the divergence and asserts both runners refuse it, with
`qec_basis_measurement_then_reset_agrees_across_runners` covering the same shape
with the reset the contract requires.

`y_tensor_y_on_a_bell_pair_measures_minus_one` anchors against hand algebra
rather than against the other runner, because two paths sharing a wrong sign
convention would agree with each other. Both runners already produced the
hand-computed value, so that convention was correct and merely unpinned.

## Hotspot notes

N/A. No hot path touched; see Benchmarks.

## Architecture or design changes

- [x] `docs/architecture/` updated

`backends.md` listed three growth caps and asserted that count in prose, so both
the table and the sentence needed the fourth. The new entry states why it is not
a `2^n` amplitude budget like its neighbours.

`qec-programs.md` described what a basis measurement records but never what it
leaves behind, which is exactly the divergence this settles. `Measure` and
`MeasurePauliProduct` take different conventions, so both rows now say which.

## Breaking changes

One, and it is a rejection rather than a silent difference.

Reusing a qubit measured in a non-Z basis, before resetting it, is now an error
from both runners. That contract was already documented as a limitation of
`run_qec_program` ("a measured qubit must be `Reset` before any later gate
reuses it") but was never enforced, so a program could ignore it and get
different answers from the two runners depending on which one it ran on.

A basis measurement leaves the qubit in the Z frame rather than in the basis it
named. The reference runner previously undid that rotation and the compiled and
deferred noisy lowerings did not, which is the divergence this settles. Rather
than pick a convention and let programs observe it, the frame is now
unobservable: no accepted program can read it. Z-basis measurements are
unaffected because they rotate nothing, and `MPP` is unaffected because it undoes
each term's rotation before taking its record.

Blast radius was measured, not estimated. With the check in place the whole suite
was run with `--no-fail-fast`, and the only case that failed was the one written
to expose the divergence in the first place. No fixture, no distance-3 program,
and no doctest reuses a non-Z-measured qubit before resetting it.

The affected reference-runner behavior is therefore reachable only from programs
that were already outside the documented contract, and they now get an error
naming the qubit instead of a quietly different post-measurement state.

`PRISM_MAX_STABILIZER_CLUSTER_QUBITS` is new and additive. Unset, it derives from
detected memory, so no existing configuration changes behavior.

## Risks and rollback

Blast radius is small and the failure mode is loud rather than silent. Both
guards can only turn a previously aborting run into a typed error, and both are
disabled by setting their environment variable high, so a wrongly tight ceiling
is recoverable without reverting.

The QEC change rejects programs that previously ran, so its blast radius is
whatever ignored the documented reset contract; the suite says that is nothing.
It has no environment escape hatch, and rolling it back means reverting the two
QEC commits, which restores the divergence rather than a working behavior.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
