### PR TITLE
perf(density-matrix): AVX2 kernel for the dense 2q Kraus sweep

### DIFF
--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -685,7 +685,9 @@ impl DensityMatrixBackend {
     /// once. Block index `4*tr + tc` orders the two-qubit row value `tr` against
     /// the column value `tc`. An all-diagonal set compiles to a diagonal
     /// superoperator and is applied as one complex multiply per amplitude in a
-    /// contiguous pass instead of the dense sweep.
+    /// contiguous pass instead of the dense sweep. On hosts with detected AVX2
+    /// and FMA the dense sweep issues each row inner product two complex terms
+    /// per FMA through `simd::PreparedKraus2q`.
     ///
     /// # Panics
     ///
@@ -725,9 +727,64 @@ impl DensityMatrixBackend {
             return;
         }
 
+        #[cfg(target_arch = "x86_64")]
+        if simd::has_avx2_fma() && simd::kraus_2q_wide_enabled() {
+            // SAFETY: AVX2 and FMA checked above; AVX2 implies the AVX the
+            // constructor requires.
+            let prepared = unsafe { simd::PreparedKraus2q::new(&s) };
+            self.kraus_2q_sweep_wide(&prepared, &positions, &flats, num_groups);
+            return;
+        }
+
         match positions[0] {
             0 | 1 => self.kraus_2q_sweep::<1>(&s, &positions, &flats, num_groups),
             _ => self.kraus_2q_sweep::<4>(&s, &positions, &flats, num_groups),
+        }
+    }
+
+    /// [`DensityMatrixBackend::kraus_2q_sweep`] with the row inner products
+    /// issued through [`simd::PreparedKraus2q`], one block per iteration
+    /// whatever the qubit pair: the vector axis is the superoperator's 16-wide
+    /// `j` axis, which does not depend on `min(q0, q1)` the way the block-run
+    /// width does.
+    #[cfg(target_arch = "x86_64")]
+    fn kraus_2q_sweep_wide(
+        &mut self,
+        prepared: &simd::PreparedKraus2q,
+        positions: &[usize; 4],
+        flats: &[usize; 16],
+        num_groups: usize,
+    ) {
+        #[cfg(feature = "parallel")]
+        if 2 * self.num_qubits >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::MIN_PAR_ITERS;
+            use crate::backend::statevector::SendPtr;
+            use rayon::prelude::*;
+
+            let ptr = SendPtr(self.sv.state.as_mut_ptr());
+            let positions = *positions;
+            let flats = *flats;
+            (0..num_groups)
+                .into_par_iter()
+                .with_min_len(MIN_PAR_ITERS)
+                .for_each(move |m| {
+                    let base = block_base(m, &positions);
+                    // SAFETY: AVX2 and FMA detected. Inserting a zero bit at
+                    // each of the four block positions is a bijection from
+                    // `m` onto the block bases, so every `base | flats[j]`
+                    // stays under `4^n` and the 16 offsets one iteration
+                    // touches are disjoint from every other iteration's.
+                    unsafe { prepared.apply_block_ptr(ptr.as_f64_ptr(), base, &flats) };
+                });
+            return;
+        }
+
+        let ptr = self.sv.state.as_mut_ptr() as *mut f64;
+        for m in 0..num_groups {
+            let base = block_base(m, positions);
+            // SAFETY: AVX2 and FMA detected. The block bases are disjoint and
+            // in bounds as in the parallel arm, on one thread.
+            unsafe { prepared.apply_block_ptr(ptr, base, flats) };
         }
     }
 
