### PR TITLE
bench(factored-stabilizer): rows interleaving gates and measurements

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -199,6 +199,39 @@ fn mps_measure_reset_circuit(n_qubits: usize, rounds: usize) -> Circuit {
     circuit
 }
 
+/// Linear cluster state on qubits `1..n` with qubit 0 as a re-attachable leaf.
+/// Each round applies S to the first `sweep_qubits` qubits, re-entangles
+/// qubit 0 via H plus CZ, then measures it. Z-measuring a leaf vertex removes
+/// only that vertex, so the chain stays one entangled cluster and every
+/// measurement pays the destabilizer rebuild. `sweep_qubits` sets the gate
+/// load between measurements: 2 leaves the rebuild dominant, `n_qubits`
+/// prices the shape under a full gate sweep.
+fn interleaved_measure_chain_circuit(
+    n_qubits: usize,
+    rounds: usize,
+    sweep_qubits: usize,
+) -> Circuit {
+    let mut circuit = Circuit::new(n_qubits, rounds);
+
+    for q in 1..n_qubits {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    for q in 1..n_qubits - 1 {
+        circuit.add_gate(Gate::Cz, &[q, q + 1]);
+    }
+
+    for round in 0..rounds {
+        for q in 0..sweep_qubits {
+            circuit.add_gate(Gate::S, &[q]);
+        }
+        circuit.add_gate(Gate::H, &[0]);
+        circuit.add_gate(Gate::Cz, &[0, 1]);
+        circuit.add_measure(0, round);
+    }
+
+    circuit
+}
+
 fn compiled_filtered_bell_pairs_circuit(n_pairs: usize) -> Circuit {
     let mut circuit = circuits::independent_bell_pairs(n_pairs);
     let n = circuit.num_qubits;
@@ -714,6 +747,30 @@ fn bench_factored_stabilizer_measurement(c: &mut Criterion) {
         group.bench_with_input(
             BenchmarkId::new("ghz_measure_all", n),
             &circuit,
+            |b, circ| {
+                b.iter(|| {
+                    run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
+                });
+            },
+        );
+    }
+
+    for &n in &[50, 100, 500] {
+        let circuit = interleaved_measure_chain_circuit(n, 10, n);
+        group.bench_with_input(
+            BenchmarkId::new("interleaved_chain_r10", n),
+            &circuit,
+            |b, circ| {
+                b.iter(|| {
+                    run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();
+                });
+            },
+        );
+
+        let lean = interleaved_measure_chain_circuit(n, 10, 2);
+        group.bench_with_input(
+            BenchmarkId::new("interleaved_chain_lean_r10", n),
+            &lean,
             |b, circ| {
                 b.iter(|| {
                     run_with(BackendKind::FactoredStabilizer, circ, 42).unwrap();

--- a/src/backend/factored_stabilizer/tests.rs
+++ b/src/backend/factored_stabilizer/tests.rs
@@ -694,3 +694,65 @@ fn par_path_128q_all_clifford_gates() {
     let mut b = FactoredStabilizerBackend::new(42);
     crate::sim::run_on(&mut b, &c).unwrap();
 }
+
+// Pins the interleaved-measure bench shape: a linear cluster state on qubits
+// 1..n with qubit 0 re-attached as a leaf each round. The leaf measurement must
+// split off only the leaf, leaving the chain one entangled cluster, so every
+// round's measurement lands on the full cluster with gates applied since the
+// last one.
+#[test]
+fn interleaved_leaf_measure_keeps_chain_entangled() {
+    let n = 12;
+    let rounds = 5;
+    let mut fact = FactoredStabilizerBackend::new(42);
+    fact.init(n, rounds).unwrap();
+
+    let mut init = Circuit::new(n, rounds);
+    for q in 1..n {
+        init.add_gate(Gate::H, &[q]);
+    }
+    for q in 1..n - 1 {
+        init.add_gate(Gate::Cz, &[q, q + 1]);
+    }
+    for inst in &init.instructions {
+        fact.apply(inst).unwrap();
+    }
+
+    for round in 0..rounds {
+        let mut layer = Circuit::new(n, rounds);
+        for q in 0..n {
+            layer.add_gate(Gate::S, &[q]);
+        }
+        layer.add_gate(Gate::H, &[0]);
+        layer.add_gate(Gate::Cz, &[0, 1]);
+        for inst in &layer.instructions {
+            fact.apply(inst).unwrap();
+        }
+
+        let merged_count = fact.subs.iter().filter(|s| s.is_some()).count();
+        assert_eq!(
+            merged_count, 1,
+            "round {}: expected one merged cluster before the measurement, got {}",
+            round, merged_count
+        );
+
+        let mut measure = Circuit::new(n, rounds);
+        measure.add_measure(0, round);
+        fact.apply(&measure.instructions[0]).unwrap();
+
+        let active_count = fact.subs.iter().filter(|s| s.is_some()).count();
+        assert_eq!(
+            active_count, 2,
+            "round {}: the measured leaf must split off alone, got {} active sub-tableaux",
+            round, active_count
+        );
+        let chain = fact.qubit_to_sub[1];
+        assert_eq!(
+            fact.subs[chain].as_ref().unwrap().n,
+            n - 1,
+            "round {}: the chain must stay one cluster of {} qubits",
+            round,
+            n - 1
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Every factored-stabilizer measurement row measures terminally, so a cluster
pays the on-demand destabilizer rebuild at most once; the shape that pays it
per measurement had no coverage. The new rows keep a chain cluster entangled
across rounds of Clifford layers, each followed by a leaf measurement: the
full-sweep variant prices the shape under a realistic gate load, the lean
variant keeps gate work small so the per-measurement reductions dominate.

## Benchmark summary

New rows, so there is no before/after on `main`. As an informational
comparison, the rows were run against the code preceding the split-detection
fix and the per-cluster lazy destabilizers: the rows do not exist at that
point, so the reference build carries the bench commits cherry-picked and the
two sides differ only in `src/`. Adjacent-binary A/B, two agreeing runs,
worst same-code control 2.4%, i7-6700K, Windows 10, rustc 1.97.0, 30 samples:

| Benchmark | Before (us) | After (us) | Change (run 1 / run 2) |
|-----------|-------------|------------|--------|
| `factored_stabilizer/measurement/interleaved_chain_r10/50` | 382.9 | 472.7 | +23.4% / +22.5% |
| `factored_stabilizer/measurement/interleaved_chain_r10/100` | 1810 | 1800 | -0.8% / -1.4% |
| `factored_stabilizer/measurement/interleaved_chain_r10/500` | 246730 | 191470 | -22.4% / -22.6% |
| `factored_stabilizer/measurement/interleaved_chain_lean_r10/50` | 295.3 | 413.9 | +40.1% / +41.9% |
| `factored_stabilizer/measurement/interleaved_chain_lean_r10/100` | 1480 | 1590 | +7.6% / +7.6% |
| `factored_stabilizer/measurement/interleaved_chain_lean_r10/500` | 151140 | 107190 | -29.1% / -29.2% |

Context rows `ghz_measure_all/{50,100,500}` read -62% to -77% on the same
runs, the composed delta of the two shipped changes, matching their recorded
individual measurements. Reading: the previously uncovered shape pays on
small clusters, washes out near 100 qubits, and wins at 500, where the
per-gate destabilizer maintenance the lazy path skips outgrows the
per-measurement reductions.

## Regression verdict

PASS. The PR adds bench rows and a test; no shipped code changes.

## Tests

`interleaved_leaf_measure_keeps_chain_entangled` pins the shape the rows rely
on (one merged cluster before every measurement, a lone split-off leaf
after). It fails on the pre-split-fix code, so it discriminates the behavior
rather than restating it.
