### PR TITLE
perf(density-matrix): batch the bra half of a fused two-qubit list

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -57,7 +57,7 @@ use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
 use crate::backend::simd;
-use crate::backend::statevector::{StatevectorBackend, insert_zero_bit};
+use crate::backend::statevector::{StatevectorBackend, insert_zero_bit, kernels};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
@@ -343,9 +343,10 @@ impl DensityMatrixBackend {
     /// order only while the whole list sits in one tier. Fusion guarantees that
     /// against the circuit's own qubit indices, and the `+n` shift onto the ket
     /// register moves gates across the tier bounds, so the ket half applies its
-    /// constituents one at a time. The bra half keeps the circuit's indices and
-    /// so is not at risk; it is applied that way only for symmetry, and batching
-    /// it is the open win recorded against this backend. `MultiFused` entries
+    /// constituents one at a time. The bra half keeps the circuit's indices, so
+    /// it batches through the tiled pass whenever
+    /// [`kernels::multi_2q_single_tier`] holds, and falls back to
+    /// per-constituent application otherwise. `MultiFused` entries
     /// are one per qubit and commute, so its list is order independent; it takes
     /// the same treatment because the one-qubit sandwich is cheaper than the
     /// tiled pass here.
@@ -367,8 +368,17 @@ impl DensityMatrixBackend {
                 for &(q0, q1, ref mat) in data.gates.iter() {
                     self.sv.apply_fused_2q(q0 + n, q1 + n, mat);
                 }
-                for &(q0, q1, ref mat) in data.gates.iter() {
-                    self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                if kernels::multi_2q_single_tier(&data.gates) {
+                    let conjugated: Vec<(usize, usize, [[Complex64; 4]; 4])> = data
+                        .gates
+                        .iter()
+                        .map(|&(q0, q1, ref mat)| (q0, q1, conjugate_4x4(mat)))
+                        .collect();
+                    self.sv.apply_multi_2q(&conjugated);
+                } else {
+                    for &(q0, q1, ref mat) in data.gates.iter() {
+                        self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                    }
                 }
                 return Ok(());
             }

--- a/src/backend/statevector/kernels.rs
+++ b/src/backend/statevector/kernels.rs
@@ -40,6 +40,17 @@ const MULTI_GATE_L2_TILE: usize = 16_384;
 const MULTI_GATE_L3_TILE: usize = 131_072;
 const MULTI_GATE_MAX_L2_TARGET: usize = max_target_for_tile(MULTI_GATE_L2_TILE);
 const MULTI_GATE_MAX_L3_TARGET: usize = max_target_for_tile(MULTI_GATE_L3_TILE);
+
+/// True when every gate's high target sits in the L2 tile, so the tiled pass
+/// runs the whole list as one tier and preserves application order. Callers
+/// that need order beyond one tier (the density-matrix bra half) batch only
+/// under this predicate and apply per constituent otherwise.
+pub(crate) fn multi_2q_single_tier(gates: &[(usize, usize, [[Complex64; 4]; 4])]) -> bool {
+    gates
+        .iter()
+        .all(|&(q0, q1, _)| q0.max(q1) <= MULTI_GATE_MAX_L2_TARGET)
+}
+
 /// Targets folded into one shared high-target traversal. `lanes * tile_len` is
 /// fixed at the L2 budget, so each lane's run shrinks as `2^-k` while the
 /// stream count grows; past three the tiles are too short to prefetch.
@@ -3380,7 +3391,7 @@ impl StatevectorBackend {
     /// cache-resident. `PreparedGate2q::apply_full` works on sub-slices because it
     /// uses `1 << (num_qubits - 2)` for iteration, relative to slice length.
     #[inline(always)]
-    pub(super) fn apply_multi_2q(&mut self, gates: &[(usize, usize, [[Complex64; 4]; 4])]) {
+    pub(crate) fn apply_multi_2q(&mut self, gates: &[(usize, usize, [[Complex64; 4]; 4])]) {
         if gates.is_empty() {
             return;
         }

--- a/src/backend/statevector/tests.rs
+++ b/src/backend/statevector/tests.rs
@@ -1843,3 +1843,14 @@ mod gpu_scaffold {
         assert!(gpu_probs[2].abs() < 1e-12);
     }
 }
+
+// The density-matrix bra half batches only under this predicate, so the
+// boundary pins max_target_for_tile(MULTI_GATE_L2_TILE): moving the tile
+// constant moves the boundary and fails here.
+#[test]
+fn multi_2q_single_tier_boundary_pins_the_l2_tile() {
+    let mat = crate::gates::Gate::Cx.matrix_4x4();
+    assert!(kernels::multi_2q_single_tier(&[(12, 13, mat)]));
+    assert!(!kernels::multi_2q_single_tier(&[(12, 14, mat)]));
+    assert!(!kernels::multi_2q_single_tier(&[(0, 1, mat), (0, 14, mat)]));
+}

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1464,3 +1464,66 @@ fn fused_gate_and_channel_matches_sequential_application() {
         }
     }
 }
+
+// The batched bra pass must preserve list order: CX(0,1) and CX(1,2) do not
+// commute, and the rotation prep keeps every pair state generic so a reorder
+// changes the distribution. Eight qubits put the doubled register above the
+// parallel threshold with four cache tiles, so the tiled parallel arm runs a
+// real multi-tile split.
+#[test]
+fn dm_multi_2q_batched_bra_preserves_gate_order() {
+    use prism_q::circuit::Instruction;
+    use prism_q::gates::Multi2qData;
+
+    let n = 8;
+    let cx = Gate::Cx.matrix_4x4();
+    let swap = Gate::Swap.matrix_4x4();
+    let gates = vec![
+        (0usize, 1usize, cx),
+        (1, 2, cx),
+        (0, 1, swap),
+        (2, 3, cx),
+        (1, 2, cx),
+    ];
+
+    let mut prep = Circuit::new(n, 0);
+    for q in 0..n {
+        prep.add_gate(Gate::Rx(0.3 + 0.2 * q as f64), &[q]);
+        prep.add_gate(Gate::Ry(0.1 + 0.15 * q as f64), &[q]);
+    }
+
+    let mut batched = DensityMatrixBackend::new(SEED);
+    batched.init(n, 0).unwrap();
+    for inst in &prep.instructions {
+        batched.apply(inst).unwrap();
+    }
+    batched
+        .apply(&Instruction::Gate {
+            gate: Gate::Multi2q(Box::new(Multi2qData {
+                gates: gates.clone(),
+            })),
+            targets: prism_q::circuit::smallvec![0, 1, 2, 3],
+        })
+        .unwrap();
+
+    let mut single = DensityMatrixBackend::new(SEED);
+    single.init(n, 0).unwrap();
+    for inst in &prep.instructions {
+        single.apply(inst).unwrap();
+    }
+    for &(q0, q1, mat) in &gates {
+        single
+            .apply(&Instruction::Gate {
+                gate: Gate::Fused2q(Box::new(mat)),
+                targets: prism_q::circuit::smallvec![q0, q1],
+            })
+            .unwrap();
+    }
+
+    assert_probs_close(
+        &batched.probabilities().unwrap(),
+        &single.probabilities().unwrap(),
+        DM_EPS,
+        "batched bra Multi2q vs per-constituent",
+    );
+}


### PR DESCRIPTION
Depends on the diagonal-Kraus branch merging first (this branch stacks on it).

## Summary

The bra half of a fused two-qubit list applied its constituents one at a time, a
full 256 MB buffer pass each at 12 qubits, although it keeps the circuit's own
qubit indices. The tiled statevector kernel preserves application order while every
gate sits in one cache tier, so the bra half now batches under an explicit
single-tier predicate placed beside the kernel and falls back to per-constituent
application past it. For a k-gate list the bra cost drops from k buffer passes to
one tiled sweep. The ket half stays per-constituent: its +n register shift moves
gates across tier bounds, where the kernel reorders.

## Benchmarks

Adjacent-binary A/B, full Criterion tier (30 samples), reference is the parent
commit. The gate circuit (random depth-10 at 12 qubits) fuses to two batches of 17
and 12 gates plus four 1q payloads and one bare CX: 64 traversal-equivalents
before, 37 after, ideal cap 42%.

| Benchmark | Before | After | Change | Controls |
| --- | ---: | ---: | ---: | --- |
| `density_matrix/fused_layers/12` | 1.520 s | 993.90 ms | -34.6% | +0.5% / +0.2% |
| `density_matrix/fused_layers/12` (second run) | 1.523 s | 998.87 ms | -34.4% | -0.2% / -0.2% |
| `density_matrix/fused_layers/8` | 5.44 ms | 5.47 ms | +0.5% | 0.4% / 2.7% |
| `density_matrix/fused_layers/10` | 92.36 ms | 92.21 ms | -0.2% | 2.9% / 2.9% |
| `density_matrix/unitary_layers/12` | 3.651 s | 3.656 s | +0.1% | 0.5% / 0.4% |
| `density_matrix/noisy_channels/kraus_amp_damp/12` | 22.90 ms | 22.94 ms | +0.1% | 0.2% / 0.3% |
| `statevector/random_d10/16` | 2.05 ms | 2.06 ms | +0.4% | 1.7% / 1.7% |

The headline reproduced across two resolutions agreeing within 0.2 points, with
same-code controls within 0.5% in both runs, under the 42% traversal-removal cap.
`/8` and `/10` are the in-group controls and read as noise, the expected null since
both sit below the two-qubit fusion threshold; in the second run their
reference-side controls spread to 37.3% and 8.2%, so that run's readings on them
are unmeasured and the first run's clean nulls stand. `unitary_layers`,
`noisy_channels`, and the statevector rows are unreachable by the diff and read
null; `statevector/random_d10/12` is unmeasured (10.9% reference control), covered
by its clean 16-qubit sibling.

Regression verdict: PASS at 5.0%.

## Correctness

The tiled kernel buckets gates into cache tiers by high target and reorders across
tiers only; under the predicate every gate sits in the L2 tier and list order is
preserved in both the serial and parallel arms (verified in review by reading the
partition code and by a mutation run: reversing the batched list fails the new
order test at 1.6e-3 against a 1e-12 bound). Tests:
`dm_multi_2q_batched_bra_preserves_gate_order` applies a non-commuting five-gate
list on a generic product state at eight qubits (a four-tile parallel split)
against per-constituent application;
`multi_2q_single_tier_boundary_pins_the_l2_tile` pins the predicate boundary at
target 13, so a change to the tile constant fails loudly.

## Hotspot notes

One conjugated-list allocation per fused-list instruction, ahead of a set of full
buffer traversals; the kernel body is untouched and the statevector's own path
through it is unchanged.