@@ -776,7 +833,10 @@ impl DensityMatrixBackend {
     /// Only `W = 1` and `W = 4` are instantiated. `W = 1` is forced when
     /// `min(q0, q1) == 0`, where one block bit is bit 0 and no run exists, and
     /// it also serves `min(q0, q1) == 1`: a two-block step measured +0.2% and
-    /// +1.9% against one, so it earned no arm of its own.
+    /// +1.9% against one, so it earned no arm of its own. Hosts with detected
+    /// AVX2 and FMA route past this sweep to
+    /// [`DensityMatrixBackend::kraus_2q_sweep_wide`] unless
+    /// `PRISM_NO_AVX2_KRAUS` is set.
     fn kraus_2q_sweep<const W: usize>(
         &mut self,
         s: &[[Complex64; 16]; 16],

--- a/src/backend/simd.rs
+++ b/src/backend/simd.rs
@@ -542,6 +542,19 @@ fn avx2_2q_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var_os("PRISM_NO_AVX2_2Q").is_none())
 }
 
+/// Kill switch for the AVX2 dense two-qubit Kraus kernel.
+///
+/// Reads `PRISM_NO_AVX2_KRAUS` once and caches the result. Set the variable
+/// to route the dense sweep through the blocked scalar path instead, for
+/// single-binary A/B timing and for exercising that path on AVX2 hosts.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub(crate) fn kraus_2q_wide_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PRISM_NO_AVX2_KRAUS").is_none())
+}
+
 /// Precomputed single-qubit gate ready for repeated application.
 ///
 /// Create once per gate via [`PreparedGate1q::new`], then call [`apply`]
@@ -2287,6 +2300,79 @@ impl PreparedGate2q {
     }
 }
 
+/// Precomputed 16x16 block superoperator for the dense two-qubit Kraus sweep,
+/// in 256-bit broadcast form.
+///
+/// Row `r` is stored as eight register pairs covering its 16 coefficients, two
+/// consecutive `j` slots per register: `rr[r][k]` holds
+/// `[re(s[r][2k]); 2, re(s[r][2k + 1]); 2]` and `ii[r][k]` the imaginary
+/// parts. [`PreparedKraus2q::apply_block_ptr`] advances each row inner product
+/// two complex terms per FMA over the always-16-wide `j` axis, so the width
+/// does not depend on the qubit pair the way the block-run sweep's does.
+#[cfg(target_arch = "x86_64")]
+pub(crate) struct PreparedKraus2q {
+    rr: [[__m256d; 8]; 16],
+    ii: [[__m256d; 8]; 16],
+}
+
+#[cfg(target_arch = "x86_64")]
+impl PreparedKraus2q {
+    /// # Safety
+    ///
+    /// Requires AVX, implied by a detected AVX2 feature.
+    #[inline]
+    pub(crate) unsafe fn new(s: &[[Complex64; 16]; 16]) -> Self {
+        // SAFETY: same contract as the enclosing unsafe fn.
+        unsafe {
+            let mut rr = [[_mm256_setzero_pd(); 8]; 16];
+            let mut ii = [[_mm256_setzero_pd(); 8]; 16];
+            for (r, row) in s.iter().enumerate() {
+                for k in 0..8 {
+                    let (a, b) = (row[2 * k], row[2 * k + 1]);
+                    rr[r][k] = _mm256_setr_pd(a.re, a.re, b.re, b.re);
+                    ii[r][k] = _mm256_setr_pd(a.im, a.im, b.im, b.im);
+                }
+            }
+            Self { rr, ii }
+        }
+    }
+
+    /// Apply the superoperator to the 16-amplitude block at `base | flats[j]`,
+    /// reading all 16 slots before the first store.
+    ///
+    /// # Safety
+    ///
+    /// AVX2 and FMA must be detected, every `base | flats[j]` must be in
+    /// bounds for `state` viewed as interleaved `Complex64`, and no other
+    /// thread may access those 16 slots.
+    #[inline]
+    #[target_feature(enable = "avx2,fma")]
+    pub(crate) unsafe fn apply_block_ptr(&self, state: *mut f64, base: usize, flats: &[usize; 16]) {
+        // SAFETY: same contract as the enclosing unsafe fn.
+        unsafe {
+            let mut v = [_mm256_setzero_pd(); 8];
+            for (k, pair) in v.iter_mut().enumerate() {
+                let lo = _mm_loadu_pd(state.add((base | flats[2 * k]) * 2));
+                let hi = _mm_loadu_pd(state.add((base | flats[2 * k + 1]) * 2));
+                *pair = _mm256_insertf128_pd(_mm256_castpd128_pd256(lo), hi, 1);
+            }
+            for (r, &out) in flats.iter().enumerate() {
+                let rr = &self.rr[r];
+                let ii = &self.ii[r];
+                let mut accx = _mm256_mul_pd(rr[0], v[0]);
+                let mut accy = _mm256_mul_pd(ii[0], v[0]);
+                for k in 1..8 {
+                    accx = _mm256_fmadd_pd(rr[k], v[k], accx);
+                    accy = _mm256_fmadd_pd(ii[k], v[k], accy);
+                }
+                let acc = _mm256_addsub_pd(accx, _mm256_shuffle_pd(accy, accy, 0b0101));
+                let sum = _mm_add_pd(_mm256_castpd256_pd128(acc), _mm256_extractf128_pd(acc, 1));
+                _mm_storeu_pd(state.add((base | out) * 2), sum);
+            }
+        }
+    }
+}
+
 #[cfg(target_arch = "x86_64")]
 // SAFETY: Mat4x4Broadcast contains only SIMD register values (pure data, no pointers).
 unsafe impl Send for Mat4x4Broadcast {}
