### PR TITLE
feat(mps): settable SVD truncation threshold

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -298,6 +298,16 @@ fn run_mps_apply_only(circuit: &Circuit, max_bond_dim: usize) {
     black_box(backend.classical_results());
 }
 
+fn run_mps_apply_only_with_epsilon(circuit: &Circuit, max_bond_dim: usize, epsilon: f64) {
+    let mut backend = MpsBackend::new(SEED, max_bond_dim);
+    backend.set_svd_epsilon(epsilon);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    backend.apply_instructions(&circuit.instructions).unwrap();
+    black_box(backend.classical_results());
+}
+
 // ---- Statevector: qubit-count sweeps ----
 
 fn bench_statevector_random(c: &mut Criterion) {
@@ -921,6 +931,13 @@ fn bench_mps_brickwork(c: &mut Criterion) {
             );
         }
     }
+
+    // Epsilon companion to the b256 rung: the raised threshold cuts the
+    // low-weight Schmidt tail before the cap discards real weight.
+    let circuit = circuits::brickwork_circuit(18, 24, SEED);
+    group.bench_with_input(BenchmarkId::new("b256_e3", 18), &circuit, |b, circ| {
+        b.iter(|| run_mps_apply_only_with_epsilon(circ, 256, 1e-3));
+    });
 
     group.finish();
 }

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -550,6 +550,27 @@ impl MpsBackend {
         backend
     }
 
+    /// Set the relative singular-value truncation threshold.
+    ///
+    /// Each SVD drops singular values at or below `epsilon` times the largest,
+    /// and the discarded weight reports through [`Self::truncation_discarded`]
+    /// and the run's exactness metadata. The construction default of 1e-12
+    /// keeps every numerically meaningful value, so results stay exact
+    /// wherever the bond cap never bites; a larger threshold trades fidelity
+    /// for lower bond dimension and run time on entangling circuits, and can
+    /// lower the total discarded weight at a fixed cap by cutting low-weight
+    /// Schmidt tails before the cap discards real weight.
+    ///
+    /// # Panics
+    /// Panics unless `0 <= epsilon < 1`.
+    pub fn set_svd_epsilon(&mut self, epsilon: f64) {
+        assert!(
+            (0.0..1.0).contains(&epsilon),
+            "svd epsilon must lie in [0, 1)"
+        );
+        self.svd_epsilon = epsilon;
+    }
+
     /// Zero the cumulative SVD-truncation weight. [`Backend::init`] does this,
     /// so a caller needs it only to scope the total to a sequence shorter than a
     /// run: the CAMPS T-gate path, which must reject silent truncation, brackets
@@ -564,8 +585,9 @@ impl MpsBackend {
     /// [`Backend::init`] or the last [`Self::reset_truncation_tracking`].
     ///
     /// [`Backend::init`]: crate::backend::Backend::init
-    /// Epsilon-threshold truncation contributes negligibly (`~svd_epsilon²`); a
-    /// meaningful value indicates the bond-dimension cap discarded real weight.
+    /// At the default threshold, epsilon truncation contributes negligibly and
+    /// a meaningful value indicates the bond-dimension cap discarded real
+    /// weight; after [`Self::set_svd_epsilon`] both sources contribute.
     pub fn truncation_discarded(&self) -> f64 {
         self.truncation_discarded
     }

--- a/src/backend/mps_tests.rs
+++ b/src/backend/mps_tests.rs
@@ -703,3 +703,57 @@ fn test_batch_phase_decomposition() {
     );
     assert_mps_matches_statevector(&c);
 }
+
+#[test]
+fn svd_epsilon_default_is_pinned() {
+    let b = MpsBackend::new(42, 64);
+    assert_eq!(b.svd_epsilon, 1e-12);
+}
+
+#[test]
+#[should_panic(expected = "svd epsilon")]
+fn svd_epsilon_rejects_one() {
+    MpsBackend::new(42, 64).set_svd_epsilon(1.0);
+}
+
+// Uncapped brickwork saturates its width ceiling, so a raised threshold must
+// show as a lower peak bond, a reported discard, and a realized error within
+// a small factor of that discard (the estimate is first order, not a
+// certificate; 10x holds well clear of the ~2.5x measured on deeper runs).
+#[test]
+fn raised_epsilon_lowers_bond_and_reports_the_discard() {
+    let circuit = crate::circuits::brickwork_circuit(14, 20, 42);
+
+    let mut exact = MpsBackend::new(42, 4096);
+    exact.init(14, 0).unwrap();
+    exact.apply_instructions(&circuit.instructions).unwrap();
+    let reference = exact.export_statevector().unwrap();
+    let exact_bond = exact.current_max_bond_dim();
+
+    let mut b = MpsBackend::new(42, 4096);
+    b.set_svd_epsilon(1e-3);
+    b.init(14, 0).unwrap();
+    b.apply_instructions(&circuit.instructions).unwrap();
+
+    assert!(
+        b.current_max_bond_dim() < exact_bond,
+        "raised threshold left the peak bond at {} against {exact_bond}",
+        b.current_max_bond_dim()
+    );
+    let discarded = b.truncation_discarded();
+    assert!(discarded > 0.0, "raised threshold reported no discard");
+    match b.exactness() {
+        crate::sim::Exactness::Approximate {
+            fidelity_lower_bound: Some(bound),
+        } => assert!((bound - (1.0 - discarded)).abs() < 1e-15),
+        other => panic!("expected a reported bound, got {other:?}"),
+    }
+
+    let v = b.export_statevector().unwrap();
+    let inner: Complex64 = reference.iter().zip(&v).map(|(r, x)| r.conj() * x).sum();
+    let realized_err = 1.0 - inner.norm_sqr();
+    assert!(
+        realized_err < 10.0 * discarded,
+        "realized error {realized_err:.3e} against reported discard {discarded:.3e}"
+    );
+}

