### PR TITLE
feat(sim): Rzz, arbitrary-axis rotations, and budgeted SPD truncation

### DIFF
--- a/benches/qec_t_strategies.rs
+++ b/benches/qec_t_strategies.rs
@@ -9,6 +9,8 @@
 //! - `qec_t_strategies_scaling`: production T-count scaling for Auto, SPD,
 //!   and CAMPS.
 //! - `spd_light_cone`: production SPD cone-skip scaling.
+//! - `pauli_engine_qaoa`: weighted MaxCut evaluation on the shared QAOA
+//!   fixture through the deterministic Pauli engine.
 //!
 //! Reference and internal sweeps are opt-in benchmarks. Enable them with
 //! `--features parallel,bench-internal`.
@@ -23,8 +25,9 @@ use prism_q::qec::cut_selection::{InteractionGraph, cut_score, min_fill_treewidt
 #[cfg(feature = "bench-internal")]
 use prism_q::qec::observable_reroute::{cone_telemetry, min_cone_z_representative, xor_z_support};
 use prism_q::{
-    Circuit, Gate, PauliTerm, QecOptions, QecProgram, QecRecordRef, QecTStrategy,
-    run_qec_program_with_strategy, run_spd_observable, run_spd_observable_light_cone,
+    BackendKind, Circuit, Gate, PauliObservable, PauliTerm, QecOptions, QecProgram, QecRecordRef,
+    QecTStrategy, circuits, run_qec_program_with_strategy, run_spd_observable,
+    run_spd_observable_light_cone, simulate,
 };
 #[cfg(feature = "bench-internal")]
 use std::collections::HashSet;
@@ -599,6 +602,41 @@ fn bench_spd_light_cone(c: &mut Criterion) {
     group.finish();
 }
 
+/// QAOA capability row: the shared QAOA fixture (native `Rzz` cost chain and
+/// `Rx` mixer) evaluated as the weighted MaxCut sum over its nearest-neighbor
+/// edges through the deterministic Pauli engine.
+fn bench_pauli_engine_qaoa(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pauli_engine_qaoa");
+    group
+        .sample_size(20)
+        .warm_up_time(Duration::from_millis(500));
+
+    let n = 16usize;
+    let circuit = circuits::qaoa_circuit(n, 2, SEED);
+    let maxcut = PauliObservable::from_terms(
+        (0..n - 1).map(|q| (1.0, vec![PauliTerm::z(q), PauliTerm::z(q + 1)])),
+    )
+    .unwrap();
+
+    group.bench_function(
+        BenchmarkId::new("spd_maxcut_chain", format!("{n}q_p2")),
+        |b| {
+            b.iter(|| {
+                simulate(&circuit)
+                    .backend(BackendKind::DeterministicPauli {
+                        epsilon: 0.0,
+                        max_terms: 0,
+                    })
+                    .seed(SEED)
+                    .observable_expectation(&maxcut)
+                    .unwrap()
+            })
+        },
+    );
+
+    group.finish();
+}
+
 #[cfg(feature = "bench-internal")]
 fn bench_qec_internal_sweeps(c: &mut Criterion) {
     let mut group = c.benchmark_group("qec_internal_sweeps");
@@ -784,7 +822,8 @@ fn bench_qec_internal_sweeps(c: &mut Criterion) {
 criterion_group! {
     name = qec_t_strategy_benches;
     config = common::criterion_config();
-    targets = bench_qec_t_strategies, bench_qec_t_scaling, bench_spd_light_cone
+    targets = bench_qec_t_strategies, bench_qec_t_scaling, bench_spd_light_cone,
+        bench_pauli_engine_qaoa
 }
 
 #[cfg(feature = "bench-internal")]
@@ -795,6 +834,7 @@ criterion_group! {
         bench_qec_t_strategies,
         bench_qec_t_scaling,
         bench_spd_light_cone,
+        bench_pauli_engine_qaoa,
         bench_qec_internal_sweeps
 }
 criterion_main!(qec_t_strategy_benches);

--- a/benches/qec_t_strategies.rs
+++ b/benches/qec_t_strategies.rs
@@ -11,6 +11,8 @@
 //! - `spd_light_cone`: production SPD cone-skip scaling.
 //! - `pauli_engine_qaoa`: weighted MaxCut evaluation on the shared QAOA
 //!   fixture through the deterministic Pauli engine.
+//! - `spd_truncation`: budgeted SPD truncation against the untruncated
+//!   engine, with a Clifford+T control the policy must not touch.
 //!
 //! Reference and internal sweeps are opt-in benchmarks. Enable them with
 //! `--features parallel,bench-internal`.
@@ -27,7 +29,7 @@ use prism_q::qec::observable_reroute::{cone_telemetry, min_cone_z_representative
 use prism_q::{
     BackendKind, Circuit, Gate, PauliObservable, PauliTerm, QecOptions, QecProgram, QecRecordRef,
     QecTStrategy, circuits, run_qec_program_with_strategy, run_spd_observable,
-    run_spd_observable_light_cone, simulate,
+    run_spd_observable_budgeted, run_spd_observable_light_cone, simulate,
 };
 #[cfg(feature = "bench-internal")]
 use std::collections::HashSet;
@@ -637,6 +639,71 @@ fn bench_pauli_engine_qaoa(c: &mut Criterion) {
     group.finish();
 }
 
+/// Hardware-efficient layers at small angles: the near-Clifford shape where
+/// budgeted truncation pays (term count is angle-independent, discarded mass
+/// is not).
+fn near_clifford_hea(n: usize, layers: usize) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    let mut angle = 0.05f64;
+    for _ in 0..layers {
+        for q in 0..n {
+            c.add_gate(Gate::Ry(angle), &[q]);
+            c.add_gate(Gate::Rz(1.3 * angle), &[q]);
+            angle += 0.003;
+        }
+        for q in 0..n - 1 {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+    }
+    c
+}
+
+/// Budgeted SPD truncation against the untruncated engine: the near-Clifford
+/// shape where the budget pays, and a Clifford+T control sized under the
+/// budget where the policy must not fire.
+fn bench_spd_truncation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spd_truncation");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(5));
+
+    let hea = near_clifford_hea(10, 3);
+    let hea_obs = [PauliTerm::x(5)];
+    group.bench_function(BenchmarkId::new("exact", "hea_10q_l3"), |b| {
+        b.iter(|| run_spd_observable(&hea, &hea_obs, 0.0, 0).unwrap())
+    });
+    for budget in [4096usize, 256] {
+        group.bench_function(
+            BenchmarkId::new(format!("budget{budget}"), "hea_10q_l3"),
+            |b| b.iter(|| run_spd_observable_budgeted(&hea, &hea_obs, budget).unwrap()),
+        );
+    }
+
+    let mut t_control = Circuit::new(10, 0);
+    for q in 0..10 {
+        t_control.add_gate(Gate::H, &[q]);
+        t_control.add_gate(Gate::T, &[q]);
+    }
+    for q in 0..9 {
+        t_control.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    let t_obs = [PauliTerm::x(5)];
+    let exact = run_spd_observable(&t_control, &t_obs, 0.0, 0).unwrap();
+    let budgeted = run_spd_observable_budgeted(&t_control, &t_obs, 4096).unwrap();
+    assert!(exact.peak_terms < 4096, "control must sit under the budget");
+    assert_eq!(budgeted.total_discarded, 0.0);
+
+    group.bench_function(BenchmarkId::new("t_control_exact", "10q"), |b| {
+        b.iter(|| run_spd_observable(&t_control, &t_obs, 0.0, 0).unwrap())
+    });
+    group.bench_function(BenchmarkId::new("t_control_budget4096", "10q"), |b| {
+        b.iter(|| run_spd_observable_budgeted(&t_control, &t_obs, 4096).unwrap())
+    });
+
+    group.finish();
+}
+
 #[cfg(feature = "bench-internal")]
 fn bench_qec_internal_sweeps(c: &mut Criterion) {
     let mut group = c.benchmark_group("qec_internal_sweeps");
@@ -823,7 +890,7 @@ criterion_group! {
     name = qec_t_strategy_benches;
     config = common::criterion_config();
     targets = bench_qec_t_strategies, bench_qec_t_scaling, bench_spd_light_cone,
-        bench_pauli_engine_qaoa
+        bench_pauli_engine_qaoa, bench_spd_truncation
 }
 
 #[cfg(feature = "bench-internal")]
@@ -835,6 +902,7 @@ criterion_group! {
         bench_qec_t_scaling,
         bench_spd_light_cone,
         bench_pauli_engine_qaoa,
+        bench_spd_truncation,
         bench_qec_internal_sweeps
 }
 criterion_main!(qec_t_strategy_benches);

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -51,8 +51,10 @@ probability extraction failures propagate as errors. `marginals()` requires
 either a direct Pauli marginal route or backend probability output; it returns
 `BackendUnsupported` instead of fabricating uniform marginals when neither path
 is available. Stochastic and deterministic Pauli marginal backends accept only
-unitary circuits of Clifford gates and Z-axis rotations (`T`, `Tdg`, `Rz`, `P`)
-without measurement, reset, or conditional instructions. Automatic dispatch
+unitary circuits of Clifford gates and Pauli rotations without measurement,
+reset, or conditional instructions: `T`, `Tdg`, `Rz`, `P`, and the two-qubit
+`Rzz` branch natively, while `Rx`, `Ry`, and multi-qubit `PauliRot` strings
+lower to Clifford conjugation around one `Rz` before the run. Automatic dispatch
 still routes only Clifford+T circuits to SPD; a circuit carrying arbitrary
 rotation angles reaches the Pauli engines by explicit backend selection.
 

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -232,7 +232,7 @@ pub fn ghz_circuit(n: usize) -> Circuit {
 
 /// Build a QAOA-style circuit: `layers` of nearest-neighbor ZZ interactions + Rx mixer.
 ///
-/// ZZ(theta) is decomposed as CX - Rz(theta) - CX. The mixer applies Rx(beta)
+/// Each ZZ interaction is a native `Rzz(theta)`. The mixer applies Rx(beta)
 /// to every qubit. Angles are drawn randomly from the given seed.
 pub fn qaoa_circuit(n: usize, layers: usize, seed: u64) -> Circuit {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,8 @@ pub use sim::stabilizer_rank::{
 };
 pub use sim::unified_pauli::{
     PauliAxis, PauliTerm, SpdObservableResult, SpdResult, SppObservableResult, SppResult,
-    inverse_light_cone, run_spd, run_spd_observable, run_spd_observable_light_cone, run_spp,
-    run_spp_observable,
+    inverse_light_cone, run_spd, run_spd_observable, run_spd_observable_budgeted,
+    run_spd_observable_light_cone, run_spp, run_spp_observable,
 };
 pub use sim::{
     BackendKind, CountsResult, Exactness, ExpectationResult, FactoredBlock, MarginalsResult,

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1742,7 +1742,7 @@ fn supports_pauli_marginal_backend(circuit: &Circuit) -> bool {
 }
 
 /// Gate-set support is left to the engines, which accept Clifford gates and
-/// Z-axis rotations and report the offending gate by name.
+/// Pauli rotations and report the offending gate by name.
 fn validate_pauli_marginal_backend(kind: &BackendKind, circuit: &Circuit) -> Result<()> {
     if has_nonunitary_or_classical_ops(circuit) {
         return Err(PrismError::IncompatibleBackend {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1704,14 +1704,17 @@ fn marginals_from_pauli_expectations(
     })
 }
 
-/// Sparse Pauli dynamics is exact when it truncated nothing. `total_discarded`
-/// is a coefficient magnitude rather than a state overlap, so a truncated run
-/// reports approximate with no fidelity bound.
-fn spd_metadata(total_discarded: f64) -> RunMetadata {
-    if total_discarded == 0.0 {
-        RunMetadata::exact(ResolvedBackend::DeterministicPauli)
-    } else {
+/// Route-level exactness per the [`Exactness`] convention: only `epsilon > 0`
+/// can discard terms, so it marks the route approximate even on a run that
+/// discarded nothing; `epsilon == 0` overflows into an error instead of an
+/// approximation and stays exact. The realized bound is a coefficient
+/// magnitude rather than a state overlap, so it stays `total_discarded` on
+/// the engine result and never a fidelity bound.
+fn spd_metadata(epsilon: f64) -> RunMetadata {
+    if epsilon > 0.0 {
         RunMetadata::approximate(ResolvedBackend::DeterministicPauli)
+    } else {
+        RunMetadata::exact(ResolvedBackend::DeterministicPauli)
     }
 }
 
@@ -1775,7 +1778,7 @@ fn run_marginals_result_with(
             let spd = unified_pauli::run_spd(circuit, *epsilon, *max_terms)?;
             return Ok(MarginalsResult {
                 marginals: expectations_to_marginals(&spd.expectations),
-                metadata: spd_metadata(spd.total_discarded),
+                metadata: spd_metadata(*epsilon),
             });
         }
         _ => {}
@@ -1789,7 +1792,7 @@ fn run_marginals_result_with(
         let spd = unified_pauli::run_spd(circuit, 0.0, AUTO_SPD_MAX_TERMS)?;
         return Ok(MarginalsResult {
             marginals: expectations_to_marginals(&spd.expectations),
-            metadata: spd_metadata(spd.total_discarded),
+            metadata: spd_metadata(0.0),
         });
     }
 
@@ -1898,24 +1901,20 @@ fn run_expectation_values_reported(
         }
         BackendKind::DeterministicPauli { epsilon, max_terms } => {
             let mut values = Vec::with_capacity(observables.len());
-            let mut discarded = 0.0;
             for obs in observables {
                 let r = unified_pauli::run_spd_observable(circuit, obs, *epsilon, *max_terms)?;
                 values.push(r.mean);
-                discarded += r.total_discarded;
             }
-            Ok(analytic_expectations(values, spd_metadata(discarded)))
+            Ok(analytic_expectations(values, spd_metadata(*epsilon)))
         }
         _ if kind.is_auto() || kind.is_stabilizer_family() => {
             if circuit.is_clifford_only() {
                 let mut values = Vec::with_capacity(observables.len());
-                let mut discarded = 0.0;
                 for obs in observables {
                     let r = unified_pauli::run_spd_observable(circuit, obs, 0.0, 0)?;
                     values.push(r.mean);
-                    discarded += r.total_discarded;
                 }
-                Ok(analytic_expectations(values, spd_metadata(discarded)))
+                Ok(analytic_expectations(values, spd_metadata(0.0)))
             } else if kind.is_auto() {
                 if circuit.num_qubits > max_statevector_qubits() {
                     return expectation_values_native(&kind, circuit, observables, seed);

--- a/src/sim/tests.rs
+++ b/src/sim/tests.rs
@@ -1657,9 +1657,12 @@ fn test_pauli_backends_return_marginals_through_builder() {
 }
 
 #[test]
-fn test_pauli_marginals_reject_gates_off_the_z_axis() {
-    let mut c = Circuit::new(1, 0);
-    c.add_gate(Gate::Rx(0.25), &[0]);
+fn test_pauli_marginals_reject_gates_outside_the_rotation_family() {
+    let mut c = Circuit::new(2, 0);
+    let one = num_complex::Complex64::new(1.0, 0.0);
+    let zero = num_complex::Complex64::new(0.0, 0.0);
+    let phase = num_complex::Complex64::from_polar(1.0, 0.25);
+    c.add_gate(Gate::Cu(Box::new([[one, zero], [zero, phase]])), &[0, 1]);
 
     for err in pauli_marginal_errors(&c) {
         assert!(
@@ -1671,6 +1674,7 @@ fn test_pauli_marginals_reject_gates_off_the_z_axis() {
     let mut supported = Circuit::new(1, 0);
     supported.add_gate(Gate::H, &[0]);
     supported.add_gate(Gate::Rz(0.25), &[0]);
+    supported.add_gate(Gate::Rx(0.25), &[0]);
     assert_eq!(
         simulate(&supported)
             .backend(BackendKind::DeterministicPauli {

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -854,6 +854,31 @@ impl WeightedPauliSum {
         discarded
     }
 
+    /// Drop exactly the smallest-magnitude surplus terms until at most
+    /// `max_terms` remain, returning the 1-norm of what was dropped. Ties at
+    /// the cut fall to map order, so which of two equal-magnitude terms
+    /// survives is not stable across runs; the returned bound holds either
+    /// way.
+    fn truncate_to_budget(&mut self, max_terms: usize) -> f64 {
+        let surplus = self.terms.len().saturating_sub(max_terms);
+        if surplus == 0 {
+            return 0.0;
+        }
+        self.scratch.clear();
+        self.scratch.extend(self.terms.drain());
+        self.scratch.select_nth_unstable_by(surplus - 1, |a, b| {
+            a.1.norm_sqr().total_cmp(&b.1.norm_sqr())
+        });
+        let mut discarded = 0.0;
+        for (_, coeff) in self.scratch.drain(..surplus) {
+            discarded += coeff.norm();
+        }
+        for (pauli, coeff) in self.scratch.drain(..) {
+            self.terms.insert(pauli, coeff);
+        }
+        discarded
+    }
+
     fn diagonal_expectation(&self) -> f64 {
         let mut sum = Complex64::new(0.0, 0.0);
         for (pauli, coeff) in &self.terms {
@@ -878,6 +903,42 @@ pub struct SpdResult {
     pub total_discarded: f64,
 }
 
+/// Truncation policy for one SPD run. Both variants report the same
+/// composable 1-norm error accounting through `total_discarded`.
+enum Truncation {
+    Threshold { epsilon: f64, max_terms: usize },
+    Budget { max_terms: usize },
+}
+
+impl Truncation {
+    /// Mid-run enforcement after one instruction. Discarded mass accumulates
+    /// into `total_discarded` only when a drop fires, so the exact path keeps
+    /// no unconditional float add in the per-instruction loop.
+    fn enforce(&self, sum: &mut WeightedPauliSum, total_discarded: &mut f64) {
+        match *self {
+            Truncation::Threshold { epsilon, max_terms } => {
+                if max_terms > 0 && sum.terms.len() > max_terms {
+                    *total_discarded += sum.truncate(epsilon);
+                }
+            }
+            Truncation::Budget { max_terms } => {
+                if sum.terms.len() > max_terms {
+                    *total_discarded += sum.truncate_to_budget(max_terms);
+                }
+            }
+        }
+    }
+
+    /// Terminal sweep after the backward pass.
+    fn final_sweep(&self, sum: &mut WeightedPauliSum, total_discarded: &mut f64) {
+        if let Truncation::Threshold { epsilon, .. } = *self {
+            if epsilon > 0.0 {
+                *total_discarded += sum.truncate(epsilon);
+            }
+        }
+    }
+}
+
 /// Deterministic SPD on a joint Pauli observable.
 ///
 /// Starts with the single weighted term `(observable, 1.0)`, backward-
@@ -896,14 +957,52 @@ pub struct SpdResult {
 /// the run is exact and errors once the sum passes an internal ceiling. With
 /// `max_terms > 0`, sub-`epsilon` terms are dropped whenever the sum exceeds
 /// the budget and `total_discarded` bounds the resulting error, per the
-/// 1-norm bound `|error| ≤ Σ |discarded|`. An `epsilon` too small to prune the
-/// growth still reaches the ceiling and errors there: the run never returns a
-/// silently over-truncated value.
+/// composable 1-norm bound `|error| ≤ Σ |discarded|` (each dropped term's
+/// exact continuation is unitary conjugation of a unit-norm operator, so its
+/// terminal contribution is at most its magnitude). An `epsilon` too small to
+/// prune the growth still reaches the ceiling and errors there: the run never
+/// returns a silently over-truncated value. See [`run_spd_observable_budgeted`]
+/// for the policy with no threshold to guess.
 pub fn run_spd_observable(
     circuit: &Circuit,
     observable: &[PauliTerm],
     epsilon: f64,
     max_terms: usize,
+) -> Result<SpdObservableResult> {
+    run_spd_observable_with(
+        circuit,
+        observable,
+        &Truncation::Threshold { epsilon, max_terms },
+    )
+}
+
+/// Deterministic SPD on a joint Pauli observable under a fixed term budget.
+///
+/// Same backward propagation as [`run_spd_observable`], but whenever the sum
+/// exceeds `max_terms` the smallest-magnitude surplus terms are dropped,
+/// exactly enough to return to the budget. No threshold needs guessing, the
+/// run cannot die at the term ceiling on account of growth the budget already
+/// caps, and `total_discarded` is the realized 1-norm error bound for the
+/// term count held. `max_terms` must be at least 1.
+pub fn run_spd_observable_budgeted(
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    max_terms: usize,
+) -> Result<SpdObservableResult> {
+    if max_terms == 0 || max_terms > SPD_MAX_TERMS_CEILING {
+        return Err(PrismError::InvalidParameter {
+            message: format!(
+                "budgeted SPD needs a term budget between 1 and {SPD_MAX_TERMS_CEILING}"
+            ),
+        });
+    }
+    run_spd_observable_with(circuit, observable, &Truncation::Budget { max_terms })
+}
+
+fn run_spd_observable_with(
+    circuit: &Circuit,
+    observable: &[PauliTerm],
+    truncation: &Truncation,
 ) -> Result<SpdObservableResult> {
     let lowered = validate_and_lower(circuit, "SPD observable")?;
     let circuit = lowered.as_ref();
@@ -920,18 +1019,14 @@ pub fn run_spd_observable(
         if let Instruction::Gate { gate, targets } = inst {
             sum.apply_backward(gate, targets);
         }
-        if max_terms > 0 && sum.terms.len() > max_terms {
-            total_discarded += sum.truncate(epsilon);
-        }
+        truncation.enforce(&mut sum, &mut total_discarded);
         check_spd_term_ceiling(sum.terms.len())?;
         if sum.terms.len() > peak_terms {
             peak_terms = sum.terms.len();
         }
     }
 
-    if epsilon > 0.0 {
-        total_discarded += sum.truncate(epsilon);
-    }
+    truncation.final_sweep(&mut sum, &mut total_discarded);
 
     Ok(SpdObservableResult {
         mean: sum.diagonal_expectation(),

--- a/src/sim/unified_pauli.rs
+++ b/src/sim/unified_pauli.rs
@@ -1,14 +1,20 @@
-//! Pauli propagation engines for circuits of Clifford gates and Z-axis
+//! Pauli propagation engines for circuits of Clifford gates and Pauli
 //! rotations: SPP samples backward Heisenberg propagation stochastically, SPD
 //! carries the full weighted Pauli sum with optional truncation. Neither
 //! materializes a state vector.
+//!
+//! Z-axis rotations (`T`, `Tdg`, `Rz`, `P`) and the two-qubit `Rzz` branch
+//! natively; `Rx`, `Ry`, and multi-qubit `PauliRot` strings lower to Clifford
+//! conjugation around one `Rz` before the run.
 
 use num_complex::Complex64;
 use rand::SeedableRng;
 use rand::{Rng, RngExt};
 use rand_chacha::ChaCha8Rng;
 
-use crate::circuit::{Circuit, Instruction, SmallVec};
+use std::borrow::Cow;
+
+use crate::circuit::{Circuit, Instruction, SmallVec, pauli_rotation_lowering};
 use crate::error::{PrismError, Result};
 use crate::gates::Gate;
 use crate::sim::compiled::{PauliVec, flip_bit, propagate_backward};
@@ -51,19 +57,45 @@ fn z_rotation_angle(gate: &Gate) -> Option<f64> {
     }
 }
 
-fn validate_pauli_unitary(circuit: &Circuit, backend: &'static str) -> Result<()> {
+#[inline]
+fn zz_rotation_angle(gate: &Gate) -> Option<f64> {
+    match gate {
+        Gate::Rzz(theta) => Some(*theta),
+        _ => None,
+    }
+}
+
+/// Validate the circuit and lower arbitrary-axis rotations in one walk.
+///
+/// `Rx`, `Ry`, and multi-qubit `PauliRot` strings expand through the shared
+/// CNOT-ladder lowering into Clifford conjugation around one `Rz`, so the
+/// engines only ever branch on Z-axis rules; `Rzz` stays native and branches
+/// directly on the `Z⊗Z` anticommutation test. The lowering tests sit on the
+/// walk's rejection path, so a circuit needing none pays no second scan and
+/// borrows through unchanged. The lowering emits only supported gates, so the
+/// rebuilt circuit needs no second validation.
+fn validate_and_lower<'c>(circuit: &'c Circuit, backend: &'static str) -> Result<Cow<'c, Circuit>> {
+    let mut needs_lowering = false;
     for inst in &circuit.instructions {
         match inst {
             Instruction::Gate { gate, .. } => {
-                if !(gate.is_clifford() || z_rotation_angle(gate).is_some()) {
-                    return Err(PrismError::BackendUnsupported {
-                        backend: backend.to_string(),
-                        operation: format!(
-                            "gate `{}` is neither Clifford nor a Z-axis rotation",
-                            gate.name()
-                        ),
-                    });
+                if gate.is_clifford()
+                    || z_rotation_angle(gate).is_some()
+                    || zz_rotation_angle(gate).is_some()
+                {
+                    continue;
                 }
+                if matches!(gate, Gate::Rx(_) | Gate::Ry(_) | Gate::PauliRot(_)) {
+                    needs_lowering = true;
+                    continue;
+                }
+                return Err(PrismError::BackendUnsupported {
+                    backend: backend.to_string(),
+                    operation: format!(
+                        "gate `{}` is neither Clifford nor a supported Pauli rotation",
+                        gate.name()
+                    ),
+                });
             }
             Instruction::Barrier { .. } => {}
             Instruction::Measure { .. }
@@ -79,14 +111,58 @@ fn validate_pauli_unitary(circuit: &Circuit, backend: &'static str) -> Result<()
             }
         }
     }
-    Ok(())
+    if !needs_lowering {
+        return Ok(Cow::Borrowed(circuit));
+    }
+
+    let mut out: Vec<Instruction> = Vec::with_capacity(circuit.instructions.len() * 2);
+    for inst in &circuit.instructions {
+        let (theta, targets, axes): (f64, &[usize], &[PauliAxis]) = match inst {
+            Instruction::Gate {
+                gate: Gate::Rx(theta),
+                targets,
+            } => (*theta, targets, &[PauliAxis::X]),
+            Instruction::Gate {
+                gate: Gate::Ry(theta),
+                targets,
+            } => (*theta, targets, &[PauliAxis::Y]),
+            Instruction::Gate {
+                gate: Gate::PauliRot(data),
+                targets,
+            } => (data.theta(), targets, data.axes()),
+            _ => {
+                out.push(inst.clone());
+                continue;
+            }
+        };
+        pauli_rotation_lowering(theta, targets, axes, |gate, tgts| {
+            out.push(Instruction::Gate {
+                gate,
+                targets: SmallVec::from_slice(tgts),
+            });
+        });
+    }
+    Ok(Cow::Owned(circuit.with_instructions(out)))
 }
 
 // ---- Coalesced circuit representation ----
 
+/// Marks a [`CoalescedOp::ZRot`] with no second qubit.
+const ZROT_SINGLE: u32 = u32::MAX;
+
+/// The ops slice streams through the SPP per-sample loop, so the layout is
+/// deliberate on two counts, both measured on op-heavy rows: the qubits pack
+/// as `u32` to hold the enum at 40 bytes (48 cost +2.6% to +5.8%), and `Rzz`
+/// shares the `ZRot` variant via the `ZROT_SINGLE` sentinel instead of adding
+/// a third variant, which kept an outlined call in the sample loop's match
+/// and cost about the same again.
 enum CoalescedOp {
     SmallCliff(Vec<(Gate, SmallVec<[usize; 4]>)>),
-    ZRot { qubit: usize, branch: RotBranch },
+    ZRot {
+        qubit: u32,
+        pair: u32,
+        branch: RotBranch,
+    },
 }
 
 fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
@@ -98,7 +174,15 @@ fn coalesce_cliffords(circuit: &Circuit) -> Vec<CoalescedOp> {
             if let Some(theta) = z_rotation_angle(gate) {
                 flush_cliff_buf(&mut cliff_buf, &mut ops);
                 ops.push(CoalescedOp::ZRot {
-                    qubit: targets[0],
+                    qubit: targets[0] as u32,
+                    pair: ZROT_SINGLE,
+                    branch: RotBranch::new(theta),
+                });
+            } else if let Some(theta) = zz_rotation_angle(gate) {
+                flush_cliff_buf(&mut cliff_buf, &mut ops);
+                ops.push(CoalescedOp::ZRot {
+                    qubit: targets[0] as u32,
+                    pair: targets[1] as u32,
                     branch: RotBranch::new(theta),
                 });
             } else {
@@ -131,7 +215,8 @@ struct RotBranch {
 }
 
 impl RotBranch {
-    /// Branch probability and importance weights for `Rz(theta)`.
+    /// Branch probability and importance weights for `Rz(theta)`; `Rzz`
+    /// shares them, since its expansion carries the same coefficients.
     ///
     /// Backward conjugation sends an in-support Pauli `P` to
     /// `cos(theta) P + (-i sin(theta)) P Z_q`. PauliVec stores the Y letter as
@@ -150,14 +235,26 @@ impl RotBranch {
     }
 }
 
+/// Stochastic branch for a `Z` or `Z⊗Z` rotation. The branch fires only when
+/// the propagated Pauli anticommutes with the generator: an X or Y letter on
+/// the qubit for `Rz`, exactly one such letter on the pair for `Rzz`. The
+/// flip right-multiplies by the generator, a pure z-bit flip on its support
+/// in the ordered `X^x Z^z` letter convention.
 #[inline(always)]
 fn branch_z_rotation(
     pauli: &mut PauliVec,
-    qubit: usize,
+    qubit: u32,
+    pair: u32,
     branch: &RotBranch,
     rng: &mut impl Rng,
 ) -> Complex64 {
-    if !pauli.has_x_or_y(qubit) {
+    let q = qubit as usize;
+    let anticommutes = if pair == ZROT_SINGLE {
+        pauli.has_x_or_y(q)
+    } else {
+        pauli.has_x_or_y(q) != pauli.has_x_or_y(pair as usize)
+    };
+    if !anticommutes {
         return Complex64::new(1.0, 0.0);
     }
 
@@ -165,7 +262,10 @@ fn branch_z_rotation(
         return Complex64::new(branch.keep_weight, 0.0);
     }
 
-    flip_bit(&mut pauli.z, qubit);
+    flip_bit(&mut pauli.z, q);
+    if pair != ZROT_SINGLE {
+        flip_bit(&mut pauli.z, pair as usize);
+    }
     Complex64::new(0.0, branch.flip_weight_im)
 }
 
@@ -192,8 +292,12 @@ fn backward_propagate_coalesced(
                     propagate_backward(&mut pauli, gate, targets);
                 }
             }
-            CoalescedOp::ZRot { qubit, branch } => {
-                weight *= branch_z_rotation(&mut pauli, *qubit, branch, rng);
+            CoalescedOp::ZRot {
+                qubit,
+                pair,
+                branch,
+            } => {
+                weight *= branch_z_rotation(&mut pauli, *qubit, *pair, branch, rng);
             }
         }
     }
@@ -206,7 +310,9 @@ fn count_branching_gates(circuit: &Circuit) -> usize {
         .instructions
         .iter()
         .filter(|inst| match inst {
-            Instruction::Gate { gate, .. } => z_rotation_angle(gate).is_some(),
+            Instruction::Gate { gate, .. } => {
+                z_rotation_angle(gate).is_some() || zz_rotation_angle(gate).is_some()
+            }
             _ => false,
         })
         .count()
@@ -218,7 +324,7 @@ pub struct SppResult {
     pub std_errors: Vec<f64>,
     /// Samples drawn per qubit, not in total.
     pub num_samples: usize,
-    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, and `P`.
+    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, `P`, and `Rzz`.
     pub t_count: usize,
     /// Fraction of samples whose propagated Pauli was diagonal (contributed a
     /// nonzero value).
@@ -386,14 +492,16 @@ fn pauli_vec_from_terms(
 }
 
 /// Estimate `⟨0^n| U† P U |0^n⟩` for joint Pauli observable `P` on a circuit
-/// `U` of Clifford gates and Z-axis rotations, via stochastic Pauli
+/// `U` of Clifford gates and Pauli rotations, via stochastic Pauli
 /// propagation.
 ///
 /// Each sample backward-propagates the observable through the circuit
-/// (Clifford segments as coalesced gate runs, `Rz(theta)` and its `T` special
-/// case via a stochastic Pauli branch that records a complex weight). The
-/// contribution is `Re(weight)` when the final Pauli is diagonal in
-/// `{I, Z}` (i.e. evaluates trivially on `|0^n⟩`), else zero.
+/// (Clifford segments as coalesced gate runs, `Rz(theta)` and the two-qubit
+/// `Rzz(theta)` via a stochastic Pauli branch that records a complex weight;
+/// `Rx`, `Ry`, and multi-qubit `PauliRot` strings lower to Clifford
+/// conjugation around one `Rz` first). The contribution is `Re(weight)` when
+/// the final Pauli is diagonal in `{I, Z}` (i.e. evaluates trivially on
+/// `|0^n⟩`), else zero.
 ///
 /// Sample variance grows with the product of `|cos θ| + |sin θ|` over the
 /// in-support rotations, so it is largest at `θ = π/4` and vanishes as the
@@ -404,7 +512,8 @@ pub fn run_spp_observable(
     num_samples: usize,
     seed: u64,
 ) -> Result<SppObservableResult> {
-    validate_pauli_unitary(circuit, "SPP observable")?;
+    let lowered = validate_and_lower(circuit, "SPP observable")?;
+    let circuit = lowered.as_ref();
     let n = circuit.num_qubits;
     let t_count = count_branching_gates(circuit);
     let ops = coalesce_cliffords(circuit);
@@ -448,7 +557,7 @@ pub fn run_spp_observable(
 }
 
 /// Estimate `⟨Z_q⟩` for every qubit of a unitary circuit of Clifford gates and
-/// Z-axis rotations, via stochastic Pauli propagation.
+/// Pauli rotations, via stochastic Pauli propagation.
 ///
 /// Draws `num_samples` backward propagations per qubit; the cost scales with
 /// samples and gate count, not `2^n`. See [`run_spp_observable`] for a single
@@ -472,7 +581,8 @@ pub fn run_spp_observable(
 /// # Ok::<(), prism_q::PrismError>(())
 /// ```
 pub fn run_spp(circuit: &Circuit, num_samples: usize, seed: u64) -> Result<SppResult> {
-    validate_pauli_unitary(circuit, "SPP")?;
+    let lowered = validate_and_lower(circuit, "SPP")?;
+    let circuit = lowered.as_ref();
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
     let t_count = count_branching_gates(circuit);
@@ -682,6 +792,55 @@ impl WeightedPauliSum {
         }
     }
 
+    /// Two-qubit analogue of [`branch_z_rotation`](Self::branch_z_rotation)
+    /// for `Rzz`: a term splits only when it anticommutes with `Z⊗Z` on the
+    /// pair, i.e. exactly one of the two qubits carries an X or Y letter. The
+    /// flip branch right-multiplies by `Z_a Z_b`, a pure z-bit flip on both
+    /// qubits in the ordered `X^x Z^z` letter convention.
+    fn branch_zz_rotation(&mut self, a: usize, b: usize, sin: f64, cos: f64) {
+        let old_terms: Vec<(PauliVec, Complex64)> = self.terms.drain().collect();
+
+        for (pauli, coeff) in old_terms {
+            if pauli.has_x_or_y(a) == pauli.has_x_or_y(b) {
+                self.insert(pauli, coeff);
+                continue;
+            }
+
+            if cos != 0.0 {
+                self.insert(pauli.clone(), coeff * cos);
+            }
+            if sin != 0.0 {
+                let mut pauli_flip = pauli;
+                flip_bit(&mut pauli_flip.z, a);
+                flip_bit(&mut pauli_flip.z, b);
+                self.insert(pauli_flip, Complex64::new(coeff.im * sin, -coeff.re * sin));
+            }
+        }
+    }
+
+    /// Backward-apply one gate: a single discriminant match, so the Clifford
+    /// path pays no rotation-probe chain per instruction. Angle cases mirror
+    /// [`z_rotation_angle`] and [`zz_rotation_angle`].
+    #[inline(always)]
+    fn apply_backward(&mut self, gate: &Gate, targets: &[usize]) {
+        match gate {
+            Gate::T => self.branch_z_rotation_angle(targets[0], std::f64::consts::FRAC_PI_4),
+            Gate::Tdg => self.branch_z_rotation_angle(targets[0], -std::f64::consts::FRAC_PI_4),
+            Gate::Rz(theta) | Gate::P(theta) => self.branch_z_rotation_angle(targets[0], *theta),
+            Gate::Rzz(theta) => {
+                let (sin, cos) = theta.sin_cos();
+                self.branch_zz_rotation(targets[0], targets[1], sin, cos);
+            }
+            _ => self.conjugate_all_backward_phased(gate, targets),
+        }
+    }
+
+    #[inline(always)]
+    fn branch_z_rotation_angle(&mut self, qubit: usize, theta: f64) {
+        let (sin, cos) = theta.sin_cos();
+        self.branch_z_rotation(qubit, sin, cos);
+    }
+
     fn truncate(&mut self, epsilon: f64) -> f64 {
         let mut discarded = 0.0;
         self.terms.retain(|_, coeff| {
@@ -710,7 +869,7 @@ impl WeightedPauliSum {
 pub struct SpdResult {
     /// `⟨Z_q⟩` per qubit; exact when nothing was truncated.
     pub expectations: Vec<f64>,
-    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, and `P`.
+    /// Branching gates in the circuit: `T`, `Tdg`, `Rz`, `P`, and `Rzz`.
     pub t_count: usize,
     /// Peak size of the weighted Pauli sum across all per-qubit runs, not the
     /// truncation budget passed in.
@@ -722,8 +881,9 @@ pub struct SpdResult {
 /// Deterministic SPD on a joint Pauli observable.
 ///
 /// Starts with the single weighted term `(observable, 1.0)`, backward-
-/// propagates through every gate, splits each in-support term at an `Rz(theta)`
-/// into `cos(theta)` and `-i sin(theta)` branches, and truncates terms whose
+/// propagates through every gate, splits each anticommuting term at an
+/// `Rz(theta)` or `Rzz(theta)` into `cos(theta)` and `-i sin(theta)`
+/// branches, and truncates terms whose
 /// magnitude falls below `epsilon` whenever the sum exceeds `max_terms`.
 /// Returns `⟨0^n| U† P U |0^n⟩` as the sum of remaining diagonal-term
 /// coefficients.
@@ -745,7 +905,8 @@ pub fn run_spd_observable(
     epsilon: f64,
     max_terms: usize,
 ) -> Result<SpdObservableResult> {
-    validate_pauli_unitary(circuit, "SPD observable")?;
+    let lowered = validate_and_lower(circuit, "SPD observable")?;
+    let circuit = lowered.as_ref();
     let n = circuit.num_qubits;
     let t_count = count_branching_gates(circuit);
     let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
@@ -757,11 +918,7 @@ pub fn run_spd_observable(
 
     for inst in circuit.instructions.iter().rev() {
         if let Instruction::Gate { gate, targets } = inst {
-            if let Some((sin, cos)) = z_rotation_angle(gate).map(f64::sin_cos) {
-                sum.branch_z_rotation(targets[0], sin, cos);
-            } else {
-                sum.conjugate_all_backward_phased(gate, targets);
-            }
+            sum.apply_backward(gate, targets);
         }
         if max_terms > 0 && sum.terms.len() > max_terms {
             total_discarded += sum.truncate(epsilon);
@@ -785,7 +942,7 @@ pub fn run_spd_observable(
 }
 
 /// Compute `⟨Z_q⟩` for every qubit of a unitary circuit of Clifford gates and
-/// Z-axis rotations, via deterministic sparse Pauli dynamics.
+/// Pauli rotations, via deterministic sparse Pauli dynamics.
 ///
 /// Each qubit's `Z_q` propagates backward as a weighted Pauli sum; every
 /// rotation with a non-Clifford angle doubles the in-support terms. When the
@@ -794,7 +951,8 @@ pub fn run_spd_observable(
 /// stay under a hard term ceiling. See [`run_spd_observable`] for a single
 /// joint observable and for the truncation contract.
 pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdResult> {
-    validate_pauli_unitary(circuit, "SPD")?;
+    let lowered = validate_and_lower(circuit, "SPD")?;
+    let circuit = lowered.as_ref();
     let n = circuit.num_qubits;
     let num_words = n.div_ceil(64);
     let t_count = count_branching_gates(circuit);
@@ -803,11 +961,23 @@ pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdR
     let mut peak_terms = 0usize;
     let mut total_discarded = 0.0;
 
-    let rotations: Vec<Option<(f64, f64)>> = circuit
+    enum Rot {
+        Single { sin: f64, cos: f64 },
+        Pair { sin: f64, cos: f64 },
+    }
+    let rotations: Vec<Option<Rot>> = circuit
         .instructions
         .iter()
         .map(|inst| match inst {
-            Instruction::Gate { gate, .. } => z_rotation_angle(gate).map(f64::sin_cos),
+            Instruction::Gate { gate, .. } => {
+                if let Some((sin, cos)) = z_rotation_angle(gate).map(f64::sin_cos) {
+                    Some(Rot::Single { sin, cos })
+                } else {
+                    zz_rotation_angle(gate)
+                        .map(f64::sin_cos)
+                        .map(|(sin, cos)| Rot::Pair { sin, cos })
+                }
+            }
             _ => None,
         })
         .collect();
@@ -818,10 +988,12 @@ pub fn run_spd(circuit: &Circuit, epsilon: f64, max_terms: usize) -> Result<SpdR
 
         for (idx, inst) in circuit.instructions.iter().enumerate().rev() {
             if let Instruction::Gate { gate, targets } = inst {
-                if let Some((sin, cos)) = rotations[idx] {
-                    sum.branch_z_rotation(targets[0], sin, cos);
-                } else {
-                    sum.conjugate_all_backward_phased(gate, targets);
+                match rotations[idx] {
+                    Some(Rot::Single { sin, cos }) => sum.branch_z_rotation(targets[0], sin, cos),
+                    Some(Rot::Pair { sin, cos }) => {
+                        sum.branch_zz_rotation(targets[0], targets[1], sin, cos)
+                    }
+                    None => sum.conjugate_all_backward_phased(gate, targets),
                 }
             }
 
@@ -897,7 +1069,8 @@ pub fn run_spd_observable_light_cone(
     epsilon: f64,
     max_terms: usize,
 ) -> Result<SpdObservableResult> {
-    validate_pauli_unitary(circuit, "light-cone SPD observable")?;
+    let lowered = validate_and_lower(circuit, "light-cone SPD observable")?;
+    let circuit = lowered.as_ref();
     let n = circuit.num_qubits;
     let t_count = count_branching_gates(circuit);
     let (obs, obs_coeff) = pauli_vec_from_terms(n, observable)?;
@@ -913,11 +1086,7 @@ pub fn run_spd_observable_light_cone(
             continue;
         }
         if let Instruction::Gate { gate, targets } = inst {
-            if let Some((sin, cos)) = z_rotation_angle(gate).map(f64::sin_cos) {
-                sum.branch_z_rotation(targets[0], sin, cos);
-            } else {
-                sum.conjugate_all_backward_phased(gate, targets);
-            }
+            sum.apply_backward(gate, targets);
         }
         if max_terms > 0 && sum.terms.len() > max_terms {
             total_discarded += sum.truncate(epsilon);

--- a/src/sim/unified_pauli_tests.rs
+++ b/src/sim/unified_pauli_tests.rs
@@ -64,11 +64,11 @@ fn test_branch_t_gate_passthrough_iz() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
     let mut pauli_i = PauliVec::new(1);
-    let w = branch_z_rotation(&mut pauli_i, 0, &t_branch(), &mut rng);
+    let w = branch_z_rotation(&mut pauli_i, 0, ZROT_SINGLE, &t_branch(), &mut rng);
     assert!((w - Complex64::new(1.0, 0.0)).norm() < 1e-14);
 
     let mut pauli_z = PauliVec::z_on_qubit(1, 0);
-    let w = branch_z_rotation(&mut pauli_z, 0, &t_branch(), &mut rng);
+    let w = branch_z_rotation(&mut pauli_z, 0, ZROT_SINGLE, &t_branch(), &mut rng);
     assert!((w - Complex64::new(1.0, 0.0)).norm() < 1e-14);
 }
 
@@ -82,7 +82,7 @@ fn test_branch_t_gate_x_branches() {
     for _ in 0..num_samples {
         let mut pauli = PauliVec::new(1);
         pauli.x[0] = 1;
-        let w = branch_z_rotation(&mut pauli, 0, &t_branch(), &mut rng);
+        let w = branch_z_rotation(&mut pauli, 0, ZROT_SINGLE, &t_branch(), &mut rng);
         assert!((w.norm() - SQRT_2).abs() < 1e-14);
         if pauli.z[0] == 0 {
             x_count += 1;
@@ -536,4 +536,11 @@ fn light_cone_spd_matches_on_entangled_observable() {
         full.mean,
         cone.mean
     );
+}
+
+// The ops slice streams through the SPP per-sample loop; a wider enum taxes
+// every circuit (measured +2.6% to +5.8% on op-heavy rows at 48 bytes).
+#[test]
+fn coalesced_op_stays_at_the_one_qubit_variant_size() {
+    assert_eq!(std::mem::size_of::<super::CoalescedOp>(), 40);
 }

--- a/tests/pauli_joint_observable.rs
+++ b/tests/pauli_joint_observable.rs
@@ -157,15 +157,18 @@ fn duplicate_pauli_factors_are_rejected() {
 }
 
 #[test]
-fn spd_rejects_gates_off_the_z_axis() {
-    let mut circuit = Circuit::new(1, 0);
-    circuit.add_gate(Gate::Rx(0.37), &[0]);
+fn spd_rejects_gates_outside_the_rotation_family() {
+    let mut circuit = Circuit::new(2, 0);
+    let phase = num_complex::Complex64::from_polar(1.0, 0.37);
+    let zero = num_complex::Complex64::new(0.0, 0.0);
+    let one = num_complex::Complex64::new(1.0, 0.0);
+    circuit.add_gate(Gate::Cu(Box::new([[one, zero], [zero, phase]])), &[0, 1]);
 
     let err = run_spd_observable(&circuit, &[PauliTerm::z(0)], 0.0, 0)
-        .expect_err("SPD must reject rotations off the Z axis");
+        .expect_err("SPD must reject gates it cannot branch or lower");
     let msg = format!("{err:?}");
     assert!(
-        msg.contains("rx"),
+        msg.contains("cu"),
         "rejection should name the gate, got {msg}"
     );
 
@@ -173,6 +176,20 @@ fn spd_rejects_gates_off_the_z_axis() {
     supported.add_gate(Gate::Rz(0.37), &[0]);
     run_spd_observable(&supported, &[PauliTerm::z(0)], 0.0, 0)
         .expect("SPD must accept a Z-axis rotation");
+}
+
+// Rx and Ry lower to Clifford conjugation around one Rz, so both engines
+// accept them; correctness is pinned by the statevector comparisons below.
+#[test]
+fn engines_accept_arbitrary_axis_rotations() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::Rx(0.37), &[0]);
+    circuit.add_gate(Gate::Ry(-1.1), &[0]);
+
+    run_spd_observable(&circuit, &[PauliTerm::z(0)], 0.0, 0)
+        .expect("SPD must accept Rx and Ry via lowering");
+    run_spp_observable(&circuit, &[PauliTerm::z(0)], 100, SEED)
+        .expect("SPP must accept Rx and Ry via lowering");
 }
 
 /// The generalized rotation branch must reduce to the T rule exactly, not
@@ -332,10 +349,209 @@ fn zero_angle_rotations_do_not_branch() {
     circuit.add_gate(Gate::H, &[0]);
     circuit.add_gate(Gate::Rz(0.0), &[0]);
     circuit.add_gate(Gate::P(0.0), &[0]);
+    circuit.add_gate(Gate::Rzz(0.0), &[0, 1]);
     circuit.add_gate(Gate::Cx, &[0, 1]);
 
     let spd = run_spd_observable(&circuit, &[PauliTerm::x(0), PauliTerm::x(1)], 0.0, 0).unwrap();
     assert_eq!(spd.peak_terms, 1);
-    assert_eq!(spd.t_count, 2);
+    assert_eq!(spd.t_count, 3);
     assert!((spd.mean - 1.0).abs() < 1e-15, "got {}", spd.mean);
+}
+
+// The two-qubit anticommutation rule: Rzz branches a term only when exactly
+// one of the pair carries an X or Y letter.
+#[test]
+fn rzz_branches_only_on_anticommuting_terms() {
+    let build = || {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::Rzz(0.37), &[0, 1]);
+        c
+    };
+
+    // X on one qubit of the pair anticommutes with Z⊗Z: one branch fires.
+    let anti = run_spd_observable(&build(), &[PauliTerm::x(0)], 0.0, 0).unwrap();
+    assert_eq!(anti.peak_terms, 2);
+    assert!(
+        (anti.mean - 0.37f64.cos()).abs() < 1e-12,
+        "got {}",
+        anti.mean
+    );
+
+    // X⊗X and Z⊗I commute with Z⊗Z: no branch, and the rotation is
+    // transparent to the propagated term.
+    let xx = run_spd_observable(&build(), &[PauliTerm::x(0), PauliTerm::x(1)], 0.0, 0).unwrap();
+    assert_eq!(xx.peak_terms, 1);
+    assert!((xx.mean - 1.0).abs() < 1e-12, "got {}", xx.mean);
+
+    let z = run_spd_observable(&build(), &[PauliTerm::z(0)], 0.0, 0).unwrap();
+    assert_eq!(z.peak_terms, 1);
+    assert!(z.mean.abs() < 1e-12, "got {}", z.mean);
+}
+
+// Native Rzz and its Cx-Rz-Cx lowering take different code paths, so agree to
+// tolerance rather than bitwise (hash-order accumulation shifts the last ulp).
+#[test]
+fn rzz_matches_its_cx_rz_cx_lowering() {
+    let theta = 1.94;
+    let native = {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::Rzz(theta), &[0, 1]);
+        c.add_gate(Gate::Rzz(-0.62), &[1, 2]);
+        c
+    };
+    let lowered = {
+        let mut c = Circuit::new(3, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::H, &[1]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Rz(theta), &[1]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        c.add_gate(Gate::Rz(-0.62), &[2]);
+        c.add_gate(Gate::Cx, &[1, 2]);
+        c
+    };
+
+    for obs in [
+        vec![PauliTerm::x(0)],
+        vec![PauliTerm::x(0), PauliTerm::y(1)],
+        vec![PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)],
+    ] {
+        let a = run_spd_observable(&native, &obs, 0.0, 0).unwrap();
+        let b = run_spd_observable(&lowered, &obs, 0.0, 0).unwrap();
+        assert!(
+            (a.mean - b.mean).abs() < 1e-12,
+            "native {:.15} vs lowered {:.15} for {obs:?}",
+            a.mean,
+            b.mean
+        );
+    }
+}
+
+/// QAOA-shaped ansatz: an `Rzz` cost ring plus an `Rx` mixer layer, one
+/// `(gamma, beta)` pair per layer.
+fn qaoa_circuit(n: usize, angles: &[(f64, f64)]) -> Circuit {
+    let mut c = Circuit::new(n, 0);
+    for q in 0..n {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for &(gamma, beta) in angles {
+        for q in 0..n {
+            c.add_gate(Gate::Rzz(gamma), &[q, (q + 1) % n]);
+        }
+        for q in 0..n {
+            c.add_gate(Gate::Rx(beta), &[q]);
+        }
+    }
+    c
+}
+
+#[test]
+fn spd_qaoa_angle_sweep_matches_the_statevector() {
+    let quarter = std::f64::consts::FRAC_PI_4;
+    for theta in [0.02, 0.4, quarter, 1.1, std::f64::consts::FRAC_PI_2 - 0.02] {
+        let circuit = qaoa_circuit(4, &[(theta, 0.5), (0.8 * theta, 0.3)]);
+        let observables = [
+            vec![PauliTerm::z(0), PauliTerm::z(1)],
+            vec![PauliTerm::x(2)],
+            vec![PauliTerm::y(0), PauliTerm::z(3)],
+        ];
+
+        let exact = simulate(&circuit)
+            .backend(BackendKind::Statevector)
+            .seed(SEED)
+            .expectation_values(&observables)
+            .unwrap();
+
+        for (obs, expected) in observables.iter().zip(exact) {
+            let spd = run_spd_observable(&circuit, obs, 0.0, 0).unwrap();
+            assert!(
+                (spd.mean - expected).abs() < 1e-9,
+                "SPD {:.15} vs statevector {expected:.15} at theta {theta:.3} for {obs:?}",
+                spd.mean
+            );
+        }
+    }
+}
+
+#[test]
+fn spp_variance_peaks_at_the_t_angle_for_rzz() {
+    let quarter = std::f64::consts::FRAC_PI_4;
+    let sweep: Vec<f64> = [0.02, 0.4, quarter, 1.1, std::f64::consts::FRAC_PI_2 - 0.02]
+        .into_iter()
+        .map(|theta| {
+            let circuit = qaoa_circuit(3, &[(theta, 0.0); 4]);
+            run_spp_observable(&circuit, &[PauliTerm::x(0)], 20_000, SEED)
+                .unwrap()
+                .variance
+        })
+        .collect();
+
+    let peak = sweep[2];
+    assert!(
+        sweep.iter().all(|v| *v <= peak),
+        "T angle should hold the maximum variance: {sweep:?}"
+    );
+    for near_clifford in [sweep[0], sweep[4]] {
+        assert!(
+            near_clifford < 0.2 * peak,
+            "near-Clifford variance {near_clifford:.4} should sit far under the peak {peak:.4}"
+        );
+    }
+}
+
+#[test]
+fn light_cone_spd_matches_full_spd_on_rzz_circuits() {
+    let circuit = qaoa_circuit(5, &[(0.37, 0.5), (1.1, 0.3)]);
+    for obs in [
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::z(1), PauliTerm::x(3)],
+    ] {
+        let full = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+        let cone = prism_q::run_spd_observable_light_cone(&circuit, &obs, 0.0, 0).unwrap();
+        assert!(
+            (full.mean - cone.mean).abs() < 1e-12,
+            "full {:.15} vs cone {:.15} for {obs:?}",
+            full.mean,
+            cone.mean
+        );
+    }
+}
+
+// Multi-qubit arbitrary-axis strings reach the engines through the shared
+// CNOT-ladder lowering.
+#[test]
+fn pauli_rot_strings_match_the_statevector() {
+    let mut circuit = Circuit::new(3, 0);
+    for q in 0..3 {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    circuit.add_pauli_rotation(0.37, &[PauliTerm::x(0), PauliTerm::y(1)]);
+    circuit.add_pauli_rotation(-1.1, &[PauliTerm::y(0), PauliTerm::z(1), PauliTerm::x(2)]);
+    circuit.add_pauli_rotation(1.94, &[PauliTerm::z(1), PauliTerm::z(2)]);
+
+    let observables = [
+        vec![PauliTerm::z(0)],
+        vec![PauliTerm::x(1), PauliTerm::y(2)],
+        vec![PauliTerm::z(0), PauliTerm::z(1), PauliTerm::z(2)],
+    ];
+    let exact = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+
+    for (obs, expected) in observables.iter().zip(exact) {
+        let spd = run_spd_observable(&circuit, obs, 0.0, 0).unwrap();
+        assert!(
+            (spd.mean - expected).abs() < 1e-9,
+            "SPD {:.15} vs statevector {expected:.15} for {obs:?}",
+            spd.mean
+        );
+        assert_eq!(spd.t_count, 3, "one branching rotation per Pauli string");
+    }
 }

--- a/tests/pauli_joint_observable.rs
+++ b/tests/pauli_joint_observable.rs
@@ -6,7 +6,8 @@ use common::SEED;
 use prism_q::circuit::Circuit;
 use prism_q::gates::Gate;
 use prism_q::{
-    BackendKind, PauliAxis, PauliTerm, run_spd_observable, run_spp_observable, simulate,
+    BackendKind, PauliAxis, PauliTerm, run_spd_observable, run_spd_observable_budgeted,
+    run_spp_observable, simulate,
 };
 
 #[test]
@@ -553,5 +554,100 @@ fn pauli_rot_strings_match_the_statevector() {
             spd.mean
         );
         assert_eq!(spd.t_count, 3, "one branching rotation per Pauli string");
+    }
+}
+
+// The composable 1-norm truncation bound: at every budget, the truncated mean
+// sits within total_discarded of both the exact SPD mean and the statevector.
+#[test]
+fn budgeted_spd_holds_its_error_bound_across_budgets() {
+    let angles: Vec<(f64, f64)> = (0..4).map(|i| (0.08 + 0.01 * i as f64, 0.06)).collect();
+    let circuit = qaoa_circuit(5, &angles);
+    // z(0), z(2) rather than a nearest-neighbor pair: the ring plus a
+    // symmetric observable pairs up equal-magnitude terms, and a tie at the
+    // truncation cut would make the discarded-mass comparison below ride on
+    // hash order.
+    let obs = vec![PauliTerm::z(0), PauliTerm::z(2)];
+
+    let exact = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+    assert_eq!(exact.total_discarded, 0.0);
+    let sv = simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_values(std::slice::from_ref(&obs))
+        .unwrap()[0];
+
+    for budget in [64usize, 32, 16, 8] {
+        let b = run_spd_observable_budgeted(&circuit, &obs, budget).unwrap();
+        assert!(
+            b.peak_terms <= budget,
+            "budget {budget} held {} terms",
+            b.peak_terms
+        );
+        assert!(
+            (b.mean - exact.mean).abs() <= b.total_discarded + 1e-12,
+            "budget {budget}: |{} - {}| > bound {}",
+            b.mean,
+            exact.mean,
+            b.total_discarded
+        );
+        assert!(
+            (b.mean - sv).abs() <= b.total_discarded + 1e-9,
+            "budget {budget}: statevector {sv} outside bound {}",
+            b.total_discarded
+        );
+    }
+
+    // Near-Clifford angles concentrate magnitude in few terms: the tightest
+    // budget must fire, and a moderate one buys most terms back for little
+    // discarded mass.
+    let tight = run_spd_observable_budgeted(&circuit, &obs, 8).unwrap();
+    assert!(tight.total_discarded > 0.0);
+    let moderate = run_spd_observable_budgeted(&circuit, &obs, 32).unwrap();
+    assert!(
+        moderate.total_discarded < tight.total_discarded,
+        "moderate {} vs tight {}",
+        moderate.total_discarded,
+        tight.total_discarded
+    );
+}
+
+// A budget above the peak never fires: same result as the exact run, zero
+// reported bound.
+#[test]
+fn budget_above_the_peak_never_fires() {
+    let mut circuit = Circuit::new(3, 0);
+    for q in 0..3 {
+        circuit.add_gate(Gate::H, &[q]);
+        circuit.add_gate(Gate::T, &[q]);
+    }
+    circuit.add_gate(Gate::Cx, &[0, 1]);
+    circuit.add_gate(Gate::T, &[1]);
+    circuit.add_gate(Gate::Cx, &[1, 2]);
+
+    let obs = vec![PauliTerm::z(1), PauliTerm::z(2)];
+    let exact = run_spd_observable(&circuit, &obs, 0.0, 0).unwrap();
+    let budgeted = run_spd_observable_budgeted(&circuit, &obs, 1 << 12).unwrap();
+    assert_eq!(budgeted.total_discarded, 0.0);
+    assert_eq!(budgeted.peak_terms, exact.peak_terms);
+    assert!(
+        (budgeted.mean - exact.mean).abs() < 1e-12,
+        "budgeted {} vs exact {}",
+        budgeted.mean,
+        exact.mean
+    );
+}
+
+#[test]
+fn out_of_range_budgets_are_rejected() {
+    let mut circuit = Circuit::new(1, 0);
+    circuit.add_gate(Gate::H, &[0]);
+    for budget in [0usize, 1 << 21] {
+        let err = run_spd_observable_budgeted(&circuit, &[PauliTerm::z(0)], budget)
+            .expect_err("an out-of-range budget must be rejected");
+        assert!(
+            matches!(err, prism_q::PrismError::InvalidParameter { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/tests/qec_t_correctness.rs
+++ b/tests/qec_t_correctness.rs
@@ -530,7 +530,7 @@ fn analytical_strategies_handle_postselection() {
 }
 
 #[test]
-fn auto_routes_non_clifford_non_t_gate_to_tensor_network() {
+fn spd_strategy_handles_arbitrary_axis_rotations() {
     let theta = std::f64::consts::FRAC_PI_3;
     let mut program = QecProgram::with_options(1, options(512));
     program.push_gate(Gate::Rx(theta), &[0]).unwrap();
@@ -539,11 +539,50 @@ fn auto_routes_non_clifford_non_t_gate_to_tensor_network() {
         .observable_include(0, &[QecRecordRef::absolute(m0)])
         .unwrap();
 
+    let expected = theta.cos();
+    for strategy in [QecTStrategy::Spd, QecTStrategy::Auto] {
+        let result = run_qec_program_with_strategy(&program, strategy).unwrap();
+        let estimate = result
+            .observable_expectations
+            .as_ref()
+            .expect("analytical strategies must populate expectations")[0];
+        assert!(
+            (estimate.mean - expected).abs() < 1e-10,
+            "{strategy:?} mean {:.12} should match cos(theta) {:.12}",
+            estimate.mean,
+            expected
+        );
+    }
+}
+
+#[test]
+fn auto_routes_non_clifford_non_rotation_gate_to_tensor_network() {
+    // The Rx(pi/3) matrix as a raw fused unitary: same physics as the
+    // rotation, but a gate the Pauli engines cannot branch or lower.
+    let theta = std::f64::consts::FRAC_PI_3;
+    let (sin, cos) = (theta / 2.0).sin_cos();
+    let fused = Gate::Fused(Box::new([
+        [
+            num_complex::Complex64::new(cos, 0.0),
+            num_complex::Complex64::new(0.0, -sin),
+        ],
+        [
+            num_complex::Complex64::new(0.0, -sin),
+            num_complex::Complex64::new(cos, 0.0),
+        ],
+    ]));
+    let mut program = QecProgram::with_options(1, options(512));
+    program.push_gate(fused, &[0]).unwrap();
+    let m0 = program.measure_z(0).unwrap();
+    program
+        .observable_include(0, &[QecRecordRef::absolute(m0)])
+        .unwrap();
+
     let spd_err = run_qec_program_with_strategy(&program, QecTStrategy::Spd)
-        .expect_err("SPD must reject gates outside Clifford+T");
+        .expect_err("SPD must reject gates outside its rotation family");
     let spd_msg = format!("{spd_err:?}");
     assert!(
-        spd_msg.contains("rx"),
+        spd_msg.contains("fused"),
         "unexpected SPD rejection: {spd_msg}"
     );
 

--- a/tests/result_metadata.rs
+++ b/tests/result_metadata.rs
@@ -279,3 +279,37 @@ fn per_shot_route_stamps_metadata() {
         Exactness::Approximate { .. }
     ));
 }
+
+// Truncation-enabled SPD marks the route approximate even when the run
+// discarded nothing; epsilon 0 cannot discard and stays exact.
+#[test]
+fn spd_exactness_marks_the_route_not_the_run() {
+    let circuit = entangling_brickwork(3, 1);
+    let observables = vec![vec![PauliTerm::z(0)]];
+
+    let exact_route = simulate(&circuit)
+        .backend(BackendKind::DeterministicPauli {
+            epsilon: 0.0,
+            max_terms: 0,
+        })
+        .seed(SEED)
+        .expectation_values_reported(&observables)
+        .unwrap();
+    assert!(exact_route.metadata.is_exact());
+
+    // A threshold far below every coefficient discards nothing, and the
+    // route still reports approximate.
+    let approx_route = simulate(&circuit)
+        .backend(BackendKind::DeterministicPauli {
+            epsilon: 1e-300,
+            max_terms: 1 << 16,
+        })
+        .seed(SEED)
+        .expectation_values_reported(&observables)
+        .unwrap();
+    assert!(!approx_route.metadata.is_exact());
+    assert!(
+        (approx_route.values[0] - exact_route.values[0]).abs() < 1e-12,
+        "nothing was discarded, so the values must agree"
+    );
+}


### PR DESCRIPTION
## Summary

The SPP and SPD Pauli engines accepted only Clifford gates and single-qubit Z
rotations, which shut out QAOA cost layers and any rotation off the Z axis,
and SPD truncation reported a discarded mass with no stated error contract.
This PR widens the gate family and settles the truncation contract. Rzz
branches natively (a term splits only when it anticommutes with Z x Z on the
pair, exactly one of the two qubits carrying an X or Y letter); Rx, Ry, and
multi-qubit PauliRot strings lower through the shared CNOT ladder to Clifford
conjugation around one Rz. The QEC SPD strategy inherits the widened gate
set, so Auto routes arbitrary-axis rotation programs to SPD instead of the
tensor network. Truncation gains a proven composable bound (dropping a term
`c*P` at any point changes the final mean by at most `|c|`, because the
dropped piece's exact continuation is unitary conjugation of a unit-norm
operator; drops compose additively), a budgeted policy
(`run_spd_observable_budgeted`: smallest-magnitude surplus dropped to a term
budget, no threshold to guess), and route-level exactness metadata (a route
with `epsilon > 0` reports approximate even when a run discarded nothing).

## Scope

- [x] New feature

## Benchmarks

Adjacent A/B via `scripts/bench_ab.sh`, ref `main` (aae4b90), features
`parallel`, full Criterion tier (sample sizes are the groups' own: 10 for
`qec_t_strategies_scaling` and `spd_truncation`, 20 for `spd_light_cone`,
30 for `spp` and `coalesce_baseline`). Two agreeing runs per invocation on
the final code.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `spd_light_cone/unrestricted/8` | 6.10 us | 5.98 us | -2.0% (-0.6%) | +1.1% | yes |
| `spd_light_cone/unrestricted/16` | 11.35 us | 11.24 us | -0.9% (-1.0%) | +2.0% | yes |
| `spd_light_cone/light_cone/8` | 2.16 us | 2.16 us | -0.2% (+0.7%) | +0.2% | yes |
| `qec_t_strategies_scaling/spd/t8` | 10.13 us | 10.09 us | -0.3% (-0.2%) | -2.4% | yes |
| `qec_t_strategies_scaling/spd/t32` | 33.19 us | 32.61 us | -1.7% (-1.3%) | +3.5% | yes |
| `spp/spp_10k/50q_1000t` | 505.99 ms | 499.54 ms | -1.3% (-1.4%) | -0.9% | yes |
| `coalesce_baseline/spp_10k/10q_d50_t5pct` | 213.39 ms | 216.00 ms | +1.2% (+1.2%) | -0.0% | yes |
| `pauli_engine_qaoa/spd_maxcut_chain/16q_p2` (new) | rejected on main | 1.60 ms (1.66 ms) | capability | two agreeing runs | n/a |
| `spd_truncation/exact/hea_10q_l3` (new) | n/a | 404.2 ms (404.6 ms) | capability | two agreeing runs | n/a |
| `spd_truncation/budget4096/hea_10q_l3` (new) | n/a | 24.6 ms (24.7 ms) | capability | two agreeing runs | n/a |
| `spd_truncation/budget256/hea_10q_l3` (new) | n/a | 2.25 ms (2.23 ms) | capability | two agreeing runs | n/a |
| `spd_truncation/t_control_budget4096/10q` (new) | n/a | 5.53 us (5.58 us) | vs t_control_exact 5.54 us | within 0.7% both runs | yes |

Regression verdict: PASS

- The capability rows cannot run on the reference: `main` rejects `rzz` in
  the engines and has no budgeted entry. Reported after-only from two
  agreeing quiet-host runs.
- Truncation payoff, measured outside Criterion on the bench shape
  (hardware-efficient layers at small angles, 10 qubits, X observable): the
  untruncated engine holds 199,512 peak terms in 467 ms; budget 4096 holds
  4,096 terms in 28.9 ms with a reported bound of 0.069 (realized error
  7.6e-5); budget 256 holds 256 terms in 2.7 ms with a bound of 0.63
  (realized error 1.8e-3). The bound held at every point; the fixture
  `budgeted_spd_holds_its_error_bound_across_budgets` pins it against the
  statevector.
- The `qec_t_strategies_scaling/camps` rows are unresolvable on this host
  (same-code control spreads to 59% at sample size 10, matching the spread
  `benches/README.md` records for the family); their Change columns are
  unmeasured, not passes. They execute none of the changed code.
- Cross-run adjudication was required for the microsecond-scale qec rows:
  each copied bench binary draws a per-run code-placement state that shifts
  its absolute times by up to 18% for a whole run while the in-run same-code
  control stays under 2%, visible as camps rows (which the diff cannot
  reach) swinging between -29% and +26% across runs. Row verdicts come from
  run pairs where both binaries measured in the same state, corroborated by
  pooled per-binary minima across all runs.
- Unmeasured gap: `run_spp_observable` has no bench row; its sampling loop
  is shared with `run_spp`, which the `spp` rows cover.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2453)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on new and changed pub items add facts the signatures lack
- [x] Golden coverage: `spd_qaoa_angle_sweep_matches_the_statevector` and
      `pauli_rot_strings_match_the_statevector` pin SPD against the
      statevector across an angle sweep at 1e-9;
      `rzz_branches_only_on_anticommuting_terms` pins the two-qubit
      anticommutation rule by term count; `rzz_matches_its_cx_rz_cx_lowering`
      pins native Rzz against its Clifford lowering;
      `spp_variance_peaks_at_the_t_angle_for_rzz` pins the sampling variance
      profile; `budgeted_spd_holds_its_error_bound_across_budgets` pins the
      truncation bound at four budgets against the exact engine and the
      statevector; `budget_above_the_peak_never_fires` pins the idle-policy
      case; `spd_exactness_marks_the_route_not_the_run` pins the metadata
      convention.

## Hotspot notes

Mechanisms found by the control rows during measurement and fixed before the
final numbers:

- A separate lowering scan per engine call cost +5% to +6% on the
  `spd_light_cone/unrestricted` rows (microsecond-scale calls). Validation
  and lowering now share one instruction walk, with the Rx/Ry/PauliRot tests
  on the rejection path.
- The SPD per-instruction dispatch chained two rotation probes before the
  Clifford arm; a single gate match (`WeightedPauliSum::apply_backward`)
  recovered the remainder.
- In SPP, a third `CoalescedOp` variant grew the op stream from 40 to 48
  bytes and kept an outlined call in the per-sample loop's match, costing
  +2.6% to +5.8% on op-heavy `spp` and `coalesce_baseline` rows. Rzz now
  shares the `ZRot` variant via a `u32` pair with a sentinel, holding the
  enum at 40 bytes (pinned by a size test) with no extra arm.
- The truncation-policy refactor keeps `run_spd` and the light-cone loop
  byte-identical and routes `run_spd_observable` through a private policy
  enum whose exact arm compiles to the pre-change comparison; discarded mass
  accumulates only inside the fired branch, so the exact path carries no
  unconditional float add per instruction.

## Breaking changes

None in signatures. Behavioral: the engines and the QEC SPD strategy accept
Rx, Ry, Rzz, and PauliRot instead of rejecting them, and QEC Auto routes
such programs to SPD rather than the tensor network. Rejection messages for
unsupported gates now read "neither Clifford nor a supported Pauli
rotation". `DeterministicPauli` results with `epsilon > 0` now report
approximate even when the run discarded nothing, per the route-level
`Exactness` convention; `epsilon = 0` still reports exact, and the auto
routes are unaffected.

## Risks and rollback

The native Rzz branch and the lowering pre-pass sit behind the existing
engine entry points; circuits without the new gates take the same code shape
as before, so the blast radius of a wrong branch rule is limited to circuits
using the new gates, which the sweep fixtures pin against the statevector.
The budgeted policy is a new opt-in entry point; existing threshold
semantics are unchanged and the exact and auto routes cannot discard. No
flags; rollback is a revert.
