### PR TITLE
perf(density-matrix): diagonal fast path for 2q Kraus channels

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2465,16 +2465,11 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
             b.iter(|| backend.apply_2q_depolarizing(0, n - 1, 0.02));
         });
 
-        // The general two-qubit channel. Both compile to one 16x16
-        // superoperator and then sweep the same `4^n` buffer; at these widths
-        // the compile is under 0.01% of the row either way, so this reads the
-        // sweep and not the operator count.
-        //
-        // The pair is not incidental. The sweep runs four blocks per step when
-        // `min(q0, q1) >= 2` and one otherwise, so `(2, 3)` reads the batched
-        // path and `(0, n-1)` the fallback. `(1, 2)` is the boundary: it once
-        // took a two-block step, which measured +0.2% and +1.9% against one and
-        // so was dropped, and the row stays to hold that null.
+        // The general two-qubit channel: every set compiles to one 16x16
+        // superoperator, and at these widths the compile is under 0.01% of the
+        // row, so each row reads its sweep and not the operator count. The zz
+        // pair compiles to a diagonal superoperator and takes the contiguous
+        // one-multiply pass; the three pairs pin its position independence.
         let zz = correlated_zz_kraus(0.02);
         group.bench_with_input(BenchmarkId::new("kraus_2q_q0_qtop", n), &n, |b, &n| {
             let mut backend = dm_backend(n);
@@ -2489,10 +2484,12 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
             b.iter(|| backend.apply_2q_kraus(1, 2, &zz));
         });
 
-        // The same channel with off-diagonal structure: the zz pair is
-        // diagonal, so no row above pins the sweep on a set that fills the
-        // superoperator. The sweep's cost is data-independent, so these
-        // compare directly against the zz rows at the same pairs.
+        // The same channel with off-diagonal structure, which fills the
+        // superoperator and holds the dense sweep: `(2, 3)` reads its
+        // four-block step and `(0, n-1)` the one-block fallback, where a
+        // two-block step once measured +0.2% and +1.9% against one and was
+        // dropped. The sweep's cost is data-independent, so these compare
+        // directly against the zz rows at the same pairs.
         let hzz = h_conjugated_zz_kraus(0.02);
         group.bench_with_input(BenchmarkId::new("kraus_2q_dense", n), &n, |b, &_n| {
             let mut backend = dm_backend(n);

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2414,6 +2414,21 @@ fn correlated_zz_channel(p: f64) -> prism_q::NoiseChannel {
     }
 }
 
+/// The correlated `ZZ` pair conjugated by `H` on `q0`: `{sqrt(1-p) I, sqrt(p) X(x)Z}`.
+/// Unitary conjugation of the whole set preserves CPTP, and the `X` factor fills the
+/// compiled 16x16 superoperator, where the `ZZ` pair compiles to its diagonal.
+fn h_conjugated_zz_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = Complex64::new(0.0, 0.0);
+    let mut k0 = [[zero; 4]; 4];
+    let mut k1 = [[zero; 4]; 4];
+    for t in 0..4 {
+        k0[t][t] = Complex64::new((1.0 - p).sqrt(), 0.0);
+        let sign = if t & 1 == 0 { 1.0 } else { -1.0 };
+        k1[t][t ^ 2] = Complex64::new(p.sqrt() * sign, 0.0);
+    }
+    vec![k0, k1]
+}
+
 fn dm_backend(n: usize) -> DensityMatrixBackend {
     let circuit = circuits::random_circuit(n, 2, SEED);
     let mut backend = DensityMatrixBackend::new(42);
@@ -2472,6 +2487,20 @@ fn bench_density_matrix_noisy_channels(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("kraus_2q_mid", n), &n, |b, &_n| {
             let mut backend = dm_backend(n);
             b.iter(|| backend.apply_2q_kraus(1, 2, &zz));
+        });
+
+        // The same channel with off-diagonal structure: the zz pair is
+        // diagonal, so no row above pins the sweep on a set that fills the
+        // superoperator. The sweep's cost is data-independent, so these
+        // compare directly against the zz rows at the same pairs.
+        let hzz = h_conjugated_zz_kraus(0.02);
+        group.bench_with_input(BenchmarkId::new("kraus_2q_dense", n), &n, |b, &_n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_kraus(2, 3, &hzz));
+        });
+        group.bench_with_input(BenchmarkId::new("kraus_2q_dense_q0", n), &n, |b, &n| {
+            let mut backend = dm_backend(n);
+            b.iter(|| backend.apply_2q_kraus(0, n - 1, &hzz));
         });
 
         // A `Fused2q` that no `Multi2q` batch absorbs, which is what fusion

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,7 @@
 - [QEC Program Execution](./architecture/qec-programs.md)
 - [Threading, SIMD, and Memory Layout](./architecture/threading-simd.md)
 - [Error Model and Public API](./architecture/api-surface.md)