--- a/src/sim/metadata.rs
+++ b/src/sim/metadata.rs
@@ -132,8 +132,16 @@ impl RunMetadata {
         matches!(self.exactness, Exactness::Exact)
     }
 
-    /// Lower bound on the fidelity of the produced state, `None` when the
-    /// result is exact or the engine reports no bound.
+    /// Reported fidelity floor for the produced state, `None` when the result
+    /// is exact or the engine reports none.
+    ///
+    /// For the MPS backend this is 1 minus the summed per-SVD relative
+    /// discarded weights: a first-order truncation estimate, not a
+    /// certificate. Truncation errors compound across SVDs, and realized
+    /// fidelity has measured below the reported value by up to a factor of
+    /// about 2.4 in the implied error on deep truncating runs. The budgeted
+    /// Pauli engines leave this `None` and report their additive observable
+    /// bound on the result types instead.
     pub fn fidelity_lower_bound(&self) -> Option<f64> {
         match self.exactness {
             Exactness::Exact => None,


### PR DESCRIPTION
## Summary

The SVD truncation threshold was a construction-time constant, so a circuit
whose Schmidt spectrum decays fast paid the same bond growth as one that does
not. A fidelity sweep on the brickwork family showed a raised threshold
dominating the default at the 256 cap, so the trade is now settable per
backend (`MpsBackend::set_svd_epsilon`) while the construction default stays
1e-12, which the sub-1e-9 cross-backend agreements require. The sweep also
measured realized fidelity below the reported `fidelity_lower_bound` on deep
truncating runs, so the metadata docs now describe that value as a
first-order estimate rather than a certificate.

## Scope

- [x] New feature (opt-in truncation threshold, one bench row, doc corrections)

## Benchmarks

Sweep, release probe on seeded deterministic apply streams, realized fidelity
taken against the exact state: at cap 256 on the brickwork family, threshold
1e-3 beats the 1e-12 default at both widths, realized error 1.40e-5 against
4.66e-3 at 18q and 1.32e-2 against 2.90e-2 at 20q, at the same peak bond 256.
Uncapped at 20q the threshold alone cuts peak bond 1024 to 643 at realized
error 1.6e-5. No single value is optimal across widths (1e-2 over-truncates
at 18q, best at 20q), which is why this ships as a knob and not a default
change. Legacy MPS rows are threshold-inert (peak bonds 4 and 2, nothing to
cut).

Adjacent-binary A/B against `main`, full Criterion at sample 30, quiet host
(a foreign compute job was waited out before the run):

| Benchmark | Ref | New | Change | Control (ref) | Control (new) | Verdict |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| mps/brickwork_d24/b256/18 | 1.254 s | 1.272 s | +1.5% | +1.6% | -1.1% | noise |
| mps/brickwork_d24/b256/20 | 2.363 s | 2.381 s | +0.8% | +1.4% | +0.2% | noise |
| mps/brickwork_d24/b32/18 | 71.28 ms | 71.50 ms | +0.3% | +1.9% | -1.5% | noise |
| mps/brickwork_d24/b32/20 | 85.34 ms | 86.06 ms | +0.9% | -0.9% | -0.6% | noise |
| mps/brickwork_d24/b64/18 | 234.61 ms | 236.03 ms | +0.6% | -0.3% | +0.9% | noise |
| mps/brickwork_d24/b64/20 | 304.68 ms | 308.04 ms | +1.1% | +0.2% | +1.5% | noise |
| mps/hotspots/long_range_cp_r4/32 | 446.11 us | 426.06 us | -4.5% | +3.5% | -3.0% | sub-threshold |
| mps/hotspots/long_range_cp_r4_b256/32 | 425.53 us | 430.96 us | +1.3% | +1.9% | +3.7% | noise |
| mps/hotspots/measure_reset_32q_r3 | 342.55 us | 342.86 us | +0.1% | +0.3% | -0.5% | noise |

`adjacent_cp_r4/{16,32}` carried same-code control spreads up to 9.5% and are
reported unmeasured, their standing behavior. The new row
`mps/brickwork_d24/b256_e3/18` has no before side; the two measured
new-binary passes read 753.0 ms and 754.84 ms (0.2% apart), 40.8% under the
b256/18 rung's 1.272 s in the same run and binary.

Regression verdict: PASS. Eleven of twelve compared rows are noise;
`long_range_cp_r4/32` read faster at -4.5%, under the gate and attributed to
layout movement from the added linked code. The setter is not on any
gate-application path; the A/B exists for that layout caveat.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new and changed `pub` items add facts the signature does
      not carry
- [x] Tests: default pinned at 1e-12, panic on out-of-range input, and a 14q
      behavior test asserting lower peak bond, a positive reported discard,
      exactness consistency, and realized error within 10x of the discard
      against an exact reference

## Hotspot notes

N/A on code: the setter writes a field read by the existing SVD sites and
nothing on the gate-application path changed. The A/B above covers the
layout-movement caveat for added linked code.

## Breaking changes

None in API. Semantics documentation change: `fidelity_lower_bound` is now
described as a first-order truncation estimate, not a strict bound, after
realized fidelity measured below it by up to about 2.4x in implied error on
deep truncating runs. The field name now overstates; renaming it is left as
an open API decision rather than bundled here.

## Risks and rollback

The knob is opt-in with the default pinned by test; no caller in dispatch,
Python, or the QEC paths sets it. Deleting the setter, the bench row, and
the three tests reverts cleanly.
