### PR TITLE
bench(mps): brickwork chi ladder with a pinned entangling floor

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -901,6 +901,30 @@ fn bench_mps_hotspots(c: &mut Criterion) {
     group.finish();
 }
 
+// The chi ladder: the one MPS group whose bond growth reaches the caps
+// (uncapped peaks 512 at 18q and 1024 at 20q against corpus peaks of 4
+// elsewhere), so these rows price the cap itself rather than allocation
+// and traversal. Shape pinned in `tests/bench_fixture_routing.rs`.
+fn bench_mps_brickwork(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mps/brickwork_d24");
+    configure_group(&mut group);
+
+    for &n in &[18, 20] {
+        let circuit = circuits::brickwork_circuit(n, 24, SEED);
+        for &cap in &[32usize, 64, 256] {
+            group.bench_with_input(
+                BenchmarkId::new(format!("b{cap}"), n),
+                &circuit,
+                |b, circ| {
+                    b.iter(|| run_mps_apply_only(circ, cap));
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
 // ---- Native shot sampling on the polynomial-state backends ----
 
 /// Terminal measurements on every qubit, the shape the native samplers serve.
@@ -2992,6 +3016,7 @@ criterion_group! {
     bench_mps_scaling,
     bench_mps_linear_chain,
     bench_mps_hotspots,
+    bench_mps_brickwork,
     bench_mps_sampling,
     // Product state
     bench_product_scaling,

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -456,6 +456,30 @@ pub fn cz_chain_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
     c
 }
 
+/// Build a non-Clifford brick-wall circuit: `depth` layers of random Ry/Rz on
+/// every qubit, each layer closed by CZ on alternating adjacent pairs.
+///
+/// No layer resets entanglement, so the Schmidt rank across a cut doubles each
+/// time a CZ crosses it (once per two layers) until it saturates at
+/// `2^min(c, n - c)` for the cut after qubit `c - 1`. The `mps/brickwork_d24`
+/// bench rows rely on that growth to reach their bond caps;
+/// `tests/bench_fixture_routing.rs` pins it through the instruction stream.
+pub fn brickwork_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    for layer in 0..depth {
+        for q in 0..n {
+            c.add_gate(Gate::Ry(rng.random::<f64>() * std::f64::consts::TAU), &[q]);
+            c.add_gate(Gate::Rz(rng.random::<f64>() * std::f64::consts::TAU), &[q]);
+        }
+        let offset = layer % 2;
+        for q in (offset..n.saturating_sub(1)).step_by(2) {
+            c.add_gate(Gate::Cz, &[q, q + 1]);
+        }
+    }
+    c
+}
+
 /// Append an inverse QFT on `n` qubits starting at index `start`.
 ///
 /// Exact inverse of the forward decomposition in `qft_textbook_steps`: reverse

--- a/tests/bench_fixture_routing.rs
+++ b/tests/bench_fixture_routing.rs
@@ -7,8 +7,9 @@
 //! affected rows stayed green, kept reporting, and went non-monotonic in qubit
 //! count. Nothing else in the suite checks the engine a run actually used.
 
+use prism_q::backend::Backend;
 use prism_q::sim::ResolvedBackend;
-use prism_q::{BackendKind, circuits, sim};
+use prism_q::{BackendKind, MpsBackend, circuits, sim};
 
 const SEED: u64 = 0xDEAD_BEEF;
 
@@ -81,6 +82,39 @@ fn diagonal_mixed_rows_reach_their_backend() {
             &circuit,
         );
     }
+}
+
+// The `mps/brickwork_d24` rows price the bond cap, so what needs pinning is
+// entanglement, not routing. The peak is measured through the instruction
+// stream (a saturated cap proves the uncapped peak meets it) rather than
+// trusted from construction: Cx on plus states holds dense_entanglement at
+// bond 1.
+#[test]
+fn brickwork_rows_saturate_the_bond_ladder() {
+    fn stream_peak_saturates(circuit: &prism_q::circuit::Circuit, cap: usize) -> bool {
+        let mut backend = MpsBackend::new(SEED, cap);
+        backend
+            .init(circuit.num_qubits, circuit.num_classical_bits)
+            .unwrap();
+        for instruction in &circuit.instructions {
+            backend.apply(instruction).unwrap();
+            if backend.current_max_bond_dim() >= cap {
+                return true;
+            }
+        }
+        false
+    }
+
+    let circuit = circuits::brickwork_circuit(18, 24, SEED);
+    assert!(
+        stream_peak_saturates(&circuit, 32),
+        "brickwork_d24/18: the bottom ladder rung no longer truncates"
+    );
+    assert!(
+        stream_peak_saturates(&circuit, 512),
+        "brickwork_d24/18: the uncapped peak no longer clears the 256 cap, \
+         so the chi ladder measures allocation and traversal instead of bond"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The MPS bench corpus could not carry a bond-dependent claim: every family
peaks at bond 4 or below, so the truncation cap was priced only by rows that
never reach it. This adds a brick-wall family whose bond growth saturates the
caps, the 32/64/256 ladder on it, and a fixture test that fails loudly if the
shape ever stops entangling.

## Scope

- [x] Build, CI, or tooling (bench rows, one fixture generator, its shape test)

## Benchmarks

New rows, so there is no before side and no A/B; the table characterizes the
new family. Full Criterion at sample 30, three runs of one binary with no
rebuild between them; each row is quoted from the two runs agreeing within
5%, and the third reading is shown.

| Benchmark | Run A | Run B | Dropped reading |
| --- | --- | --- | --- |
| mps/brickwork_d24/b32/18 | 72.5 ms | 75.6 ms | 107.2 ms (slow excursion, 10% outliers) |
| mps/brickwork_d24/b64/18 | 254.1 ms | 265.2 ms | 234.1 ms (fast) |
| mps/brickwork_d24/b256/18 | 1.306 s | 1.321 s | 1.363 s |
| mps/brickwork_d24/b32/20 | 87.9 ms | 86.3 ms | 91.1 ms |
| mps/brickwork_d24/b64/20 | 319.6 ms | 328.8 ms | 304.0 ms (fast) |
| mps/brickwork_d24/b256/20 | 2.391 s | 2.335 s | 2.433 s |

Two dropped readings are fast, which host contamination does not explain, so
the quoted b64 pairs may sit a few percent high; the agreement rule still
picks them uniquely.

The family reaches the caps: the instruction-stream peak bond is 512 uncapped
at 18q and 1024 at 20q, exact doubling per cut crossing, with the 1e-12
epsilon removing nothing. Where bond grows, cap 256 costs 5.1x (18q) and 7.3x
(20q) over cap 64 and holds the reported fidelity lower bound at 0.998 and
0.977, against 0.755 and 0.645 at cap 64 and about 0.3 at cap 32. That is the
first measured backing for 256 as the dispatch and Python default: it is the
one ladder rung that keeps the bound near 1 on entangling workloads, and the
existing guard rows already pin its cost equivalence with 64 where bond stays
low.

Regression verdict: PASS. No existing row's code is touched; the diff adds a
generator with no callers on any simulation path, bench rows, and a test.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry
- [ ] Golden tests: N/A, no new gate, backend, or fusion pass; the new test
      pins the fixture's bond saturation through the instruction stream

## Hotspot notes

N/A, no hot-path changes.

## Breaking changes

None.

## Risks and rollback

Bench and test additions plus one fixture generator with no simulation-path
callers; deleting the generator, the group, and the test reverts cleanly.
