### PR TITLE
perf(factored-stabilizer): lazy destabilizers per cluster

### DIFF
--- a/src/backend/factored_stabilizer/mod.rs
+++ b/src/backend/factored_stabilizer/mod.rs
@@ -55,6 +55,9 @@ struct SubTableau {
     xz: Vec<u64>,
     phase: Vec<bool>,
     qubits: SmallVec<[usize; 8]>,
+    /// Destabilizer rows are stale: gates sweep only the stabilizer half and
+    /// set this, and measurement materializes fresh destabilizers on demand.
+    lazy_destab: bool,
 }
 
 impl SubTableau {
@@ -73,6 +76,7 @@ impl SubTableau {
             xz,
             phase,
             qubits: SmallVec::from_elem(global_qubit, 1),
+            lazy_destab: false,
         }
     }
 
@@ -97,66 +101,90 @@ impl SubTableau {
         false
     }
 
+    /// Stabilizer-half row window for gate kernels (rows n..2n+1), skipping
+    /// the destabilizers and marking them stale for the next measurement to
+    /// rebuild.
+    fn gate_rows(&mut self) -> (&mut [u64], &mut [bool]) {
+        self.lazy_destab = true;
+        let start = self.n * self.stride();
+        (&mut self.xz[start..], &mut self.phase[self.n..])
+    }
+
     fn apply_h(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::h_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::h_all(xz, phase, nw, par, a);
     }
 
     fn apply_s(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::s_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::s_all(xz, phase, nw, par, a);
     }
 
     fn apply_sdg(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::sdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sdg_all(xz, phase, nw, par, a);
     }
 
     fn apply_x(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::x_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::x_all(xz, phase, nw, par, a);
     }
 
     fn apply_y(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::y_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::y_all(xz, phase, nw, par, a);
     }
 
     fn apply_z(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::z_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::z_all(xz, phase, nw, par, a);
     }
 
     fn apply_sx(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::sx_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sx_all(xz, phase, nw, par, a);
     }
 
     fn apply_sxdg(&mut self, a: usize) {
         let par = self.par_rows();
-        rowops::sxdg_all(&mut self.xz, &mut self.phase, self.num_words, par, a);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::sxdg_all(xz, phase, nw, par, a);
     }
 
     fn apply_cx(&mut self, ctrl: usize, tgt: usize) {
         let par = self.par_rows();
-        rowops::cx_all(
-            &mut self.xz,
-            &mut self.phase,
-            self.num_words,
-            par,
-            ctrl,
-            tgt,
-        );
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::cx_all(xz, phase, nw, par, ctrl, tgt);
     }
 
     fn apply_cz(&mut self, a: usize, b: usize) {
         let par = self.par_rows();
-        rowops::cz_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::cz_all(xz, phase, nw, par, a, b);
     }
 
     fn apply_swap(&mut self, a: usize, b: usize) {
         let par = self.par_rows();
-        rowops::swap_all(&mut self.xz, &mut self.phase, self.num_words, par, a, b);
+        let nw = self.num_words;
+        let (xz, phase) = self.gate_rows();
+        rowops::swap_all(xz, phase, nw, par, a, b);
     }
 
     fn dispatch_gate(&mut self, gate: &Gate, local_targets: &[usize]) -> Result<()> {
@@ -196,6 +224,15 @@ impl SubTableau {
     }
 
     fn measure(&mut self, local_q: usize, rng: &mut ChaCha8Rng) -> bool {
+        if self.lazy_destab {
+            rowops::materialize_destabilizers(
+                &mut self.xz,
+                &mut self.phase,
+                self.n,
+                self.num_words,
+            );
+            self.lazy_destab = false;
+        }
         let n = self.n;
         let word = local_q / 64;
         let bit_mask = 1u64 << (local_q % 64);
@@ -557,35 +594,10 @@ impl FactoredStabilizerBackend {
         let mut new_phase = vec![false; total_rows];
 
         let dst_ref = self.subs[dst_idx].as_ref().unwrap();
+        // Destabilizer rows are not copied: a merge only happens on the way
+        // into a cross-cluster gate, which stales them immediately, so the
+        // merged cluster starts lazy and the next measurement rebuilds them.
         #[allow(clippy::needless_range_loop)]
-        for r in 0..a {
-            remap_row(
-                &dst_ref.xz,
-                dst_ref.stride(),
-                r,
-                &dst_positions,
-                dst_ref.num_words,
-                &mut new_xz,
-                new_stride,
-                r,
-                new_nw,
-            );
-            new_phase[r] = dst_ref.phase[r];
-        }
-        for r in 0..b {
-            remap_row(
-                &src.xz,
-                src.stride(),
-                r,
-                &src_positions,
-                src.num_words,
-                &mut new_xz,
-                new_stride,
-                a + r,
-                new_nw,
-            );
-            new_phase[a + r] = src.phase[r];
-        }
         for r in 0..a {
             remap_row(
                 &dst_ref.xz,
@@ -621,6 +633,7 @@ impl FactoredStabilizerBackend {
         d.xz = new_xz;
         d.phase = new_phase;
         d.qubits = merged_qubits;
+        d.lazy_destab = true;
 
         for &q in &src.qubits {
             self.qubit_to_sub[q] = dst_idx;
@@ -640,6 +653,7 @@ impl FactoredStabilizerBackend {
         // stabilizer row k+q holds the pivot at qubit q and the unit
         // destabilizer at row q is its partner.
         rowops::materialize_destabilizers(&mut sub.xz, &mut sub.phase, k, sub.num_words);
+        sub.lazy_destab = false;
 
         let sub = self.subs[sub_idx].as_ref().unwrap();
         let mut parent: Vec<usize> = (0..k).collect();
@@ -715,6 +729,7 @@ impl FactoredStabilizerBackend {
                 xz: cxz,
                 phase: cphase,
                 qubits: cqubits,
+                lazy_destab: false,
             };
 
             let slot = self.find_free_slot();

--- a/src/backend/factored_stabilizer/tests.rs
+++ b/src/backend/factored_stabilizer/tests.rs
@@ -265,6 +265,55 @@ fn split_into_more_than_64_components() {
     );
 }
 
+// The deterministic measurement branch reads destabilizer bits, so a
+// measurement on a cluster whose gates ran after the last materialization
+// must rebuild them first. State is |11>, so measuring q1 must read 1; stale
+// destabilizers from the gate-only window read 0.
+#[test]
+fn deterministic_measure_after_gates_rebuilds_destabilizers() {
+    let mut fact = FactoredStabilizerBackend::new(42);
+    fact.init(2, 1).unwrap();
+
+    let mut c = Circuit::new(2, 1);
+    c.add_gate(Gate::X, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_measure(1, 0);
+
+    for inst in &c.instructions {
+        fact.apply(inst).unwrap();
+    }
+
+    assert!(
+        fact.classical_results()[0],
+        "measuring q1 of |11> must read 1"
+    );
+}
+
+// A merge drops the destabilizer rows of both sides, so a deterministic
+// measurement after a cross-cluster gate must rebuild them for the merged
+// tableau.
+#[test]
+fn deterministic_measure_after_merge() {
+    let mut fact = FactoredStabilizerBackend::new(42);
+    fact.init(2, 3).unwrap();
+
+    let mut c = Circuit::new(2, 3);
+    c.add_gate(Gate::X, &[0]);
+    c.add_measure(0, 0);
+    c.add_measure(1, 1);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_measure(1, 2);
+
+    for inst in &c.instructions {
+        fact.apply(inst).unwrap();
+    }
+
+    let bits = fact.classical_results();
+    assert!(bits[0], "measuring q0 of |1> must read 1");
+    assert!(!bits[1], "measuring q1 of |0> must read 0");
+    assert!(bits[2], "after CX(0,1) on |10>, measuring q1 must read 1");
+}
+
 #[test]
 fn product_state_stays_factored() {
     let mut fact = FactoredStabilizerBackend::new(42);


### PR DESCRIPTION
## Description

Gates on a factored sub-tableau swept all 2n+1 rows to keep destabilizer rows
current that nothing reads between measurements: the export paths read only
stabilizer rows, and split detection rebuilds destabilizers from the
stabilizer half on every measurement anyway. Gate kernels now sweep only the
stabilizer half plus scratch through a row-window slice, merges skip the
destabilizer copies entirely (a merge only happens on the way into a
cross-cluster gate, which would stale them immediately), and a measurement
rebuilds the rows on demand through the shared Gaussian elimination. This is
the per-cluster analog of the dense backend's lazy destabilizer mode, without
the circuit-shape predicate: a per-cluster staleness flag replaces it.

## Benchmark summary

Adjacent-binary A/B via `scripts/bench_ab.sh`, 30 samples, full Criterion,
reference `main` at the split-detection fix, `--features parallel`, threshold
5%, i7-6700K, Windows 10 (MINGW64), rustc 1.97.0, bench profile `lto = "fat"`
/ `codegen-units = 1`, RUSTFLAGS unset, two independent invocations run
sequentially with one bench process at a time. Run 2 shown; run 1 replication
in the last column.

| Benchmark | Ref | New | Change | Run 1 |
|-----------|----:|----:|-------:|------:|
| `factored_stabilizer/scaling/50` | 153.14 us | 119.05 us | -22.3% | -23.1% |
| `factored_stabilizer/scaling/100` | 286.55 us | 231.47 us | -19.2% | -20.7% |
| `factored_stabilizer/scaling/500` | 1.55 ms | 1.22 ms | -21.2% | unresolved (ref control -6.3%) |
| `factored_stabilizer/scaling/1000` | 3.63 ms | 2.82 ms | -22.5% | -24.5% |
| `factored_stabilizer/scaling/10` | 51.33 us | 49.12 us | -4.3% | -4.7% |
| `factored_stabilizer/measurement/ghz_measure_all/50` | 287.26 us | 198.03 us | -31.1% | -31.6% |
| `factored_stabilizer/measurement/ghz_measure_all/100` | 1.44 ms | 772.15 us | -46.4% | -46.0% |
| `factored_stabilizer/measurement/ghz_measure_all/500` | 162.13 ms | 84.50 ms | -47.9% | -48.0% |
| `factored_stabilizer/measurement/ghz_measure_all/10` | unmeasured | | | |
| `factored_stabilizer/local_blocks/5x2/10` | 37.39 us | 37.30 us | -0.3% | -1.6% |
| `factored_stabilizer/local_blocks/5x4/20` | 56.39 us | 54.95 us | -2.5% | -3.7% |
| `factored_stabilizer/local_blocks/10x5/50` | 123.24 us | 118.82 us | -3.6% | -3.9% |
| `factored_stabilizer/local_blocks/20x5/100` | 171.09 us | 164.38 us | -3.9% | -4.4% |
| `factored_stabilizer/local_blocks/50x5/250` | 334.24 us | 318.65 us | -4.7% | -5.7% |
| `stabilizer/scaling/1000` (untouched control) | 2.77 ms | 2.79 ms | +0.7% | +0.2% |
| `stabilizer/scaling/5000` (untouched control) | 38.53 ms | 38.25 ms | -0.7% | -0.5% |

Caveats:

- Headline band: -19% to -25% on `factored_stabilizer/scaling/{50,100,500,
  1000}` across two runs. Run 1's scaling/500 row was unresolvable (same-code
  ref control -6.3%) and is not counted; run 2 resolved it with controls at
  or under 3.3%.
- The reference includes the split-detection fix; its post-fix
  `ghz_measure_all/500` time matches this A/B's ref column (162.15 ms there,
  162.13 ms here), so the -48% is additional, not a re-measurement of that
  fix.
- `ghz_measure_all/10` is unmeasured: same-code control spreads of 29.1% and
  39.7% on this host. `scaling/10` reads -4.3%/-4.7%, sub-threshold, in a row
  family with a documented same-code spread above the gate; it is not
  counted.
- `local_blocks` was predicted null and instead reads as small consistent
  wins, sub-threshold against the 5% gate (three larger rows -3.6% to -5.7%
  across runs, controls at or under 1.5%). Consistent with halved gate sweeps
  and skipped destabilizer copies on intra-block merges; the runs do not
  separate the two contributors.
- Coverage gap: no bench row interleaves gates and measurements on a
  persistent cluster. The scaling and local_blocks circuits contain no
  measurements and ghz measures terminally, so every covered row pays the
  on-demand destabilizer rebuild at most once per cluster. A workload
  alternating gates and measurements on one large entangled cluster pays the
  rebuild per measurement and is unbenchmarked; this is the plausible
  regression shape for the change.

## Regression verdict

PASS at 5%. No row exceeded both the gate and its own same-code control
spread in either run.

## Tests

- `deterministic_measure_after_gates_rebuilds_destabilizers`: |11> built with
  gates after the last materialization; the deterministic measurement reads
  destabilizer bits and must rebuild first, or it reads 0 instead of 1.
- `deterministic_measure_after_merge`: a cross-cluster gate drops both sides'
  destabilizer rows; the following deterministic measurement must rebuild for
  the merged tableau.
- Randomized mono-versus-factored equivalence and the cross-backend matrices
  pass unchanged, pinning exact classical-result parity across seeds.

## Documentation

Field and method docstrings on the new staleness flag and row window. No
architecture-page change: backend boundaries are unchanged.