@@ -2303,6 +2389,12 @@ unsafe impl Sync for Mat4x4Broadcast {}
 unsafe impl Send for PreparedGate2q {}
 // SAFETY: PreparedGate2q contains immutable SIMD broadcast data and no raw pointers.
 unsafe impl Sync for PreparedGate2q {}
+#[cfg(target_arch = "x86_64")]
+// SAFETY: PreparedKraus2q contains immutable SIMD broadcast data and no raw pointers.
+unsafe impl Send for PreparedKraus2q {}
+#[cfg(target_arch = "x86_64")]
+// SAFETY: PreparedKraus2q contains immutable SIMD broadcast data and no raw pointers.
+unsafe impl Sync for PreparedKraus2q {}
 
 #[cfg(test)]
 #[path = "simd_tests.rs"]

--- a/src/backend/simd_tests.rs
+++ b/src/backend/simd_tests.rs
@@ -446,6 +446,54 @@ fn test_prepared_2q_apply_tiled_matches_apply_full() {
     }
 }
 
+// PreparedKraus2q must agree with scalar evaluation of the same 16x16
+// superoperator on scattered block slots, at a contiguous and a strided slot
+// layout. Runs only where AVX2 and FMA are detected; the dispatcher never
+// selects it elsewhere.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn test_prepared_kraus_2q_matches_scalar_reference() {
+    if !has_avx2_fma() {
+        return;
+    }
+    use rand::RngExt;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let mut s = [[c(0.0, 0.0); 16]; 16];
+    for row in s.iter_mut() {
+        for e in row.iter_mut() {
+            *e = c(rng.random_range(-1.0..1.0), rng.random_range(-1.0..1.0));
+        }
+    }
+
+    let flats_variants: [[usize; 16]; 2] =
+        [std::array::from_fn(|j| j), std::array::from_fn(|j| 3 * j)];
+    for flats in &flats_variants {
+        let len = flats[15] + 1;
+        let mut buf: Vec<Complex64> = (0..len)
+            .map(|_| c(rng.random_range(-1.0..1.0), rng.random_range(-1.0..1.0)))
+            .collect();
+        let mut reference = buf.clone();
+
+        let v: [Complex64; 16] = std::array::from_fn(|j| reference[flats[j]]);
+        for (r, row) in s.iter().enumerate() {
+            let mut acc = c(0.0, 0.0);
+            for (coeff, val) in row.iter().zip(v.iter()) {
+                acc += coeff * val;
+            }
+            reference[flats[r]] = acc;
+        }
+
+        // SAFETY: AVX2 and FMA checked above.
+        let prepared = unsafe { PreparedKraus2q::new(&s) };
+        // SAFETY: AVX2 and FMA checked above; every slot index is in bounds
+        // and no other thread touches the buffer.
+        unsafe { prepared.apply_block_ptr(buf.as_mut_ptr() as *mut f64, 0, flats) };
+        assert_state_close(&buf, &reference, &format!("stride {}", flats[1]));
+    }
+}
+
 // Drive every SIMD tier the host supports against the scalar reference. The
 // dispatcher runs only the best tier, so SSE2/FMA never execute on an AVX2 host
 // without forcing them here.
