### PR TITLE
perf(density-matrix): accept fused gates and cut the channel kernels

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2305,6 +2305,68 @@ fn bench_density_matrix_unitary_layers(c: &mut Criterion) {
     group.finish();
 }
 
+/// The same layers through the `Simulate` terminal, the only density-matrix
+/// entry point that runs `fuse_circuit`.
+///
+/// `density_matrix/unitary_layers` calls `apply_instructions` directly and so
+/// never reaches the fusion pipeline whatever `supports_fused_gates` returns.
+/// Widths bracket the fusion constants: 8 is below `MIN_QUBITS_FOR_FUSION` and
+/// fuses nothing, which makes it the in-group control; 10 admits one-qubit
+/// fusion only; 12 adds the two-qubit and tiled passes.
+fn bench_density_matrix_fused_layers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/fused_layers");
+    configure_group(&mut group);
+
+    for &n in &[8, 10, 12] {
+        let circuit = circuits::random_circuit(n, 10, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(BackendKind::DensityMatrix)
+                        .seed(SEED)
+                        .run()
+                        .unwrap(),
+                );
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// The two noisy-sampling routes over the same circuit and noise model, swept
+/// over width and shot count.
+///
+/// One exact density-matrix evolution answers any shot count, so the exact
+/// route is near flat in shots and grows as `4^n`; the trajectory route
+/// re-simulates per shot, so it is linear in shots and grows as `2^n`. Two
+/// shot counts per width give both the intercept and the slope, which is what
+/// a routing rule keyed on width alone cannot have.
+fn bench_density_matrix_exact_vs_trajectory(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/exact_vs_trajectory");
+    configure_group(&mut group);
+
+    for &n in &[8usize, 10, 12] {
+        let circuit = non_clifford_noise_circuit(n, 4);
+        let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.001);
+        for &shots in &[256usize, 4096] {
+            for (label, kind) in [
+                ("exact", BackendKind::DensityMatrix),
+                ("trajectory", BackendKind::Statevector),
+            ] {
+                group.bench_function(BenchmarkId::new(label, format!("{n}q_{shots}")), |b| {
+                    b.iter(|| {
+                        run_shots_with_noise(kind.clone(), &circuit, &noise, shots, SEED).unwrap();
+                    });
+                });
+            }
+        }
+    }
+
+    group.finish();
+}
+
 /// Kraus set for amplitude damping at rate `gamma`.
 fn amplitude_damping_kraus(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
     let c = |re: f64| Complex64::new(re, 0.0);
@@ -2388,14 +2450,42 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
             b.iter(|| backend.apply_2q_depolarizing(0, n - 1, 0.02));
         });
 
-        // The general two-qubit channel `depolarizing_2q` now lowers onto. Both
-        // compile to one 16x16 superoperator and then sweep the same `4^n`
-        // buffer; at these widths the compile is under 0.01% of the row either
-        // way, so this reads the sweep and not the operator count.
+        // The general two-qubit channel. Both compile to one 16x16
+        // superoperator and then sweep the same `4^n` buffer; at these widths
+        // the compile is under 0.01% of the row either way, so this reads the
+        // sweep and not the operator count.
+        //
+        // The pair is not incidental. The sweep runs four blocks per step when
+        // `min(q0, q1) >= 2` and one otherwise, so `(2, 3)` reads the batched
+        // path and `(0, n-1)` the fallback. `(1, 2)` is the boundary: it once
+        // took a two-block step, which measured +0.2% and +1.9% against one and
+        // so was dropped, and the row stays to hold that null.
         let zz = correlated_zz_kraus(0.02);
