### PR TITLE
feat(tn): mid-circuit measurement without the dense collapse

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -62,6 +62,8 @@ worth the disk.
 | `tn/scalar_hea_l6` | Same contraction at 6 layers, 20–50 qubits, the only rows where qubit count drives how many contractions reach the faer arm (`bench-internal`) |
 | `tn/scalar_hea_l7` | Same contraction at 7 layers, 30–50 qubits, where the greedy tree's peak intermediate is non-monotonic in width; the rows that measure contraction tree quality (`bench-internal`) |
 | `tn/rdm_chain` | Single-qubit reduced density matrix on CZ chains at 40 and 60 qubits, query-shaped rows past the dense ceiling; depth 4 weighs per-contraction overhead, depth 8 the arithmetic |
+| `tn/midmeasure_chain` | CZ chain with one measurement and one reset at half depth, 16 and 20 qubits; the row where measurement path cost lands mid-run |
+| `tn/noisy_chain` | Depolarizing trajectories on the measured CZ chain at 16 qubits, 100 shots; moves with the measurement path as much as the noise machinery |
 
 The `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1161,6 +1161,64 @@ fn bench_tn_rdm_chain(c: &mut Criterion) {
     group.finish();
 }
 
+/// Build a CZ-chain circuit with one measurement and one reset at half depth.
+fn mid_measured_chain(n: usize, depth: usize) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    let singles = [Gate::H, Gate::S, Gate::T, Gate::X];
+    let mut c = Circuit::new(n, 1);
+    for layer in 0..depth {
+        for q in 0..n {
+            c.add_gate(singles[rng.random_range(0..singles.len())].clone(), &[q]);
+        }
+        let offset = layer % 2;
+        for q in (offset..n - 1).step_by(2) {
+            c.add_gate(Gate::Cz, &[q, q + 1]);
+        }
+        if layer + 1 == depth / 2 {
+            c.add_measure(n / 2, 0);
+            c.add_reset(n / 4);
+        }
+    }
+    c
+}
+
+/// Mid-circuit measurement on a chain, where the measurement path's cost
+/// lands mid-run rather than at the terminal readout.
+fn bench_tn_midmeasure_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/midmeasure_chain");
+    configure_group(&mut group);
+
+    for &n in &[16, 20] {
+        let circuit = mid_measured_chain(n, 4);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_with(BackendKind::TensorNetwork, circ, 42).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Depolarizing trajectories on the chain shape, the priced noisy row.
+///
+/// Terminal measurements dominate the per-shot cost, so this row moves with
+/// the measurement path as much as with the noise machinery.
+fn bench_tn_noisy_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/noisy_chain");
+    configure_group(&mut group);
+
+    let n = 16;
+    let mut circuit = circuits::cz_chain_circuit(n, 4, SEED);
+    circuit.measure_all();
+    let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+    group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+        b.iter(|| {
+            run_shots_with_noise(BackendKind::TensorNetwork, circ, &noise, 100, 42).unwrap();
+        });
+    });
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2924,6 +2982,8 @@ criterion_group! {
     bench_tn_scalar_wide_deep,
     bench_tn_scalar_tree_quality,
     bench_tn_rdm_chain,
+    bench_tn_midmeasure_chain,
+    bench_tn_noisy_chain,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -131,9 +131,11 @@ Shots and Pauli expectations answer from the per-qubit states rather than the `2
 
 ## Tensor Network
 
-Deferred contraction with a greedy min-size heuristic. Gates append tensors; contraction happens lazily at measurement or probability extraction. `MAX_PROB_QUBITS = 25` guards against exponential blowup.
+Deferred contraction planned on metadata: a greedy min-size pass picks the pair order, seeded noisy restarts rerun it when the greedy tree's peak intermediate grows large, and the kernel replays the winner. Gates append tensors; contraction happens lazily at probability extraction, where `MAX_PROB_QUBITS = 25` guards against the dense readout.
 
