### PR TITLE
perf(mps): contract measurement environments once instead of twice

### DIFF
--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -1806,7 +1806,7 @@ impl MpsBackend {
 
         let measured = usize::from(self.rng.random::<f64>() < prob[1].clamp(0.0, 1.0));
         self.classical_bits[classical_bit] = measured == 1;
-        self.project_site_outcome(qubit, measured);
+        self.project_site_outcome(qubit, measured, prob[measured].clamp(0.0, 1.0));
     }
 
     fn site_outcome_probabilities(&self, site: usize) -> [f64; 2] {
@@ -1875,8 +1875,10 @@ impl MpsBackend {
         prob
     }
 
-    fn project_site_outcome(&mut self, site: usize, outcome: usize) -> f64 {
-        let prob = self.site_outcome_probabilities(site)[outcome].clamp(0.0, 1.0);
+    /// Take the Born probability from the caller so the site environments are
+    /// contracted once per measurement rather than twice, the convention
+    /// [`Self::collapse_site_to_zero`] already uses for reset.
+    fn project_site_outcome(&mut self, site: usize, outcome: usize, prob: f64) -> f64 {
         if prob <= NORM_CLAMP_MIN {
             return 0.0;
         }
@@ -1927,7 +1929,9 @@ impl MpsBackend {
     /// requested branch should be discarded by the caller.
     pub(crate) fn project_z_outcome(&mut self, qubit: usize, outcome: bool) -> f64 {
         let site = self.site_for_logical(qubit);
-        self.project_site_outcome(site, usize::from(outcome))
+        let outcome = usize::from(outcome);
+        let prob = self.site_outcome_probabilities(site)[outcome].clamp(0.0, 1.0);
+        self.project_site_outcome(site, outcome, prob)
     }
 
     fn reduced_density_site(&self, site: usize) -> [[Complex64; 2]; 2] {


### PR DESCRIPTION
## Summary

The measure path computed both chain environments to sample the outcome, then
recomputed both inside the projection to renormalize, although the state had not
changed between the two computations. The projection now takes the Born probability
from the caller, the convention the reset path already uses, so a measurement
contracts each environment once. Outcomes, normalization, and the RNG stream are
unchanged; the value passed is the one the sampling threshold already used.

## Benchmarks

Adjacent-binary A/B, full Criterion tier (30 samples), reference is the commit
before the change. Three runs; the gate row resolved cleanly in two.

| Benchmark | Run 1 | Run 3 | Control worst | Reading |
| --- | ---: | ---: | ---: | --- |
| `mps/hotspots/measure_reset_32q_r3` | -22.4% | -25.8% | 1.7% | faster |
| `mps/hotspots/adjacent_cp_r4/32` | +4.0% | -0.2% | 4.0% / 0.3% | noise |
| `mps/sampling/{24,32,48,64}` | +1.0% to +1.7% | -0.8% to +1.0% | under gate | null |
| `mps/random_d10/*`, `mps/linear_chain_d10/*` | within 2.2% | not re-run | under gate | null |

A second run read -32.0% on the gate row but its reference-side same-code control
moved +26.4%, above the 5% gate, so that run is unmeasured on this row. The new
binary's absolute time was stable across all three runs (352.8, 354.1, 342.2 us)
while the reference spiked only in the disturbed run (521.0 against 454.5 and
460.9 us), placing the disturbance on the reference passes.

The change removes one of the three environment contractions on the row (48
measures drop from two contractions to one, 48 resets stay at one), capping the
row at 33%. The measured 22 to 26% sits under the cap and implies the contraction
share of row runtime is about 67 to 77%. `adjacent_cp_r4/32` read +4.0% in one
run, no larger than its own same-code control spread, and -0.2% in the cleanest
run: noise, and the diff does not touch gate application. The `long_range_cp_r4`
rows are unmeasured on this host: their same-code control spreads reached 35.5%,
consistent with the previously recorded layout spread on this group. No claim
depends on them.

Regression verdict: PASS at 5.0%.

## Correctness

The removed second computation ran on state unmodified since the first, so the
passed value is the same value bit for bit on the serial path; on the parallel
path the rayon sum could differ in the last ulp between the two old calls, and
the single value feeds only a discard threshold and a normalization scale, both
tolerant. All callers updated; the CAMPS projection entry computes the
probability itself and keeps its exact semantics. Existing measurement matrices
and MPS correctness suites pass unchanged (2200 tests).