+- [Performance Decision Log](./architecture/performance-decisions.md)
 
 # Reference
 

--- a/docs/architecture/performance-decisions.md
+++ b/docs/architecture/performance-decisions.md
@@ -1,0 +1,40 @@
+# Performance Decision Log
+
+Dated record of decisions that changed how a performance-sensitive kernel or pipeline
+is built. Each entry states the context, the options with their measured or estimated
+cost, the decision, the measurement behind it, and the condition under which to
+revisit. Newest entries first.
+
+## 2026-08-22 Rank compute-bound work by whether the arithmetic is removable
+
+- **Context**: two density-matrix channel kernels carried the same diagnosis,
+  compute-bound at about 1.7x the one-sweep memory floor their one-qubit siblings set
+  over the same `4^n` buffer. The diagnosis was correct both times and predicted the
+  payoff only once.
+- **Options considered**: remove the arithmetic algebraically, or reorganize how it
+  issues. The two-qubit depolarizing kernel had removable arithmetic: the Pauli twirl
+  collapses its 16x16 block superoperator to `alpha B + beta Tr(B) I4`, 256 complex
+  multiply-accumulates per block down to 16 scales. The general two-qubit Kraus sweep
+  did not: 16 multiply-accumulates per amplitude with no algebraic identity to delete
+  them, leaving a wider sweep for instruction-level parallelism as the only lever.
+- **Decision**: rank compute-bound optimization candidates by whether the arithmetic
+  is removable (a closed form, operator structure such as diagonality) before
+  considering vectorization. A removable-flops candidate is bounded by the gap to the
+  memory floor. A reorganization candidate is bounded by the gap to the issue ceiling,
+  which for interleaved `Complex64` arithmetic under AVX2 sits near 23% of FMA peak:
+  AVX2 has no complex FMA, so each complex multiply pays a shuffle pair plus
+  `vfmaddsub`, and lane width buys only address generation and load efficiency.
+- **Measurement**: the closed-form depolarizing rewrite landed -49.0% at 10 qubits
+  and -39.4% at 12 (`density_matrix/noisy_channels/depolarizing_2q/{10,12}`), moving
+  the kernel from 1.72x to 1.04x its memory floor. Widening the general Kraus sweep
+  landed -5.4% and -4.5% (`density_matrix/noisy_channels/kraus_2q_adjacent/{10,12}`);
+  that kernel ran at 57.6 to 60.4 Gflop/s against a 256 Gflop/s AVX2 FMA peak. A
+  first deliberate application of the rule, detecting diagonal superoperators in the
+  same Kraus sweep, landed -53.0% to -55.6% at 10 qubits and -36.6% to -40.2% at 12
+  on the `density_matrix/noisy_channels/kraus_2q` rows, again onto the floor. The
+  statevector already encodes the same rule: all-diagonal `MultiFused` batches
+  dispatch to a path costing one complex multiply per element instead of the dense
+  kernel (see [Backends](./backends.md)).
+- **Revisit trigger**: a state layout with split real and imaginary arrays, or
+  hardware with a complex FMA instruction, changes the issue ceiling that bounds
+  reorganization candidates.

--- a/docs/architecture/performance-decisions.md
+++ b/docs/architecture/performance-decisions.md
@@ -38,3 +38,34 @@ revisit. Newest entries first.
 - **Revisit trigger**: a state layout with split real and imaginary arrays, or
   hardware with a complex FMA instruction, changes the issue ceiling that bounds
   reorganization candidates.
