### PR TITLE
fix(factored-stabilizer): reduce clusters before split detection

### DIFF
--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -629,12 +629,19 @@ impl FactoredStabilizerBackend {
     }
 
     fn try_split(&mut self, sub_idx: usize) -> bool {
-        let sub = self.subs[sub_idx].as_ref().unwrap();
+        let sub = self.subs[sub_idx].as_mut().unwrap();
         let k = sub.n;
         if k <= 1 {
             return false;
         }
 
+        // Stored generators can hide a product structure ({Z0, Z0Z1} spans
+        // both qubits yet generates {Z0, Z1}), so reduce first: afterward
+        // stabilizer row k+q holds the pivot at qubit q and the unit
+        // destabilizer at row q is its partner.
+        rowops::materialize_destabilizers(&mut sub.xz, &mut sub.phase, k, sub.num_words);
+
+        let sub = self.subs[sub_idx].as_ref().unwrap();
         let mut parent: Vec<usize> = (0..k).collect();
         let mut uf_rank = vec![0u8; k];
         let stride = sub.stride();
@@ -657,27 +664,16 @@ impl FactoredStabilizerBackend {
         }
 
         let mut num_components = 0usize;
-        let mut component_root = [usize::MAX; 64];
+        let mut comp_of_root = vec![usize::MAX; k];
         let mut qubit_component = vec![0usize; k];
         #[allow(clippy::needless_range_loop)]
         for q in 0..k {
             let r = uf_find(&mut parent, q);
-            let mut found = false;
-            for c in 0..num_components {
-                if component_root[c] == r {
-                    qubit_component[q] = c;
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                if num_components >= 64 {
-                    return false;
-                }
-                component_root[num_components] = r;
-                qubit_component[q] = num_components;
+            if comp_of_root[r] == usize::MAX {
+                comp_of_root[r] = num_components;
                 num_components += 1;
             }
+            qubit_component[q] = comp_of_root[r];
         }
 
         if num_components <= 1 {
@@ -705,94 +701,12 @@ impl FactoredStabilizerBackend {
                 cqubits.push(sub.qubits[lq]);
             }
 
-            let mut destab_idx = 0usize;
-            let mut stab_idx = 0usize;
-
-            for r in 0..k {
-                let base = r * sub.stride();
-                let mut has_support = false;
-                for &lq in local_qs {
-                    let w = lq / 64;
-                    let bit = 1u64 << (lq % 64);
-                    if (sub.xz[base + w] & bit) != 0
-                        || (sub.xz[base + sub.num_words + w] & bit) != 0
-                    {
-                        has_support = true;
-                        break;
-                    }
-                }
-                if !has_support {
-                    continue;
-                }
-                if destab_idx >= cn {
-                    continue;
-                }
-                let dst_row = destab_idx;
-                for (new_local, &old_local) in local_qs.iter().enumerate() {
-                    let ow = old_local / 64;
-                    let ob = old_local % 64;
-                    let nww = new_local / 64;
-                    let nb = new_local % 64;
-                    if sub.xz[base + ow] & (1u64 << ob) != 0 {
-                        cxz[dst_row * cstride + nww] |= 1u64 << nb;
-                    }
-                    if sub.xz[base + sub.num_words + ow] & (1u64 << ob) != 0 {
-                        cxz[dst_row * cstride + cnw + nww] |= 1u64 << nb;
-                    }
-                }
-                cphase[dst_row] = sub.phase[r];
-                destab_idx += 1;
-            }
-
-            for r in k..2 * k {
-                let base = r * sub.stride();
-                let mut has_support = false;
-                for &lq in local_qs {
-                    let w = lq / 64;
-                    let bit = 1u64 << (lq % 64);
-                    if (sub.xz[base + w] & bit) != 0
-                        || (sub.xz[base + sub.num_words + w] & bit) != 0
-                    {
-                        has_support = true;
-                        break;
-                    }
-                }
-                if !has_support {
-                    continue;
-                }
-                if stab_idx >= cn {
-                    continue;
-                }
-                let dst_row = cn + stab_idx;
-                for (new_local, &old_local) in local_qs.iter().enumerate() {
-                    let ow = old_local / 64;
-                    let ob = old_local % 64;
-                    let nww = new_local / 64;
-                    let nb = new_local % 64;
-                    if sub.xz[base + ow] & (1u64 << ob) != 0 {
-                        cxz[dst_row * cstride + nww] |= 1u64 << nb;
-                    }
-                    if sub.xz[base + sub.num_words + ow] & (1u64 << ob) != 0 {
-                        cxz[dst_row * cstride + cnw + nww] |= 1u64 << nb;
-                    }
-                }
-                cphase[dst_row] = sub.phase[r];
-                stab_idx += 1;
-            }
-
-            while destab_idx < cn {
-                let q = destab_idx;
-                let w = q / 64;
-                let b = q % 64;
-                cxz[destab_idx * cstride + w] |= 1u64 << b;
-                destab_idx += 1;
-            }
-            while stab_idx < cn {
-                let q = stab_idx;
-                let w = q / 64;
-                let b = q % 64;
-                cxz[(cn + stab_idx) * cstride + cnw + w] |= 1u64 << b;
-                stab_idx += 1;
+            // The reduced basis ties destabilizer row lq and stabilizer row
+            // k+lq to qubit lq, so both land in lq's component and the pair
+            // moves to matching local rows ci and cn+ci.
+            for (ci, &lq) in local_qs.iter().enumerate() {
+                copy_component_row(&sub, lq, local_qs, &mut cxz, &mut cphase, cnw, ci);
+                copy_component_row(&sub, k + lq, local_qs, &mut cxz, &mut cphase, cnw, cn + ci);
             }
 
             let new_sub = SubTableau {
@@ -1030,6 +944,35 @@ fn remap_row(
             dst_xz[dst_base + dst_nw + dw] |= 1u64 << db;
         }
     }
+}
+
+/// Copy one row of a reduced parent tableau into a component tableau,
+/// remapping parent-local qubit columns to component-local columns. The row's
+/// support must lie inside `local_qs`; columns outside it are dropped.
+fn copy_component_row(
+    sub: &SubTableau,
+    src_row: usize,
+    local_qs: &[usize],
+    cxz: &mut [u64],
+    cphase: &mut [bool],
+    cnw: usize,
+    dst_row: usize,
+) {
+    let cstride = 2 * cnw;
+    let base = src_row * sub.stride();
+    for (new_local, &old_local) in local_qs.iter().enumerate() {
+        let ow = old_local / 64;
+        let ob = old_local % 64;
+        let nww = new_local / 64;
+        let nb = new_local % 64;
+        if sub.xz[base + ow] & (1u64 << ob) != 0 {
+            cxz[dst_row * cstride + nww] |= 1u64 << nb;
+        }
+        if sub.xz[base + sub.num_words + ow] & (1u64 << ob) != 0 {
+            cxz[dst_row * cstride + cnw + nww] |= 1u64 << nb;
+        }
+    }
+    cphase[dst_row] = sub.phase[src_row];
 }
 
 fn uf_find(parent: &mut [usize], x: usize) -> usize {

--- a/src/backend/factored_stabilizer/tests.rs
+++ b/src/backend/factored_stabilizer/tests.rs
@@ -237,6 +237,34 @@ fn split_after_measuring_a_merged_cluster() {
     );
 }
 
+// A collapsed GHZ chain factors into one cluster per qubit, which exceeds
+// the former 64-component ceiling in split detection.
+#[test]
+fn split_into_more_than_64_components() {
+    let n = 100;
+    let mut fact = FactoredStabilizerBackend::new(42);
+    fact.init(n, 1).unwrap();
+
+    let mut c = Circuit::new(n, 1);
+    c.add_gate(Gate::H, &[0]);
+    for q in 0..n - 1 {
+        c.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    c.add_measure(0, 0);
+
+    for inst in &c.instructions {
+        fact.apply(inst).unwrap();
+    }
+
+    let active_count = fact.subs.iter().filter(|s| s.is_some()).count();
+    assert_eq!(
+        active_count, n,
+        "a measured GHZ chain is a product state and must split per qubit, got {} active \
+         sub-tableaux",
+        active_count
+    );
+}
+
 #[test]
 fn product_state_stays_factored() {
     let mut fact = FactoredStabilizerBackend::new(42);

--- a/src/backend/factored_stabilizer/tests.rs
+++ b/src/backend/factored_stabilizer/tests.rs
@@ -213,6 +213,30 @@ fn split_after_bell_measure() {
     );
 }
 
+// One merged cluster, not two that were never merged: measuring either half of
+// a Bell pair leaves a product state, so the cluster must factor back apart.
+#[test]
+fn split_after_measuring_a_merged_cluster() {
+    let mut fact = FactoredStabilizerBackend::new(42);
+    fact.init(2, 1).unwrap();
+
+    let mut c = Circuit::new(2, 1);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_measure(0, 0);
+
+    for inst in &c.instructions {
+        fact.apply(inst).unwrap();
+    }
+
+    let active_count = fact.subs.iter().filter(|s| s.is_some()).count();
+    assert_eq!(
+        active_count, 2,
+        "a measured Bell pair is a product state and must split, got {} active sub-tableaux",
+        active_count
+    );
+}
+
 #[test]
 fn product_state_stays_factored() {
     let mut fact = FactoredStabilizerBackend::new(42);

--- a/src/backend/stabilizer/kernels/rowops.rs
+++ b/src/backend/stabilizer/kernels/rowops.rs
@@ -292,3 +292,135 @@ pub(crate) fn zero_row(xz: &mut [u64], phase: &mut [bool], nw: usize, r: usize) 
     xz[start..start + stride].fill(0);
     phase[r] = false;
 }
+
+/// Rebuild rows 0..n as unit destabilizers via Gaussian elimination and
+/// replace the stabilizer half (rows n..2n) with the reduced basis they pair
+/// with. Row operations preserve the stabilizer group and its phases, so the
+/// state is unchanged; the write-back is what makes destabilizer i
+/// anticommute with stabilizer i and commute with every other generator,
+/// which measurement relies on. After the call, stabilizer row n+q is the
+/// unique generator with a pivot at qubit q, so each generator's support is
+/// confined to one entanglement component of the state.
+pub(crate) fn materialize_destabilizers(xz: &mut [u64], phase: &mut [bool], n: usize, nw: usize) {
+    if n == 0 {
+        return;
+    }
+    let stride = 2 * nw;
+
+    xz[..n * stride].fill(0);
+    phase[..n].fill(false);
+
+    let mut stab_copy: Vec<u64> = xz[n * stride..2 * n * stride].to_vec();
+    let mut stab_phase: Vec<bool> = phase[n..2 * n].to_vec();
+    let mut pivot_row: Vec<u64> = vec![0u64; stride];
+
+    for col in 0..n {
+        let mut pivot = None;
+        for row in col..n {
+            let word = col / 64;
+            let bit = col % 64;
+            if stab_copy[row * stride + word] & (1u64 << bit) != 0 {
+                pivot = Some(row);
+                break;
+            }
+        }
+
+        if pivot.is_none() {
+            for row in col..n {
+                let word = col / 64;
+                let bit = col % 64;
+                if stab_copy[row * stride + nw + word] & (1u64 << bit) != 0 {
+                    pivot = Some(row);
+                    break;
+                }
+            }
+
+            if let Some(p) = pivot {
+                if p != col {
+                    let col_off = col * stride;
+                    let p_off = p * stride;
+                    for w in 0..stride {
+                        stab_copy.swap(col_off + w, p_off + w);
+                    }
+                    stab_phase.swap(col, p);
+                }
+
+                let word = col / 64;
+                let bit = col % 64;
+                let bit_mask = 1u64 << bit;
+                pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
+                let sp = stab_phase[col];
+
+                for row in 0..n {
+                    if row == col {
+                        continue;
+                    }
+                    if stab_copy[row * stride + nw + word] & bit_mask != 0 {
+                        let dst = &mut stab_copy[row * stride..(row + 1) * stride];
+                        let initial =
+                            if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
+                        let (dx, dz) = dst.split_at_mut(nw);
+                        let sum = rowmul_words(
+                            dx,
+                            &mut dz[..nw],
+                            &pivot_row[..nw],
+                            &pivot_row[nw..2 * nw],
+                            initial,
+                        );
+                        stab_phase[row] = (sum & 3) >= 2;
+                    }
+                }
+
+                xz[col * stride + word] |= bit_mask;
+                phase[col] = false;
+            } else {
+                xz[col * stride + col / 64] |= 1u64 << (col % 64);
+                phase[col] = false;
+            }
+            continue;
+        }
+
+        let p = pivot.unwrap();
+        if p != col {
+            let col_off = col * stride;
+            let p_off = p * stride;
+            for w in 0..stride {
+                stab_copy.swap(col_off + w, p_off + w);
+            }
+            stab_phase.swap(col, p);
+        }
+
+        let word = col / 64;
+        let bit = col % 64;
+        let bit_mask = 1u64 << bit;
+        pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
+        let sp = stab_phase[col];
+
+        for row in 0..n {
+            if row == col {
+                continue;
+            }
+            if stab_copy[row * stride + word] & bit_mask != 0 {
+                let dst = &mut stab_copy[row * stride..(row + 1) * stride];
+                let initial = if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
+                let (dx, dz) = dst.split_at_mut(nw);
+                let sum = rowmul_words(
+                    dx,
+                    &mut dz[..nw],
+                    &pivot_row[..nw],
+                    &pivot_row[nw..2 * nw],
+                    initial,
+                );
+                stab_phase[row] = (sum & 3) >= 2;
+            }
+        }
+
+        xz[col * stride + nw + word] |= bit_mask;
+        phase[col] = false;
+    }
+
+    xz[n * stride..2 * n * stride].copy_from_slice(&stab_copy);
+    for (i, p) in stab_phase.into_iter().enumerate() {
+        phase[n + i] = p;
+    }
+}

--- a/src/backend/stabilizer/mod.rs
+++ b/src/backend/stabilizer/mod.rs
@@ -574,7 +574,12 @@ impl StabilizerBackend {
             return;
         }
         let sgi_live = self.sgi_enabled();
-        self.materialize_destabilizers();
+        kernels::rowops::materialize_destabilizers(
+            &mut self.xz,
+            &mut self.phase,
+            self.n,
+            self.num_words,
+        );
         self.lazy_destab = false;
         self.gate_row_start = 0;
         if sgi_live {
@@ -587,144 +592,6 @@ impl StabilizerBackend {
         // heavy. Rebuilding here would re-arm the guard over an index that the
         // dense paths do not maintain, and a later bulk entry would then run
         // SGI against stale supports.
-    }
-
-    /// Rebuild rows 0..n as unit destabilizers via Gaussian elimination and
-    /// replace the stabilizer half with the reduced basis they pair with.
-    /// Row operations preserve the stabilizer group and its phases, so the
-    /// state is unchanged; the write-back is what makes destabilizer i
-    /// anticommute with stabilizer i and commute with every other generator,
-    /// which measurement relies on.
-    fn materialize_destabilizers(&mut self) {
-        let n = self.n;
-        if n == 0 {
-            return;
-        }
-        let nw = self.num_words;
-        let stride = self.stride();
-
-        for i in 0..n {
-            let base = i * stride;
-            for w in 0..stride {
-                self.xz[base + w] = 0;
-            }
-            self.phase[i] = false;
-        }
-
-        let mut stab_copy: Vec<u64> = self.xz[n * stride..2 * n * stride].to_vec();
-        let mut stab_phase: Vec<bool> = self.phase[n..2 * n].to_vec();
-        let mut pivot_row: Vec<u64> = vec![0u64; stride];
-
-        for col in 0..n {
-            let mut pivot = None;
-            for row in col..n {
-                let word = col / 64;
-                let bit = col % 64;
-                if stab_copy[row * stride + word] & (1u64 << bit) != 0 {
-                    pivot = Some(row);
-                    break;
-                }
-            }
-
-            if pivot.is_none() {
-                for row in col..n {
-                    let word = col / 64;
-                    let bit = col % 64;
-                    if stab_copy[row * stride + nw + word] & (1u64 << bit) != 0 {
-                        pivot = Some(row);
-                        break;
-                    }
-                }
-
-                if let Some(p) = pivot {
-                    if p != col {
-                        let col_off = col * stride;
-                        let p_off = p * stride;
-                        for w in 0..stride {
-                            stab_copy.swap(col_off + w, p_off + w);
-                        }
-                        stab_phase.swap(col, p);
-                    }
-
-                    let word = col / 64;
-                    let bit = col % 64;
-                    let bit_mask = 1u64 << bit;
-                    pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
-                    let sp = stab_phase[col];
-
-                    for row in 0..n {
-                        if row == col {
-                            continue;
-                        }
-                        if stab_copy[row * stride + nw + word] & bit_mask != 0 {
-                            let dst = &mut stab_copy[row * stride..(row + 1) * stride];
-                            let initial =
-                                if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
-                            let (dx, dz) = dst.split_at_mut(nw);
-                            let sum = rowmul_words(
-                                dx,
-                                &mut dz[..nw],
-                                &pivot_row[..nw],
-                                &pivot_row[nw..2 * nw],
-                                initial,
-                            );
-                            stab_phase[row] = (sum & 3) >= 2;
-                        }
-                    }
-
-                    self.xz[col * stride + word] |= bit_mask;
-                    self.phase[col] = false;
-                } else {
-                    self.xz[col * stride + col / 64] |= 1u64 << (col % 64);
-                    self.phase[col] = false;
-                }
-                continue;
-            }
-
-            let p = pivot.unwrap();
-            if p != col {
-                let col_off = col * stride;
-                let p_off = p * stride;
-                for w in 0..stride {
-                    stab_copy.swap(col_off + w, p_off + w);
-                }
-                stab_phase.swap(col, p);
-            }
-
-            let word = col / 64;
-            let bit = col % 64;
-            let bit_mask = 1u64 << bit;
-            pivot_row.copy_from_slice(&stab_copy[col * stride..(col + 1) * stride]);
-            let sp = stab_phase[col];
-
-            for row in 0..n {
-                if row == col {
-                    continue;
-                }
-                if stab_copy[row * stride + word] & bit_mask != 0 {
-                    let dst = &mut stab_copy[row * stride..(row + 1) * stride];
-                    let initial =
-                        if sp { 2u64 } else { 0 } + if stab_phase[row] { 2u64 } else { 0 };
-                    let (dx, dz) = dst.split_at_mut(nw);
-                    let sum = rowmul_words(
-                        dx,
-                        &mut dz[..nw],
-                        &pivot_row[..nw],
-                        &pivot_row[nw..2 * nw],
-                        initial,
-                    );
-                    stab_phase[row] = (sum & 3) >= 2;
-                }
-            }
-
-            self.xz[col * stride + nw + word] |= bit_mask;
-            self.phase[col] = false;
-        }
-
-        self.xz[n * stride..2 * n * stride].copy_from_slice(&stab_copy);
-        for (i, p) in stab_phase.into_iter().enumerate() {
-            self.phase[n + i] = p;
-        }
     }
 
     pub fn raw_tableau(&self) -> (&[u64], &[bool]) {


### PR DESCRIPTION
## Description

Split detection unioned the support of the raw stored generators, so a
factorable cluster whose generators overlap never split: a measured Bell pair
keeps `Z0Z1` beside the new `Z0` and reads as one component even though
{`Z0`, `Z0Z1`} generates the same group as {`Z0`, `Z1`}. The existing
`split_after_bell_measure` test passed only because its two Bell pairs were
never merged; the new `split_after_measuring_a_merged_cluster` test pins the
miss by measurement. A cluster that never splits also keeps growing into the
merged-cluster qubit cap, so the defect converts silent wrong shape into hard
rejections on long-running sparse workloads.

The fix reduces the cluster to the canonical basis with one pivot per qubit
before the support scan, reusing the dense backend's destabilizer
materialization, now shared from the stabilizer row kernels. Each reduced
generator is confined to one entanglement component, so the scan finds the
finest factorization, the per-component rebuild becomes a paired row copy
(destabilizer row q and stabilizer row k+q both belong to qubit q's
component), and the former 64-component ceiling is lifted, pinned by a
100-way-split test.

## Benchmark summary

Adjacent-binary A/B (`scripts/bench_ab.sh`), reference `main` (71aa91d),
`--features parallel`, threshold 5%, i7-6700K, Windows 10 (MINGW64), rustc
1.97.0, bench profile `lto = "fat"` / `codegen-units = 1`, RUSTFLAGS unset,
runs sequential with one bench process at a time. 30 samples unless marked;
two agreeing runs cited per win row.

| Benchmark | Before | After | Change | Confirming run | Samples |
|-----------|-------:|------:|-------:|---------------:|--------:|
| `factored_stabilizer/measurement/ghz_measure_all/50` | 532.95 us | 291.23 us | -45.4% | -45.6% | 30 |
| `factored_stabilizer/measurement/ghz_measure_all/100` | 3.40 ms | 1.44 ms | -57.7% | -57.5% | 30 |
| `factored_stabilizer/measurement/ghz_measure_all/500` | 377.92 ms | 161.60 ms | -57.2% | -57.2% | 30 |
| `factored_stabilizer/measurement/ghz_measure_all/10` | ~17 us | ~18 us | unmeasured | see caveat | 30, 200 |
| `factored_stabilizer/scaling/10` | 51.48 us | 51.92 us | +0.9% | | 30 |
| `factored_stabilizer/scaling/50` | 140.96 us | 142.88 us | +1.4% | | 200 |
| `factored_stabilizer/scaling/100` | 280.32 us | 286.22 us | +2.1% | | 30 |
| `factored_stabilizer/scaling/500` | 1.66 ms | 1.58 ms | -4.9% | | 30 |
| `factored_stabilizer/scaling/1000` | 3.76 ms | 3.69 ms | -1.8% | | 200 |
| `factored_stabilizer/local_blocks/*` (5 rows) | | | -1.2% to +0.6% | | 30 |
| `stabilizer/measurement/ghz_measure_all/1000` | 2.44 ms | 2.44 ms | +0.0% | | 30 |
| `stabilizer/measurement/ghz_measure_all/5000` | 50.25 ms | 50.20 ms | -0.1% | | 30 |

Caveats:

- `ghz_measure_all/10`: same-code control spread 36.8% then 6.0% across two
  runs, above the 5% gate both times, so the row is unmeasured on this host.
  Both reads are positive; a cost of roughly the reduction pass is expected on
  this row from the diff and is neither claimed nor excluded. The neighboring
  `factored_stabilizer/scaling/10` row is already documented as unresolvable
  at +9% to +13% same-code in `benches/README.md`.
- The `scaling` and `local_blocks` circuits contain no measurement or reset,
  so the changed factored code never executes on those rows. `scaling/50`
  (+1.4%) and `scaling/1000` (-1.8%) resolved above their own controls but
  below the gate; the diff relocates a function of about 130 lines between
  modules, and moves of this size on unreached rows are consistent with the
  linked-code layout sensitivity documented in `benches/README.md`.
- `stabilizer/measurement/ghz_measure_all/{1000,5000}` execute the relocated
  reduction on the dense backend and read +0.0% / -0.1%, so the relocation is
  perf-neutral where it runs.
- Coverage gap: no bench row measures repeated measurement on a cluster that
  stays entangled, where the per-measurement reduction runs with no split
  payoff. Tracked as follow-up.

## Regression verdict

PASS at 5%. No row exceeded both the gate and its own same-code control
spread in any of the three runs.

## Tests

- `split_after_measuring_a_merged_cluster`: the pinning test, one merged Bell
  pair measured on one half, asserts the cluster factors back apart.
- `split_into_more_than_64_components`: a measured 100-qubit GHZ chain must
  shatter into 100 singleton clusters, exceeding the former component cap.
- `split_after_bell_measure` stays green; randomized mono-versus-factored
  equivalence and the cross-backend matrices
  (`backend_matrix`, `measurement_matrix`, `backend_equivalence`,
  `factored_correctness`) pass unchanged.

## Documentation

Docstring on the shared `materialize_destabilizers` kernel extended with the
pivot-per-qubit invariant the new caller relies on. No architecture-page
change: backend boundaries are unchanged.
