### PR TITLE
perf(mps): hold gate scratch across calls and halve the branch Gram

### DIFF
--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -229,6 +229,16 @@ pub fn svd(a: &[Complex64], m: usize, n: usize) -> SvdResult {
     svd_jacobi(a, m, n)
 }
 
+/// Return a length-`len` window of `buf`, growing it only past its high-water
+/// mark, so a steady-state call allocates and clears nothing. Callers
+/// overwrite every element of the window before reading it.
+fn scratch_slice(buf: &mut Vec<Complex64>, len: usize) -> &mut [Complex64] {
+    if buf.len() < len {
+        buf.resize(len, ZERO);
+    }
+    &mut buf[..len]
+}
+
 fn truncated_svd_rank(singular_values: &[f64], epsilon: f64, max_bond_dim: usize) -> usize {
     let s_max = singular_values.first().copied().unwrap_or(0.0);
     let threshold = epsilon * s_max;
@@ -509,7 +519,6 @@ fn pauli_matrix_entry(axis: Option<MpsPauliAxis>, j: usize, k: usize) -> Complex
 }
 
 /// Matrix Product State backend with bounded bond dimension.
-#[derive(Clone)]
 pub struct MpsBackend {
     num_qubits: usize,
     max_bond_dim: usize,
@@ -524,6 +533,38 @@ pub struct MpsBackend {
     /// construction, so the per-gate check is a field compare rather than an
     /// atomic load.
     workspace_cap: u128,
+    /// Grow-only scratch for [`Self::apply_adjacent_two_qubit`], held across
+    /// calls so the four contraction buffers cost no allocation per gate.
+    /// Every element of each call's window is written by assignment before
+    /// any read, so stale contents never leak between calls.
+    scratch_theta: Vec<Complex64>,
+    scratch_right_t: Vec<Complex64>,
+    scratch_theta_prime: Vec<Complex64>,
+    scratch_mat: Vec<Complex64>,
+}
+
+// Manual so clones start with empty scratch: the buffers are write-before-read
+// and the stabilizer-rank path clones branch states per shot, so copying their
+// contents would be pure memcpy waste.
+impl Clone for MpsBackend {
+    fn clone(&self) -> Self {
+        Self {
+            num_qubits: self.num_qubits,
+            max_bond_dim: self.max_bond_dim,
+            svd_epsilon: self.svd_epsilon,
+            sites: self.sites.clone(),
+            logical_to_site: self.logical_to_site.clone(),
+            site_to_logical: self.site_to_logical.clone(),
+            classical_bits: self.classical_bits.clone(),
+            rng: self.rng.clone(),
+            truncation_discarded: self.truncation_discarded,
+            workspace_cap: self.workspace_cap,
+            scratch_theta: Vec::new(),
+            scratch_right_t: Vec::new(),
+            scratch_theta_prime: Vec::new(),
+            scratch_mat: Vec::new(),
+        }
+    }
 }
 
 impl MpsBackend {
@@ -540,6 +581,10 @@ impl MpsBackend {
             rng: ChaCha8Rng::seed_from_u64(seed),
             truncation_discarded: 0.0,
             workspace_cap: crate::backend::mps_workspace_cap_elements(),
+            scratch_theta: Vec::new(),
+            scratch_right_t: Vec::new(),
+            scratch_theta_prime: Vec::new(),
+            scratch_mat: Vec::new(),
         }
     }
 
@@ -638,6 +683,19 @@ impl MpsBackend {
     /// Contracts left-to-right through the environment tensor in two
     /// passes per site, avoiding the naive four-loop sum.
     pub fn inner_product(&self, other: &Self) -> Result<Complex64> {
+        self.inner_product_with_scratch(other, &mut Vec::new(), &mut Vec::new())
+    }
+
+    /// [`Self::inner_product`] with caller-owned scratch. `tmp` and
+    /// `next_env` are cleared and resized per site, so a caller evaluating
+    /// many overlaps pays one small environment allocation per call instead
+    /// of two per site.
+    pub(crate) fn inner_product_with_scratch(
+        &self,
+        other: &Self,
+        tmp: &mut Vec<Complex64>,
+        next_env: &mut Vec<Complex64>,
+    ) -> Result<Complex64> {
         if self.num_qubits != other.num_qubits {
             return Err(crate::error::PrismError::InvalidParameter {
                 message: format!(
@@ -668,7 +726,8 @@ impl MpsBackend {
             let br_b = b.bond_right;
 
             // Step 1: tmp[β, j, α'] = Σ_α env[α, β] · conj(A[α, j, α'])
-            let mut tmp = vec![ZERO; bl_b * 2 * br_a];
+            tmp.clear();
+            tmp.resize(bl_b * 2 * br_a, ZERO);
             for alpha in 0..bl_a {
                 for j in 0..2 {
                     for alpha_p in 0..br_a {
@@ -684,8 +743,9 @@ impl MpsBackend {
                 }
             }
 
-            // Step 2: new_env[α', β'] = Σ_{β, j} tmp[β, j, α'] · B[β, j, β']
-            let mut new_env = vec![ZERO; br_a * br_b];
+            // Step 2: next_env[α', β'] = Σ_{β, j} tmp[β, j, α'] · B[β, j, β']
+            next_env.clear();
+            next_env.resize(br_a * br_b, ZERO);
             for beta in 0..bl_b {
                 for j in 0..2 {
                     for beta_p in 0..br_b {
@@ -695,13 +755,13 @@ impl MpsBackend {
                         }
                         for alpha_p in 0..br_a {
                             let t = tmp[beta * (2 * br_a) + j * br_a + alpha_p];
-                            new_env[alpha_p * br_b + beta_p] += t * b_val;
+                            next_env[alpha_p * br_b + beta_p] += t * b_val;
                         }
                     }
                 }
             }
 
-            env = new_env;
+            std::mem::swap(&mut env, next_env);
             env_cols = br_b;
         }
 
@@ -933,10 +993,10 @@ impl MpsBackend {
         let left_data = &self.sites[left_site].data;
         let right_data = &self.sites[right_site].data;
         let chunk_size = 2 * 2 * br;
-        let mut theta = vec![ZERO; bl * chunk_size];
+        let theta = scratch_slice(&mut self.scratch_theta, bl * chunk_size);
 
         // Transpose right: (bond_mid, 2, br) → (2, br, bond_mid) for sequential gamma access.
-        let mut right_t = vec![ZERO; bond_mid * 2 * br];
+        let right_t = scratch_slice(&mut self.scratch_right_t, bond_mid * 2 * br);
         for gamma in 0..bond_mid {
             for j in 0..2usize {
                 for beta in 0..br {
@@ -1003,7 +1063,8 @@ impl MpsBackend {
         }
 
         // 2. Apply gate: Θ'[α, i', j', β] = Σ_{i,j} G[i'2+j', i2+j] · Θ[α,i,j,β]
-        let mut theta_prime = vec![ZERO; bl * chunk_size];
+        let theta = &self.scratch_theta[..bl * chunk_size];
+        let theta_prime = scratch_slice(&mut self.scratch_theta_prime, bl * chunk_size);
 
         #[cfg(feature = "parallel")]
         if bl >= MIN_BOND_FOR_PAR {
@@ -1069,7 +1130,8 @@ impl MpsBackend {
         //    M[(α*2+i), (j*br+β)] = Θ'[α, i, j, β]
         let rows = bl * 2;
         let cols = 2 * br;
-        let mut mat = vec![ZERO; rows * cols];
+        let theta_prime = &self.scratch_theta_prime[..bl * chunk_size];
+        let mat = scratch_slice(&mut self.scratch_mat, rows * cols);
         for alpha in 0..bl {
             for i in 0..2 {
                 for j in 0..2 {
@@ -1083,7 +1145,7 @@ impl MpsBackend {
             }
         }
 
-        let svd_result = svd(&mat, rows, cols);
+        let svd_result = svd(mat, rows, cols);
         let chi_new = truncated_svd_rank(&svd_result.s, self.svd_epsilon, self.max_bond_dim);
         self.record_truncation(&svd_result.s, chi_new);
 

--- a/src/backend/mps_tests.rs
+++ b/src/backend/mps_tests.rs
@@ -757,3 +757,29 @@ fn raised_epsilon_lowers_bond_and_reports_the_discard() {
         "realized error {realized_err:.3e} against reported discard {discarded:.3e}"
     );
 }
+
+// One scratch pair reused across overlaps of different bond shapes must give
+// the same values as fresh-allocation calls; stale contents from a larger
+// pair must not leak into a smaller one.
+#[test]
+fn inner_product_scratch_reuse_matches_fresh() {
+    let run = |depth: usize, seed: u64| {
+        let circuit = crate::circuits::brickwork_circuit(8, depth, seed);
+        let mut b = MpsBackend::new(42, 64);
+        b.init(8, 0).unwrap();
+        b.apply_instructions(&circuit.instructions).unwrap();
+        b
+    };
+    let big = run(8, 42);
+    let small = run(2, 43);
+
+    let mut tmp = Vec::new();
+    let mut next_env = Vec::new();
+    for (bra, ket) in [(&big, &small), (&small, &small), (&big, &big)] {
+        let reused = bra
+            .inner_product_with_scratch(ket, &mut tmp, &mut next_env)
+            .unwrap();
+        let fresh = bra.inner_product(ket).unwrap();
+        assert_eq!(reused, fresh);
+    }
+}

--- a/src/sim/stabilizer_rank.rs
+++ b/src/sim/stabilizer_rank.rs
@@ -832,12 +832,24 @@ fn weighted_mps_norm_sq(branches: &[WeightedMpsBranch]) -> Result<f64> {
         return Ok(0.0);
     }
 
+    // Gram term (i, j) is the conjugate of (j, i), so the upper triangle plus
+    // the diagonal carries the whole sum; the scratch pair is reused across
+    // every overlap in the sweep.
     let mut total = Complex64::new(0.0, 0.0);
-    for left in branches {
+    let mut tmp = Vec::new();
+    let mut next_env = Vec::new();
+    for (i, left) in branches.iter().enumerate() {
         let left_weight = left.weight.conj();
-        for right in branches {
-            let overlap = left.state.inner_product(&right.state)?;
-            total += left_weight * right.weight * overlap;
+        let diag = left
+            .state
+            .inner_product_with_scratch(&left.state, &mut tmp, &mut next_env)?;
+        total += left_weight * left.weight * diag;
+        for right in &branches[i + 1..] {
+            let overlap =
+                left.state
+                    .inner_product_with_scratch(&right.state, &mut tmp, &mut next_env)?;
+            let term = left_weight * right.weight * overlap;
+            total += term + term.conj();
         }
     }
 

--- a/src/sim/stabilizer_rank_tests.rs
+++ b/src/sim/stabilizer_rank_tests.rs
@@ -562,3 +562,34 @@ fn test_approx_handles_many_t_gates() {
     assert!(result.num_terms <= 32);
     assert_eq!(result.t_count, 10);
 }
+
+// Term (i, j) of the branch Gram is the conjugate of (j, i); the triangle
+// evaluation must match the full B x B sum.
+#[test]
+fn triangle_gram_matches_the_full_sum() {
+    let mut c = Circuit::new(3, 0);
+    c.add_gate(Gate::H, &[0]);
+    c.add_gate(Gate::T, &[0]);
+    c.add_gate(Gate::Cx, &[0, 1]);
+    c.add_gate(Gate::T, &[1]);
+    c.add_gate(Gate::H, &[2]);
+    c.add_gate(Gate::T, &[2]);
+
+    let branches = build_mps_branches_for_unitary(&c, 42).unwrap();
+    assert!(branches.len() >= 8, "expected a T-branched state");
+
+    let mut full = Complex64::new(0.0, 0.0);
+    for left in &branches {
+        for right in &branches {
+            let overlap = left.state.inner_product(&right.state).unwrap();
+            full += left.weight.conj() * right.weight * overlap;
+        }
+    }
+
+    let triangle = weighted_mps_norm_sq(&branches).unwrap();
+    assert!(
+        (triangle - full.re).abs() < 1e-12,
+        "triangle {triangle} against full Gram {}",
+        full.re
+    );
+}


### PR DESCRIPTION
## Summary

The MPS two-qubit kernel allocated four zero-filled buffers per gate, and the
stabilizer-rank norm evaluated the full B x B branch Gram although term
(i, j) is the conjugate of (j, i). The gate scratch now lives on the backend
as grow-only fields sliced per call, `inner_product` gains a caller-scratch
variant, and the Gram evaluates the diagonal plus the upper triangle. Review
also caught the derived `Clone` copying dead scratch into every per-shot
branch clone; `Clone` is now manual and clones start with empty scratch.

## Scope

- [x] Performance improvement

## Benchmarks

Two full adjacent-binary A/B runs against `main`, full Criterion at sample
30, quiet host (7.2-7.5% editor churn), one binary pair per run. Both runs
PASS at 5% with no regressions. Rows below quote run 2 with run 1 in
parentheses; controls are the quoted run's.

| Benchmark | Before | After | Change | Control (ref) | Control (new) | Within 5% threshold? |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| stabilizer_rank/shots_terminal/128q_chi16_64shots | 3.680 s | 757.95 ms | -79.4% (-80.4%) | -0.7% | +2.7% | improvement |
| stabilizer_rank/shots_terminal/32q_chi16_64shots | 856.59 ms | 195.59 ms | -77.2% (run 1 same on wide controls) | +2.5% | +2.3% | improvement |
| stabilizer_rank/shots_terminal/32q_chi2_64shots | 21.49 ms | 11.27 ms | -47.6% (-49.1%) | +2.3% | +0.2% | improvement |
| stabilizer_rank/shots_terminal/1000q_chi2_64shots | 605.54 ms | 349.79 ms | -42.2% (-45.4% on wide controls) | -1.8% | -0.6% | improvement |
| mps/hotspots/long_range_cp_r4/16 | 134.75 us | 104.09 us | -22.8% (-20.3%) | -1.8% | -0.8% | improvement |
| mps/hotspots/long_range_cp_r4/32 | 451.90 us | 359.69 us | -20.4% (run 1; run 2 -18.9% on wide controls) | +2.2% | -2.6% | improvement |
| mps/hotspots/adjacent_cp_r4/16 | 52.84 us | 44.33 us | -16.1% (-16.6%) | -2.1% | +2.3% | improvement |
| mps/hotspots/measure_reset_32q_r3 | 354.67 us | 333.74 us | -5.9% (run 1; run 2 -9.3% on wide controls) | -2.1% | +1.8% | improvement, see note |
| mps/brickwork_d24/b256/18 | 1.296 s | 1.281 s | -1.2% (-4.2%) | -0.4% | +0.3% | sub-threshold |

The shot-family wins exceed the 1.9x triangle-count projection because the
removed per-site allocations and the clone fix compound with it. The
measure_reset row was filed as a must-not-move control, and it moved: its
per-round H and Cx gates ride `apply_adjacent_two_qubit`, so the move is the
mechanism, not noise. The saturated-bond brickwork rows barely move, as
expected where the cubic SVD term dominates the quadratic fill. The 64q and
128q chi2 to chi8 shot rows read -47% to -77% in both runs but carried
same-code control spreads up to 39%, so they are reported directionally
consistent and unresolvable rather than booked.

Regression verdict: PASS (both runs).

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Tests: Gram-triangle equality against the full sum at 1e-12; scratch
      reuse across shrinking windows matches fresh allocation exactly; the
      full MPS and stabilizer-rank suites pass unchanged
- [x] No new `unsafe`: the scratch windows are safe slices whose every
      element is written by assignment before any read (verified per window
      in review)

## Hotspot notes

`apply_adjacent_two_qubit` (every MPS two-qubit gate and SWAP hop),
`inner_product` (per branch pair per norm evaluation), and
`weighted_mps_norm_sq` (per shot) are the hot functions; the A/B rows above
cover all three.

## Breaking changes

None. `Clone` behavior is semantically identical; clones start with empty
scratch that refills on first use.

## Risks and rollback

Retained scratch stays below the per-gate workspace the existing cap check
already sanctions, and clones do not carry it. Reverting the commit restores
the per-call allocations with no interface change.