-Two queries stay off the dense route by contracting the network against its conjugate.
+Measurement and reset do not contract to the dense state: the outcome draws from the single-qubit reduced density matrix and the renormalizing projector is absorbed into the tensor holding the measured qubit's output leg, so the network keeps its deferred form, mid-circuit measurement carries no width ceiling, and the tensor count does not grow across measurements.
+
+Two further queries stay off the dense route by contracting the network against its conjugate.
 The bra copy's legs are shifted clear of the ket index space, and each qubit's boundary
 is either closed against its twin, which is a trace, or joined through an operator. A
 one-qubit reduced density matrix leaves that qubit's ket and bra indices open and

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -2,14 +2,17 @@
 //!
 //! Represents the quantum state as a network of tensors. Gate application
 //! appends gate tensors to the network (deferred contraction). Contraction
-//! happens lazily when `probabilities()` or measurement is requested.
+//! happens lazily when `probabilities()` or another query is requested.
 //!
 //! # Memory layout
 //!
 //! - Each tensor: contiguous `Vec<Complex64>` plus a shape vector and leg ids
 //!   (up to 6 held inline).
 //! - Gates append tensors, so memory grows with gate count until a query
-//!   contracts the network; measurement leaves one dense rank-n tensor.
+//!   contracts the network. Measurement and reset absorb a projector into the
+//!   tensor holding the measured qubit's output leg and keep the deferred
+//!   form: the outcome marginal contracts the doubled network, so mid-circuit
+//!   measurement carries no dense width ceiling and does not grow the network.
 //!
 //! # Gate support
 //!
@@ -1123,29 +1126,55 @@ impl TensorNetworkBackend {
         id
     }
 
