### PR TITLE
bench(mps): bond-256 guard rows for the default cap

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -770,6 +770,16 @@ fn bench_mps_scaling(c: &mut Criterion) {
             });
         });
     }
+
+    // Bond 256 is the Auto-dispatch and Python default. This family peaks at
+    // bond 4, far below either cap, so the row does the same work as the 64-cap
+    // row and guards against the cap entering the cost path.
+    let circuit = circuits::random_circuit(20, 10, SEED);
+    group.bench_with_input(BenchmarkId::new("b256", 20), &circuit, |b, circ| {
+        b.iter(|| {
+            run_with(BackendKind::Mps { max_bond_dim: 256 }, circ, 42).unwrap();
+        });
+    });
     group.finish();
 }
 
@@ -785,6 +795,7 @@ fn bench_mps_linear_chain(c: &mut Criterion) {
             });
         });
     }
+
     group.finish();
 }
 
@@ -816,6 +827,18 @@ fn bench_mps_hotspots(c: &mut Criterion) {
     group.bench_function("measure_reset_32q_r3", |b| {
         b.iter(|| run_mps_apply_only(&meas_reset, 64));
     });
+
+    // Routed long-range pairs sit adjacent after the SWAPs and peak at bond 2,
+    // so this row matches the 64-cap row and guards the routing path against
+    // cap-dependent cost at the bond 256 default.
+    let long_range_256 = mps_long_range_phase_circuit(32, 4);
+    group.bench_with_input(
+        BenchmarkId::new("long_range_cp_r4_b256", 32),
+        &long_range_256,
+        |b, circ| {
+            b.iter(|| run_mps_apply_only(circ, 256));
+        },
+    );
 
     group.finish();
 }
@@ -859,6 +882,7 @@ fn bench_mps_sampling(c: &mut Criterion) {
             });
         });
     }
+
     group.finish();
 }
 


### PR DESCRIPTION
## Summary

Auto dispatch and the Python constructor default to bond 256 while every
bench row runs at 64 or 32, so the cap users actually receive had no
coverage. A peak-bond measurement found that no bench family exceeds bond 4
(`random_d10/20` peaks at 4, `long_range_cp_r4` at 2 because routed partners
sit adjacent after the SWAP chain, and the `dense_entanglement` families are
product states throughout), so a 64 versus 256 ladder is not measurable on
the current corpus. The two rows instead pin the caps' cost equivalence and
would catch a change that makes `max_bond_dim` enter the cost path, such as
cap-sized preallocation.

## Benchmark summary

New rows, no before/after. Three full-Criterion runs on a quiet host
(30 samples, i7-6700K, Windows 10, rustc 1.97.0, foreign process load
audited at or below 0.036 cores per run):

| Benchmark | Run 1 | Run 2 | Run 3 |
|-----------|-------|-------|-------|
| `mps/random_d10/20` | 5.803 ms | 5.797 ms | 5.789 ms |
| `mps/random_d10/b256/20` | 5.793 ms | 5.792 ms | 5.776 ms |
| `mps/hotspots/long_range_cp_r4/32` | 447.0 us | 578.9 us | 439.3 us |
| `mps/hotspots/long_range_cp_r4_b256/32` | 442.3 us | 451.8 us | 435.3 us |

The random pair is inside 0.4% on every run. The long_range pair agrees on
runs 1 and 3; run 2's 64-cap reading is a +30% same-code outlier against its
own runs 1 and 3, consistent with the hotspots family's recorded host noise,
and is reported as unresolved rather than as a difference.

## Regression verdict

PASS. New rows only; the pairs are cost-identical within noise, as the
peak-bond numbers predict.
