### PR TITLE
perf(sim): parallel MPS shot sampling with whole-word unpack

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -340,6 +340,16 @@ impl BasisSamples {
         self.words.len() / self.words_per_shot
     }
 
+    /// Word storage, [`Self::words_per_shot`] consecutive words per shot, so a
+    /// sampler filling shots in parallel can split it into disjoint chunks.
+    pub(crate) fn words_mut(&mut self) -> &mut [u64] {
+        &mut self.words
+    }
+
+    pub(crate) fn words_per_shot(&self) -> usize {
+        self.words_per_shot
+    }
+
     /// Measured outcome for `qubit` in `shot`, `true` for |1⟩.
     #[inline(always)]
     pub fn bit(&self, shot: usize, qubit: usize) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -346,6 +346,35 @@ impl BasisSamples {
         let word = self.words[shot * self.words_per_shot + qubit / 64];
         (word >> (qubit % 64)) & 1 == 1
     }
+
+    /// Unpack qubits `0..num_bits` of every shot, one set bit at a time rather
+    /// than one [`Self::bit`] call per qubit. Only correct when classical bit
+    /// `i` carries qubit `i`; callers test that before choosing this path.
+    pub(crate) fn to_shots(&self, num_bits: usize) -> Vec<Vec<bool>> {
+        let mut shots = vec![vec![false; num_bits]; self.num_shots()];
+        let live_words = num_bits.div_ceil(64).min(self.words_per_shot);
+        // Only the word straddling `num_bits` is masked, which is not
+        // necessarily the last live one: a register narrower than the classical
+        // register runs out of words first, and every word it does hold is
+        // wholly in range.
+        let straddling_word = num_bits / 64;
+        let tail = num_bits % 64;
+        for (s, shot) in shots.iter_mut().enumerate() {
+            let row = &self.words[s * self.words_per_shot..(s + 1) * self.words_per_shot];
+            for (w, &word) in row[..live_words].iter().enumerate() {
+                let mut bits = word;
+                if tail != 0 && w == straddling_word {
+                    bits &= (1u64 << tail) - 1;
+                }
+                let base = w * 64;
+                while bits != 0 {
+                    shot[base + bits.trailing_zeros() as usize] = true;
+                    bits &= bits - 1;
+                }
+            }
+        }
+        shots
+    }
 }
 
 /// Trait that all simulation backends must implement.

--- a/src/backend/mps.rs
+++ b/src/backend/mps.rs
@@ -54,6 +54,10 @@ const MAX_SVD_SWEEPS: usize = 100;
 const SVD_CONVERGENCE: f64 = 1e-14;
 #[cfg(feature = "parallel")]
 const MIN_BOND_FOR_PAR: usize = 32;
+/// Shot count at or above which native sampling splits the shot loop across
+/// the Rayon pool; per-shot substreams keep the output identical either way.
+#[cfg(feature = "parallel")]
+const MIN_SHOTS_FOR_PAR: usize = 32;
 /// Leaves per Rayon task in the dense expansion, as a bit count. The split
 /// depth is chosen to leave at least `2^6` amplitudes under each prefix, so
 /// the gate is per-task work rather than total element count: each element