-    fn replace_with_statevector(&mut self, state: Vec<Complex64>) {
-        let n = self.num_qubits;
-        self.tensors.clear();
-        self.next_leg = 0;
-        self.output_legs.clear();
+    /// Draw the outcome for `qubit` from its reduced density matrix and append
+    /// the renormalizing projector, keeping the network in deferred form.
+    ///
+    /// The marginal contracts the doubled network, so no `2^n` vector is built
+    /// and measurement carries no dense width ceiling. One rng draw per call,
+    /// in program order, matching every other backend's outcome stream.
+    fn collapse_qubit(&mut self, qubit: usize, reset: bool) -> Result<bool> {
+        use rand::RngExt;
 
-        for _ in 0..n {
-            let leg = self.fresh_leg();
-            self.output_legs.push(leg);
-        }
+        let rho = self.reduced_density_matrix_1q(qubit)?;
+        let trace = (rho[0][0].re + rho[1][1].re).max(NORM_CLAMP_MIN);
+        let prob_one = (rho[1][1].re / trace).clamp(0.0, 1.0);
+        let outcome = self.rng.random::<f64>() < prob_one;
+        let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
+        self.append_collapse(qubit, outcome, reset, inv_norm);
+        Ok(outcome)
+    }
 
-        let mut shape: SmallVec<[usize; 6]> = SmallVec::new();
-        let mut legs: SmallVec<[LegId; 6]> = SmallVec::new();
-        for q in (0..n).rev() {
-            shape.push(2);
-            legs.push(self.output_legs[q]);
-        }
+    /// Absorb the rank-2 tensor that keeps only `outcome` on `qubit`, scaled by
+    /// `inv_norm`, into the tensor holding the qubit's output leg, mapping the
+    /// kept branch to `|0>` when `reset` is set.
+    ///
+    /// Contracting into the owner instead of appending keeps the tensor count
+    /// constant across measurements, so a measure or reset loop costs one
+    /// doubled contraction per event rather than growing the network it
+    /// contracts.
+    fn append_collapse(&mut self, qubit: usize, outcome: bool, reset: bool, inv_norm: f64) {
+        let in_leg = self.output_legs[qubit];
+        let out_leg = self.fresh_leg();
+        let zero = Complex64::new(0.0, 0.0);
+        let scale = Complex64::new(inv_norm, 0.0);
 
-        self.tensors.push(Tensor {
-            data: state,
-            shape,
-            legs,
-        });
+        let in_idx = usize::from(outcome);
+        let out_idx = if reset { 0 } else { in_idx };
+        let mut data = vec![zero; 4];
+        data[out_idx * 2 + in_idx] = scale;
+
+        let projector = Tensor {
+            data,
+            shape: smallvec::smallvec![2, 2],
+            legs: smallvec::smallvec![out_leg, in_leg],
+        };
+        let owner = self
+            .tensors
+            .iter()
+            .position(|t| t.legs.contains(&in_leg))
+            .expect("every output leg has an owner");
+        self.tensors[owner] = contract(&self.tensors[owner], &projector);
+        self.output_legs[qubit] = out_leg;
     }
 
     fn append_1q_matrix(&mut self, target: usize, mat: &[[Complex64; 2]; 2]) {
@@ -1255,28 +1284,7 @@ impl TensorNetworkBackend {
     }
 
     fn apply_reset(&mut self, qubit: usize) -> Result<()> {
-        use rand::RngExt;
-
-        let amplitudes = self.contract_to_statevector()?;
-        let mask = 1usize << qubit;
-
-        let mut prob_one = 0.0f64;
-        for (idx, amp) in amplitudes.iter().enumerate() {
-            if idx & mask != 0 {
-                prob_one += amp.norm_sqr();
-            }
-        }
-        let outcome = self.rng.random::<f64>() < prob_one;
-        let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
-
-        let mut collapsed = vec![Complex64::new(0.0, 0.0); amplitudes.len()];
-        for (idx, amp) in amplitudes.iter().enumerate() {
-            if (idx & mask != 0) == outcome {
-                collapsed[idx & !mask] = amp * inv_norm;
-            }
-        }
-
-        self.replace_with_statevector(collapsed);
+        self.collapse_qubit(qubit, true)?;
         Ok(())
     }
 
@@ -1443,36 +1451,8 @@ impl Backend for TensorNetworkBackend {
                 qubit,
                 classical_bit,
             } => {
-                use rand::RngExt;
-
-                let amplitudes = self.contract_to_statevector()?;
-
-                let mut prob_one = 0.0f64;
-                for (idx, amp) in amplitudes.iter().enumerate() {
-                    if (idx >> qubit) & 1 == 1 {
-                        prob_one += amp.norm_sqr();
-                    }
-                }
-
-                let outcome = self.rng.random::<f64>() < prob_one;
+                let outcome = self.collapse_qubit(*qubit, false)?;
                 self.classical_bits[*classical_bit] = outcome;
-
-                let mut collapsed = amplitudes;
-                let mut norm_sq = 0.0f64;
-                for (idx, amp) in collapsed.iter_mut().enumerate() {
-                    let bit = (idx >> qubit) & 1 == 1;
-                    if bit != outcome {
-                        *amp = Complex64::new(0.0, 0.0);
-                    } else {
-                        norm_sq += amp.norm_sqr();
-                    }
-                }
-                let norm = norm_sq.clamp(NORM_CLAMP_MIN, 1.0).sqrt();
-                for amp in &mut collapsed {
-                    *amp /= norm;
-                }
-
-                self.replace_with_statevector(collapsed);
             }
             Instruction::Reset { qubit } => {
                 self.apply_reset(*qubit)?;
@@ -1999,6 +1979,90 @@ mod tests {
                 result.data[0].re
             );
         }
+    }
+
+    // Mid-circuit measure and reset must agree with the statevector on the
+    // seeded outcome stream, not just on the marginals, and on the final
+    // distribution after further gates.
+    #[test]
+    fn test_mid_circuit_measure_reset_matches_statevector() {
+        let mut c = Circuit::new(5, 2);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Ry(0.7), &[2]);
+        c.add_measure(1, 0);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_reset(0);
+        c.add_gate(Gate::Cx, &[0, 3]);
+        c.add_measure(2, 1);
+        c.add_gate(Gate::Ry(0.3), &[4]);
+
+        for seed in [42u64, 7, 12345] {
+            let mut sv = StatevectorBackend::new(seed);
+            sv.init(5, 2).unwrap();
+            let mut tn = TensorNetworkBackend::new(seed);
+            tn.init(5, 2).unwrap();
+            for inst in &c.instructions {
+                sv.apply(inst).unwrap();
+                tn.apply(inst).unwrap();
+            }
+            assert_eq!(
+                tn.classical_results(),
+                sv.classical_results(),
+                "seed {seed}"
+            );
+            assert_probs_close(&tn.probabilities().unwrap(), &sv.probabilities().unwrap());
+        }
+    }
+
+    // A measurement past the dense query ceiling must succeed and keep the
+    // deferred form: no rank-n tensor, and the network still answers
+    // expectation queries that never build a 2^n vector.
+    #[test]
+    fn test_measurement_past_dense_ceiling_keeps_network() {
+        let n = 30;
+        let mut tn = TensorNetworkBackend::new(42);
+        tn.init(n, 1).unwrap();
+        tn.apply(&Instruction::Gate {
+            gate: Gate::H,
+            targets: smallvec::smallvec![0],
+        })
+        .unwrap();
+        tn.apply(&Instruction::Gate {
+            gate: Gate::Cx,
+            targets: smallvec::smallvec![0, 1],
+        })
+        .unwrap();
+        tn.apply(&Instruction::Gate {
+            gate: Gate::Cx,
+            targets: smallvec::smallvec![1, 2],
+        })
+        .unwrap();
+        tn.apply(&Instruction::Measure {
+            qubit: 1,
+            classical_bit: 0,
+        })
+        .unwrap();
+
+        assert!(tn.tensors.len() > 1);
+        assert!(tn.tensors.iter().all(|t| t.rank() < 6));
+
+        let outcome = tn.classical_results()[0];
+        let expected = if outcome { -1.0 } else { 1.0 };
+        let exps = tn
+            .pauli_expectations(&[vec![PauliTerm::z(0)], vec![PauliTerm::z(2)]])
+            .unwrap();
+        assert!(
+            (exps[0] - expected).abs() < EPS,
+            "{} vs {expected}",
+            exps[0]
+        );
+        assert!(
+            (exps[1] - expected).abs() < EPS,
+            "{} vs {expected}",
+            exps[1]
+        );
     }
 
     // Two entangled components of unequal size, so join_disjoint merges tensors


