### PR TITLE
bench(mps): routed brick-wall family at real bond

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -942,6 +942,22 @@ fn bench_mps_brickwork(c: &mut Criterion) {
     group.finish();
 }
 
+// The routed family: per-layer random matchings keep the entangling gates
+// non-adjacent at real bond, so this row prices SWAP routing where the
+// other MPS rows cannot reach it. Shape pinned in
+// `tests/bench_fixture_routing.rs`.
+fn bench_mps_matched(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mps/matched_d12");
+    configure_group(&mut group);
+
+    let circuit = circuits::matched_brickwork_circuit(16, 12, SEED);
+    group.bench_with_input(BenchmarkId::new("b64", 16), &circuit, |b, circ| {
+        b.iter(|| run_mps_apply_only(circ, 64));
+    });
+
+    group.finish();
+}
+
 // ---- Native shot sampling on the polynomial-state backends ----
 
 /// Terminal measurements on every qubit, the shape the native samplers serve.
@@ -3034,6 +3050,7 @@ criterion_group! {
     bench_mps_linear_chain,
     bench_mps_hotspots,
     bench_mps_brickwork,
+    bench_mps_matched,
     bench_mps_sampling,
     // Product state
     bench_product_scaling,

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -480,6 +480,36 @@ pub fn brickwork_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
     c
 }
 
+/// Build a brick-wall circuit whose entangling layer is a fresh random
+/// perfect matching: `depth` layers of random Ry/Rz on every qubit, then CZ
+/// on each pair of a seeded shuffle of the register.
+///
+/// Pair distances average about `n / 3` and change every layer, so gates
+/// stay mostly non-adjacent under any site layout and entanglement grows
+/// across every cut; a fixed pairing would instead let SWAP routing park
+/// each pair adjacent after one layer and hold the chain at bond 2. At odd
+/// `n` one qubit of the shuffle sits out each layer.
+/// `tests/bench_fixture_routing.rs` pins both properties.
+pub fn matched_brickwork_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    for _ in 0..depth {
+        for q in 0..n {
+            c.add_gate(Gate::Ry(rng.random::<f64>() * std::f64::consts::TAU), &[q]);
+            c.add_gate(Gate::Rz(rng.random::<f64>() * std::f64::consts::TAU), &[q]);
+        }
+        let mut order: Vec<usize> = (0..n).collect();
+        for i in (1..n).rev() {
+            let j = rng.random_range(0..=i);
+            order.swap(i, j);
+        }
+        for pair in order.chunks_exact(2) {
+            c.add_gate(Gate::Cz, &[pair[0], pair[1]]);
+        }
+    }
+    c
+}
+
 /// Append an inverse QFT on `n` qubits starting at index `start`.
 ///
 /// Exact inverse of the forward decomposition in `qft_textbook_steps`: reverse

--- a/tests/bench_fixture_routing.rs
+++ b/tests/bench_fixture_routing.rs
@@ -117,6 +117,41 @@ fn brickwork_rows_saturate_the_bond_ladder() {
     );
 }
 
+// The `mps/matched_d12` row prices SWAP routing at real bond, so its two
+// claims are that gates stay non-adjacent and that the bond saturates the
+// cap. The second check is the one that catches a fixed pairing: its gates
+// still count as non-adjacent, but routing parks each pair and drains the
+// chain to bond 2.
+#[test]
+fn matched_rows_route_and_saturate() {
+    let circuit = circuits::matched_brickwork_circuit(16, 12, SEED);
+    let non_adjacent = circuit
+        .instructions
+        .iter()
+        .filter(|instruction| {
+            matches!(instruction, prism_q::Instruction::Gate { targets, .. }
+                if targets.len() == 2 && targets[0].abs_diff(targets[1]) > 1)
+        })
+        .count();
+    assert!(
+        non_adjacent >= 50,
+        "matched_d12/16: only {non_adjacent} non-adjacent gates; the row no \
+         longer prices routing"
+    );
+
+    let mut backend = MpsBackend::new(SEED, 64);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    for instruction in &circuit.instructions {
+        backend.apply(instruction).unwrap();
+        if backend.current_max_bond_dim() >= 64 {
+            return;
+        }
+    }
+    panic!("matched_d12/16: the bond never saturated the 64 cap");
+}
+
 #[test]
 fn statevector_corpus_rows_reach_the_statevector() {
     for n in [16usize, 20] {


### PR DESCRIPTION
## Summary

No MPS row prices SWAP routing where bond has grown: the long-range rows
peak at bond 2, and every other family entangles adjacently. On a per-layer
random-matching brick-wall shape, routing measures 86% of weighted two-qubit
kernel work at saturated bond, so the regime deserves a standing row. A
swap-free MPO application was prototyped against it and rejected on
measurement: it wins only at spans 2 to 4 at real bond, and in that window
epsilon truncation in non-canonical gauge loses exactness (1.76e-8 against
the statevector on a mixed sequence, with the loss invisible to the
truncation accounting), so the SWAP chain stays and the coverage lands.

## Scope

- [x] Build, CI, or tooling (bench row, one fixture generator, its shape pin)

## Benchmarks

New row, no before side. Full Criterion at sample 30, two runs of one
binary:

| Benchmark | Run A | Run B | Spread |
| --- | ---: | ---: | ---: |
| mps/matched_d12/b64/16 | 1.037 s | 1.049 s | 1.2% |

The fixture note worth keeping: a fixed distant pairing is a trap. SWAP
routing parks each pair adjacent after one layer (28 swaps total on a
16-qubit, 16-layer probe) and holds the chain at bond 2 with mutually
unentangled pairs; the matching must change per layer, and the shape pin's
saturation check fails a fixture that regresses to that.

Regression verdict: N/A on existing rows, no hot-path changes; the
generator has no callers on any simulation path.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Tests: the shape pin asserts the non-adjacency count and cap-64
      stream saturation through the instruction stream

## Hotspot notes

N/A, no hot-path changes.

## Breaking changes

None.

## Risks and rollback

Bench and test additions plus one fixture generator; deleting the
generator, the group, and the pin reverts cleanly.