@@ -586,7 +634,7 @@ fn target_feature_kernel_count_is_pinned() {
     let root = env!("CARGO_MANIFEST_DIR");
     // Per-file expected counts; the breakdown makes a drift easy to localise.
     let expected: [(&str, usize); 4] = [
-        ("src/backend/simd.rs", 29),
+        ("src/backend/simd.rs", 30),
         ("src/backend/word_ops.rs", 2),
         ("src/backend/stabilizer/kernels/simd.rs", 3),
         ("src/backend/statevector/kernels.rs", 11),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@ pub mod conformance;
 pub mod framework;
 pub mod matrix;
 
+use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::statevector::StatevectorBackend;
 use prism_q::circuit::{Circuit, Instruction};
@@ -21,8 +22,54 @@ pub const MPS_EPS: f64 = 1e-9;
 pub const TN_EPS: f64 = 1e-10;
 pub const PRODUCT_EPS: f64 = 1e-12;
 pub const FACTORED_EPS: f64 = 1e-10;
+pub const DM_EPS: f64 = 1e-12;
 
 pub const SEED: u64 = 42;
+
+/// The 16 two-qubit Pauli Kraus operators of symmetric depolarizing with
+/// parameter `p`, weighted `sqrt(1-p)` on `I(x)I` and `sqrt(p/15)` elsewhere,
+/// indexed `2*bit(q0) + bit(q1)`. The closed-form
+/// `DensityMatrixBackend::apply_2q_depolarizing` replaces this set, so the
+/// two are independent implementations of the same channel.
+pub fn depolarizing_2q_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let c = Complex64::new;
+    let paulis: [[[Complex64; 2]; 2]; 4] = [
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]],
+        [[c(0.0, 0.0), c(1.0, 0.0)], [c(1.0, 0.0), c(0.0, 0.0)]],
+        [[c(0.0, 0.0), c(0.0, -1.0)], [c(0.0, 1.0), c(0.0, 0.0)]],
+        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-1.0, 0.0)]],
+    ];
+    let mut kraus = vec![[[c(0.0, 0.0); 4]; 4]; 16];
+    for a in 0..4 {
+        for b in 0..4 {
+            let w = if a == 0 && b == 0 {
+                (1.0 - p).sqrt()
+            } else {
+                (p / 15.0).sqrt()
+            };
+            let k = &mut kraus[4 * a + b];
+            for (t, row) in k.iter_mut().enumerate() {
+                for (tp, entry) in row.iter_mut().enumerate() {
+                    *entry = c(w, 0.0) * paulis[a][t >> 1][tp >> 1] * paulis[b][t & 1][tp & 1];
+                }
+            }
+        }
+    }
+    kraus
+}
+
+/// Every `n`-qubit Pauli as `(xmask, zmask, num_y)`; the `4^n` expectations
+/// determine `rho` uniquely.
+pub fn all_pauli_masks(n: usize) -> Vec<(usize, usize, u32)> {
+    let d = 1usize << n;
+    let mut masks = Vec::with_capacity(d * d);
+    for xmask in 0..d {
+        for zmask in 0..d {
+            masks.push((xmask, zmask, (xmask & zmask).count_ones()));
+        }
+    }
+    masks
+}
 
 /// Statevector probabilities used as the reference for the backend matrices.
 ///

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -4,7 +4,10 @@
 
 mod common;
 
-use common::{SEED, assert_fused_matches_unfused, assert_probs_close};
+use common::{
+    DM_EPS, SEED, all_pauli_masks, assert_fused_matches_unfused, assert_probs_close,
+    depolarizing_2q_kraus,
+};
 use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