+
+### 2026-08-22 Split real and imaginary state arrays stay out of the crate
+
+- **Context**: the 2026-08-22 entry names a split re/im layout as the revisit trigger
+  on the interleaved-complex issue ceiling. A four-item optimization campaign left the
+  dense two-qubit Kraus sweep as the one clearly compute-bound kernel in the corpus
+  (22 to 24% of FMA peak on the `density_matrix/noisy_channels/kraus_2q_dense` rows);
+  the campaign's other kernels are bit-plane, hash, traversal, or bandwidth bound and
+  gain nothing from an arithmetic-issue change.
+- **Options considered**: migrate the crate's state representation to split re/im
+  arrays; convert per tile inside compute-bound kernels only; keep the interleaved
+  layout.
+- **Decision**: keep the interleaved layout. The measured issue-rate gain is real and
+  large, but the corpus rows that could use it are bandwidth bound at their benched
+  sizes, so a whole-crate migration (every backend kernel, the SIMD helpers, GPU
+  transfer paths, and the Python boundary) buys the gap to the memory floor on one
+  kernel family and noise elsewhere.
+- **Measurement**: a single-thread probe applied the same dense 16x16 block
+  superoperator to one million contiguous 16-amplitude blocks in both layouts on the
+  i7-6700K reference host. Interleaved `Complex64`: 9.6 Gflop/s, 15% of the 64
+  Gflop/s single-core FMA peak. Split re/im with direct AVX2 FMA: 52.9 Gflop/s, a
+  5.5x issue-rate change with results agreeing to 7e-16. The split figure sits at the
+  single-core DRAM bandwidth limit for the 256 MB working set, so at benched sizes
+  the layout moves the kernel from issue bound to bandwidth bound and the row-level
+  gain is the remaining gap to the memory floor, roughly 35 to 40% on the dense
+  Kraus rows, not 5.5x. The full ratio is reachable only for cache-resident states.
+- **Revisit trigger**: a workload class dominated by compute-bound kernels on
+  cache-resident states (density matrices at 10 qubits and below under high shot
+  counts, or repeated small-register sweeps), or a measured per-tile conversion
+  variant whose gain survives the conversion cost, or hardware with a complex FMA
+  instruction.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -15,6 +15,13 @@ reference under [Fusion Pipeline](../architecture/fusion.md) and
 3. **SIMD** vectorizes the inner complex-arithmetic loop with AVX2+FMA, FMA, and BMI2,
    with a scalar fallback on non-x86_64.
 
