### PR TITLE
perf(tn): plan contraction on metadata with seeded noisy restarts

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -60,8 +60,10 @@ worth the disk.
 | `tn/scalar_hea_l2` | Tensor-network scalar contraction, hardware-efficient ansatz, 2 layers, 20–50 qubits (`bench-internal`) |
 | `tn/scalar_depth_20q` | Same contraction at 20 qubits, 4–7 layers, where intermediates grow large enough to reach the parallel contraction arms (`bench-internal`) |
 | `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
+| `tn/scalar_hea_l7` | Same contraction at 7 layers, 30–50 qubits, where the greedy tree's peak intermediate is non-monotonic in width; the rows that measure contraction tree quality (`bench-internal`) |
+| `tn/rdm_chain` | Single-qubit reduced density matrix on CZ chains at 40 and 60 qubits, query-shaped rows past the dense ceiling; depth 4 weighs per-contraction overhead, depth 8 the arithmetic |
 
-The two `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
+The `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs
 `--features "parallel bench-internal"` or it silently reports zero rows. Cargo
 fingerprints feature sets separately, so the first such run pays a cold build in

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -7,6 +7,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use num_complex::Complex64;
 use prism_q::backend::Backend;
 use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::backend::tensornetwork::TensorNetworkBackend;
 #[cfg(feature = "bench-internal")]
 use prism_q::backend::tensornetwork::scalar_expectation;
 use prism_q::circuit::fusion::fuse_circuit;
@@ -1086,8 +1087,7 @@ fn bench_tn_scalar_wide_deep(_c: &mut Criterion) {}
 /// `MIN_FAER_GEMM_WORK`; `tn/scalar_depth_20q` reaches it but only at 20 qubits.
 /// Six layers puts 12 contractions over the threshold at 20 qubits and 37 at 50,
 /// so a change to the crossover shows up here as a function of width. Seven
-/// layers would be the natural next row and is left out: its peak intermediate
-/// jumps to 16.8M elements and an iteration costs 3.3 s.
+/// layers lives in `tn/scalar_hea_l7`, where tree quality is the variable.
 #[cfg(feature = "bench-internal")]
 fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
     let mut group = c.benchmark_group("tn/scalar_hea_l6");
@@ -1099,6 +1099,62 @@ fn bench_tn_scalar_wide_deep(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
                 black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
+#[cfg(not(feature = "bench-internal"))]
+fn bench_tn_scalar_tree_quality(_c: &mut Criterion) {}
+
+/// The rows where contraction tree quality is the variable.
+///
+/// Seven layers is where the greedy planner's tree is on record as
+/// non-monotonic in width: peak intermediate 16.8M elements at 30 and 50
+/// qubits against 1.05M at 40. A planner change moves these rows through the
+/// tree it picks, not through kernel arithmetic, which the depth and width
+/// sweeps above already cover.
+#[cfg(feature = "bench-internal")]
+fn bench_tn_scalar_tree_quality(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/scalar_hea_l7");
+    configure_group(&mut group);
+
+    for &n in &[30, 40, 50] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 7, SEED);
+        let observable = [PauliTerm::z(0), PauliTerm::z(n / 2)];
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(scalar_expectation(circ, &observable).unwrap());
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Reduced density matrix on a long chain, past the dense query ceiling.
+///
+/// The query doubles the network against its conjugate and contracts with one
+/// ket and one bra leg open, so the rows exercise tree choice on a doubled
+/// low-treewidth network at widths where `probabilities()` cannot answer.
+/// Depth 4 peaks at 64 elements whatever the width, so those rows weigh
+/// per-contraction overhead; depth 8 at 60 qubits peaks at 1M elements and
+/// weighs the arithmetic.
+fn bench_tn_rdm_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/rdm_chain");
+    configure_group(&mut group);
+
+    for &(n, depth) in &[(40usize, 4usize), (60, 4), (60, 8)] {
+        let circuit = circuits::cz_chain_circuit(n, depth, SEED);
+        let mut tn = TensorNetworkBackend::new(SEED);
+        tn.init(n, 0).unwrap();
+        for inst in &circuit.instructions {
+            tn.apply(inst).unwrap();
+        }
+        let label = format!("{n}_d{depth}");
+        group.bench_with_input(BenchmarkId::from_parameter(label), &tn, |b, backend| {
+            b.iter(|| {
+                black_box(backend.reduced_density_matrix_1q(n / 2).unwrap());
             });
         });
     }
@@ -2866,6 +2922,8 @@ criterion_group! {
     bench_tn_scalar_expectation,
     bench_tn_scalar_depth,
     bench_tn_scalar_wide_deep,
+    bench_tn_scalar_tree_quality,
+    bench_tn_rdm_chain,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -32,9 +32,17 @@
 //!
 //! # Contraction strategy
 //!
-//! Greedy min-size heuristic: repeatedly contract the pair of tensors whose
-//! result has the smallest total element count, preferring pairs sharing a leg.
-//! O(T·r·log T) for T tensors of rank at most r.
+//! A metadata-only planner picks the pair order, then the kernel replays it.
+//! The baseline plan is the greedy min-size heuristic: repeatedly contract the
+//! pair of tensors whose result has the smallest total element count,
+//! preferring pairs sharing a leg. O(T·r·log T) for T tensors of rank at most
+//! r. When the greedy plan's peak intermediate reaches
+//! `RESTART_PEAK_THRESHOLD`, the planner reruns with seeded multiplicative
+//! noise on the size key, `PLAN_RESTARTS_PER_TEMPERATURE` passes at each
+//! `PLAN_NOISE_TEMPERATURES` entry, and keeps the tree with the smallest peak
+//! intermediate, the greedy tree included, so the peak never rises. Planning
+//! touches shapes and legs only, so a restart costs a heap walk, not data
+//! movement.
 //!
 //! # Observables contract natively; shots stay on the dense route
 //!
@@ -361,7 +369,72 @@ fn contract(a: &Tensor, b: &Tensor) -> Tensor {
     }
 }
 
-fn contraction_result_size(a: &Tensor, b: &Tensor) -> usize {
+/// Shape and legs of a tensor, all the planner reads.
+#[derive(Clone)]
+struct TensorMeta {
+    shape: SmallVec<[usize; 6]>,
+    legs: SmallVec<[LegId; 6]>,
+}
+
+impl TensorMeta {
+    fn of(tensor: &Tensor) -> Self {
+        Self {
+            shape: tensor.shape.clone(),
+            legs: tensor.legs.clone(),
+        }
+    }
+
+    fn num_elements(&self) -> usize {
+        self.shape.iter().product::<usize>().max(1)
+    }
+}
+
+/// Pair order for one contraction, with the two counts plans are ranked by.
+///
+/// `pairs` holds slot indices, inputs first, each result appended at the next
+/// index. `peak` is the largest result element count; `total` sums them and
+/// breaks peak ties.
+struct ContractionPlan {
+    pairs: Vec<(usize, usize)>,
+    peak: usize,
+    total: usize,
+}
+
+/// Noisy passes per temperature once the greedy plan's peak intermediate
+/// reaches [`RESTART_PEAK_THRESHOLD`].
+///
+/// Sized against the temperature sweep on `hardware_efficient_ansatz(n, 7)`
+/// scalar networks: first improvements appeared as late as a temperature's
+/// 23rd pass, and a fully fruitless 32-pass sweep cost 110 ms per
+/// temperature against the multi-second contraction the threshold
+/// guarantees.
+const PLAN_RESTARTS_PER_TEMPERATURE: u64 = 32;
+
+/// Peak intermediate element count at which the noisy restarts run.
+///
+/// Below it the contraction is cheap enough that extra planning passes cost
+/// more than a better tree returns; the depth-swept bench rows peak an order
+/// of magnitude under this and stay on the single greedy pass.
+const RESTART_PEAK_THRESHOLD: usize = 1 << 22;
+
+/// Noise scales for the restart sweep, in doublings of the size key.
+///
+/// Measured on `hardware_efficient_ansatz(n, 7)` scalar networks under the
+/// per-pass seeding: 0.25 and below found nothing at n = 50 in 32 passes,
+/// 2.0 and 4.0 found nothing at either width, and 0.5 and 1.0 carried every
+/// improvement seen.
+const PLAN_NOISE_TEMPERATURES: [f64; 2] = [0.5, 1.0];
+
+/// Fixed base seed for the restart noise, so one network always maps to one
+/// tree.
+///
+/// Planning runs inside `&self` queries that cannot reach the run rng, and
+/// drawing from it would shift the measurement outcome stream relative to the
+/// other backends. Each (temperature, pass) reseeds from this base, so a
+/// pass's noise does not depend on how early the passes before it aborted.
+const PLAN_NOISE_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
+
+fn contraction_result_size(a: &TensorMeta, b: &TensorMeta) -> usize {
     let mut a_free_size = 1usize;
     let mut b_free_size = 1usize;
     for (ai, &a_leg) in a.legs.iter().enumerate() {
@@ -379,13 +452,50 @@ fn contraction_result_size(a: &Tensor, b: &Tensor) -> usize {
     a_free_size * b_free_size
 }
 
-/// Contraction candidates ordered by result element count, then by the higher
-/// slot id descending, then the lower.
+/// Compute the free legs of `a` then `b`, in each operand's axis order,
+/// matching the result [`contract`] builds for the same pair.
+fn contract_meta(a: &TensorMeta, b: &TensorMeta) -> TensorMeta {
+    let mut shape: SmallVec<[usize; 6]> = SmallVec::new();
+    let mut legs: SmallVec<[LegId; 6]> = SmallVec::new();
+    for (ai, &leg) in a.legs.iter().enumerate() {
+        if !b.legs.contains(&leg) {
+            shape.push(a.shape[ai]);
+            legs.push(leg);
+        }
+    }
+    for (bi, &leg) in b.legs.iter().enumerate() {
+        if !a.legs.contains(&leg) {
+            shape.push(b.shape[bi]);
+            legs.push(leg);
+        }
+    }
+    TensorMeta { shape, legs }
+}
+
+/// Contraction candidates ordered by size key, then by the higher slot id
+/// descending, then the lower.
 ///
-/// Newest-first on ties keeps the contraction on its frontier instead of letting
-/// fresh tensors accumulate legs. Reversing the tie-break raises peak
-/// intermediates 16x on `hardware_efficient_ansatz(50, 3)`.
-type PairQueue = BinaryHeap<Reverse<(usize, Reverse<usize>, Reverse<usize>)>>;
+/// The key is the result element count, scaled by Gumbel noise on a noisy
+/// planning pass. Newest-first on ties keeps the contraction on its frontier
+/// instead of letting fresh tensors accumulate legs. Reversing the tie-break
+/// raises peak intermediates 16x on `hardware_efficient_ansatz(50, 3)`.
+type PairQueue = BinaryHeap<Reverse<(u64, Reverse<usize>, Reverse<usize>)>>;
+
+/// Compute the size key for one candidate pair.
+///
+/// The noisy arm multiplies by `2^(temperature * gumbel)` and compares the
+/// result through its bit pattern, which orders positive floats numerically.
+fn pair_key(cost: usize, noise: Option<(&mut ChaCha8Rng, f64)>) -> u64 {
+    match noise {
+        None => cost as u64,
+        Some((rng, temperature)) => {
+            use rand::RngExt;
+            let uniform: f64 = rng.random::<f64>();
+            let gumbel = -(-uniform.max(f64::MIN_POSITIVE).ln()).ln();
+            ((cost as f64) * (temperature * gumbel).exp2()).to_bits()
+        }
+    }
+}
 
 /// Record `slot` against each of its legs and queue it against every live tensor
 /// already sharing one, pruning contracted slots off the holder lists it walks.
@@ -393,24 +503,30 @@ type PairQueue = BinaryHeap<Reverse<(usize, Reverse<usize>, Reverse<usize>)>>;
 /// A tensor carrying one leg twice would otherwise queue against itself; no
 /// valid circuit produces one.
 fn queue_slot_pairs(
-    slots: &[Option<Tensor>],
+    slots: &[Option<TensorMeta>],
     slot: usize,
     leg_holders: &mut Vec<SmallVec<[usize; 2]>>,
     queue: &mut PairQueue,
+    noise: &mut Option<(&mut ChaCha8Rng, f64)>,
 ) {
-    let tensor = slots[slot].as_ref().expect("slot just filled");
-    for &leg in &tensor.legs {
+    let meta = slots[slot].as_ref().expect("slot just filled");
+    for &leg in &meta.legs {
         if leg >= leg_holders.len() {
             leg_holders.resize(leg + 1, SmallVec::new());
         }
         leg_holders[leg].retain(|held| slots[*held].is_some());
         for &other in leg_holders[leg].iter().filter(|&&held| held != slot) {
             let cost = contraction_result_size(
-                tensor,
+                meta,
                 slots[other].as_ref().expect("holder list pruned above"),
             );
             queue.push(Reverse((
-                cost,
+                pair_key(
+                    cost,
+                    noise
+                        .as_mut()
+                        .map(|(rng, temperature)| (&mut **rng, *temperature)),
+                ),
                 Reverse(other.max(slot)),
                 Reverse(other.min(slot)),
             )));
@@ -422,13 +538,90 @@ fn queue_slot_pairs(
 /// Pop the cheapest queued pair whose members are both still live.
 ///
 /// Returns `None` once no two live tensors share a leg.
-fn pop_live_pair(queue: &mut PairQueue, slots: &[Option<Tensor>]) -> Option<(usize, usize)> {
+fn pop_live_pair(queue: &mut PairQueue, slots: &[Option<TensorMeta>]) -> Option<(usize, usize)> {
     while let Some(Reverse((_, Reverse(j), Reverse(i)))) = queue.pop() {
         if slots[i].is_some() && slots[j].is_some() {
             return Some((i, j));
         }
     }
     None
+}
+
+/// Run one greedy planning pass over the metadata, deterministic when `noise`
+/// is `None` and Gumbel-perturbed otherwise.
+///
+/// Returns `None` as soon as a result exceeds `abort_above` elements: the pass
+/// can no longer beat the plan holding that peak, and abandoning it keeps a
+/// failed restart from paying for a full walk. Peak ties complete, since they
+/// can still win on `total`.
+fn plan_pairs(
+    mut slots: Vec<Option<TensorMeta>>,
+    mut noise: Option<(&mut ChaCha8Rng, f64)>,
+    abort_above: usize,
+) -> Option<ContractionPlan> {
+    let mut leg_holders: Vec<SmallVec<[usize; 2]>> = Vec::new();
+    let mut queue: PairQueue = BinaryHeap::new();
+
+    for slot in 0..slots.len() {
+        queue_slot_pairs(&slots, slot, &mut leg_holders, &mut queue, &mut noise);
+    }
+
+    let mut plan = ContractionPlan {
+        pairs: Vec::new(),
+        peak: 0,
+        total: 0,
+    };
+    while let Some((i, j)) = pop_live_pair(&mut queue, &slots) {
+        let a = slots[i].take().expect("popped pair is live");
+        let b = slots[j].take().expect("popped pair is live");
+        let result = contract_meta(&a, &b);
+        let elements = result.num_elements();
+        if elements > abort_above {
+            return None;
+        }
+        plan.peak = plan.peak.max(elements);
+        plan.total += elements;
+        plan.pairs.push((i, j));
+        slots.push(Some(result));
+        queue_slot_pairs(
+            &slots,
+            slots.len() - 1,
+            &mut leg_holders,
+            &mut queue,
+            &mut noise,
+        );
+    }
+    Some(plan)
+}
+
+/// Plan greedily, then rerun with noise when the greedy peak intermediate
+/// reaches [`RESTART_PEAK_THRESHOLD`], keeping the best plan by peak then
+/// total.
+///
+/// The greedy plan competes, so the peak never rises. The restart arm walks
+/// `tensors` a second time; below the threshold the single pass pays one
+/// metadata copy and no more.
+fn plan_with_restarts(tensors: &[Tensor]) -> ContractionPlan {
+    let slots: Vec<Option<TensorMeta>> = tensors.iter().map(|t| Some(TensorMeta::of(t))).collect();
+    let mut plan = plan_pairs(slots, None, usize::MAX).expect("unbounded pass completes");
+    if plan.peak >= RESTART_PEAK_THRESHOLD {
+        let metas: Vec<TensorMeta> = tensors.iter().map(TensorMeta::of).collect();
+        for (temp_index, &temperature) in PLAN_NOISE_TEMPERATURES.iter().enumerate() {
+            for pass in 0..PLAN_RESTARTS_PER_TEMPERATURE {
+                let pass_seed = PLAN_NOISE_SEED ^ (((temp_index as u64) << 32) | pass);
+                let mut rng = ChaCha8Rng::seed_from_u64(pass_seed);
+                let slots: Vec<Option<TensorMeta>> = metas.iter().cloned().map(Some).collect();
+                let Some(candidate) = plan_pairs(slots, Some((&mut rng, temperature)), plan.peak)
+                else {
+                    continue;
+                };
+                if (candidate.peak, candidate.total) < (plan.peak, plan.total) {
+                    plan = candidate;
+                }
+            }
+        }
+    }
+    plan
 }
 
 /// Multiply out the tensors left once no pair shares a leg, smallest first.
@@ -459,26 +652,20 @@ fn join_disjoint(mut slots: Vec<Option<Tensor>>) -> Tensor {
     slots[last].take().expect("queued slots are live")
 }
 
-/// Contract an entire tensor network with the greedy min-size heuristic.
+/// Contract an entire tensor network along a planned pair order.
 ///
-/// Only pairs involving the tensor a contraction produced change cost, so
-/// candidates come off a leg-indexed queue.
+/// Planning walks metadata only; the replay here is where data moves. Pairs
+/// the plan leaves uncontracted share no leg and go to [`join_disjoint`].
 fn greedy_contract(tensors: &mut Vec<Tensor>) -> Tensor {
     debug_assert!(!tensors.is_empty());
 
+    let plan = plan_with_restarts(tensors);
+
     let mut slots: Vec<Option<Tensor>> = std::mem::take(tensors).into_iter().map(Some).collect();
-    let mut leg_holders: Vec<SmallVec<[usize; 2]>> = Vec::new();
-    let mut queue: PairQueue = BinaryHeap::new();
-
-    for slot in 0..slots.len() {
-        queue_slot_pairs(&slots, slot, &mut leg_holders, &mut queue);
-    }
-
-    while let Some((i, j)) = pop_live_pair(&mut queue, &slots) {
-        let a_tensor = slots[i].take().expect("popped pair is live");
-        let b_tensor = slots[j].take().expect("popped pair is live");
+    for &(i, j) in &plan.pairs {
+        let a_tensor = slots[i].take().expect("planned pair is live");
+        let b_tensor = slots[j].take().expect("planned pair is live");
         slots.push(Some(contract(&a_tensor, &b_tensor)));
-        queue_slot_pairs(&slots, slots.len() - 1, &mut leg_holders, &mut queue);
     }
 
     join_disjoint(slots)
@@ -1733,6 +1920,85 @@ mod tests {
             crate::sim::run_expectation_values(&circuit, &[terms.to_vec()], 42).unwrap()[0];
         let actual = expectation_zero_state(&circuit, &terms).unwrap();
         assert!((actual - expected).abs() < EPS, "{actual} vs {expected}");
+    }
+
+    fn scalar_network(circuit: &Circuit, terms: &[PauliTerm]) -> ScalarExpectationNetwork {
+        let mut network = ScalarExpectationNetwork::new(circuit.num_qubits);
+        for instruction in &circuit.instructions {
+            let Instruction::Gate { gate, targets } = instruction else {
+                continue;
+            };
+            network.append_gate(gate, targets).unwrap();
+        }
+        network.append_observable(terms).unwrap();
+        network
+    }
+
+    // hardware_efficient_ansatz(30, 7) is a recorded case of the greedy tree
+    // peaking at 16.8M elements, past RESTART_PEAK_THRESHOLD, so the restart
+    // arm runs. Planning walks metadata only, so no contraction executes here.
+    #[test]
+    fn test_plan_restarts_deterministic_and_never_worse() {
+        let circuit = crate::circuits::hardware_efficient_ansatz(30, 7, 42);
+        let terms = [PauliTerm::z(0), PauliTerm::z(15)];
+        let network = scalar_network(&circuit, &terms);
+        let slots: Vec<Option<TensorMeta>> = network
+            .tensors
+            .iter()
+            .map(|t| Some(TensorMeta::of(t)))
+            .collect();
+
+        let greedy = plan_pairs(slots, None, usize::MAX).unwrap();
+        assert!(
+            greedy.peak >= RESTART_PEAK_THRESHOLD,
+            "fixture no longer reaches the restart arm: greedy peak {}",
+            greedy.peak
+        );
+
+        let best_a = plan_with_restarts(&network.tensors);
+        let best_b = plan_with_restarts(&network.tensors);
+        assert_eq!(best_a.pairs, best_b.pairs);
+        assert!(best_a.peak <= greedy.peak);
+        println!(
+            "greedy peak {} restart peak {} ({} pairs)",
+            greedy.peak,
+            best_a.peak,
+            best_a.pairs.len()
+        );
+    }
+
+    // Every noise stream must land on the same scalar: replay correctness for
+    // arbitrary plan orders is the risk the planner split introduces.
+    #[test]
+    fn test_noisy_plans_execute_to_the_same_scalar() {
+        let circuit = crate::circuits::hardware_efficient_ansatz(8, 3, 42);
+        let terms = [PauliTerm::z(0), PauliTerm::x(4)];
+        let expected = expectation_zero_state(&circuit, &terms).unwrap();
+
+        for seed in 0..5u64 {
+            let network = scalar_network(&circuit, &terms);
+            let slots: Vec<Option<TensorMeta>> = network
+                .tensors
+                .iter()
+                .map(|t| Some(TensorMeta::of(t)))
+                .collect();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let plan = plan_pairs(slots, Some((&mut rng, 1.0)), usize::MAX).unwrap();
+
+            let mut slots: Vec<Option<Tensor>> = network.tensors.into_iter().map(Some).collect();
+            for &(i, j) in &plan.pairs {
+                let a = slots[i].take().unwrap();
+                let b = slots[j].take().unwrap();
+                slots.push(Some(contract(&a, &b)));
+            }
+            let result = join_disjoint(slots);
+            assert_eq!(result.data.len(), 1);
+            assert!(
+                (result.data[0].re - expected).abs() < EPS,
+                "seed {seed}: {} vs {expected}",
+                result.data[0].re
+            );
+        }
     }
 
     // Two entangled components of unequal size, so join_disjoint merges tensors


### PR DESCRIPTION
## Summary

The tensor-network backend chose contraction pairs greedily while executing
them, so a bad tree could never be retried, and tree quality is non-monotonic
in width: peak intermediate 16.8M elements at 30 and 50 qubits against 1.05M
at 40 on the 7-layer ansatz shapes. Planning now runs on shapes and legs
alone, and when the greedy plan's peak intermediate reaches 2^22 elements the
planner reruns with seeded Gumbel noise on the size key (32 passes at each of
two temperatures), keeping the best tree by peak then total. The greedy plan
competes, so the planned peak never rises, and a failed restart pass aborts at
the first result that cannot win. Scoring stays on result size throughout: an
earlier measurement found a flop objective raising both peak and
multiply-accumulates on every scalar row.

The deterministic single pass reproduces the previous greedy order exactly, so
below-threshold networks execute the identical tree. Planner noise draws from
a fixed named seed, not the run rng, so measurement outcome streams are
byte-identical to before and one network always maps to one tree.

## Benchmark summary

New rows land one commit ahead of the planner change, so the A/B reference
carries them. `tn/scalar_hea_l7` (30/40/50 qubits) measures tree quality;
`tn/rdm_chain` rows are query-shaped guards whose peaks sit below the restart
threshold, so they gate the planner-split overhead, not the restarts.

Two agreeing clean runs (30 samples, adjacent-binary A/B; two further runs
were discarded whole for same-code control breaches of 20.2% and 76.2%):

| Benchmark | Before | After | Change (runs 1 / 4) |
|-----------|--------|-------|---------------------|
| `tn/scalar_hea_l7/30` | 1.256 s | 338.6 ms | -73.0% / -73.4% |
| `tn/scalar_hea_l7/50` | 3.006 s | 2.217 s | -26.2% / -26.3% |
| `tn/scalar_hea_l7/40` | 426.4 ms | 428.7 ms | +0.5% / -0.2% (same-tree control) |
| `tn/scalar_depth_20q/4..7` | | | -0.3% to +4.1%, within control |
| `tn/scalar_hea_l6/20..50` | | | -0.9% to +1.8%, within control |
| `tn/rdm_chain/60_d8` | 126.9 ms | 126.7 ms | -0.2% / +0.3% |

Planned peak intermediate on the winning rows falls 16.8M to 2.1M elements
(30q) and 16.8M to 8.4M (50q); planner cost is 136 ms and 229 ms against
multi-second contractions. At 40 qubits the greedy peak (1.05M) stays below
the threshold, so both sides execute the same tree; that row reading noise in
both runs bounds the split overhead on a 400 ms row.

`tn/scalar_hea_l2` rows are excluded from the verdict: four same-code runs on
this host reverse sign with spreads near 15%, so nothing gates on them in
either direction. Their eight readings here were all positive (+0.7% to
+6.7%), consistent with the waived mechanism below and with the recorded
layout term for this file (adding linked-but-uncalled code moved rows 4.1% to
13.2%; the one-binary switch method is unavailable because the interleaved
walk was deleted).

## Regression verdict

WAIVER. `tn/random_d10/8` regressed +4.9% / +6.2% / +8.5% over three runs
(sign-consistent, beyond its controls), and `tn/linear_chain/4` straddles the
gate at +3.3% / +3.7% / +6.0%. Mechanism: planning now rebuilds each result's
shape from metadata before the replay computes it again, a per-step constant
of roughly 50 to 100 ns. At 4 to 8 qubits fusion mostly does not run (its
thresholds start at 10 qubits), so these rows contract ~90 rank-1/2 tensors
in tens of microseconds and the constant reads as 3 to 9%. The same constant
is unmeasurable on every row at or above 12 qubits. These widths are
statevector territory the module docstring already routes away from this
backend; recovering them would mean re-interleaving the deterministic pass
behind a cheap peak bound, which is noted as future work in the internal
tracker.

Rows whose same-code control exceeded the gate in a given run are reported
unmeasured for that run (`tn/random_d10/4` in the confirming run).

## Hotspot notes

`contract`, `transpose`, and `join_disjoint` are untouched; the diff moves
pair selection into a metadata pass and replays it. The noisy key goes
through platform libm (`ln`, `exp2`), so tree selection above the threshold
can differ by an ulp across toolchains; correctness and the never-worse peak
bound hold either way, and the below-threshold plan is bit-portable.

## Tests

Planner determinism plus the never-worse peak bound on a fixture past the
threshold, and noisy plans under five seeds executing to the
statevector-checked scalar; the existing golden set unchanged. Full suite
green at `parallel gpu distributed`.

## Documentation

Module docstring updated (contraction strategy section); bench README rows
table extended. No architecture-page change: the backend's position and
applicability are unchanged.