@@ -60,8 +63,6 @@ fn phase_damping(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
         [[c(0.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(g, 0.0)]],
     ]
 }
-
-const DM_EPS: f64 = 1e-12;
 
 fn statevector_probs(circuit: &Circuit) -> Vec<f64> {
     let mut backend = StatevectorBackend::new(SEED);
@@ -734,47 +735,6 @@ fn dm_bare_fused_2q_matches_its_unfused_pair() {
     plain.add_gate(Gate::H, &[2]);
 
     assert_probs_close(&dm_probs(&fused), &dm_probs(&plain), DM_EPS, "bare Fused2q");
-}
-
-// The 16 Pauli Kraus operators the twirled closed form replaces, weighted
-// sqrt(1-p) on I(x)I and sqrt(p/15) elsewhere, indexed 2*bit(q0)+bit(q1).
-fn depolarizing_2q_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
-    let paulis: [[[Complex64; 2]; 2]; 4] = [
-        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(1.0, 0.0)]],
-        [[c(0.0, 0.0), c(1.0, 0.0)], [c(1.0, 0.0), c(0.0, 0.0)]],
-        [[c(0.0, 0.0), c(0.0, -1.0)], [c(0.0, 1.0), c(0.0, 0.0)]],
-        [[c(1.0, 0.0), c(0.0, 0.0)], [c(0.0, 0.0), c(-1.0, 0.0)]],
-    ];
-    let mut kraus = vec![[[c(0.0, 0.0); 4]; 4]; 16];
-    for a in 0..4 {
-        for b in 0..4 {
-            let w = if a == 0 && b == 0 {
-                (1.0 - p).sqrt()
-            } else {
-                (p / 15.0).sqrt()
-            };
-            let k = &mut kraus[4 * a + b];
-            for (t, row) in k.iter_mut().enumerate() {
-                for (tp, entry) in row.iter_mut().enumerate() {
-                    *entry = c(w, 0.0) * paulis[a][t >> 1][tp >> 1] * paulis[b][t & 1][tp & 1];
-                }
-            }
-        }
-    }
-    kraus
-}
-
-// Every `n`-qubit Pauli as (xmask, zmask, num_y); the 4^n expectations
-// determine rho uniquely.
-fn all_pauli_masks(n: usize) -> Vec<(usize, usize, u32)> {
-    let d = 1usize << n;
-    let mut masks = Vec::with_capacity(d * d);
-    for xmask in 0..d {
-        for zmask in 0..d {
-            masks.push((xmask, zmask, (xmask & zmask).count_ones()));
-        }
-    }
-    masks
 }
 
 #[test]

