### PR TITLE
chore: badge the published artifacts and retarget a crate keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/prism-q"
 repository = "https://github.com/AbeCoull/prism-q"
 homepage = "https://github.com/AbeCoull/prism-q"
-keywords = ["quantum", "quantum-computing", "simulator", "stabilizer", "qec"]
+keywords = ["quantum", "quantum-computing", "openqasm", "stabilizer", "qec"]
 categories = ["science", "science::quantum-computing", "simulation", "mathematics"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@
  ╚═╝     ╚═╝  ╚═╝╚═╝╚══════╝╚═╝     ╚═╝       ╚══▀▀═╝
 ```
 
+[![Crates.io](https://img.shields.io/crates/v/prism-q?logo=rust)](https://crates.io/crates/prism-q)
+[![docs.rs](https://img.shields.io/docsrs/prism-q?logo=docsdotrs&logoColor=white)](https://docs.rs/prism-q)
+[![PyPI](https://img.shields.io/pypi/v/prism-q?logo=pypi&logoColor=white)](https://pypi.org/project/prism-q/)
 [![CI](https://github.com/AbeCoull/prism-q/actions/workflows/ci.yml/badge.svg)](https://github.com/AbeCoull/prism-q/actions/workflows/ci.yml)
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AbeCoull/4ea63a3791840048749e67b2484098a3/raw/coverage.json)
-![Rust](https://img.shields.io/badge/rust-1.87%2B-orange?logo=rust)
+![MSRV](https://img.shields.io/crates/msrv/prism-q?logo=rust)
 ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)
 ![OpenQASM](https://img.shields.io/badge/OpenQASM-3.0-purple)
 


### PR DESCRIPTION
## Summary

The crate has shipped on crates.io since 0.30.0 and wheels ship on PyPI, but the README
showed neither, so a reader arriving at the repository had no signal the project was
installable from either ecosystem. This adds version badges for both plus docs.rs, and
retargets one of the five crate keyword slots.

## Scope

- [x] Documentation
- [x] Build, CI, or tooling

## Benchmarks

N/A, no hot-path changes. The diff is a README badge block and one crate keyword;
neither reaches compiled code.

## Correctness

Ran: `cargo fmt --check` and `cargo check --features parallel`, both clean.

Not run: the test, doctest, clippy, and rustdoc gate. The README is not pulled in with
`include_str!`, so it carries no doctests, and crate keywords are crates.io metadata the
compiler never reads. Nothing in this diff can change a test outcome. CI covers it.

Badge endpoints were fetched before committing and all five resolve:
`crates.io: v0.30.0`, `docs: passing`, `pypi: v0.30.0`, `msrv: 1.87.0`, and the existing
coverage endpoint.

## Breaking changes

None.

## Risks and rollback

The keyword change is inert until the next `cargo publish`; the crates.io page keeps
showing the old set until then. Badges are external images, so the failure mode is a
broken image in the README, fixed by reverting two lines.

One knock-on worth noting: the MSRV badge was a hardcoded `1.87` string and is now
`img.shields.io/crates/msrv/prism-q`, which reads `rust-version` from the published
manifest. That drops the README from the list of places an MSRV bump has to touch by
hand, and it means the badge tracks the last published version rather than the working
tree. Between a bump landing and the next release, the badge shows the older floor.

The downloads badge was left off deliberately. At 820 it argues against the project
rather than for it.