### PR DESCRIPTION
## Summary

Measure and reset on the tensor-network backend contracted the whole network
into a rank-n statevector and rebuilt it as one dense tensor, so a single
mid-circuit measurement capped the rest of the run at 25 qubits and discarded
the deferred structure. The outcome now draws from the single-qubit reduced
density matrix (the existing doubled-network machinery), and the
renormalizing projector is absorbed into the tensor holding the measured
qubit's output leg: the network keeps its deferred form, measurement carries
no width ceiling, and the tensor count does not grow across measurements.
One rng draw per event in program order, so seeded outcome streams match the
other backends unchanged; the 193-test cross-backend conformance set passes
as is.

## Benchmark summary

New rows land one commit ahead of the backend change, so the A/B reference
carries them. Two agreeing clean runs, 30 samples, adjacent-binary A/B; the
gating rows held sub-4% same-code controls (run 1 flagged the 20-qubit
midmeasure row on a 5.5% control; run 2 resolved it at sub-1%).

| Benchmark | Before | After | Change (runs 1 / 2) |
|-----------|--------|-------|---------------------|
| `tn/midmeasure_chain/16` | 6.31 ms | 1.38 ms | -78.2% / -78.4% |
| `tn/midmeasure_chain/20` | 102.6 ms | 15.5 ms | -84.9% / -85.8% |
| `tn/noisy_chain/16` | 833.9 ms | 486.9 ms | -41.6% / -38.4% |

Every other `tn/` row read within its own control in both runs. The win
below the ceiling comes from replacing a dense contraction plus `2^n`
collapse passes per event with a sub-millisecond doubled-network contraction
on these chain shapes.

The width claim has no bench row by construction: the reference errors on
any measurement above 25 qubits, so a before/after cannot exist. It is
test-backed instead: a 30-qubit measurement succeeds with the network still
deferred and expectation queries still answering.

## Regression verdict

PASS at 5.0%, both runs, no waiver. Rows whose same-code control exceeded
the gate in a given run are reported unmeasured for that run.

## Hotspot notes

The contraction kernels and planner are untouched; the diff replaces the
Measure and Reset arms and deletes the dense rebuild. The reduced-density-
matrix contraction carries no memory guard past the dense ceiling, the same
exposure the pre-existing expectation paths have: a pathologically entangled
wide network fails by allocation rather than by a clean error. A doubled
network whose planned peak crosses the restart threshold would pay noisy
planning per measurement; the nearest benched shape sits 4x under it.

## Tests

Seeded outcome-stream parity with the statevector across three seeds on a
mid-circuit measure-and-reset fixture, and a 30-qubit measurement asserting
the deferred form survives (no rank-n tensor, expectations answer). Full
suite green at `parallel gpu distributed`, cross-backend conformance
included.

## Documentation

Module docstring rewritten for the projector path; backends architecture
page updated (it still described dense collapse under a 25-qubit ceiling);
bench README rows table extended.