+The levers are ordered, and lever 3 comes with a prior question: can the arithmetic be
+removed rather than issued faster? A kernel whose operations an algebraic identity or an
+operator structure deletes is bounded by its memory floor; vectorizing what remains is
+bounded by the complex-arithmetic issue ceiling, near 23% of FMA peak in the interleaved
+layout. The measured case for that ordering is in the
+[Performance Decision Log](../architecture/performance-decisions.md).
+
 ## Threading
 
 Rayon parallel kernels engage at **≥14 qubits** (below that, thread-pool overhead

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -57,7 +57,7 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
 use crate::backend::simd;
-use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
+use crate::backend::statevector::{StatevectorBackend, insert_zero_bit, kernels};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
@@ -343,9 +343,10 @@ impl DensityMatrixBackend {
     /// order only while the whole list sits in one tier. Fusion guarantees that
     /// against the circuit's own qubit indices, and the `+n` shift onto the ket
     /// register moves gates across the tier bounds, so the ket half applies its
-    /// constituents one at a time. The bra half keeps the circuit's indices and
-    /// so is not at risk; it is applied that way only for symmetry, and batching
-    /// it is the open win recorded against this backend. `MultiFused` entries
+    /// constituents one at a time. The bra half keeps the circuit's indices, so
+    /// it batches through the tiled pass whenever
+    /// [`kernels::multi_2q_single_tier`] holds, and falls back to
+    /// per-constituent application otherwise. `MultiFused` entries
     /// are one per qubit and commute, so its list is order independent; it takes
     /// the same treatment because the one-qubit sandwich is cheaper than the
     /// tiled pass here.
@@ -367,8 +368,17 @@ impl DensityMatrixBackend {
                 for &(q0, q1, ref mat) in data.gates.iter() {
                     self.sv.apply_fused_2q(q0 + n, q1 + n, mat);
                 }
-                for &(q0, q1, ref mat) in data.gates.iter() {
-                    self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                if kernels::multi_2q_single_tier(&data.gates) {
+                    let conjugated: Vec<(usize, usize, [[Complex64; 4]; 4])> = data
+                        .gates
+                        .iter()
+                        .map(|&(q0, q1, ref mat)| (q0, q1, conjugate_4x4(mat)))
+                        .collect();
+                    self.sv.apply_multi_2q(&conjugated);
+                } else {
+                    for &(q0, q1, ref mat) in data.gates.iter() {
+                        self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                    }
                 }
                 return Ok(());
             }

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -150,6 +150,18 @@ fn block_base(m: usize, positions: &[usize; 4]) -> usize {
     base
 }
 
+/// Index into the 16-entry superoperator diagonal for the amplitude at buffer
+/// index `idx`: `4 * tr + tc` with `tr` read from the ket bits and `tc` from
+/// the bra bits of `(q0, q1)`, matching the flat order in
+/// [`DensityMatrixBackend::block_layout`].
+#[inline(always)]
+fn diag_slot(idx: usize, q0: usize, q1: usize, n: usize) -> usize {
+    ((idx >> (q0 + n)) & 1) << 3
+        | ((idx >> (q1 + n)) & 1) << 2
+        | ((idx >> q0) & 1) << 1
+        | ((idx >> q1) & 1)
+}
+
 fn conjugate_2x2(m: &[[Complex64; 2]; 2]) -> [[Complex64; 2]; 2] {
     [
         [m[0][0].conj(), m[0][1].conj()],
@@ -661,7 +673,9 @@ impl DensityMatrixBackend {
     /// The Kraus set is compiled once into a 16x16 block superoperator over the
     /// four-bit `(q0-row, q1-row, q0-col, q1-col)` block, so the buffer is swept
     /// once. Block index `4*tr + tc` orders the two-qubit row value `tr` against
-    /// the column value `tc`.
+    /// the column value `tc`. An all-diagonal set compiles to a diagonal
+    /// superoperator and is applied as one complex multiply per amplitude in a
+    /// contiguous pass instead of the dense sweep.
     ///
     /// # Panics
     ///
@@ -688,9 +702,50 @@ impl DensityMatrixBackend {
 
         let (positions, flats, num_groups) = self.block_layout(q0, q1);
 
+        // Off-diagonal entries of an all-diagonal set only ever accumulate
+        // `kr * conj(0.0)`, so exact zero is the test.
+        let zero = Complex64::new(0.0, 0.0);
+        let diagonal = s
+            .iter()
+            .enumerate()
+            .all(|(r, row)| row.iter().enumerate().all(|(c, &e)| r == c || e == zero));
+        if diagonal {
+            let diag = std::array::from_fn(|i| s[i][i]);
+            self.kraus_2q_diagonal_sweep(&diag, q0, q1);
+            return;
+        }
+
         match positions[0] {
             0 | 1 => self.kraus_2q_sweep::<1>(&s, &positions, &flats, num_groups),
             _ => self.kraus_2q_sweep::<4>(&s, &positions, &flats, num_groups),
+        }
+    }
+
+    /// Apply a diagonal block superoperator in one contiguous pass: the
+    /// amplitude at `idx` is scaled by `diag[diag_slot(idx, q0, q1, n)]`, one
+    /// complex multiply against the dense sweep's 16 multiply-accumulates.
+    fn kraus_2q_diagonal_sweep(&mut self, diag: &[Complex64; 16], q0: usize, q1: usize) {
+        let n = self.num_qubits;
+
+        #[cfg(feature = "parallel")]
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::MIN_PAR_ELEMS;
+            use rayon::prelude::*;
+
+            let diag = *diag;
+            self.sv
+                .state
+                .par_iter_mut()
+                .enumerate()
+                .with_min_len(MIN_PAR_ELEMS)
+                .for_each(move |(idx, amp)| {
+                    *amp *= diag[diag_slot(idx, q0, q1, n)];
+                });
+            return;
+        }
+
+        for (idx, amp) in self.sv.state.iter_mut().enumerate() {
+            *amp *= diag[diag_slot(idx, q0, q1, n)];
         }
     }
 

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -40,6 +40,17 @@ const MULTI_GATE_L2_TILE: usize = 16_384;
 const MULTI_GATE_L3_TILE: usize = 131_072;
 const MULTI_GATE_MAX_L2_TARGET: usize = max_target_for_tile(MULTI_GATE_L2_TILE);
 const MULTI_GATE_MAX_L3_TARGET: usize = max_target_for_tile(MULTI_GATE_L3_TILE);
+
+/// True when every gate's high target sits in the L2 tile, so the tiled pass
+/// runs the whole list as one tier and preserves application order. Callers
+/// that need order beyond one tier (the density-matrix bra half) batch only
+/// under this predicate and apply per constituent otherwise.
+pub(crate) fn multi_2q_single_tier(gates: &[(usize, usize, [[Complex64; 4]; 4])]) -> bool {
+    gates
+        .iter()
+        .all(|&(q0, q1, _)| q0.max(q1) <= MULTI_GATE_MAX_L2_TARGET)
+}
+
 /// Targets folded into one shared high-target traversal. `lanes * tile_len` is
 /// fixed at the L2 budget, so each lane's run shrinks as `2^-k` while the
 /// stream count grows; past three the tiles are too short to prefetch.
@@ -3380,7 +3391,7 @@ impl StatevectorBackend {
     /// cache-resident. `PreparedGate2q::apply_full` works on sub-slices because it
     /// uses `1 << (num_qubits - 2)` for iteration, relative to slice length.
     #[inline(always)]
-    pub(super) fn apply_multi_2q(&mut self, gates: &[(usize, usize, [[Complex64; 4]; 4])]) {
+    pub(crate) fn apply_multi_2q(&mut self, gates: &[(usize, usize, [[Complex64; 4]; 4])]) {
         if gates.is_empty() {
             return;
         }

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1843,3 +1843,14 @@ mod gpu_scaffold {
         assert!(gpu_probs[2].abs() < 1e-12);
     }
 }
+
+// The density-matrix bra half batches only under this predicate, so the
+// boundary pins max_target_for_tile(MULTI_GATE_L2_TILE): moving the tile
+// constant moves the boundary and fails here.
+#[test]
+fn multi_2q_single_tier_boundary_pins_the_l2_tile() {
+    let mat = crate::gates::Gate::Cx.matrix_4x4();
+    assert!(kernels::multi_2q_single_tier(&[(12, 13, mat)]));
+    assert!(!kernels::multi_2q_single_tier(&[(12, 14, mat)]));
+    assert!(!kernels::multi_2q_single_tier(&[(0, 1, mat), (0, 14, mat)]));
+}

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1464,3 +1464,66 @@ fn fused_gate_and_channel_matches_sequential_application() {
         }
     }
 }
+
+// The batched bra pass must preserve list order: CX(0,1) and CX(1,2) do not
+// commute, and the rotation prep keeps every pair state generic so a reorder
+// changes the distribution. Eight qubits put the doubled register above the
+// parallel threshold with four cache tiles, so the tiled parallel arm runs a
+// real multi-tile split.
+#[test]
+fn dm_multi_2q_batched_bra_preserves_gate_order() {
+    use prism_q::circuit::Instruction;
+    use prism_q::gates::Multi2qData;
+
+    let n = 8;
+    let cx = Gate::Cx.matrix_4x4();
+    let swap = Gate::Swap.matrix_4x4();
+    let gates = vec![
+        (0usize, 1usize, cx),
+        (1, 2, cx),
+        (0, 1, swap),
+        (2, 3, cx),
+        (1, 2, cx),
+    ];
+
+    let mut prep = Circuit::new(n, 0);
+    for q in 0..n {
+        prep.add_gate(Gate::Rx(0.3 + 0.2 * q as f64), &[q]);
+        prep.add_gate(Gate::Ry(0.1 + 0.15 * q as f64), &[q]);
+    }
+
+    let mut batched = DensityMatrixBackend::new(SEED);
+    batched.init(n, 0).unwrap();
+    for inst in &prep.instructions {
+        batched.apply(inst).unwrap();
+    }
+    batched
+        .apply(&Instruction::Gate {
+            gate: Gate::Multi2q(Box::new(Multi2qData {
+                gates: gates.clone(),
+            })),
+            targets: prism_q::circuit::smallvec![0, 1, 2, 3],
+        })
+        .unwrap();
+
+    let mut single = DensityMatrixBackend::new(SEED);
+    single.init(n, 0).unwrap();
+    for inst in &prep.instructions {
+        single.apply(inst).unwrap();
+    }
+    for &(q0, q1, mat) in &gates {
+        single
+            .apply(&Instruction::Gate {
+                gate: Gate::Fused2q(Box::new(mat)),
+                targets: prism_q::circuit::smallvec![q0, q1],
+            })
+            .unwrap();
+    }
+
+    assert_probs_close(
+        &batched.probabilities().unwrap(),
+        &single.probabilities().unwrap(),
+        DM_EPS,
+        "batched bra Multi2q vs per-constituent",
+    );
+}

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -812,6 +812,125 @@ fn dm_two_qubit_depolarizing_matches_kraus_sum() {
     }
 }
 
+fn diag_2q_kraus(scale: f64, entries: [Complex64; 4]) -> [[Complex64; 4]; 4] {
+    let mut m = [[c(0.0, 0.0); 4]; 4];
+    for (t, row) in m.iter_mut().enumerate() {
+        row[t] = c(scale, 0.0) * entries[t];
+    }
+    m
+}
+
+fn mat4_mul(a: &[[Complex64; 4]; 4], b: &[[Complex64; 4]; 4]) -> [[Complex64; 4]; 4] {
+    let mut out = [[c(0.0, 0.0); 4]; 4];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, entry) in row.iter_mut().enumerate() {
+            for k in 0..4 {
+                *entry += a[i][k] * b[k][j];
+            }
+        }
+    }
+    out
+}
+
+// (H (x) I) K (H (x) I) per operator, H on the high `t` bit (q0). H is real and
+// self-inverse, so the conjugated channel equals the original sandwiched in H.
+fn h_conjugated_on_q0(kraus: &[[[Complex64; 4]; 4]]) -> Vec<[[Complex64; 4]; 4]> {
+    let h = std::f64::consts::FRAC_1_SQRT_2;
+    let mut hi = [[c(0.0, 0.0); 4]; 4];
+    for (t, row) in hi.iter_mut().enumerate() {
+        for (tp, entry) in row.iter_mut().enumerate() {
+            if t & 1 == tp & 1 {
+                let sign = if t & 2 != 0 && tp & 2 != 0 { -h } else { h };
+                *entry = c(sign, 0.0);
+            }
+        }
+    }
+    kraus
+        .iter()
+        .map(|k| mat4_mul(&mat4_mul(&hi, k), &hi))
+        .collect()
+}
+
+fn apply_h(backend: &mut DensityMatrixBackend, q: usize) {
+    backend
+        .apply(&prism_q::circuit::Instruction::Gate {
+            gate: Gate::H,
+            targets: [q].into_iter().collect(),
+        })
+        .unwrap();
+}
+
+#[test]
+fn dm_diagonal_2q_kraus_matches_the_conjugated_dense_route() {
+    // An all-diagonal set takes the one-multiply contiguous pass; conjugating
+    // every operator by H on q0 fills the superoperator and forces the dense
+    // sweep, and sum_k K rho K^dag = H (sum_k K' (H rho H) K'^dag) H relates
+    // the two routes exactly. The distinct-phase set has pairwise-distinct
+    // off-diagonal slot factors, so a swapped or transposed bit in the
+    // diagonal key changes some expectation; the zz pair alone is symmetric
+    // under a q0/q1 key swap. The conjugated sets carry order-p off-diagonals,
+    // pinning that near-diagonal sets stay on the dense sweep.
+    let one = c(1.0, 0.0);
+    let phase = |t: f64| c(t.cos(), t.sin());
+    for (n, pairs) in [
+        (3usize, &[(0usize, 1usize), (1, 2)][..]),
+        (5, &[(2, 3)][..]),
+        (PAR_N, &[(0, PAR_N - 1), (2, 5)][..]),
+    ] {
+        let circuit = circuits::random_circuit(n, 4, SEED);
+        let masks = all_pauli_masks(n);
+        for &(q0, q1) in pairs {
+            for p in [0.02f64, 0.3] {
+                let sets = [
+                    vec![
+                        diag_2q_kraus((1.0 - p).sqrt(), [one, one, one, one]),
+                        diag_2q_kraus(p.sqrt(), [one, -one, -one, one]),
+                    ],
+                    vec![
+                        diag_2q_kraus((1.0 - p).sqrt(), [one, one, one, one]),
+                        diag_2q_kraus(p.sqrt(), [phase(0.0), phase(0.1), phase(0.4), phase(1.0)]),
+                    ],
+                ];
+                for (which, set) in sets.iter().enumerate() {
+                    let mut direct = run_dm(&circuit);
+                    direct.apply_2q_kraus(q0, q1, set);
+
+                    let mut conjugated = run_dm(&circuit);
+                    apply_h(&mut conjugated, q0);
+                    conjugated.apply_2q_kraus(q0, q1, &h_conjugated_on_q0(set));
+                    apply_h(&mut conjugated, q0);
+
+                    let got = direct.expectations_pauli(&masks);
+                    let want = conjugated.expectations_pauli(&masks);
+                    for (k, (a, b)) in got.iter().zip(&want).enumerate() {
+                        assert!(
+                            (a - b).abs() < DM_EPS,
+                            "n={n} pair=({q0},{q1}) p={p} set {which} pauli {:?}: \
+                             diagonal {a}, dense {b}",
+                            masks[k]
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+#[should_panic(expected = "distinct targets")]
+fn dm_diagonal_2q_kraus_on_a_repeated_qubit_panics() {
+    // The diagonal dispatch stays behind block_layout's assert, so a repeated
+    // target panics rather than scaling the wrong entries.
+    let one = c(1.0, 0.0);
+    let set = vec![
+        diag_2q_kraus((1.0f64 - 0.02).sqrt(), [one, one, one, one]),
+        diag_2q_kraus(0.02f64.sqrt(), [one, -one, -one, one]),
+    ];
+    let mut backend = DensityMatrixBackend::new(SEED);
+    backend.init(4, 0).unwrap();
+    backend.apply_2q_kraus(2, 2, &set);
+}
+
 #[test]
 fn dm_measure_basis_state_deterministic() {
     let mut c = Circuit::new(2, 2);


### PR DESCRIPTION
## Summary

An all-diagonal Kraus set (dephasing, correlated ZZ, coherent phase noise) compiles to a
diagonal 16x16 block superoperator, but the sweep applied it dense: 16 complex
multiply-accumulates per amplitude to deliver 16 scales. Detect the diagonal exactly on
the compiled operator and take a contiguous one-multiply pass instead; the diagonal rows
land at the one-sweep memory floor their one-qubit siblings set. The decision rule this
confirms (rank compute-bound candidates by whether the arithmetic is removable before
considering vectorization) starts the performance decision log in the rendered book.

## Scope

- [x] Performance improvement
- [x] Documentation

## Benchmarks

Adjacent-binary A/B, full Criterion tier (30 samples), reference is the first commit of
this branch so the new dense-set rows exist on both sides. One earlier run was discarded
whole: its same-code controls spread up to 38.6% on rows the diff cannot reach. The run
below has a worst same-code control spread of 3.0% across all 31 rows.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `noisy_channels/kraus_2q_q0_qtop/10` | 2.36 ms | 1.05 ms | -55.6% | -1.6% / +0.5% | faster |
| `noisy_channels/kraus_2q_q0_qtop/12` | 37.27 ms | 22.29 ms | -40.2% | +0.7% / -0.6% | faster |
| `noisy_channels/kraus_2q_mid/10` | 2.31 ms | 1.04 ms | -55.0% | -0.6% / -1.5% | faster |
| `noisy_channels/kraus_2q_mid/12` | 36.46 ms | 22.32 ms | -38.8% | -0.3% / -0.7% | faster |
| `noisy_channels/kraus_2q_adjacent/10` | 2.22 ms | 1.04 ms | -53.0% | -0.4% / -1.6% | faster |
| `noisy_channels/kraus_2q_adjacent/12` | 35.10 ms | 22.26 ms | -36.6% | +0.4% / +0.1% | faster |
| `noisy_channels/kraus_2q_dense/10` | 2.22 ms | 2.23 ms | +0.5% | -0.7% / -1.4% | yes (null) |
| `noisy_channels/kraus_2q_dense/12` | 35.17 ms | 35.13 ms | -0.1% | +0.7% / +0.0% | yes (null) |
| `noisy_channels/kraus_2q_dense_q0/10` | 2.36 ms | 2.35 ms | -0.5% | -1.1% / -0.3% | yes (null) |
| `noisy_channels/kraus_2q_dense_q0/12` | 37.20 ms | 37.22 ms | +0.1% | +0.4% / +0.1% | yes (null) |
| `noisy_channels/depolarizing_2q/12` | 24.50 ms | 24.59 ms | +0.4% | +0.2% / +0.7% | yes (control) |
| `noisy_channels/kraus_amp_damp/12` | 22.98 ms | 22.86 ms | -0.6% | +1.1% / +0.0% | yes (control) |
| `fused_layers/8` | 5.29 ms | 5.32 ms | +0.5% | +1.1% / +0.3% | yes (control) |

All rows are `density_matrix/`. The three `kraus_2q` rows all apply a diagonal correlated
ZZ pair and are the gating rows. The two `kraus_2q_dense` rows, added in the first
commit, apply the same pair conjugated by H on one qubit, which fills the superoperator:
they hold the dense sweep on both its block-width arms and read null. `fused_layers/8` is
a row the diff cannot reach. Remaining group rows (`kraus_depolarizing`, `fused_2q_gate`,
measure, reset, purity, wider `fused_layers`) all read as noise within their controls.

Floor check: the diagonal rows land at 1.04 to 1.05 ms (10q) and 22.26 to 22.32 ms
(12q) against the one-qubit sibling `kraus_amp_damp` at 1.06 to 1.07 ms and 22.86 to
22.98 ms, so the kernel now sits at the cost of one buffer sweep.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2418)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with warnings denied
- [x] Docstrings on changed `pub` items add facts the signature does not carry

Tests: `dm_diagonal_2q_kraus_matches_the_conjugated_dense_route` checks the diagonal
path against the dense sweep on the same kernel through an exact H-conjugation identity,
over five qubit pairs covering both block-width arms and the parallel threshold, with a
distinct-phase fixture whose slot factors break every key-packing symmetry the ZZ pair
cannot see. `dm_diagonal_2q_kraus_on_a_repeated_qubit_panics` pins that diagonal
dispatch stays behind the block-layout assert. The existing hand-algebra anchors
(`density_matrix_correlated_zz_dephasing_keeps_the_joint_term` and the Z-on-high-qubit
case in `golden_small_circuits.rs`) route through the new path and pin its values.

## Hotspot notes

`DensityMatrixBackend::apply_2q_kraus` gains an exact-zero scan of the compiled 16x16
(256 entries, once per call) and dispatches diagonal operators to
`kraus_2q_diagonal_sweep`, a contiguous safe pass with no gather and no `unsafe`. The
dense sweep is untouched. Detection is exact by design: sets built through matrix
products carry float dust off the diagonal and correctly stay on the dense path.

## Architecture or design changes

- [x] `docs/architecture/performance-decisions.md` created (linked from `SUMMARY.md`),
      first entry records the removable-vs-reorganizable rule with its measurements;
      `docs/guides/performance.md` orders the levers and links the log.

## Breaking changes

None.

## Risks and rollback

Detection is a pure dispatch branch ahead of the unchanged dense sweep; deleting the
branch restores the prior behavior without touching the kernel. There is no false
positive to guard: a set whose compiled superoperator is exactly diagonal is a diagonal
channel, and the scale pass is its correct application whatever the operators look like.
