### PR TITLE
perf(sparse): monomial fast path for the fused 4x4 kernel

### DIFF
--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -326,7 +326,69 @@ impl SparseBackend {
         }
     }
 
+    /// Exact structural test for a monomial 4x4: one nonzero per source basis
+    /// state and per destination. Structural zeros only, no tolerance, so a
+    /// matrix product carrying float dust off its pattern stays on the general
+    /// path.
+    fn monomial_4x4(mat: &[[Complex64; 4]; 4]) -> Option<([usize; 4], [Complex64; 4])> {
+        let zero = Complex64::new(0.0, 0.0);
+        let mut dest = [usize::MAX; 4];
+        let mut scale = [zero; 4];
+        let mut used = 0u8;
+        for (col, mat_row) in mat.iter().enumerate() {
+            for (row, &coeff) in mat_row.iter().enumerate() {
+                if coeff != zero {
+                    if dest[row] != usize::MAX {
+                        return None;
+                    }
+                    dest[row] = col;
+                    scale[row] = coeff;
+                }
+            }
+        }
+        for &d in &dest {
+            if d == usize::MAX || used & (1 << d) != 0 {
+                return None;
+            }
+            used |= 1 << d;
+        }
+        Some((dest, scale))
+    }
+
+    /// A monomial 4x4 maps each occupied basis state to exactly one
+    /// destination, so no cancellation can arise, the invariant `apply_cx`
+    /// states. A sub-unit scale (a normalized Kraus branch routed through a
+    /// fused payload) can still shrink amplitudes below epsilon, so only that
+    /// case pays the prune pass, as `apply_diagonal_1q` does.
+    fn apply_monomial_2q(&mut self, q0: usize, q1: usize, dest: [usize; 4], scale: [Complex64; 4]) {
+        if dest == [0, 1, 2, 3] {
+            for (idx, amp) in self.state.iter_mut() {
+                let row = ((*idx >> q0) & 1) * 2 + ((*idx >> q1) & 1);
+                *amp *= scale[row];
+            }
+        } else {
+            let mask0 = 1usize << q0;
+            let mask1 = 1usize << q1;
+            self.swap_buf.clear();
+            self.swap_buf.reserve(self.state.len());
+            self.swap_buf.extend(self.state.drain().map(|(idx, amp)| {
+                let row = ((idx >> q0) & 1) * 2 + ((idx >> q1) & 1);
+                let col = dest[row];
+                let new_idx = idx & !(mask0 | mask1) | (((col >> 1) & 1) << q0) | ((col & 1) << q1);
+                (new_idx, amp * scale[row])
+            }));
+            std::mem::swap(&mut self.state, &mut self.swap_buf);
+        }
+        if scale.iter().any(|c| c.norm_sqr() < 1.0 - 1e-12) {
+            self.prune();
+        }
+    }
+
     fn apply_fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) -> Result<()> {
+        if let Some((dest, scale)) = Self::monomial_4x4(mat) {
+            self.apply_monomial_2q(q0, q1, dest, scale);
+            return Ok(());
+        }
         self.check_entry_growth(4)?;
         let mask0 = 1usize << q0;
         let mask1 = 1usize << q1;

--- a/tests/backend_equivalence.rs
+++ b/tests/backend_equivalence.rs
@@ -1333,3 +1333,37 @@ fn native_marginals_match_the_dense_route() {
         }
     }
 }
+
+// Explicit fused payloads pin the kernel below the fusion thresholds and in
+// both target orders: iSWAP is a scaled permutation, the CZ compound is
+// diagonal, the XX+YY quarter turn is dense and must stay on the general path,
+// and the phased 3-cycle is asymmetric so a transposed extraction changes the
+// distribution.
+#[test]
+fn sparse_explicit_fused_2q_shapes_sv() {
+    let o = Complex64::new(0.0, 0.0);
+    let l = Complex64::new(1.0, 0.0);
+    let i = Complex64::new(0.0, 1.0);
+    let iswap = [[l, o, o, o], [o, o, i, o], [o, i, o, o], [o, o, o, l]];
+    let cz_s = [[l, o, o, o], [o, i, o, o], [o, o, l, o], [o, o, o, -i]];
+    let h = std::f64::consts::FRAC_1_SQRT_2;
+    let c = Complex64::new(h, 0.0);
+    let ic = Complex64::new(0.0, h);
+    let xxyy = [[l, o, o, o], [o, c, ic, o], [o, ic, c, o], [o, o, o, l]];
+    let cycle3 = [[o, o, o, -i], [o, -l, o, o], [l, o, o, o], [o, o, i, o]];
+
+    let mut circuit = Circuit::new(4, 0);
+    for q in 0..4 {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    circuit.add_gate(Gate::Fused2q(Box::new(iswap)), &[0, 1]);
+    circuit.add_gate(Gate::Fused2q(Box::new(iswap)), &[3, 2]);
+    circuit.add_gate(Gate::Fused2q(Box::new(cz_s)), &[1, 2]);
+    circuit.add_gate(Gate::Fused2q(Box::new(xxyy)), &[0, 3]);
+    circuit.add_gate(Gate::Fused2q(Box::new(cycle3)), &[1, 3]);
+    for q in 0..4 {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    let mut backend = SparseBackend::new(SEED);
+    common::assert_backend_matches_sv(&mut backend, &circuit, EPS, "explicit fused 2q shapes");
+}

--- a/tests/sparse_correctness.rs
+++ b/tests/sparse_correctness.rs
@@ -1,5 +1,5 @@
 //! Cross-backend correctness for `SparseBackend` against the statevector
-//! reference and the unfused apply loop, across eight circuit families at
+//! reference and the unfused apply loop, across nine circuit families at
 //! sizes up to 12q.
 
 mod common;
@@ -125,4 +125,40 @@ fn sparse_cz_chain_12q_fused() {
         "cz_chain 12q d5 fused",
         &circuits::cz_chain_circuit(12, 5, SEED),
     );
+}
+
+// ===== monomial fused 4x4 =====
+
+// Interference layers after the fused block make the final probabilities
+// sensitive to every monomial phase, not just the permutation.
+fn monomial_rich_circuit(n: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(prism_q::gates::Gate::H, &[q]);
+    }
+    c.add_barrier(&(0..n).collect::<Vec<_>>());
+    for pair in 0..(n / 2) {
+        let a = 2 * pair;
+        let b = a + 1;
+        c.add_gate(prism_q::gates::Gate::S, &[a]);
+        c.add_gate(prism_q::gates::Gate::Cx, &[a, b]);
+        c.add_gate(prism_q::gates::Gate::Z, &[b]);
+        c.add_gate(prism_q::gates::Gate::X, &[a]);
+        c.add_gate(prism_q::gates::Gate::Cx, &[b, a]);
+    }
+    c.add_barrier(&(0..n).collect::<Vec<_>>());
+    for q in 0..n {
+        c.add_gate(prism_q::gates::Gate::H, &[q]);
+    }
+    c
+}
+
+#[test]
+fn sparse_monomial_2q_12q_sv() {
+    check_sv_cross("monomial 2q 12q sv", &monomial_rich_circuit(12));
+}
+
+#[test]
+fn sparse_monomial_2q_12q_fused() {
+    check_fused_vs_unfused("monomial 2q 12q fused", &monomial_rich_circuit(12));
 }