-        group.bench_with_input(BenchmarkId::new("kraus_2q", n), &n, |b, &n| {
+        group.bench_with_input(BenchmarkId::new("kraus_2q_q0_qtop", n), &n, |b, &n| {
             let mut backend = dm_backend(n);
             b.iter(|| backend.apply_2q_kraus(0, n - 1, &zz));
+        });
+        group.bench_with_input(BenchmarkId::new("kraus_2q_adjacent", n), &n, |b, &_n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_kraus(2, 3, &zz));
+        });
+        group.bench_with_input(BenchmarkId::new("kraus_2q_mid", n), &n, |b, &_n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_kraus(1, 2, &zz));
+        });
+
+        // A `Fused2q` that no `Multi2q` batch absorbs, which is what fusion
+        // emits for an isolated two-qubit run. It takes the bra register
+        // through `conjugate_gate`; without that arm it costs two extra
+        // full-buffer conjugations, and no circuit row reaches it because the
+        // brick layers in `random_circuit` batch every run.
+        group.bench_with_input(BenchmarkId::new("fused_2q_gate", n), &n, |b, &_n| {
+            let mut backend = dm_backend(n);
+            let fused = Instruction::Gate {
+                gate: Gate::Fused2q(Box::new(Gate::Cx.matrix_4x4())),
+                targets: SmallVec::from_slice(&[0, 1]),
+            };
+            b.iter(|| backend.apply(&fused).unwrap());
         });
 
         for &(qubit, label) in &[(0usize, "measure_q0"), (n - 1, "measure_qtop")] {
@@ -2723,6 +2813,8 @@ criterion_group! {
     bench_coalesce_baseline,
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
+    bench_density_matrix_fused_layers,
+    bench_density_matrix_exact_vs_trajectory,
     bench_density_matrix_noisy_channels,
     bench_density_matrix_noisy_shots,
     bench_density_matrix_neutrality,

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -20,14 +20,16 @@
 //! Supported: exact unitary evolution, basis-state probabilities, the one-qubit
 //! reduced density matrix, projective measurement with stochastic collapse,
 //! reset, classically-conditioned gates, exact one-qubit Kraus channels
-//! (`apply_1q_kraus`), exact two-qubit Kraus channels (`apply_2q_kraus`, which
-//! `apply_2q_depolarizing` lowers onto), and
+//! (`apply_1q_kraus`), exact two-qubit Kraus channels (`apply_2q_kraus`, with
+//! `apply_2q_depolarizing` taking the twirled closed form instead), and
 //! exact `Tr(rho P)` expectation (`expectation_pauli`, reachable through
-//! `pauli_expectations`). Batched payload shapes (`QftBlock`, `BatchPhase`,
-//! `BatchRzz`, `DiagonalBatch`, `MultiFused`, `Multi2q`) carry qubit indices
-//! outside the instruction targets and are remapped onto the ket register
-//! before the left product; `sim` does not produce them here, since
-//! `supports_fused_gates` returns `false`, but a direct `Backend::apply` can.
+//! `pauli_expectations`). Fused gates are accepted, so `sim` fuses for this
+//! backend. The diagonal batches (`QftBlock`, `BatchPhase`, `BatchRzz`,
+//! `DiagonalBatch`) carry qubit indices outside the instruction targets and are
+//! remapped onto the ket register before the left product; the tiled shapes
+//! (`MultiFused`, `Multi2q`) apply their constituent gates one at a time
+//! instead. See [`Backend::supports_fused_gates`] for the ordering contract
+//! that requires it.
 //!
 //! # When to prefer this backend
 //!
@@ -137,11 +139,32 @@ fn row_aligned_tile(cmask: usize, rmask: usize) -> usize {
     (cmask << 1).max(crate::backend::MIN_PAR_ELEMS).min(rmask)
 }
 
+/// Base buffer index of block `m`, expanding the four block bit positions out
+/// of the compacted index. `positions` must be ascending.
+#[inline(always)]
+fn block_base(m: usize, positions: &[usize; 4]) -> usize {
+    let mut base = m;
+    for &pos in positions {
+        base = insert_zero_bit(base, pos);
+    }
+    base
+}
+
 fn conjugate_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
     [
         [m[0][0].conj(), m[0][1].conj()],
         [m[1][0].conj(), m[1][1].conj()],
     ]
+}
+
+fn conjugate_4x4(m: &[[Complex64; 4]; 4]) -> [[Complex64; 4]; 4] {
+    let mut out = *m;
+    for row in &mut out {
+        for entry in row {
+            *entry = entry.conj();
+        }
+    }
+    out
 }
 
 /// The gate's 2x2 matrix, or `None` for anything else. `Gate::num_qubits` is
@@ -178,6 +201,7 @@ fn conjugate_gate(gate: &Gate) -> Option<Gate> {
     match gate {
         Gate::Cx | Gate::Cz | Gate::Swap => Some(gate.clone()),
         Gate::Rzz(theta) => Some(Gate::Rzz(-*theta)),
+        Gate::Fused2q(mat) => Some(Gate::Fused2q(Box::new(conjugate_4x4(mat)))),
         Gate::Cu(mat) => Some(Gate::Cu(Box::new(conjugate_2x2(mat)))),
         Gate::Mcu(data) => Some(Gate::Mcu(Box::new(McuData {
             mat: conjugate_2x2(&data.mat),
@@ -189,9 +213,12 @@ fn conjugate_gate(gate: &Gate) -> Option<Gate> {
 
 /// The gate with every qubit index stored inside its payload shifted onto the
 /// ket register. Offsetting the instruction targets is not enough for the
-/// batched shapes, whose application indices live in the payload, nor for
+/// diagonal batches, whose application indices live in the payload, nor for
 /// `QftBlock`, whose whole range lives in the variant. Borrows the gate when it
 /// carries no such index.
+///
+/// `MultiFused` and `Multi2q` are deliberately absent: shifting a `Multi2q`
+/// payload reorders it, so both apply their constituents directly.
 fn ket_register_gate(gate: &Gate, n: usize) -> Cow<'_, Gate> {
     match gate {
         Gate::BatchPhase(data) => {
@@ -221,21 +248,6 @@ fn ket_register_gate(gate: &Gate, n: usize) -> Cow<'_, Gate> {
                 }
             }
             Cow::Owned(Gate::DiagonalBatch(data))
-        }
-        Gate::MultiFused(data) => {
-            let mut data = data.clone();
-            for entry in &mut data.gates {
-                entry.0 += n;
-            }
-            Cow::Owned(Gate::MultiFused(data))
-        }
-        Gate::Multi2q(data) => {
-            let mut data = data.clone();
-            for entry in &mut data.gates {
-                entry.0 += n;
-                entry.1 += n;
-            }
-            Cow::Owned(Gate::Multi2q(data))
         }
         Gate::QftBlock { start, num } => Cow::Owned(Gate::QftBlock {
             start: start + n as u8,
@@ -312,22 +324,43 @@ impl DensityMatrixBackend {
     /// conjugating the whole buffer around the gate, which costs two extra
     /// passes.
     ///
-    /// A one-qubit gate can instead compile to a block superoperator and sweep
-    /// the buffer once, which wins once the buffer stops fitting in cache. Below
-    /// that the superoperator's dense 4x4 block loses to two cheap passes, so
-    /// the crossover is the point where the embedded `2n`-qubit statevector
-    /// reaches the kernels' own parallel threshold.
+    /// One-qubit gates take [`DensityMatrixBackend::apply_1q_sandwich`].
+    ///
+    /// `Multi2q` carries a gate list that the statevector kernel partitions by
+    /// cache tier and runs one tier at a time, which preserves application
+    /// order only while the whole list sits in one tier. Fusion guarantees that
+    /// against the circuit's own qubit indices, and the `+n` shift onto the ket
+    /// register moves gates across the tier bounds, so the ket half applies its
+    /// constituents one at a time. The bra half keeps the circuit's indices and
+    /// so is not at risk; it is applied that way only for symmetry, and batching
+    /// it is the open win recorded against this backend. `MultiFused` entries
+    /// are one per qubit and commute, so its list is order independent; it takes
+    /// the same treatment because the one-qubit sandwich is cheaper than the
+    /// tiled pass here.
     fn apply_unitary(&mut self, gate: &Gate, targets: &[usize]) -> Result<()> {
         let n = self.num_qubits;
 
         if let Some(mat) = matrix_1q(gate) {
-            if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
-                let s = block_superoperator(&[mat]);
-                self.apply_block_superoperator(targets[0], &s);
+            return self.apply_1q_sandwich(targets[0], &mat);
+        }
+
+        match gate {
+            Gate::MultiFused(data) => {
+                for (qubit, mat) in data.gates.iter() {
+                    self.apply_1q_sandwich(*qubit, mat)?;
+                }
                 return Ok(());
             }
-            self.sv.apply_1q_matrix(targets[0] + n, &mat)?;
-            return self.sv.apply_1q_matrix(targets[0], &conjugate_2x2(&mat));
+            Gate::Multi2q(data) => {
+                for &(q0, q1, ref mat) in data.gates.iter() {
+                    self.sv.apply_fused_2q(q0 + n, q1 + n, mat);
+                }
+                for &(q0, q1, ref mat) in data.gates.iter() {
+                    self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                }
+                return Ok(());
+            }
+            _ => {}
         }
 
         let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
@@ -351,6 +384,22 @@ impl DensityMatrixBackend {
         })?;
         self.conjugate_buffer();
         Ok(())
+    }
+
+    /// Evolve `rho -> U rho U^dagger` for a one-qubit `U`.
+    ///
+    /// Above the parallel threshold the two products compile to one block
+    /// superoperator and sweep the buffer once; below it the superoperator's
+    /// dense 4x4 block loses to two cheap register passes.
+    fn apply_1q_sandwich(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
+        let n = self.num_qubits;
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            let s = block_superoperator(&[*matrix]);
+            self.apply_block_superoperator(qubit, &s);
+            return Ok(());
+        }
+        self.sv.apply_1q_matrix(qubit + n, matrix)?;
+        self.sv.apply_1q_matrix(qubit, &conjugate_2x2(matrix))
     }
 
     /// `P(qubit = |1>) = Tr(P_1 rho)`, the sum of the diagonal `rho` entries
@@ -503,34 +552,106 @@ impl DensityMatrixBackend {
     /// Apply symmetric two-qubit depolarizing on `(q0, q1)`:
     /// `rho -> (1-p) rho + (p/15) sum_{P != I(x)I} P rho P`, summed over the 15
     /// non-identity two-qubit Paulis.
+    ///
+    /// The Pauli twirl `sum_P P B P = 4 Tr(B) I4` over all 16 two-qubit Paulis
+    /// holds for any 4x4 `B`, so on each `(q0, q1)` block the map collapses to
+    /// `B -> alpha B + beta Tr(B) I4` with `alpha = 1 - 16p/15` and
+    /// `beta = 4p/15`. That is one real scale per amplitude against the 16
+    /// complex multiply-accumulates the equivalent 16x16 superoperator pays in
+    /// [`DensityMatrixBackend::apply_2q_kraus`].
+    ///
+    /// # Panics
+    ///
+    /// If `q0` and `q1` are equal or outside the register, as
+    /// [`DensityMatrixBackend::apply_2q_kraus`] does.
     pub fn apply_2q_depolarizing(&mut self, q0: usize, q1: usize, p: f64) {
-        let c1 = Complex64::new(1.0, 0.0);
-        let c0 = Complex64::new(0.0, 0.0);
-        let ci = Complex64::new(0.0, 1.0);
-        let paulis: [[[Complex64; 2]; 2]; 4] = [
-            [[c1, c0], [c0, c1]],
-            [[c0, c1], [c1, c0]],
-            [[c0, -ci], [ci, c0]],
-            [[c1, c0], [c0, -c1]],
-        ];
-        let mut kraus = [[[c0; 4]; 4]; 16];
-        for a in 0..4 {
-            for b in 0..4 {
-                let w = if a == 0 && b == 0 {
-                    (1.0 - p).sqrt()
-                } else {
-                    (p / 15.0).sqrt()
-                };
-                let w = Complex64::new(w, 0.0);
-                let k = &mut kraus[4 * a + b];
-                for (t, row) in k.iter_mut().enumerate() {
-                    for (tp, entry) in row.iter_mut().enumerate() {
-                        *entry = w * paulis[a][t >> 1][tp >> 1] * paulis[b][t & 1][tp & 1];
+        let alpha = 1.0 - 16.0 * p / 15.0;
+        let beta = 4.0 * p / 15.0;
+        let (positions, flats, num_groups) = self.block_layout(q0, q1);
+
+        #[cfg(feature = "parallel")]
+        if 2 * self.num_qubits >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::MIN_PAR_ITERS;
+            use crate::backend::statevector::SendPtr;
+            use rayon::prelude::*;
+
+            let ptr = SendPtr(self.sv.state.as_mut_ptr());
+            (0..num_groups)
+                .into_par_iter()
+                .with_min_len(MIN_PAR_ITERS)
+                .for_each(move |m| {
+                    let base = block_base(m, &positions);
+                    // SAFETY: inserting a zero bit at each of the four block
+                    // positions is a bijection from `m` onto the block bases, so
+                    // the 16 offsets one iteration touches are disjoint from
+                    // every other iteration's. The safe alternative needs the
+                    // 16 entries as disjoint sub-slices, which they are not:
+                    // they are strided across four independent bit positions.
+                    unsafe {
+                        let mut trace = Complex64::new(0.0, 0.0);
+                        for t in 0..4 {
+                            trace += ptr.load(base | flats[5 * t]);
+                        }
+                        let shift = trace * beta;
+                        for (i, &off) in flats.iter().enumerate() {
+                            let mut out = ptr.load(base | off) * alpha;
+                            if i % 5 == 0 {
+                                out += shift;
+                            }
+                            ptr.store(base | off, out);
+                        }
                     }
+                });
+            return;
+        }
+
+        for m in 0..num_groups {
+            let base = block_base(m, &positions);
+            let mut trace = Complex64::new(0.0, 0.0);
+            for t in 0..4 {
+                trace += self.sv.state[base | flats[5 * t]];
+            }
+            let shift = trace * beta;
+            for (i, &off) in flats.iter().enumerate() {
+                let mut out = self.sv.state[base | off] * alpha;
+                if i % 5 == 0 {
+                    out += shift;
                 }
+                self.sv.state[base | off] = out;
             }
         }
-        self.apply_2q_kraus(q0, q1, &kraus);
+    }
+
+    /// Block traversal for a two-qubit map on `(q0, q1)`: the four buffer bit
+    /// positions the block spans in ascending order, the 16 offsets from a
+    /// block base indexed `4 * tr + tc`, and the number of blocks. Block index
+    /// `5 * t` is the diagonal entry `tr == tc == t`.
+    ///
+    /// The four positions must be distinct and inside the register, or the
+    /// zero-bit insertion in [`block_base`] stops being a bijection onto the
+    /// block bases and the sweep reads and writes the wrong entries. Both
+    /// callers are public, so this is the choke point that enforces it.
+    fn block_layout(&self, q0: usize, q1: usize) -> ([usize; 4], [usize; 16], usize) {
+        let n = self.num_qubits;
+        assert!(
+            q0 != q1 && q0 < n && q1 < n,
+            "two-qubit channel on ({q0}, {q1}) needs distinct targets inside the {n}-qubit register"
+        );
+        let mut positions = [q0, q1, q0 + n, q1 + n];
+        positions.sort_unstable();
+
+        let mut flats = [0usize; 16];
+        for tr in 0..4 {
+            for tc in 0..4 {
+                flats[4 * tr + tc] = (if tr & 2 != 0 { 1usize << (q0 + n) } else { 0 })
+                    | (if tr & 1 != 0 { 1usize << (q1 + n) } else { 0 })
+                    | (if tc & 2 != 0 { 1usize << q0 } else { 0 })
+                    | (if tc & 1 != 0 { 1usize << q1 } else { 0 });
+            }
+        }
+
+        let d = self.dim();
+        (positions, flats, (d * d) >> 4)
     }
 
     /// Apply a general two-qubit channel `rho -> sum_k K_k rho K_k^dagger` on
@@ -541,6 +662,11 @@ impl DensityMatrixBackend {
     /// four-bit `(q0-row, q1-row, q0-col, q1-col)` block, so the buffer is swept
     /// once. Block index `4*tr + tc` orders the two-qubit row value `tr` against
     /// the column value `tc`.
+    ///
+    /// # Panics
+    ///
+    /// If `q0` and `q1` are equal or outside the register. A model built through
+    /// [`NoiseModel`](crate::NoiseModel) is rejected before it reaches here.
     pub fn apply_2q_kraus(&mut self, q0: usize, q1: usize, kraus: &[[[Complex64; 4]; 4]]) {
         // S[4*tr+tc][4*trp+tcp] = sum_k K_k[tr][trp] * conj(K_k[tc][tcp]).
         let mut s = [[Complex64::new(0.0, 0.0); 16]; 16];
@@ -560,78 +686,101 @@ impl DensityMatrixBackend {
             }
         }
 
-        let n = self.num_qubits;
-        let d = self.dim();
-        let mut positions = [q0, q1, q0 + n, q1 + n];
-        positions.sort_unstable();
-        let flat_offset = |tr: usize, tc: usize| {
-            (if tr & 2 != 0 { 1usize << (q0 + n) } else { 0 })
-                | (if tr & 1 != 0 { 1usize << (q1 + n) } else { 0 })
-                | (if tc & 2 != 0 { 1usize << q0 } else { 0 })
-                | (if tc & 1 != 0 { 1usize << q1 } else { 0 })
-        };
-        let mut flats = [0usize; 16];
-        for tr in 0..4 {
-            for tc in 0..4 {
-                flats[4 * tr + tc] = flat_offset(tr, tc);
-            }
-        }
+        let (positions, flats, num_groups) = self.block_layout(q0, q1);
 
-        let num_groups = (d * d) >> 4;
+        match positions[0] {
+            0 | 1 => self.kraus_2q_sweep::<1>(&s, &positions, &flats, num_groups),
+            _ => self.kraus_2q_sweep::<4>(&s, &positions, &flats, num_groups),
+        }
+    }
+
+    /// Sweep the buffer applying the compiled 16x16 block superoperator `s`,
+    /// `W` blocks per iteration.
+    ///
+    /// `W` must divide `2^positions[0]`. Blocks whose compacted indices form an
+    /// aligned run of that length have consecutive bases, because
+    /// [`insert_zero_bit`] preserves every bit below its position and no `flats`
+    /// entry has a bit below `positions[0]`. Each of the 16 slots is then a
+    /// contiguous run of `W` amplitudes, which amortizes the base and offset
+    /// arithmetic over `W` blocks and gives the accumulator chains room to
+    /// overlap. The arithmetic itself stays scalar: the crate builds at the
+    /// x86-64 baseline and every wide kernel here takes its width from
+    /// `#[target_feature]` dispatch in [`crate::backend::simd`], which this does
+    /// not use.
+    ///
+    /// Only `W = 1` and `W = 4` are instantiated. `W = 1` is forced when
+    /// `min(q0, q1) == 0`, where one block bit is bit 0 and no run exists, and
+    /// it also serves `min(q0, q1) == 1`: a two-block step measured +0.2% and
+    /// +1.9% against one, so it earned no arm of its own.
+    fn kraus_2q_sweep<const W: usize>(
+        &mut self,
+        s: &[[Complex64; 16]; 16],
+        positions: &[usize; 4],
+        flats: &[usize; 16],
+        num_groups: usize,
+    ) {
+        let zero = Complex64::new(0.0, 0.0);
+        let steps = num_groups / W;
 
         #[cfg(feature = "parallel")]
-        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+        if 2 * self.num_qubits >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
             use crate::backend::MIN_PAR_ITERS;
             use crate::backend::statevector::SendPtr;
             use rayon::prelude::*;
 
             let ptr = SendPtr(self.sv.state.as_mut_ptr());
-            (0..num_groups)
+            let s = *s;
+            let positions = *positions;
+            let flats = *flats;
+            (0..steps)
                 .into_par_iter()
-                .with_min_len(MIN_PAR_ITERS)
-                .for_each(move |m| {
-                    let mut base = m;
-                    for &pos in &positions {
-                        base = insert_zero_bit(base, pos);
-                    }
-                    let mut v = [Complex64::new(0.0, 0.0); 16];
+                .with_min_len(MIN_PAR_ITERS.div_ceil(W))
+                .for_each(move |step| {
+                    let base = block_base(step * W, &positions);
+                    let mut v = [[zero; W]; 16];
                     // SAFETY: inserting a zero bit at each of the four block
-                    // positions is a bijection from `m` onto the block bases, so
-                    // the 16 offsets one iteration touches are disjoint from
-                    // every other iteration's. The safe alternative needs the
-                    // 16 entries as disjoint sub-slices, which they are not:
-                    // they are strided across four independent bit positions.
+                    // positions is a bijection from the compacted index onto the
+                    // block bases, so the `16 * W` offsets one iteration touches
+                    // are disjoint from every other iteration's. The safe
+                    // alternative needs them as disjoint sub-slices, which they
+                    // are not: the 16 slots are strided across four independent
+                    // bit positions.
                     unsafe {
-                        for (k, &off) in flats.iter().enumerate() {
-                            v[k] = ptr.load(base | off);
-                        }
-                        for (i, &off) in flats.iter().enumerate() {
-                            let mut acc = Complex64::new(0.0, 0.0);
-                            for j in 0..16 {
-                                acc += s[i][j] * v[j];
+                        for (slot, &off) in v.iter_mut().zip(flats.iter()) {
+                            for (j, lane) in slot.iter_mut().enumerate() {
+                                *lane = ptr.load((base | off) + j);
                             }
-                            ptr.store(base | off, acc);
+                        }
+                        for (row, &off) in s.iter().zip(flats.iter()) {
+                            let mut acc = [zero; W];
+                            for (&coeff, slot) in row.iter().zip(v.iter()) {
+                                for (a, &lane) in acc.iter_mut().zip(slot.iter()) {
+                                    *a += coeff * lane;
+                                }
+                            }
+                            for (j, &a) in acc.iter().enumerate() {
+                                ptr.store((base | off) + j, a);
+                            }
                         }
                     }
                 });
             return;
         }
 
-        for m in 0..num_groups {
-            let mut base = m;
-            for &pos in &positions {
-                base = insert_zero_bit(base, pos);
-            }
-            let mut v = [Complex64::new(0.0, 0.0); 16];
+        for step in 0..steps {
+            let base = block_base(step * W, positions);
+            let mut v = [[zero; W]; 16];
             for (k, &off) in flats.iter().enumerate() {
-                v[k] = self.sv.state[base | off];
+                v[k].copy_from_slice(&self.sv.state[(base | off)..(base | off) + W]);
             }
-            for (i, &off) in flats.iter().enumerate() {
-                let mut acc = Complex64::new(0.0, 0.0);
-                for j in 0..16 {
-                    acc += s[i][j] * v[j];
+            for (row, &off) in s.iter().zip(flats.iter()) {
+                let mut acc = [zero; W];
+                for (&coeff, slot) in row.iter().zip(v.iter()) {
+                    for (a, &lane) in acc.iter_mut().zip(slot.iter()) {
+                        *a += coeff * lane;
+                    }
                 }
-                self.sv.state[base | off] = acc;
+                self.sv.state[(base | off)..(base | off) + W].copy_from_slice(&acc);
             }
         }
     }
@@ -761,8 +910,11 @@ impl Backend for DensityMatrixBackend {
         self.num_qubits
     }
 
+    /// `MultiFused` and `Multi2q` apply their constituents one at a time here
+    /// rather than through the tiled kernels, which the ket register's shifted
+    /// indices would reorder.
     fn supports_fused_gates(&self) -> bool {
-        false
+        true
     }
 
     fn qubit_probability(&self, qubit: usize) -> Result<f64> {
@@ -815,13 +967,6 @@ impl Backend for DensityMatrixBackend {
     /// favour of `apply_1q_kraus` on the mixture; this keeps the trait method
     /// allocation-free on every backend that holds a state.
     fn apply_1q_matrix(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
-        let n = self.num_qubits;
-        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
-            let s = block_superoperator(&[*matrix]);
-            self.apply_block_superoperator(qubit, &s);
-            return Ok(());
-        }
-        self.sv.apply_1q_matrix(qubit + n, matrix)?;
-        self.sv.apply_1q_matrix(qubit, &conjugate_2x2(matrix))
+        self.apply_1q_sandwich(qubit, matrix)
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -469,6 +469,12 @@ pub trait Backend {
     /// Backends that operate on symbolic gate representations (e.g. stabilizer
     /// tableau) cannot decode a fused matrix back to individual gates. The
     /// simulation engine skips the fusion pass when this returns `false`.
+    ///
+    /// Returning `true` also accepts `MultiFused` and `Multi2q`, whose payload
+    /// gate lists must be applied in the order they are stored. Fusion emits
+    /// each list within one cache tier so the tiled kernels preserve that
+    /// order; a backend that rewrites the payload's qubit indices can push
+    /// gates across a tier boundary and get them silently reordered.
     fn supports_fused_gates(&self) -> bool {
         true
     }

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{SEED, assert_probs_close};
+use common::{SEED, assert_fused_matches_unfused, assert_probs_close};
 use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
@@ -648,6 +648,168 @@ fn dm_two_qubit_depolarizing_bell_analytic() {
     assert!((probs[2] - off_bell).abs() < DM_EPS, "p10: {probs:?}");
     let total: f64 = probs.iter().sum();
     assert!((total - 1.0).abs() < DM_EPS, "trace preserved: {total}");
+}
+
+fn count_gates(circuit: &Circuit, want: fn(&Gate) -> bool) -> usize {
+    circuit
+        .instructions
+        .iter()
+        .filter(
+            |inst| matches!(inst, prism_q::circuit::Instruction::Gate { gate, .. } if want(gate)),
+        )
+        .count()
+}
+
+#[test]
+fn dm_fused_route_matches_unfused_across_fusion_widths() {
+    // 8 is below MIN_QUBITS_FOR_FUSION and fuses nothing, 10 admits one-qubit
+    // fusion, 12 the two-qubit and Multi2q passes. MultiFused needs 14 and the
+    // diagonal batches 16, both past the 4^n ceiling, so neither is reachable
+    // here and neither is covered. The payload assertions are what keep the
+    // widths meaningful: a reorder that dropped 12q to Fused2q-only would still
+    // match probabilities, and Multi2q ordering is the reason this test exists.
+    for (n, want_multi2q, want_fused1q) in [(8usize, 0, 0), (10, 0, 1), (12, 1, 0)] {
+        let circuit = circuits::random_circuit(n, 4, SEED);
+        let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+        assert!(
+            count_gates(&fused, |g| matches!(g, Gate::Multi2q(_))) >= want_multi2q,
+            "expected {want_multi2q} Multi2q at {n}q, got {:?}",
+            count_gates(&fused, |g| matches!(g, Gate::Multi2q(_)))
+        );
+        assert!(
+            count_gates(&fused, |g| matches!(g, Gate::Fused(_))) >= want_fused1q,
+            "expected {want_fused1q} fused 1q run at {n}q"
+        );
+        if n == 8 {
+            assert_eq!(
+                fused.instructions.len(),
+                circuit.instructions.len(),
+                "8q must fuse nothing, it is the control"
+            );
+        }
+        assert_fused_matches_unfused(
+            || DensityMatrixBackend::new(SEED),
+            &circuit,
+            DM_EPS,
+            &format!("density matrix fused vs unfused at {n}q"),
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "distinct targets")]
+fn dm_two_qubit_channel_on_a_repeated_qubit_panics() {
+    // The block traversal needs four distinct bit positions. NoiseModel rejects
+    // this before it reaches a backend, so the panic covers only direct callers
+    // of the public kernel.
+    let mut backend = DensityMatrixBackend::new(SEED);
+    backend.init(4, 0).unwrap();
+    backend.apply_2q_depolarizing(2, 2, 0.02);
+}
+
+#[test]
+#[should_panic(expected = "inside the 4-qubit register")]
+fn dm_two_qubit_channel_outside_the_register_panics() {
+    let mut backend = DensityMatrixBackend::new(SEED);
+    backend.init(4, 0).unwrap();
+    backend.apply_2q_depolarizing(0, 4, 0.02);
+}
+
+#[test]
+fn dm_bare_fused_2q_matches_its_unfused_pair() {
+    // A Fused2q that no Multi2q batch absorbs takes conjugate_gate rather than
+    // the buffer-conjugation fallback. Built directly, since random_circuit's
+    // brick layers batch every 2q run into Multi2q.
+    let mat = Gate::Cx.matrix_4x4();
+    let mut fused = Circuit::new(3, 0);
+    fused.add_gate(Gate::H, &[0]);
+    fused.add_gate(Gate::Ry(0.7), &[1]);
+    fused.add_gate(Gate::Fused2q(Box::new(mat)), &[0, 1]);
+    fused.add_gate(Gate::H, &[2]);
+
+    let mut plain = Circuit::new(3, 0);
+    plain.add_gate(Gate::H, &[0]);
+    plain.add_gate(Gate::Ry(0.7), &[1]);
+    plain.add_gate(Gate::Cx, &[0, 1]);
+    plain.add_gate(Gate::H, &[2]);
+
+    assert_probs_close(&dm_probs(&fused), &dm_probs(&plain), DM_EPS, "bare Fused2q");
+}
+
+// The 16 Pauli Kraus operators the twirled closed form replaces, weighted
+// sqrt(1-p) on I(x)I and sqrt(p/15) elsewhere, indexed 2*bit(q0)+bit(q1).
+fn depolarizing_2q_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let paulis: [[[Complex64; 2]; 2]; 4] = [
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]],
+        [[c(0.0, 0.0), c(1.0, 0.0)], [c(1.0, 0.0), c(0.0, 0.0)]],
+        [[c(0.0, 0.0), c(0.0, -1.0)], [c(0.0, 1.0), c(0.0, 0.0)]],
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-1.0, 0.0)]],
+    ];
+    let mut kraus = vec![[[c(0.0, 0.0); 4]; 4]; 16];
+    for a in 0..4 {
+        for b in 0..4 {
+            let w = if a == 0 && b == 0 {
+                (1.0 - p).sqrt()
+            } else {
+                (p / 15.0).sqrt()
+            };
+            let k = &mut kraus[4 * a + b];
+            for (t, row) in k.iter_mut().enumerate() {
+                for (tp, entry) in row.iter_mut().enumerate() {
+                    *entry = c(w, 0.0) * paulis[a][t >> 1][tp >> 1] * paulis[b][t & 1][tp & 1];
+                }
+            }
+        }
+    }
+    kraus
+}
+
+// Every `n`-qubit Pauli as (xmask, zmask, num_y); the 4^n expectations
+// determine rho uniquely.
+fn all_pauli_masks(n: usize) -> Vec<(usize, usize, u32)> {
+    let d = 1usize << n;
+    let mut masks = Vec::with_capacity(d * d);
+    for xmask in 0..d {
+        for zmask in 0..d {
+            masks.push((xmask, zmask, (xmask & zmask).count_ones()));
+        }
+    }
+    masks
+}
+
+#[test]
+fn dm_two_qubit_depolarizing_matches_kraus_sum() {
+    // The closed form and the 16-operator Kraus sum are separate kernels,
+    // compared here by full tomography. A pair selects the Kraus sweep's block
+    // width, 4 when min(q0,q1) >= 2 and 1 otherwise, and n selects the arm:
+    // 2n < 14 is serial. The pairs are each width on each arm. p = 15/16 is the
+    // edge where alpha goes to zero.
+    for (n, pairs) in [
+        (3usize, &[(0usize, 1usize), (1, 2)][..]),
+        (5, &[(2, 3)][..]),
+        (PAR_N, &[(0, PAR_N - 1), (2, 5)][..]),
+    ] {
+        let circuit = circuits::random_circuit(n, 4, SEED);
+        let masks = all_pauli_masks(n);
+        for &(q0, q1) in pairs {
+            for p in [0.02, 0.3, 15.0 / 16.0, 1.0] {
+                let mut closed = run_dm(&circuit);
+                closed.apply_2q_depolarizing(q0, q1, p);
+                let mut kraus = run_dm(&circuit);
+                kraus.apply_2q_kraus(q0, q1, &depolarizing_2q_kraus(p));
+
+                let got = closed.expectations_pauli(&masks);
+                let want = kraus.expectations_pauli(&masks);
+                for (k, (a, b)) in got.iter().zip(&want).enumerate() {
+                    assert!(
+                        (a - b).abs() < DM_EPS,
+                        "n={n} pair=({q0},{q1}) p={p} pauli {:?}: closed {a}, kraus {b}",
+                        masks[k]
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The density-matrix backend rejected fused gates and lowered two-qubit depolarizing
onto its general Kraus path, so it re-derived work the fusion pipeline had already
done and paid a dense 16x16 superoperator for a channel with a closed form. This
accepts fused gates, takes the twirled form for depolarizing, and widens the general
Kraus sweep. Enabling fusion also required fixing an ordering hazard and a missing
conjugate arm, both of which are silent, and both of which are described below.

## Scope

- [x] Bug fix
- [x] Performance improvement

## Benchmarks

`scripts/bench_ab.sh`, 30 samples, full tier, i7-6700K. Two reference binaries were
needed because three rows are new and one changes an existing row's name, so no
single row name carries a before and an after: the reference is built from this same
tree with the change under test backed out, which isolates it from the refactor.

Fusion acceptance and the conjugate arm, against a tree without them:

| Benchmark | Before | After | Change | Control (same code) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | --- |
| `density_matrix/noisy_channels/fused_2q_gate/10` | 4.45 ms | 2.10 ms | -52.9% | 3.1% | faster |
| `density_matrix/noisy_channels/fused_2q_gate/12` | 93.56 ms | 45.82 ms | -51.0% | 0.4% | faster |
| `density_matrix/fused_layers/8` | 5.39 ms | 5.32 ms | -1.4% | 1.0% | noise |
| `density_matrix/fused_layers/10` | 90.46 ms | 89.64 ms | -0.9% | 1.9% | noise |
| `density_matrix/fused_layers/12` | 1.512 s | 1.512 s | -0.0% | 0.1% | noise |

The Kraus block width, same method:

| Benchmark | Before | After | Change | Control (same code) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | --- |
| `density_matrix/noisy_channels/kraus_2q_adjacent/10` | 2.38 ms | 2.25 ms | -5.4% | 1.3% | faster |
| `density_matrix/noisy_channels/kraus_2q_adjacent/12` | 36.63 ms | 34.97 ms | -4.5% | 0.2% | faster |
| `density_matrix/noisy_channels/kraus_2q_mid/10` | 2.34 ms | 2.34 ms | +0.2% | 0.5% | noise |
| `density_matrix/noisy_channels/kraus_2q_mid/12` | 36.62 ms | 37.33 ms | +1.9% | 0.4% | noise |
| `density_matrix/noisy_channels/kraus_2q_q0_qtop/10` | 2.37 ms | 2.37 ms | +0.1% | 0.1% | noise |
| `density_matrix/noisy_channels/kraus_2q_q0_qtop/12` | 37.23 ms | 37.26 ms | +0.1% | 0.3% | noise |

The closed-form depolarizing, against `main`:

| Benchmark | Before | After | Change | Control (same code) | Within 5%? |
| --- | ---: | ---: | ---: | ---: | --- |
| `density_matrix/noisy_channels/depolarizing_2q/10` | 2.54 ms | 1.30 ms | -49.0% | 13.4% | faster |
| `density_matrix/noisy_channels/depolarizing_2q/12` | 40.58 ms | 24.58 ms | -39.4% | 14.0% | faster |
| `density_matrix/noisy_channels/kraus_amp_damp/12` | 23.60 ms | 23.67 ms | +0.3% | 7.4% | noise |
| `density_matrix/noisy_channels/kraus_depolarizing/12` | 23.71 ms | 23.64 ms | -0.3% | 4.2% | noise |

Controls the diff cannot reach: `fused_layers/8` sits below `MIN_QUBITS_FOR_FUSION`
and fuses nothing; `kraus_2q_q0_qtop` has `min(q0, q1) = 0` and takes the unchanged
fallback; `kraus_amp_damp` and `kraus_depolarizing` are one-qubit kernels. All read
null.

The depolarizing table is the one run whose controls exceed the gate, at 4.2% to
14.0%. The effect is three to four times that spread and the one-qubit siblings over
the same buffer do not move, so the direction is not in doubt, but read those two
rows as "large" rather than as 39.4% and 49.0% exactly.

Regression verdict: PASS.

Two rows moved and were not claimed. A two-block Kraus step for `min(q0, q1) == 1`
measured +0.2% and +1.9%, so that arm was removed rather than shipped; `kraus_2q_mid`
stays to hold the null. And `density_matrix/exact_vs_trajectory` is added by this PR
but exercises none of it: `uniform_depolarizing` emits one-qubit channels only, and
the exact noisy route iterates instructions without calling `fuse_circuit`. It is
routing and scaling context for a separate question, not coverage of this change.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2416)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry
- [x] New fusion path has golden tests against the statevector backend

Two silent defects turned up while enabling fusion, neither reachable before it.

`apply_multi_2q` partitions its gate list by cache tier and runs one tier at a time,
so application order survives only while the whole list sits in one tier.
`fuse_multi_2q_gates` guarantees that against the circuit's own qubit indices, and
the `+n` shift onto the ket register moves gates across the bounds. At 12 qubits a
17-gate batch that is uniformly L2 on the circuit splits across all three tiers and
reorders pairs that share a qubit, returning wrong probabilities with no error. The
tiled payloads now apply their constituents directly. Pinned by
`dm_fused_route_matches_unfused_across_fusion_widths`, which asserts the `Multi2q`
is present at 12 qubits rather than only comparing probabilities: a reorder that
split the run would otherwise still pass.

A bare `Fused2q`, which fusion emits for any two-qubit run shorter than
`MIN_MULTI_2Q_BATCH`, had no `conjugate_gate` arm and fell back to conjugating the
whole buffer around the gate. A `Cx` that absorbs one one-qubit gate went from three
buffer passes to four, so accepting fused gates was a regression on isolated
two-qubit gates. No circuit row could see it, because the brick layers in
`random_circuit` batch every run into `Multi2q`; `fused_2q_gate` applies the gate
directly and is the row that measures it.

Separately, `apply_2q_kraus` and `apply_2q_depolarizing` are public and a caller
passing `q0 == q1` broke the block traversal's bijection and silently read the wrong
entries. `NoiseModel` has always rejected that, so only direct callers were exposed.
Both now panic, documented under `# Panics`, which also covers an out-of-range qubit
that would previously have hit a shift overflow.

## Hotspot notes

`apply_2q_depolarizing` is now memory-bound: at 12 qubits it runs 1.04x the one-qubit
Kraus sweep over the same buffer, against 1.72x before, and both sit at 21.8 to
25.8 GB/s, which is this host's achievable DRAM bandwidth. It touches each amplitude
once, so its traffic is at minimum and further work there is dead.

`apply_2q_kraus` is not. A general two-qubit channel costs 16 complex
multiply-accumulates per amplitude that no algebra removes, and the kernel issues
them at 22.5% of this host's 256 Gflop/s AVX2-FMA peak, rising to 23.6%. That is
near the ceiling for the interleaved layout `Complex64` gives, since AVX2 has no
complex FMA. The block width buys address arithmetic and instruction-level
parallelism, not wider arithmetic: the crate carries no `target-cpu`, so it builds at
the x86-64 baseline, and every wide kernel in the tree takes its width from
`#[target_feature]` dispatch rather than from autovectorization.

Three follow-ups are recorded, none taken here: batching the bra half of `Multi2q`
through the tiled kernel, which is sound because the bra register keeps the circuit's
own indices and stays in one tier; a diagonal-superoperator fast path, since an
all-diagonal Kraus set makes the compiled 16x16 exactly 16 of 256 entries nonzero;
and a `#[target_feature]` kernel over the 16-wide inner axis, which is available for
every qubit pair rather than only those the block width can serve.

## Architecture or design changes

- [x] No structural change. The backend's position in dispatch is unchanged and it
      remains explicit-dispatch only.

`Backend::supports_fused_gates` now documents that returning `true` accepts
`MultiFused` and `Multi2q`, whose payload gate lists must be applied in the stored
order, and that rewriting their qubit indices can push gates across a tier boundary.
That contract was implicit and is what the ordering defect above violated.

## Breaking changes

None for callers going through `NoiseModel` or the `Simulate` builder. A direct
caller of `DensityMatrixBackend::apply_2q_kraus` or `apply_2q_depolarizing` passing a
repeated or out-of-range qubit now panics where it previously returned a wrong state.

## Risks and rollback

Confined to one backend that `Auto` never selects, so nothing routes here without an
explicit `BackendKind::DensityMatrix`. The fusion behaviour is a single flag on
`supports_fused_gates`; returning `false` restores the previous path without
reverting the commit, and the closed-form and block-width changes are independent of
it.

## Pre-merge checklist

- [x] Commit message follows the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
- [ ] CI is green

One deviation worth stating: this is three areas in one commit against a rule that
allows at most two. They share a file and a measurement session, and splitting them
means reconstructing intermediate states of files all three touch. The commit message
names each area rather than treating the scope as tight.