@@ -2406,6 +2410,12 @@ impl Backend for MpsBackend {
     /// Sequential conditional sampling over the chain: `O(n·χ²)` per shot after
     /// one `O(n·χ³)` sweep for the right environments.
     ///
+    /// Each shot draws from its own ChaCha8 substream keyed on `(seed, shot)`
+    /// (streams 2 and up: 0 is the backend's own draw stream, 1 the
+    /// trajectory noise stream), so the sampled words are identical at any
+    /// thread count and the shot loop parallelizes at or above
+    /// `MIN_SHOTS_FOR_PAR`.
+    ///
     /// Sites are visited left to right and each bit is recorded against the
     /// logical qubit currently hosted there, so a layout permuted by SWAP
     /// routing needs no canonicalization pass.
@@ -2424,34 +2434,60 @@ impl Backend for MpsBackend {
             .max()
             .unwrap_or(1);
 
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let words_per_shot = samples.words_per_shot();
+        let sample_shot =
+            |shot: usize, shot_words: &mut [u64], left: &mut [Complex64], w: &mut [Complex64]| {
+                let mut rng = ChaCha8Rng::seed_from_u64(seed);
+                rng.set_stream(shot as u64 + 2);
+                left[0] = ONE;
+                left[1..].fill(ZERO);
+                for (site, right_env) in right.iter().enumerate() {
+                    let br = self.sites[site].bond_right;
+                    let prob = self.site_conditional_weights(site, left, right_env, w);
+
+                    let total = prob[0] + prob[1];
+                    let prob_one = if total > 0.0 {
+                        (prob[1] / total).clamp(0.0, 1.0)
+                    } else {
+                        0.0
+                    };
+                    let outcome = usize::from(rng.random::<f64>() < prob_one);
+                    if outcome == 1 {
+                        let qubit = self.logical_for_site(site);
+                        shot_words[qubit / 64] |= 1u64 << (qubit % 64);
+                    }
+
+                    let scale = 1.0 / prob[outcome].max(NORM_CLAMP_MIN).sqrt();
+                    left[..br].copy_from_slice(&w[outcome * br..(outcome + 1) * br]);
+                    for value in &mut left[..br] {
+                        *value *= scale;
+                    }
+                }
+            };
+
+        #[cfg(feature = "parallel")]
+        if num_shots >= MIN_SHOTS_FOR_PAR {
+            samples
+                .words_mut()
+                .par_chunks_mut(words_per_shot)
+                .enumerate()
+                .for_each_init(
+                    || (vec![ZERO; max_bond], vec![ZERO; 2 * max_bond]),
+                    |(left, w), (shot, shot_words)| sample_shot(shot, shot_words, left, w),
+                );
+            return Ok(samples);
+        }
+
         let mut left = vec![ZERO; max_bond];
         let mut w = vec![ZERO; 2 * max_bond];
-
         for shot in 0..num_shots {
-            left[0] = ONE;
-            left[1..].fill(ZERO);
-            for (site, right_env) in right.iter().enumerate() {
-                let br = self.sites[site].bond_right;
-                let prob = self.site_conditional_weights(site, &left, right_env, &mut w);
-
-                let total = prob[0] + prob[1];
-                let prob_one = if total > 0.0 {
-                    (prob[1] / total).clamp(0.0, 1.0)
-                } else {
-                    0.0
-                };
-                let outcome = usize::from(rng.random::<f64>() < prob_one);
-                if outcome == 1 {
-                    samples.set(shot, self.logical_for_site(site));
-                }
-
-                let scale = 1.0 / prob[outcome].max(NORM_CLAMP_MIN).sqrt();
-                left[..br].copy_from_slice(&w[outcome * br..(outcome + 1) * br]);
-                for value in &mut left[..br] {
-                    *value *= scale;
-                }
-            }
+            let start = shot * words_per_shot;
+            sample_shot(
+                shot,
+                &mut samples.words_mut()[start..start + words_per_shot],
+                &mut left,
+                &mut w,
+            );
         }
         Ok(samples)
     }

--- a/src/sim/shots.rs
+++ b/src/sim/shots.rs
@@ -195,6 +195,15 @@ pub(crate) fn shots_from_basis_samples(
     meas_map: &[(usize, usize)],
     num_classical_bits: usize,
 ) -> Vec<Vec<bool>> {
+    let dense_identity_map = meas_map.len() == num_classical_bits
+        && meas_map
+            .iter()
+            .enumerate()
+            .all(|(idx, &(qubit, classical_bit))| idx == qubit && idx == classical_bit);
+    if dense_identity_map {
+        return samples.to_shots(num_classical_bits);
+    }
+
     let mut shots = vec![vec![false; num_classical_bits]; samples.num_shots()];
     for (index, shot) in shots.iter_mut().enumerate() {
         for &(qubit, cbit) in meas_map {
@@ -294,6 +303,78 @@ mod tests {
     use super::*;
     use crate::sim::compiled::PackedShots;
     use crate::sim::probability::{FactoredBlock, Probabilities};
+
+    fn basis_samples_fixture(num_shots: usize, num_qubits: usize) -> crate::backend::BasisSamples {
+        let mut samples = crate::backend::BasisSamples::new(num_shots, num_qubits);
+        for shot in 0..num_shots {
+            for qubit in 0..num_qubits {
+                if (shot * 31 + qubit * 7) % 3 == 0 {
+                    samples.set(shot, qubit);
+                }
+            }
+        }
+        samples
+    }
+
+    fn shots_per_bit(
+        samples: &crate::backend::BasisSamples,
+        meas_map: &[(usize, usize)],
+        num_classical_bits: usize,
+    ) -> Vec<Vec<bool>> {
+        let mut shots = vec![vec![false; num_classical_bits]; samples.num_shots()];
+        for (index, shot) in shots.iter_mut().enumerate() {
+            for &(qubit, cbit) in meas_map {
+                shot[cbit] = samples.bit(index, qubit);
+            }
+        }
+        shots
+    }
+
+    #[test]
+    fn basis_sample_fast_path_matches_per_bit_expansion() {
+        for num_qubits in [4usize, 64, 70, 129] {
+            let samples = basis_samples_fixture(17, num_qubits);
+            let meas_map: Vec<(usize, usize)> = (0..num_qubits).map(|q| (q, q)).collect();
+            assert_eq!(
+                shots_from_basis_samples(&samples, &meas_map, num_qubits),
+                shots_per_bit(&samples, &meas_map, num_qubits)
+            );
+        }
+    }
+
+    #[test]
+    fn basis_sample_fast_path_ignores_qubits_above_the_classical_register() {
+        let samples = basis_samples_fixture(9, 70);
+        let meas_map: Vec<(usize, usize)> = (0..5).map(|q| (q, q)).collect();
+        assert_eq!(
+            shots_from_basis_samples(&samples, &meas_map, 5),
+            shots_per_bit(&samples, &meas_map, 5)
+        );
+    }
+
+    // A classical register wider than the qubit register: the straddling word
+    // lies past the last word the samples hold, so nothing may be masked off.
+    #[test]
+    fn basis_sample_unpack_keeps_every_bit_of_a_narrow_register() {
+        let samples = basis_samples_fixture(5, 70);
+        let unpacked = samples.to_shots(130);
+        for (shot, row) in unpacked.iter().enumerate() {
+            for (qubit, &got) in row[..70].iter().enumerate() {
+                assert_eq!(got, samples.bit(shot, qubit), "shot {shot} qubit {qubit}");
+            }
+            assert!(row[70..].iter().all(|b| !b));
+        }
+    }
+
+    #[test]
+    fn basis_sample_permuted_map_takes_the_general_path() {
+        let samples = basis_samples_fixture(6, 8);
+        let meas_map = [(3, 0), (0, 1), (7, 2)];
+        assert_eq!(
+            shots_from_basis_samples(&samples, &meas_map, 3),
+            shots_per_bit(&samples, &meas_map, 3)
+        );
+    }
 
     #[test]
     fn build_cdf_normalizes_last_to_one() {

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -294,3 +294,44 @@ fn compiled_sampler_reproducible_at_fixed_thread_count() {
         "same seed and pool width must reproduce shots"
     );
 }
+
+// The MPS sampler draws each shot from a substream keyed on (seed, shot), so
+// the words are identical at any thread count; the pins are same-seed
+// stability and counts summing to shots, never a fixed bitstring. Ignored
+// under miri like the dense sampling case above.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn mps_terminal_shots_identical_across_thread_counts() {
+    let mut circuit = prism_q::circuits::brickwork_circuit(12, 8, SEED);
+    circuit.measure_all();
+    let kind = BackendKind::Mps { max_bond_dim: 64 };
+
+    let shots = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(kind.clone())
+                .seed(SEED)
+                .shots(SAMPLING_SHOTS)
+                .expect("shots")
+                .shots
+        })
+    };
+    let single = shots(1);
+    assert_eq!(single.len(), SAMPLING_SHOTS);
+    assert_eq!(single, shots(THREADS_HI), "mps terminal shots differ");
+    assert_eq!(single, shots(1), "mps terminal shots not seed stable");
+
+    let counts = in_pool(THREADS_HI, || {
+        simulate(&circuit)
+            .backend(kind.clone())
+            .seed(SEED)
+            .sample_counts(SAMPLING_SHOTS)
+            .expect("counts")
+            .counts
+    });
+    assert_eq!(
+        counts.values().sum::<u64>(),
+        SAMPLING_SHOTS as u64,
+        "mps counts do not sum to the shot count"
+    );
+}


### PR DESCRIPTION
## Summary

The native shot terminal expanded one bit() call per (shot, qubit) from
words already packing 64 outcomes, and the MPS sampler walked its per-shot
conditional sweep serially on one RNG stream. The first commit lands the
whole-word unpack for the identity measurement map (what measure_all
produces), serving every native-sampling backend. The second parallelizes
the MPS shot loop: each shot draws from a ChaCha8 substream keyed on
(seed, shot), streams 2 and up (0 is the backend's own draw stream, 1 the
trajectory noise stream), writing disjoint word chunks, so the output is
identical at any thread count and the old key-and-stream overlap between
the sampler and the backend's own RNG is gone.

Sampled bitstrings for a given seed change with the substream scheme. No
test pinned them; the reproducibility contract is same-seed stability and
counts summing to shots, which both hold at any thread count and are now
pinned in `tests/determinism.rs`.

## Scope

- [x] Performance improvement

## Benchmarks

Two adjacent-binary A/B runs against `main`, full Criterion at sample 30,
quiet host. Both PASS with no regressions. Rows quote run 1 with run 2 in
parentheses; controls are run 1's.

| Benchmark | Before | After | Change | Control (ref) | Control (new) | Within 5% threshold? |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| mps/sampling/24 | 1.11 ms | 602.24 us | -45.7% (-44.5%) | -0.7% | +0.1% | improvement |
| mps/sampling/32 | 1.44 ms | 726.32 us | -49.5% (-48.1%) | -0.2% | +1.1% | improvement |
| mps/sampling/48 | 2.13 ms | 999.71 us | -53.0% (-51.2%) | -0.2% | -0.6% | improvement |
| mps/sampling/64 | 2.79 ms | 1.25 ms | -55.1% (-54.6%) | -0.1% | -0.4% | improvement |
| product/sampling/64 | 720.93 us | 690.15 us | -4.3% (-5.0%) | +0.7% | +0.4% | improvement, fast path only |
| product/sampling/128 | 1.45 ms | 1.38 ms | -5.0% (-4.4%) | -0.3% | -0.1% | improvement, fast path only |
| product/sampling/256 | 2.98 ms | 2.79 ms | -6.3% (-4.9%) | +0.3% | -0.2% | improvement, fast path only |
| product/sampling/512 | 5.82 ms | 5.49 ms | -5.7% (-5.0%) | +0.9% | -0.6% | improvement, fast path only |

The sparse/sampling rows read noise in both runs (48q disagreed across
runs, +2.8% then -5.8%, so it is not a result), with the usual rows
unresolvable on this host. The product rows move on the shared unpack
alone; their per-shot loops stay serial and belong to later work, as do
the factored and sparse loops, which fit the same substream pattern.

Regression verdict: PASS (both runs).

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Tests: whole-word unpack against per-bit expansion at 4/64/70/129
      qubits including the straddling-word cases; thread-count identity,
      seed stability, and counts-sum-to-shots for the MPS sampler in
      `tests/determinism.rs`
- [x] No new `unsafe`; parallel writes go through disjoint per-shot word
      chunks

## Hotspot notes

`shots_from_basis_samples` (every native shot terminal) and
`MpsBackend::sample_basis_states` (the per-shot conditional walk) are the
hot functions; the rows above cover both.

## Breaking changes

Sampled bitstrings for a given seed differ from previous releases on MPS
native sampling, and on every native terminal the shot expansion order is
unchanged but faster. Counts distributions are unchanged.

## Risks and rollback

The serial arm shares the substream construction, so disabling parallelism
cannot change results. Reverting restores the previous draw sequence.