--- a/tests/density_matrix_kraus_scalar_fallback.rs
+++ b/tests/density_matrix_kraus_scalar_fallback.rs
@@ -1,0 +1,41 @@
+//! With `PRISM_NO_AVX2_KRAUS` set, the dense two-qubit Kraus sweep takes the
+//! blocked scalar path on hosts whose detected AVX2 would otherwise route it
+//! to the wide kernel. Own file: the switch is read once per process.
+
+mod common;
+
+use common::{DM_EPS, SEED, all_pauli_masks, depolarizing_2q_kraus};
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::{circuits, sim};
+
+#[test]
+fn dense_scalar_sweep_matches_closed_form_depolarizing() {
+    // SAFETY: no other thread touches the environment at this point.
+    unsafe { std::env::set_var("PRISM_NO_AVX2_KRAUS", "1") };
+    let p = 0.3;
+    let kraus = depolarizing_2q_kraus(p);
+    // (3,0,1) and (5,2,3) run the serial arm at W = 1 and W = 4; the 7-qubit
+    // pairs run the rayon arm (2n >= 14) at both widths.
+    for (n, q0, q1) in [(3usize, 0usize, 1usize), (5, 2, 3), (7, 0, 6), (7, 2, 5)] {
+        let circuit = circuits::random_circuit(n, 4, SEED);
+        let masks = all_pauli_masks(n);
+
+        let mut closed = DensityMatrixBackend::new(SEED);
+        sim::run_on(&mut closed, &circuit).unwrap();
+        closed.apply_2q_depolarizing(q0, q1, p);
+
+        let mut swept = DensityMatrixBackend::new(SEED);
+        sim::run_on(&mut swept, &circuit).unwrap();
+        swept.apply_2q_kraus(q0, q1, &kraus);
+
+        let want = closed.expectations_pauli(&masks);
+        let got = swept.expectations_pauli(&masks);
+        for (k, (a, b)) in got.iter().zip(&want).enumerate() {
+            assert!(
+                (a - b).abs() < DM_EPS,
+                "n={n} pair=({q0},{q1}) pauli {:?}: sweep {a}, closed {b}",
+                masks[k]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The dense two-qubit Kraus sweep was issue-bound: the crate builds at the x86-64 baseline, so the 16x16 block superoperator ran its 256 complex multiply-accumulates per block through packed SSE2, near 23% of the host's FMA peak. A runtime-dispatched AVX2+FMA kernel (`PreparedKraus2q`) vectorizes the 16-wide inner-product axis instead of the block axis, two complex terms per FMA, which works for every qubit pair including `min(q0, q1) = 0`. An earlier measurement bracketed the realistic cap at the memory-floor gap, roughly 35 to 40% at the row level; the change collects it and the sweep is now memory-bound at benched widths.

The blocked scalar sweep remains the path for hosts without AVX2 and FMA. `PRISM_NO_AVX2_KRAUS` routes back to it in one binary, for timing attribution and for exercising the fallback on AVX2 hosts.

## Benchmark summary

Adjacent-binary A/B against main, 30 samples, quiet host, two runs agreeing within 1.2 points on every moving row. i7-6700K, Windows 10, rustc 1.97.0, `--features parallel`. Values are run 1 / run 2.

| Benchmark | Before (ms) | After (ms) | Change |
|-----------|-------------|------------|--------|
| `density_matrix/noisy_channels/kraus_2q_dense/10` | 2.28 / 2.24 | 1.31 / 1.23 | -42.5% / -45.1% |
| `density_matrix/noisy_channels/kraus_2q_dense/12` | 35.24 / 35.34 | 21.98 / 21.96 | -37.6% / -37.9% |
| `density_matrix/noisy_channels/kraus_2q_dense_q0/10` | 2.39 / 2.37 | 1.28 / 1.27 | -46.3% / -46.2% |
| `density_matrix/noisy_channels/kraus_2q_dense_q0/12` | 37.51 / 37.39 | 24.95 / 24.91 | -33.5% / -33.4% |

The 12q dense row lands at 22.0 ms against the 22.3 to 22.4 ms diagonal-superoperator rows, the one-sweep floor on this host. The 14 in-group control rows (1q Kraus, diagonal 2q Kraus at three pairs, closed-form depolarizing, bare fused 2q) read noise in both runs; worst same-code control spread 2.6% and 3.7%.

Two scope notes. At 10q and 12q only the rayon arm is measured, since the parallel threshold sits at `2n >= 14`; the serial arm is correctness-tested only. Per-call superoperator compile plus broadcast-table prep sits inside the timed loop and is under 0.01% of a row.

## Regression verdict

PASS. No row regressed beyond its control spread in either run.

## Tests

- Per-tier equivalence test for the new kernel against scalar evaluation of the same superoperator, at a contiguous and a strided slot layout, plus the `#[target_feature]` kernel-count pin.
- New `tests/density_matrix_kraus_scalar_fallback.rs` pins the scalar sweep against the closed-form depolarizing channel at both block widths and both arms, under the kill switch, so the fallback stays exercised on AVX2 hosts.
- The existing dense-route tomography test exercises the wide kernel on AVX2 hosts, including a `min(q0, q1) = 0` pair on the rayon arm.

## Documentation

Docstrings on the new items; `apply_2q_kraus` and `kraus_2q_sweep` docs carry the dispatch facts. No architecture-page change: the backend's structure is unchanged.
