### PR TITLE
perf(stabilizer): run lazy destabilizers on the general Clifford route

### DIFF
--- a/src/backend/stabilizer/kernels/mod.rs
+++ b/src/backend/stabilizer/kernels/mod.rs
@@ -75,65 +75,101 @@ impl StabilizerBackend {
         false
     }
 
+    /// Tableau rows a gate must update: the full tableau when eager, the
+    /// stabilizer half plus scratch when destabilizers are deferred.
+    #[inline(always)]
+    fn gate_rows(&mut self) -> (&mut [u64], &mut [bool]) {
+        let start = self.gate_row_start;
+        let stride = 2 * self.num_words;
+        (&mut self.xz[start * stride..], &mut self.phase[start..])
+    }
+
     #[inline(always)]
     fn apply_h(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::h_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::h_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_s(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::s_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::s_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_sdg(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::sdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sdg_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_x(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::x_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::x_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_y(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::y_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::y_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_z(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::z_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::z_all(xz, phase, nw, par, a);
+    }
+
+    #[inline(always)]
+    fn apply_sx(&mut self, a: usize) {
+        let par = self.par_rows();
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sx_all(xz, phase, nw, par, a);
+    }
+
+    #[inline(always)]
+    fn apply_sxdg(&mut self, a: usize) {
+        let par = self.par_rows();
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sxdg_all(xz, phase, nw, par, a);
     }
 
     #[inline(always)]
     fn apply_cx(&mut self, control: usize, target: usize) {
         let par = self.par_rows();
-        rowops::cx_all(
-            &mut self.xz,
-            &mut self.phase,
-            self.num_words,
-            par,
-            control,
-            target,
-        );
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::cx_all(xz, phase, nw, par, control, target);
     }
 
     #[inline(always)]
     fn apply_cz(&mut self, a: usize, b: usize) {
         let par = self.par_rows();
-        rowops::cz_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::cz_all(xz, phase, nw, par, a, b);
     }
 
     #[inline(always)]
     fn apply_swap(&mut self, a: usize, b: usize) {
         let par = self.par_rows();
-        rowops::swap_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::swap_all(xz, phase, nw, par, a, b);
     }
 
     pub(super) fn sgi_enabled(&self) -> bool {
@@ -408,6 +444,7 @@ impl StabilizerBackend {
     }
 
     fn sgi_measure(&mut self, qubit: usize, classical_bit: usize) {
+        self.ensure_destabilizers();
         let n = self.n;
         let word = qubit / 64;
         let bit_mask = 1u64 << (qubit % 64);
@@ -457,7 +494,6 @@ impl StabilizerBackend {
     /// SGI measurement rebuilds the qubit index that every later SGI gate
     /// iterates.
     fn sgi_reset(&mut self, qubit: usize) {
-        self.ensure_destabilizers();
         let scratch = self.classical_bits.len();
         self.classical_bits.push(false);
         self.sgi_measure(qubit, scratch);
@@ -514,7 +550,7 @@ impl StabilizerBackend {
         self.rebuild_qubit_active();
     }
 
-    fn rebuild_qubit_active(&mut self) {
+    pub(super) fn rebuild_qubit_active(&mut self) {
         let n = self.n;
         let stride = self.stride();
         let nw = self.num_words;
@@ -641,18 +677,6 @@ impl StabilizerBackend {
         let outcome: bool = self.rng.random();
         self.phase[p_row] = outcome;
         self.classical_bits[classical_bit] = outcome;
-    }
-
-    #[inline(always)]
-    fn apply_sx(&mut self, a: usize) {
-        let par = self.par_rows();
-        rowops::sx_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
-    }
-
-    #[inline(always)]
-    fn apply_sxdg(&mut self, a: usize) {
-        let par = self.par_rows();
-        rowops::sxdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
     }
 
     pub(super) fn apply_instructions_sgi(&mut self, instructions: &[Instruction]) -> Result<()> {

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -555,9 +555,8 @@ impl StabilizerBackend {
     /// Defer destabilizer rows: gates update only the n stabilizer rows until
     /// a measurement or reset materializes the destabilizers via Gaussian
     /// elimination. Halves gate cost for long Clifford prefixes with few
-    /// measurements. The per-instruction [`Backend::apply`] path switches back
-    /// to an eager tableau before the first gate; only the bulk apply paths
-    /// preserve laziness.
+    /// measurements. Both the per-instruction [`Backend::apply`] path and the
+    /// bulk apply paths preserve laziness across gates.
     pub fn enable_lazy_destab(&mut self) {
         if self.lazy_destab || self.n == 0 {
             return;
@@ -574,19 +573,28 @@ impl StabilizerBackend {
         if !self.lazy_destab {
             return;
         }
+        let sgi_live = self.sgi_enabled();
         self.materialize_destabilizers();
         self.lazy_destab = false;
         self.gate_row_start = 0;
-        let n = self.n;
-        for q in 0..n {
-            if !self.qubit_active[q].contains(&(q as u32)) {
-                self.qubit_active[q].push(q as u32);
-            }
+        if sgi_live {
+            // Materialization replaced the stabilizer half with its reduced
+            // basis, so the per-row supports the index tracked no longer
+            // describe the rows.
+            self.rebuild_qubit_active();
         }
-        self.total_weight = self.qubit_active.iter().map(|v| v.len()).sum();
-        self.sgi_max_active = self.qubit_active.iter().map(|v| v.len()).max().unwrap_or(0);
+        // When the SGI guard is off, the index is dead and the counters stay
+        // heavy. Rebuilding here would re-arm the guard over an index that the
+        // dense paths do not maintain, and a later bulk entry would then run
+        // SGI against stale supports.
     }
 
+    /// Rebuild rows 0..n as unit destabilizers via Gaussian elimination and
+    /// replace the stabilizer half with the reduced basis they pair with.
+    /// Row operations preserve the stabilizer group and its phases, so the
+    /// state is unchanged; the write-back is what makes destabilizer i
+    /// anticommute with stabilizer i and commute with every other generator,
+    /// which measurement relies on.
     fn materialize_destabilizers(&mut self) {
         let n = self.n;
         if n == 0 {
@@ -605,6 +613,7 @@ impl StabilizerBackend {
 
         let mut stab_copy: Vec<u64> = self.xz[n * stride..2 * n * stride].to_vec();
         let mut stab_phase: Vec<bool> = self.phase[n..2 * n].to_vec();
+        let mut pivot_row: Vec<u64> = vec![0u64; stride];
 
         for col in 0..n {
             let mut pivot = None;
@@ -640,15 +649,14 @@ impl StabilizerBackend {
                     let word = col / 64;
                     let bit = col % 64;
                     let bit_mask = 1u64 << bit;
+                    pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
+                    let sp = stab_phase[col];
 
                     for row in 0..n {
                         if row == col {
                             continue;
                         }
                         if stab_copy[row * stride + nw + word] & bit_mask != 0 {
-                            let src: Vec<u64> =
-                                stab_copy[col * stride..(col + 1) * stride].to_vec();
-                            let sp = stab_phase[col];
                             let dst = &mut stab_copy[row * stride..(row + 1) * stride];
                             let initial =
                                 if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
@@ -656,8 +664,8 @@ impl StabilizerBackend {
                             let sum = rowmul_words(
                                 dx,
                                 &mut dz[..nw],
-                                &src[..nw],
-                                &src[nw..2 * nw],
+                                &pivot_row[..nw],
+                                &pivot_row[nw..2 * nw],
                                 initial,
                             );
                             stab_phase[row] = (sum & 3) >= 2;
@@ -686,26 +694,36 @@ impl StabilizerBackend {
             let word = col / 64;
             let bit = col % 64;
             let bit_mask = 1u64 << bit;
+            pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
+            let sp = stab_phase[col];
 
             for row in 0..n {
                 if row == col {
                     continue;
                 }
                 if stab_copy[row * stride + word] & bit_mask != 0 {
-                    let src: Vec<u64> = stab_copy[col * stride..(col + 1) * stride].to_vec();
-                    let sp = stab_phase[col];
                     let dst = &mut stab_copy[row * stride..(row + 1) * stride];
                     let initial =
                         if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
                     let (dx, dz) = dst.split_at_mut(nw);
-                    let sum =
-                        rowmul_words(dx, &mut dz[..nw], &src[..nw], &src[nw..2 * nw], initial);
+                    let sum = rowmul_words(
+                        dx,
+                        &mut dz[..nw],
+                        &pivot_row[..nw],
+                        &pivot_row[nw..2 * nw],
+                        initial,
+                    );
                     stab_phase[row] = (sum & 3) >= 2;
                 }
             }
 
             self.xz[col * stride + nw + word] |= bit_mask;
             self.phase[col] = false;
+        }
+
+        self.xz[n * stride..2 * n * stride].copy_from_slice(&stab_copy);
+        for (i, p) in stab_phase.into_iter().enumerate() {
+            self.phase[n + i] = p;
         }
     }
 
@@ -1428,18 +1446,6 @@ impl Backend for StabilizerBackend {
                     return self.apply_region(region);
                 }
             }
-        }
-        if self.lazy_destab
-            && matches!(
-                instruction,
-                Instruction::Gate { .. } | Instruction::Conditional { .. }
-            )
-        {
-            // Lazy destabilizer mode is optimized for bulk apply paths.
-            // If callers drive the backend instruction-by-instruction, switch
-            // back to an eager tableau before the first gate to preserve the
-            // standard `apply` semantics.
-            self.ensure_destabilizers();
         }
         match instruction {
             Instruction::Gate { gate, targets } => self.dispatch_gate(gate, targets)?,

--- a/src/backend/stabilizer/tests.rs
+++ b/src/backend/stabilizer/tests.rs
@@ -971,6 +971,152 @@ fn test_pcc_random_pairs_matches_gate_by_gate() {
     );
 }
 
+// The per-instruction path must stay lazy across gates, reconstruct on the
+// first measurement, and produce the exact outcome sequence of an eager run:
+// gates update the stabilizer half identically in both modes, so pivot
+// classification and RNG draws align, and deterministic outcomes are unique.
+#[test]
+fn lazy_destab_apply_path_matches_eager_exactly() {
+    for n in [3usize, 5, 8, 16, 80, 300] {
+        for seed in 0..20u64 {
+            let mut circuit = crate::circuits::clifford_heavy_circuit(n, 10, seed);
+            circuit.measure_all();
+
+            let mut eager = StabilizerBackend::new(seed);
+            eager.init(n, n).unwrap();
+            for inst in &circuit.instructions {
+                eager.apply(inst).unwrap();
+            }
+
+            let mut lazy = StabilizerBackend::new(seed);
+            lazy.init(n, n).unwrap();
+            lazy.enable_lazy_destab();
+            let mut seen_lazy_gates = false;
+            for inst in &circuit.instructions {
+                if matches!(inst, Instruction::Measure { .. }) && !seen_lazy_gates {
+                    assert!(
+                        lazy.lazy_destab,
+                        "n={n} seed={seed}: gates materialized the destabilizers"
+                    );
+                    seen_lazy_gates = true;
+                }
+                lazy.apply(inst).unwrap();
+            }
+            assert!(
+                !lazy.lazy_destab,
+                "n={n} seed={seed}: measurement left the tableau lazy"
+            );
+
+            assert_eq!(
+                eager.classical_results(),
+                lazy.classical_results(),
+                "n={n} seed={seed}: outcome sequence diverged"
+            );
+        }
+    }
+}
+
+// A materialization on the bulk route must not re-arm the SGI guard over an
+// index the dense paths do not maintain. The shape needs every ingredient: a
+// CX fan-out from qubit 0 trips the sgi_max_active high-water mark and hands
+// the stream to the word-batch path, the uncompute leaves the actual supports
+// light so a counter rebuild at the measurement would re-arm the guard, the
+// random Bell measurement migrates the pivot row into a destabilizer slot the
+// stale index does not list, and the guarded regions re-enter instruction
+// dispatch where the guard is re-checked. A stale index there breaks Bell
+// correlation.
+#[test]
+fn lazy_destab_bulk_region_after_measurement_keeps_correlation() {
+    use crate::circuit::{ClassicalCondition, GuardedRegion};
+    let n = 300;
+    for seed in 0..40u64 {
+        let mut c = Circuit::new(n, 2);
+        for q in 1..=40 {
+            c.add_gate(Gate::Cx, &[0, q]);
+        }
+        for q in 1..=40 {
+            c.add_gate(Gate::Cx, &[0, q]);
+        }
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.instructions.push(Instruction::Measure {
+            qubit: 0,
+            classical_bit: 0,
+        });
+        for condition in [
+            ClassicalCondition::BitIsZero(0),
+            ClassicalCondition::BitIsOne(0),
+        ] {
+            c.instructions
+                .push(Instruction::Region(Box::new(GuardedRegion::new(
+                    condition,
+                    vec![Instruction::Measure {
+                        qubit: 1,
+                        classical_bit: 1,
+                    }],
+                ))));
+        }
+
+        let mut lazy = StabilizerBackend::new_lazy(seed);
+        lazy.init(n, 2).unwrap();
+        lazy.apply_instructions(&c.instructions).unwrap();
+        let bits = lazy.classical_results();
+        assert_eq!(
+            bits[0], bits[1],
+            "seed={seed}: Bell correlation broken on the lazy bulk route"
+        );
+    }
+}
+
+// Symplectic pairing after Gaussian-elimination reconstruction: destabilizer i
+// anticommutes with stabilizer i and commutes with every other generator.
+#[test]
+fn lazy_destab_reconstruction_restores_symplectic_pairing() {
+    fn anticommutes(b: &StabilizerBackend, row_a: usize, row_b: usize) -> bool {
+        let nw = b.num_words;
+        let stride = 2 * nw;
+        let (a, bb) = (&b.xz[row_a * stride..], &b.xz[row_b * stride..]);
+        let mut acc = 0u32;
+        for w in 0..nw {
+            acc ^= (a[w] & bb[nw + w]).count_ones() ^ (a[nw + w] & bb[w]).count_ones();
+        }
+        acc % 2 == 1
+    }
+
+    for n in [3usize, 5, 8, 16, 80, 300] {
+        let circuit = crate::circuits::clifford_heavy_circuit(n, 10, 42);
+        let mut b = StabilizerBackend::new(42);
+        b.init(n, 0).unwrap();
+        b.enable_lazy_destab();
+        for inst in &circuit.instructions {
+            b.apply(inst).unwrap();
+        }
+        assert!(
+            b.lazy_destab,
+            "n={n}: gate application must not materialize"
+        );
+        b.ensure_destabilizers();
+
+        for i in 0..n {
+            for j in 0..n {
+                assert_eq!(
+                    anticommutes(&b, i, n + j),
+                    i == j,
+                    "n={n}: destab {i} vs stab {j} pairing broken"
+                );
+                assert!(
+                    !anticommutes(&b, i, j),
+                    "n={n}: destabs {i},{j} must commute"
+                );
+                assert!(
+                    !anticommutes(&b, n + i, n + j),
+                    "n={n}: stabs {i},{j} must commute"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn lazy_destab_matches_eager() {
     for n in [3, 5, 10] {

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -481,19 +481,45 @@ pub(super) fn build_statevector(accel: &Accel, seed: u64) -> StatevectorBackend 
     }
 }
 
-fn build_stabilizer(accel: &Accel, seed: u64) -> StabilizerBackend {
+/// True when no instruction can force destabilizer materialization: gates,
+/// satisfied conditionals, and barriers only. Measurements, resets, and
+/// guarded regions (whose bodies can hold either) all disqualify.
+fn stabilizer_can_run_lazy(circuit: &Circuit) -> bool {
+    circuit.instructions.iter().all(|inst| {
+        matches!(
+            inst,
+            Instruction::Gate { .. }
+                | Instruction::Conditional { .. }
+                | Instruction::Barrier { .. }
+        )
+    })
+}
+
+fn build_stabilizer(accel: &Accel, lazy: bool, seed: u64) -> StabilizerBackend {
+    // Lazy destabilizers: gates touch half the tableau. The plan sets `lazy`
+    // only for circuits that never measure or reset, so the Gaussian
+    // elimination that materialization costs is never paid; on a measuring
+    // circuit the reconstruction can exceed the gate savings (the GHZ
+    // measure-all shape loses outright, since its SGI gate cost is already
+    // near zero). GPU init overrides the flag; the soft-fallback host path
+    // keeps it.
+    let stab = if lazy {
+        StabilizerBackend::new_lazy(seed)
+    } else {
+        StabilizerBackend::new(seed)
+    };
     match accel {
-        Accel::Cpu => StabilizerBackend::new(seed),
+        Accel::Cpu => stab,
         #[cfg(feature = "gpu")]
         Accel::Gpu {
             context,
             soft: true,
-        } => StabilizerBackend::new(seed).with_gpu_auto(context.clone()),
+        } => stab.with_gpu_auto(context.clone()),
         #[cfg(feature = "gpu")]
         Accel::Gpu {
             context,
             soft: false,
-        } => StabilizerBackend::new(seed).with_gpu(context.clone()),
+        } => stab.with_gpu(context.clone()),
     }
 }
 
@@ -513,6 +539,7 @@ pub(super) enum BackendPlan {
     },
     Stabilizer {
         accel: Accel,
+        lazy: bool,
     },
     Statevector {
         accel: Accel,
@@ -551,7 +578,9 @@ impl BackendPlan {
                 Box::new(crate::backend::factored_stabilizer::FactoredStabilizerBackend::new(seed))
             }
             BackendPlan::Mps { max_bond_dim } => Box::new(MpsBackend::new(seed, *max_bond_dim)),
-            BackendPlan::Stabilizer { accel } => Box::new(build_stabilizer(accel, seed)),
+            BackendPlan::Stabilizer { accel, lazy } => {
+                Box::new(build_stabilizer(accel, *lazy, seed))
+            }
             BackendPlan::Statevector { accel } => Box::new(build_statevector(accel, seed)),
             BackendPlan::DensityMatrix => Box::new(DensityMatrixBackend::new(seed)),
             #[cfg(feature = "distributed")]
@@ -563,7 +592,7 @@ impl BackendPlan {
 
     pub(super) fn is_gpu(&self) -> bool {
         match self {
-            BackendPlan::Stabilizer { accel } | BackendPlan::Statevector { accel } => {
+            BackendPlan::Stabilizer { accel, .. } | BackendPlan::Statevector { accel } => {
                 !matches!(accel, Accel::Cpu)
             }
             _ => false,
@@ -602,7 +631,7 @@ impl BackendPlan {
     #[cfg(test)]
     pub(super) fn accel(&self) -> &Accel {
         match self {
-            BackendPlan::Stabilizer { accel } | BackendPlan::Statevector { accel } => accel,
+            BackendPlan::Stabilizer { accel, .. } | BackendPlan::Statevector { accel } => accel,
             _ => &Accel::Cpu,
         }
     }
@@ -677,6 +706,7 @@ pub(super) fn plan_for_family(
         },
         Family::Stabilizer => BackendPlan::Stabilizer {
             accel: accel_for(kind, Family::Stabilizer, num_qubits),
+            lazy: false,
         },
         Family::Statevector => BackendPlan::Statevector {
             accel: accel_for(kind, Family::Statevector, num_qubits),
@@ -735,7 +765,11 @@ pub(super) fn resolve(
             return ExecutionPlan::Backend(BackendPlan::Distributed(context.clone()));
         }
     };
-    ExecutionPlan::Backend(plan_for_family(kind, family, circuit.num_qubits))
+    let mut plan = plan_for_family(kind, family, circuit.num_qubits);
+    if let BackendPlan::Stabilizer { lazy, .. } = &mut plan {
+        *lazy = stabilizer_can_run_lazy(circuit);
+    }
+    ExecutionPlan::Backend(plan)
 }
 
 /// Backend plan for a run that starts from a caller-supplied state.


### PR DESCRIPTION
## Summary

Lazy destabilizer tracking existed but only the temporal-Clifford prefix path enabled
it, and the per-instruction apply path defeated it by materializing before the first
gate. Gate kernels now honor the deferred row window on every path, and dispatch
enables the mode for Clifford circuits that never measure or reset, so gates touch
n+1 of 2n+1 tableau rows and the Gaussian elimination that materialization costs is
never paid on the routed path. Measuring circuits build the same eager backend as
before: on the GHZ measure-all shape the sparse-generator-index path already touches
only a few rows per gate, so the reconstruction would be pure added cost.

## Benchmarks

Adjacent-binary A/B, full Criterion tier (30 samples), reference is the commit before
the change. Gate rows and controls:

| Benchmark | Before | After | Change | Control (ref) | Control (new) |
| --- | ---: | ---: | ---: | ---: | ---: |
| `stabilizer/scaling/50` | 121.12 us | 93.78 us | -22.6% | +0.6% | +0.4% |
| `stabilizer/scaling/100` | 227.14 us | 178.94 us | -21.2% | -1.6% | -2.6% |
| `stabilizer/scaling/500` | 1.70 ms | 1.20 ms | -29.4% | +1.1% | +1.9% |
| `stabilizer/scaling/1000` | 4.10 ms | 2.81 ms | -31.6% | -0.0% | -3.5% |
| `stabilizer/scaling/5000` | 46.97 ms | 38.45 ms | -18.1% | +1.9% | -0.6% |
| `stabilizer/measurement/ghz_measure_all/1000` | 2.40 ms | 2.40 ms | +0.2% | +0.9% | +0.6% |
| `stabilizer/measurement/ghz_measure_all/5000` | 50.30 ms | 50.59 ms | +0.6% | +1.2% | +0.2% |
| `compiled_sampler/noiseless/noiseless_1000q_10k` | 33.98 ms | 33.30 ms | -2.0% | +4.0% | -1.8% |

The `scaling` rows are the gate rows: gate-only Clifford circuits on the general
route. The win peaks at 1000 qubits (1.46x, under the 2x bound the mechanism sets)
and narrows at 5000, where the sparse-generator index serves most gates and the
halvable full-sweep fraction shrinks. The `ghz_measure_all` rows execute the same
eager path as the reference and hold null; their worst member reads +2.7% at 50
qubits, a sub-threshold move within the 5% gate. `compiled_sampler/noiseless` runs
the column-major forward simulation, which this change cannot reach, and holds null.
15 further rows in the run (sub-200 us micro rows and the auto group, worst
same-code control 24.6%, plus `noiseless_500q_10k` at a -6.3% control) could not
resolve the 5% gate on this host and are reported as unmeasured; no claim depends
on them.

Regression verdict: PASS at 5.0%.

## Correctness

Two defects surfaced while wiring the route; both predate the change, both were
unreachable from shipped paths, and both are fixed and pinned here:

- `materialize_destabilizers` built unit destabilizers paired with a row-reduced
  stabilizer basis it then discarded, so deterministic measurement after
  reconstruction multiplied the wrong stabilizer subset. The reduced basis is now
  written back; row operations preserve the group and its phases. Pinned by
  `lazy_destab_apply_path_matches_eager_exactly` (exact outcome-sequence equality,
  3 to 300 qubits, 20 seeds) and
  `lazy_destab_reconstruction_restores_symplectic_pairing`.
- Materialization on the word-batch path rebuilt the sparse-generator-index
  counters, re-arming the guard over an index the dense paths do not maintain; a
  guarded region after a mid-circuit measurement then ran the SGI path against
  stale supports and broke Bell correlation on 19 of 40 seeds at 300 qubits. The
  rebuild now happens only while the guard is live. Pinned by
  `lazy_destab_bulk_region_after_measurement_keeps_correlation`, verified to fail
  against the unconditional-rebuild variant.

A sibling hazard remains on the per-instruction path when an external caller drives
`Backend::apply` gate by gate at 256+ qubits and then enters a bulk path; it
predates this change, no sim-level route hits it, and the root fix is index
invalidation on dense mutation.

## Hotspot notes

Gate kernels slice the tableau from `gate_row_start`; eager mode slices from zero
and compiles to the previous full sweep. No allocation added to gate application.
The Gaussian elimination allocates its pivot-row scratch once per column instead of
once per eliminated row.

## Tests

`cargo nextest run --features parallel` (2203 tests), `cargo test --doc --features
parallel`, `cargo clippy --all-targets --features parallel -- -D warnings -D
clippy::undocumented_unsafe_blocks`, `cargo fmt --check`, and
`cargo check --all-targets --features "parallel gpu distributed"` for the
feature-gated dispatch arms.