### PR DESCRIPTION
## Summary

A monomial fused 4x4 maps each occupied basis state to exactly one destination, so
the general path's hash accumulation, growth check, and unconditional prune pass are
removable, and a diagonal one needs no map rebuild at all. Detection is exact on
structural zeros, so matrix products carrying float dust stay on the general path.
A probe on the random depth-10 fixtures found roughly seven of ten fused 4x4s
reaching the kernel are monomial (an earlier measurement on the same fixtures found
62%).

## Benchmarks

Three adjacent-binary A/B runs, full Criterion tier (30 samples), reference is the
commit before the change; run 2 used an independent reference build at a fresh path.

| Benchmark | Run 1 | Run 2 | Run 3 | Reading |
| --- | ---: | ---: | ---: | --- |
| `compare/clifford_d10/sparse/12` | -5.7% | unmeasured | -8.4% | win, resolved twice |
| `compare/clifford_d10/sparse/16` | -0.2% | -5.4% | unmeasured | unresolved, conflicting reads |
| `compare/clifford_d10/sparse/20` | -3.9% (noise) | -9.1% | -7.7% (unmeasured) | one resolved read, same-signed elsewhere |
| `sparse/random_d10/12` | -3.2% | -2.4% | unmeasured | sub-threshold move, resolved twice |
| `sparse/random_d10/16` | -3.4% | -0.5% (noise) | -1.8% | sub-threshold move |
| `sparse/random_d10/20` | +1.2% (noise) | -3.2% | -0.7% (noise) | measured null |

The claimable result is `compare/clifford_d10/sparse/12` at -5.7% to -8.4%,
resolved beyond both of its same-code controls in two of three runs with no
contradicting read. The `random_d10/{12,16}` rows move -0.5% to -3.4%, consistent
in sign but below the 5% gate: sub-threshold moves, not wins. `compare/sparse/16`
and `/20` are unresolved on this host (conflicting or single-run reads).
`random_d10/20` is a measured null.

Regression verdict: PASS. Two of three runs flagged one row each: run 1
`compare/clifford_d10/sparse/4` at +5.8%, run 2 `compare/clifford_d10/statevector/12`
at +5.5%. Neither row can execute the changed code: fused 4x4 payloads are minted
only at 12 qubits and above, and the statevector backend does not touch the sparse
kernel. Neither move reproduced in the other runs (`sparse/4` read -0.9% and -1.1%,
including against the independent reference build; `statevector/12` read +0.0% with
tight controls in run 1). Both fit the recorded 13-16% build-to-build layout spread
on sparse micro rows that within-run controls cannot see. Run 3 was partially
disturbed (worst same-code control 40.8%); its four voided rows are unmeasured and
its clean-control rows are used as corroboration only.

## Correctness

Detection is structural: one nonzero per source state and per destination, exact
zero compares, no tolerance. The permutation arm is a 1:1 index remap, so the entry
count cannot grow and no cancellation can arise; a sub-unit scale (a normalized
Kraus branch routed through a fused payload) still pays the prune pass, the same
guard the diagonal 1q path carries. Tests:
`sparse_monomial_2q_12q_{sv,fused}` run a barrier-fenced circuit whose six fused
4x4s are all monomial (verified by probe) against the statevector and the unfused
loop, with interference layers making the probabilities phase-sensitive.
`sparse_explicit_fused_2q_shapes_sv` pins the kernel below the fusion thresholds
in both target orders: a scaled permutation (iSWAP), a diagonal compound, an
asymmetric phased 3-cycle (a transposed extraction changes the distribution), and
a dense payload that must stay on the general path.

## Hotspot notes

The detection scan is 16 entries with early exit, once per gate call, ahead of a
map-proportional sweep. No allocation added; `dest` and `scale` are stack arrays.
