### PR TITLE
feat(tn): native qubit-by-qubit shot sampling

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -64,7 +64,7 @@ worth the disk.
 | `tn/rdm_chain` | Single-qubit reduced density matrix on CZ chains at 40 and 60 qubits, query-shaped rows past the dense ceiling; depth 4 weighs per-contraction overhead, depth 8 the arithmetic |
 | `tn/midmeasure_chain` | CZ chain with one measurement and one reset at half depth, 16 and 20 qubits; the row where measurement path cost lands mid-run |
 | `tn/noisy_chain` | Depolarizing trajectories on the measured CZ chain at 16 qubits, 100 shots; moves with the measurement path as much as the noise machinery |
-| `tn/sample_chain` | Terminal shot sampling on measured CZ chains at 16 and 40 qubits, 32 shots; 16 is the honest comparison against the dense funnel, 40 is past the dense ceiling |
+| `tn/sample_chain` | Terminal shot sampling on measured CZ chains at 16 and 40 qubits, 32 shots; 16 guards the dense arm, 40 prices the conditional sweep past the dense ceiling |
 
 The `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs

--- a/benches/README.md
+++ b/benches/README.md
@@ -64,6 +64,7 @@ worth the disk.
 | `tn/rdm_chain` | Single-qubit reduced density matrix on CZ chains at 40 and 60 qubits, query-shaped rows past the dense ceiling; depth 4 weighs per-contraction overhead, depth 8 the arithmetic |
 | `tn/midmeasure_chain` | CZ chain with one measurement and one reset at half depth, 16 and 20 qubits; the row where measurement path cost lands mid-run |
 | `tn/noisy_chain` | Depolarizing trajectories on the measured CZ chain at 16 qubits, 100 shots; moves with the measurement path as much as the noise machinery |
+| `tn/sample_chain` | Terminal shot sampling on measured CZ chains at 16 and 40 qubits, 32 shots; 16 is the honest comparison against the dense funnel, 40 is past the dense ceiling |
 
 The `tn/scalar_*` groups are compiled out unless `bench-internal` is enabled, and
 `bench_ab.sh` defaults to `--features parallel`, so a gating run over them needs

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1219,6 +1219,28 @@ fn bench_tn_noisy_chain(c: &mut Criterion) {
     group.finish();
 }
 
+/// Terminal shot sampling on the measured chain.
+///
+/// At 16 qubits the dense funnel also answers, so the row is the honest
+/// comparison between routes and may read against the native path there.
+/// 40 qubits is past the dense ceiling, where the row could not exist
+/// before native sampling.
+fn bench_tn_sample_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tn/sample_chain");
+    configure_group(&mut group);
+
+    for &n in &[16usize, 40] {
+        let mut circuit = circuits::cz_chain_circuit(n, 4, SEED);
+        circuit.measure_all();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_shots_with(BackendKind::TensorNetwork, circ, 32, 42).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
 // ---- Cross-backend comparisons ----
 
 fn bench_compare_clifford(c: &mut Criterion) {
@@ -2984,6 +3006,7 @@ criterion_group! {
     bench_tn_rdm_chain,
     bench_tn_midmeasure_chain,
     bench_tn_noisy_chain,
+    bench_tn_sample_chain,
     // Auto dispatch
     bench_auto_random,
     bench_auto_qft,

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1221,10 +1221,10 @@ fn bench_tn_noisy_chain(c: &mut Criterion) {
 
 /// Terminal shot sampling on the measured chain.
 ///
-/// At 16 qubits the dense funnel also answers, so the row is the honest
-/// comparison between routes and may read against the native path there.
-/// 40 qubits is past the dense ceiling, where the row could not exist
-/// before native sampling.
+/// At 16 qubits the sampler answers from the dense distribution, so the row
+/// guards that arm against the routed dense funnel it replaces. At 40 qubits
+/// the conditional sweep is the route, priced against per-shot projector
+/// trajectories.
 fn bench_tn_sample_chain(c: &mut Criterion) {
     let mut group = c.benchmark_group("tn/sample_chain");
     configure_group(&mut group);

--- a/docs/architecture/samplers.md
+++ b/docs/architecture/samplers.md
@@ -94,8 +94,14 @@ lives in `mps_conditional_path_probabilities_match_the_dense_vector`
 (`src/backend/mps.rs`), and the corpus-wide comparison is the query matrix in
 `tests/conformance_matrix.rs`.
 
-The tensor network stays on the dense route by decision, not by omission; its
-module docstring records why.
+The tensor network answers below its dense ceiling from one contraction of
+the full distribution, and past it samples qubit by qubit: each bit draws
+from the conditioned single-qubit marginal, contracted on the doubled
+network, and the outcome projector is absorbed before the next qubit's
+marginal. A sweep shot costs one doubled contraction per qubit with peaks set
+by treewidth rather than `2^n`, which is what carries sampling past the
+ceiling; the measured crossover that put the dense arm below it is recorded
+in the backend's module docstring.
 
 ## Weighted observables and commuting-set grouping (`src/sim/observable.rs`)
 

--- a/src/backend/tensornetwork.rs
+++ b/src/backend/tensornetwork.rs
@@ -30,8 +30,6 @@
 //!
 //! - High-treewidth circuits, where contraction intermediates outgrow the
 //!   dense statevector.
-//! - Shot- or observable-heavy workloads; both route through `probabilities()`
-//!   (see below).
 //!
 //! # Contraction strategy
 //!
@@ -47,7 +45,7 @@
 //! touches shapes and legs only, so a restart costs a heap walk, not data
 //! movement.
 //!
-//! # Observables contract natively; shots stay on the dense route
+//! # Observables and shots both contract natively
 //!
 //! `Backend::pauli_expectations` and `Backend::reduced_density_matrix_1q` both
 //! answer by doubling the network against its conjugate: the bra copy's legs are
@@ -58,13 +56,13 @@
 //! An identity factor is a closed leg rather than an appended tensor, so a
 //! weight-`k` observable adds `k` tensors to a network of `2T`, not `n`.
 //!
-//! `Backend::sample_basis_states` is not overridden, and shots continue to route
-//! through `probabilities()`. Sampling one bitstring from a deferred network
-//! means contracting it once per qubit to get each conditional, so a shot costs
-//! `n` contractions against the single contraction the dense route pays for the
-//! whole distribution. That is strictly worse whenever the statevector fits, and
-//! when it does not fit the per-qubit contractions do not fit either: the cost is
-//! set by treewidth, which conditioning does not reduce.
+//! `Backend::sample_basis_states` answers below the dense ceiling from one
+//! contraction of the full distribution, a measured 66x cheaper than the
+//! sweep at 16 qubits and 32 shots. Past the ceiling it samples qubit by
+//! qubit: each bit is drawn from the conditioned single-qubit marginal, and
+//! the outcome projector is absorbed before the next qubit's marginal, so a
+//! shot costs `n` doubled contractions whose peak is set by treewidth rather
+//! than `2^n`.
 //!
 //! `expectation_zero_state` remains a separate path, contracting `⟨0|U†PU|0⟩`
 //! from a circuit rather than an evolved backend, and is what the QEC estimator
@@ -79,7 +77,10 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use smallvec::SmallVec;
 
-use crate::backend::{Backend, NORM_CLAMP_MIN, dense_statevector_len, tensor_probability_len};
+use crate::backend::{
+    Backend, BasisSamples, NORM_CLAMP_MIN, dense_statevector_len, reserve_dense_output,
+    tensor_probability_len,
+};
 use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
@@ -1135,13 +1136,74 @@ impl TensorNetworkBackend {
     fn collapse_qubit(&mut self, qubit: usize, reset: bool) -> Result<bool> {
         use rand::RngExt;
 
+        let uniform = self.rng.random::<f64>();
+        self.collapse_qubit_with(qubit, reset, uniform)
+    }
+
+    /// Collapse `qubit` with a caller-supplied uniform draw, so the native
+    /// sampler can drive collapses from its own seeded stream without
+    /// touching the run rng.
+    fn collapse_qubit_with(&mut self, qubit: usize, reset: bool, uniform: f64) -> Result<bool> {
         let rho = self.reduced_density_matrix_1q(qubit)?;
         let trace = (rho[0][0].re + rho[1][1].re).max(NORM_CLAMP_MIN);
         let prob_one = (rho[1][1].re / trace).clamp(0.0, 1.0);
-        let outcome = self.rng.random::<f64>() < prob_one;
+        let outcome = uniform < prob_one;
         let inv_norm = crate::backend::measurement_inv_norm(outcome, prob_one);
         self.append_collapse(qubit, outcome, reset, inv_norm);
         Ok(outcome)
+    }
+
+    /// Draw one shot into `samples` by fixing qubits in index order, each bit
+    /// from its conditioned marginal with the outcome projector absorbed.
+    fn sample_one_shot(
+        &mut self,
+        rng: &mut ChaCha8Rng,
+        shot: usize,
+        samples: &mut BasisSamples,
+    ) -> Result<()> {
+        use rand::RngExt;
+
+        for qubit in 0..self.num_qubits {
+            let uniform = rng.random::<f64>();
+            if self.collapse_qubit_with(qubit, false, uniform)? {
+                samples.set(shot, qubit);
+            }
+        }
+        Ok(())
+    }
+
+    /// Qubit-by-qubit conditional sampling, one doubled-network contraction
+    /// per qubit per shot; the module docstring carries the cost trade.
+    ///
+    /// A pre-flight plans the first marginal and reserves its peak
+    /// intermediate as a feasibility proxy: later marginals open a different
+    /// qubit and can plan a different tree, so the gate is heuristic, not a
+    /// guarantee. The state is restored after every shot, errors included.
+    fn sample_native(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let n = self.num_qubits;
+        let mut samples = BasisSamples::new(num_shots, n);
+
+        let (network, _, _) = self.double_for_partial_trace(0);
+        let slots: Vec<Option<TensorMeta>> =
+            network.iter().map(|t| Some(TensorMeta::of(t))).collect();
+        let plan = plan_pairs(slots, None, usize::MAX).expect("unbounded pass completes");
+        let mut probe: Vec<Complex64> = Vec::new();
+        reserve_dense_output(&mut probe, plan.peak, self.name(), "native sampling")?;
+        drop(probe);
+
+        let tensors = self.tensors.clone();
+        let output_legs = self.output_legs.clone();
+        let next_leg = self.next_leg;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        for shot in 0..num_shots {
+            let drawn = self.sample_one_shot(&mut rng, shot, &mut samples);
+            self.tensors.clone_from(&tensors);
+            self.output_legs.clone_from(&output_legs);
+            self.next_leg = next_leg;
+            drawn?;
+        }
+        Ok(samples)
     }
 
     /// Absorb the rank-2 tensor that keeps only `outcome` on `qubit`, scaled by
@@ -1493,6 +1555,39 @@ impl Backend for TensorNetworkBackend {
             return Ok(amplitudes.par_iter().map(|a| a.norm_sqr()).collect());
         }
         Ok(amplitudes.iter().map(|a| a.norm_sqr()).collect())
+    }
+
+    fn supports_native_sampling(&self) -> bool {
+        true
+    }
+
+    /// Draw shots from the dense distribution below the ceiling and from the
+    /// qubit-by-qubit conditional sweep past it.
+    ///
+    /// One full-distribution contraction plus a draw per shot undercuts the
+    /// per-shot sweep by a measured 66x at 16 qubits and 32 shots on the
+    /// chain shape, so the dense arm answers wherever `probabilities()` can;
+    /// the sweep is the route that exists past that ceiling.
+    fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
+        let n = self.num_qubits;
+        if n == 0 || num_shots == 0 {
+            return Ok(BasisSamples::new(num_shots, n));
+        }
+
+        if tensor_probability_len(self.name(), n).is_ok() {
+            use rand::RngExt;
+
+            let mut samples = BasisSamples::new(num_shots, n);
+            let cdf = crate::sim::shots::build_cdf(&self.probabilities()?);
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            for shot in 0..num_shots {
+                let r = rng.random::<f64>();
+                samples.set_index(shot, crate::sim::shots::sample_from_cdf(&cdf, r));
+            }
+            return Ok(samples);
+        }
+
+        self.sample_native(num_shots, seed)
     }
 
     fn num_qubits(&self) -> usize {
@@ -2063,6 +2158,97 @@ mod tests {
             "{} vs {expected}",
             exps[1]
         );
+    }
+
+    // Joint distribution check for the conditional sweep against the dense
+    // route with per-outcome binomial bands, plus the contract that sampling
+    // leaves the state untouched. Calls the sweep directly: the public path
+    // takes the dense arm at this width.
+    #[test]
+    fn test_native_sampling_matches_dense_distribution() {
+        let circuit = crate::circuits::cz_chain_circuit(6, 3, 42);
+        let mut tn = TensorNetworkBackend::new(42);
+        tn.init(6, 0).unwrap();
+        for inst in &circuit.instructions {
+            tn.apply(inst).unwrap();
+        }
+        let probs_before = tn.probabilities().unwrap();
+
+        let shots = 2000usize;
+        let samples = tn.sample_native(shots, 42).unwrap();
+
+        let mut counts = vec![0usize; 1 << 6];
+        for shot in 0..shots {
+            let mut index = 0usize;
+            for q in 0..6 {
+                if samples.bit(shot, q) {
+                    index |= 1 << q;
+                }
+            }
+            counts[index] += 1;
+        }
+        for (index, (&count, &p)) in counts.iter().zip(&probs_before).enumerate() {
+            let freq = count as f64 / shots as f64;
+            let sigma = (p * (1.0 - p) / shots as f64).sqrt().max(1e-3);
+            assert!(
+                (freq - p).abs() < 6.0 * sigma,
+                "outcome {index}: {freq} vs {p}"
+            );
+        }
+
+        assert_probs_close(&tn.probabilities().unwrap(), &probs_before);
+    }
+
+    // Per-qubit counts convergence where the dense route cannot answer at
+    // all: 30 independent rotations, marginals known analytically.
+    #[test]
+    fn test_native_sampling_past_dense_ceiling() {
+        let n = 30;
+        let mut tn = TensorNetworkBackend::new(42);
+        tn.init(n, 0).unwrap();
+        for q in 0..n {
+            tn.apply(&Instruction::Gate {
+                gate: Gate::Ry(0.9),
+                targets: smallvec::smallvec![q],
+            })
+            .unwrap();
+        }
+
+        let shots = 500usize;
+        let samples = tn.sample_basis_states(shots, 42).unwrap();
+        let p_one = (0.45f64).sin().powi(2);
+        let sigma = (p_one * (1.0 - p_one) / shots as f64).sqrt();
+        for q in [0usize, 7, 15, 29] {
+            let count = (0..shots).filter(|&shot| samples.bit(shot, q)).count();
+            let freq = count as f64 / shots as f64;
+            assert!(
+                (freq - p_one).abs() < 5.0 * sigma,
+                "qubit {q}: {freq} vs {p_one}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sample_basis_states_repeats_from_the_seed() {
+        let circuit = crate::circuits::cz_chain_circuit(6, 3, 42);
+        let mut tn = TensorNetworkBackend::new(42);
+        tn.init(6, 0).unwrap();
+        for inst in &circuit.instructions {
+            tn.apply(inst).unwrap();
+        }
+
+        let first = tn.sample_basis_states(64, 42).unwrap();
+        let second = tn.sample_basis_states(64, 42).unwrap();
+        let other = tn.sample_basis_states(64, 43).unwrap();
+
+        let bits = |s: &BasisSamples| -> Vec<bool> {
+            (0..64)
+                .flat_map(|shot| (0..6).map(move |q| (shot, q)))
+                .map(|(shot, q)| s.bit(shot, q))
+                .collect()
+        };
+        assert_eq!(bits(&first), bits(&second));
+        assert_ne!(bits(&first), bits(&other));
     }
 
     // Two entangled components of unequal size, so join_disjoint merges tensors


### PR DESCRIPTION
## Summary

Shot requests on the tensor-network backend funneled through
`probabilities()` under its 25-qubit ceiling, so terminal sampling past that
width had no direct answer. `sample_basis_states` now samples qubit by qubit
past the ceiling: each bit draws from the conditioned single-qubit marginal
on the doubled network, and the outcome projector is absorbed before the
next qubit's marginal, so a shot costs one treewidth-bounded contraction per
qubit and no `2^n` vector exists. Below the ceiling the sampler answers from
one contraction of the full distribution plus a draw per shot: an interim
build without that arm measured the sweep at 66x the dense route on the
16-qubit chain row at 32 shots, which crossed the threshold set before the
run for requiring the dense arm.

Sampling is seeded from the request alone (the run rng is never touched, so
measurement outcome streams are unchanged), restores the network after every
shot including on error, and pre-flights the first marginal's planned peak
through the allocation guard as a feasibility proxy. The draw convention is
one uniform per qubit per shot, matching the MPS and product native
samplers.

## Benchmark summary

New rows land one commit ahead of the sampler, so the A/B reference carries
them. Two agreeing clean runs (30 samples, adjacent-binary A/B; one further
run was discarded whole because its two reference passes ran about 10%
faster than the same cached binary in every other run on record while its
new-side times matched the agreeing runs):

| Benchmark | Before | After | Change (two clean runs) |
|-----------|--------|-------|-------------------------|
| `tn/sample_chain/16` | 1.23 ms | 1.22 ms | -0.1% / -0.1% (dense-arm guard) |
| `tn/sample_chain/40` | 520.8 ms | 525.9 ms | +1.0% / +1.3% |
| all other `tn/` rows | | | within their own controls |

At 40 qubits the reference answers through per-shot projector trajectories,
so that row compares the sweep against a working route: the sweep is
cost-neutral there (about 16.4 ms per shot either way on the depth-4 chain),
and its value is the sampling surface plus skipping the per-shot rebuild and
fusion. Per-qubit-position plan caching, estimated in review at 25 to 55% of
per-shot sweep time, is filed as the follow-up with these rows as its gates.

## Regression verdict

PASS at 5.0%, both clean runs, no waiver.

## Hotspot notes

Contraction kernels, planner, and the measurement path are untouched; the
sampler composes the existing collapse machinery with a caller-supplied
uniform. Per-shot restore is a metadata clone, under 1% of a sweep shot.

## Tests

Joint-distribution equivalence of the sweep against the dense route with
per-outcome binomial bands (the sweep is called directly, since the public
path takes the dense arm at that width), analytic per-qubit convergence at
30 qubits where the dense route cannot answer, exact seed replay including
across back-to-back calls on one backend, and the cross-backend conformance
suite. Full suite green at `parallel gpu distributed`.

## Documentation

Module docstring rewritten (the sampling section previously argued native
sampling was strictly worse, an argument the projector measurement path
retired); samplers architecture page updated; bench README rows table
extended.
