### PR TITLE
bench(sparse): replace misrouted fixtures with pinned-entry families

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -109,6 +109,14 @@ All seeded with `0xDEAD_BEEF` for reproducibility.
 - **Clifford-heavy**: H, S, X, Y, Z + CX only.
 - **Sparse entanglement**: H on all qubits + single CX(0, n-1) per layer.
 - **Dense entanglement**: H on all qubits + linear CX chain per layer.
+- **Sparse walk** (`circuits::sparse_walk_circuit`): H on the low k qubits,
+  then layers of seeded diagonal phases and basis permutations over the whole
+  register, holding the amplitude map at exactly 2^k entries. The
+  `sparse/walk_k12` and `sparse/sampling_k12` rows fix k = 12; the
+  `sparse/densify` rows sweep k at 20 qubits against a dense arm on the same
+  workload, tracing the load-factor crossover. The entry count and the routing
+  (the register must not split to the decomposed path) are pinned in
+  `tests/bench_fixture_routing.rs`.
 
 ## Running benchmarks
 
@@ -357,7 +365,6 @@ on them; `bench_ab.sh` lists them under the table on every run.
 
 | Row family | Same-code spread observed |
 | --- | --- |
-| `sparse/low_entanglement/{8,12,16,20}` | -4.4% to +15.5%, no consistent sign |
 | `stabilizer/scaling/10`, `factored_stabilizer/scaling/10` | +9% to +13% (L1 resident) |
 | `stabilizer_rank/shots_mid_circuit` | -17.8% to +88% |
 | `gpu_stab_direct/clifford_d10/{2000,5000}` | +118% to +124% (bimodal clock state) |
@@ -369,9 +376,14 @@ on them; `bench_ab.sh` lists them under the table on every run.
 Those last three were measured on a host at roughly 50% background load, so treat
 them as an upper bound rather than an intrinsic property of the row.
 
-Gate sparse work on `sparse/random_d10` and `compare/*/sparse/*`, and the
-stabilizer families on their 50q+ rows, which reproduced consistent signs across
-independent pairs.
+Gate sparse work on `sparse/random_d10`, `sparse/walk_k12`, and
+`compare/*/sparse/*`, and the stabilizer families on their 50q+ rows.
+`sparse/random_d10` and the compare rows reproduced consistent signs across
+independent pairs. The quarantined `sparse/low_entanglement` family this table
+used to carry is removed rather than repaired: its register split, so the rows
+ran the decomposed route at microsecond scale, and on the sparse backend the
+fixture densifies to `2^n` entries, the opposite of the regime the name
+promised. `sparse/walk_k12` replaces it.
 
 ## Reproducibility checklist
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -365,6 +365,7 @@ on them; `bench_ab.sh` lists them under the table on every run.
 
 | Row family | Same-code spread observed |
 | --- | --- |
+| `sparse/densify/map/{8,14}` | map/14 flips +9% to +16% between same-code process instances with tight in-run controls (bimodal, 5.4 to 6.3 ms); map/8 is a 145 us row with control excursions to 9%. Curve points, not gate rows; the other densify rows held 3.4% or better over three runs |
 | `stabilizer/scaling/10`, `factored_stabilizer/scaling/10` | +9% to +13% (L1 resident) |
 | `stabilizer_rank/shots_mid_circuit` | -17.8% to +88% |
 | `gpu_stab_direct/clifford_d10/{2000,5000}` | +118% to +124% (bimodal clock state) |

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -16,9 +16,9 @@ use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::sim;
 use prism_q::{
-    BackendKind, ClassicalCondition, Instruction, MpsBackend, Parameters, PauliObservable,
-    PauliTerm, PreparedCircuit, run_expectation_gradient, run_expectation_gradient_shift,
-    run_expectation_values, run_observable_expectation,
+    BackendKind, ClassicalCondition, Instruction, MpsBackend, Parameters, PauliAxis,
+    PauliObservable, PauliTerm, PreparedCircuit, run_expectation_gradient,
+    run_expectation_gradient_shift, run_expectation_values, run_observable_expectation,
 };
 use rand::RngExt;
 use rand::SeedableRng;
@@ -809,17 +809,61 @@ fn bench_sparse_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_sparse_low_entanglement(c: &mut Criterion) {
-    let mut group = c.benchmark_group("sparse/low_entanglement");
+/// One Z term keeps the readout at one map walk, so the rows price the gate
+/// kernels rather than a dense probability export whose presence would depend
+/// on the host memory cap.
+fn z0_observable() -> Vec<Vec<PauliTerm>> {
+    vec![vec![PauliTerm::new(0, PauliAxis::Z)]]
+}
+
+fn bench_sparse_walk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse/walk_k12");
     configure_group(&mut group);
 
-    for &n in &[4, 8, 12, 16, 20] {
-        let circuit = sparse_entanglement_circuit(n, 5);
+    let observables = z0_observable();
+    for &n in &[32, 48, 64] {
+        let circuit = circuits::sparse_walk_circuit(n, 12, 5, SEED);
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                run_with(BackendKind::Sparse, circ, 42).unwrap();
+                black_box(
+                    sim::simulate(circ)
+                        .backend(BackendKind::Sparse)
+                        .seed(42)
+                        .expectation_values(&observables)
+                        .unwrap(),
+                )
             });
         });
+    }
+    group.finish();
+}
+
+/// Map against dense on one workload as the H prefix widens: entries go
+/// 2^8 to 2^20 on a 20-qubit register while the layer stream stays identical,
+/// so the pair of arms traces the load-factor crossover.
+fn bench_sparse_densify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse/densify");
+    configure_group(&mut group);
+
+    let observables = z0_observable();
+    for &k in &[8, 12, 14, 16, 18, 20] {
+        let circuit = circuits::sparse_walk_circuit(20, k, 2, SEED);
+        for (arm, kind) in [
+            ("map", BackendKind::Sparse),
+            ("dense", BackendKind::Statevector),
+        ] {
+            group.bench_with_input(BenchmarkId::new(arm, k), &circuit, |b, circ| {
+                b.iter(|| {
+                    black_box(
+                        sim::simulate(circ)
+                            .backend(kind.clone())
+                            .seed(42)
+                            .expectation_values(&observables)
+                            .unwrap(),
+                    )
+                });
+            });
+        }
     }
     group.finish();
 }
@@ -1001,15 +1045,42 @@ fn bench_mps_sampling(c: &mut Criterion) {
     group.finish();
 }
 
+/// Shot count for both sparse sampling groups: sized so the sampling loop is
+/// roughly half of a populated row (measured against the bare run of the same
+/// fixture), and high enough to lift the empty-map rows off the microsecond
+/// scale this host cannot resolve.
+const SPARSE_SAMPLING_SHOTS: usize = 20_000;
+
+/// Two map entries, so the rows price shot conversion, not sampling over a
+/// populated map; `sparse/sampling_k12` holds the populated case.
 fn bench_sparse_sampling(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse/sampling");
     configure_group(&mut group);
 
     for &n in &SAMPLING_QUBITS {
-        let circuit = measure_all(&sparse_entanglement_circuit(n, 2));
+        let circuit = measure_all(&circuits::ghz_circuit(n));
         group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
             b.iter(|| {
-                black_box(run_shots_with(BackendKind::Sparse, circ, SAMPLING_SHOTS, SEED).unwrap())
+                black_box(
+                    run_shots_with(BackendKind::Sparse, circ, SPARSE_SAMPLING_SHOTS, SEED).unwrap(),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_sparse_sampling_populated(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sparse/sampling_k12");
+    configure_group(&mut group);
+
+    for &n in &[32, 64] {
+        let circuit = measure_all(&circuits::sparse_walk_circuit(n, 12, 2, SEED));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    run_shots_with(BackendKind::Sparse, circ, SPARSE_SAMPLING_SHOTS, SEED).unwrap(),
+                )
             });
         });
     }
@@ -3043,8 +3114,10 @@ criterion_group! {
     bench_factored_stabilizer_measurement,
     // Sparse
     bench_sparse_scaling,
-    bench_sparse_low_entanglement,
+    bench_sparse_walk,
+    bench_sparse_densify,
     bench_sparse_sampling,
+    bench_sparse_sampling_populated,
     // MPS
     bench_mps_scaling,
     bench_mps_linear_chain,

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -81,6 +81,12 @@ impl SparseBackend {
         }
     }
 
+    /// Number of nonzero amplitudes currently stored, the `k` in the O(k) cost
+    /// of every gate walk.
+    pub fn entry_count(&self) -> usize {
+        self.state.len()
+    }
+
     #[inline(always)]
     fn prune(&mut self) {
         let eps = self.epsilon;

--- a/src/circuits.rs
+++ b/src/circuits.rs
@@ -510,6 +510,53 @@ pub fn matched_brickwork_circuit(n: usize, depth: usize, seed: u64) -> Circuit {
     c
 }
 
+/// Build a sparse-regime workload: H on the low `k` qubits, then `depth`
+/// layers of seeded diagonal phases (Rz, P, T, Rzz) and basis permutations
+/// (X, brick-layer Cx, Swap) over the whole register.
+///
+/// The prefix puts the amplitude map at exactly `2^k` entries and no later
+/// gate can grow or drain it: diagonals scale amplitudes in place and
+/// permutations remap keys one to one, so the entry count is pinned for the
+/// whole walk while the keys spread over all `n` bits. The brick Cx layers
+/// keep the interaction graph connected at `depth >= 2`, which keeps the
+/// decomposed route from claiming the register.
+/// `tests/bench_fixture_routing.rs` pins both properties.
+///
+/// # Panics
+/// Panics if `k > n` or `n < 2`.
+pub fn sparse_walk_circuit(n: usize, k: usize, depth: usize, seed: u64) -> Circuit {
+    assert!(
+        k <= n && n >= 2,
+        "sparse_walk_circuit needs k <= n and n >= 2"
+    );
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut c = Circuit::new(n, 0);
+    for q in 0..k {
+        c.add_gate(Gate::H, &[q]);
+    }
+    for layer in 0..depth {
+        for q in 0..n {
+            let theta = rng.random::<f64>() * std::f64::consts::TAU;
+            match rng.random_range(0..4) {
+                0 => c.add_gate(Gate::Rz(theta), &[q]),
+                1 => c.add_gate(Gate::P(theta), &[q]),
+                2 => c.add_gate(Gate::T, &[q]),
+                _ => c.add_gate(Gate::X, &[q]),
+            }
+        }
+        let offset = layer % 2;
+        for q in (offset..n - 1).step_by(2) {
+            c.add_gate(Gate::Cx, &[q, q + 1]);
+        }
+        for q in (offset..n - 1).step_by(5) {
+            let theta = rng.random::<f64>() * std::f64::consts::TAU;
+            c.add_gate(Gate::Rzz(theta), &[q, q + 1]);
+        }
+        c.add_gate(Gate::Swap, &[layer % (n - 1), layer % (n - 1) + 1]);
+    }
+    c
+}
+
 /// Append an inverse QFT on `n` qubits starting at index `start`.
 ///
 /// Exact inverse of the forward decomposition in `qft_textbook_steps`: reverse

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -20,10 +20,12 @@ impl FxHasher {
 impl Hasher for FxHasher {
     /// The multiply-xor step drives entropy toward the high bits while the
     /// table takes its bucket index from the low ones, so structured keys
-    /// cluster. Basis-state indices from a low-entanglement circuit are exactly
+    /// cluster. Basis-state indices from a structured circuit are exactly
     /// that, and the clustering grows with the key count: without this
-    /// finalizer `sparse/low_entanglement` regresses 11.8% at 20 qubits while
-    /// the high-entropy `sparse/random_d10` rows are unaffected.
+    /// finalizer a fixture holding every index of a 20-qubit register in the
+    /// map regressed 11.8% while the high-entropy `sparse/random_d10` rows
+    /// were unaffected. The `sparse/densify` rows sweep the same key-count
+    /// growth.
     #[inline]
     fn finish(&self) -> u64 {
         let mut h = self.hash;

--- a/tests/bench_fixture_routing.rs
+++ b/tests/bench_fixture_routing.rs
@@ -152,6 +152,79 @@ fn matched_rows_route_and_saturate() {
     panic!("matched_d12/16: the bond never saturated the 64 cap");
 }
 
+// The sparse walk rows price map-walk kernels at a pinned entry count, and
+// the densify rows trace the load-factor crossover against the dense arm, so
+// the claims are that the register does not split (the decomposed route
+// claimed the family these rows replaced) and that the map holds exactly 2^k
+// entries once the H prefix has run: every later gate scales amplitudes in
+// place or permutes keys one to one. The count is checked through the fused
+// stream the bench executes, so a fusion change that starts branching or
+// draining the map fails here.
+fn sparse_entry_peak_and_final(circuit: &prism_q::circuit::Circuit) -> (usize, usize) {
+    let fused = prism_q::circuit::fusion::fuse_circuit(circuit, true);
+    let mut backend = prism_q::SparseBackend::new(SEED);
+    backend
+        .init(circuit.num_qubits, circuit.num_classical_bits)
+        .unwrap();
+    let mut peak = 0;
+    for instruction in &fused.instructions {
+        backend.apply(instruction).unwrap();
+        peak = peak.max(backend.entry_count());
+    }
+    (peak, backend.entry_count())
+}
+
+#[test]
+fn sparse_walk_rows_pin_route_and_entry_count() {
+    for (n, depth) in [(32usize, 5usize), (48, 5), (64, 5), (32, 2), (64, 2)] {
+        let circuit = circuits::sparse_walk_circuit(n, 12, depth, SEED);
+        assert_resolves(
+            &format!("walk_k12 shape {n}/d{depth}"),
+            BackendKind::Sparse,
+            &circuit,
+        );
+        let (peak, last) = sparse_entry_peak_and_final(&circuit);
+        assert_eq!(
+            (peak, last),
+            (1 << 12, 1 << 12),
+            "walk_k12 {n}/d{depth}: the map no longer holds a pinned 4096 entries"
+        );
+    }
+}
+
+#[test]
+fn sparse_densify_rows_pin_entry_ladder() {
+    for k in [8usize, 14, 20] {
+        let circuit = circuits::sparse_walk_circuit(20, k, 2, SEED);
+        let (peak, last) = sparse_entry_peak_and_final(&circuit);
+        assert_eq!(
+            (peak, last),
+            (1 << k, 1 << k),
+            "densify k={k}: the ladder no longer walks the map to 2^k entries"
+        );
+    }
+    // Route is set by the layer stream, which is identical across k.
+    let circuit = circuits::sparse_walk_circuit(20, 8, 2, SEED);
+    assert_resolves("densify/map/8", BackendKind::Sparse, &circuit);
+    assert_resolves("densify/dense/8", BackendKind::Statevector, &circuit);
+}
+
+// `sparse/sampling` prices shot conversion on a near-empty map; the GHZ
+// chain keeps the register connected, unlike the split fixture it replaced.
+#[test]
+fn sparse_sampling_fixture_reaches_the_sparse_backend() {
+    for n in [24usize, 64] {
+        let circuit = circuits::ghz_circuit(n);
+        assert_resolves(&format!("sampling/{n}"), BackendKind::Sparse, &circuit);
+        let (peak, last) = sparse_entry_peak_and_final(&circuit);
+        assert_eq!(
+            (peak, last),
+            (2, 2),
+            "sampling/{n}: the empty-map control stopped being empty"
+        );
+    }
+}
+
 #[test]
 fn statevector_corpus_rows_reach_the_statevector() {
     for n in [16usize, 20] {


### PR DESCRIPTION
## Summary

The `sparse/low_entanglement` family never reached the sparse backend: its
fixture entangles only the register ends, the register splits, and the
decomposed route claims every row above 4 qubits regardless of the requested
backend, so the rows measured per-block product states at 22-46 us. On the
sparse backend the same fixture densifies to `2^n` entries, the opposite of
the regime the name promised. `sparse/sampling` shared the fixture and the
split, with a 1-entry post-fusion map. This PR replaces the family with a
fixture whose amplitude map is provably pinned at `2^k` entries, refixes the
sampling group, adds a populated-map sampling row, and adds a map-against-dense
ladder that measures where the map stops paying.

New surface: `circuits::sparse_walk_circuit` (H on the low k qubits, then
seeded diagonal phases and basis permutations over the whole register) and
`SparseBackend::entry_count`. The entry count and the routing are pinned in
`tests/bench_fixture_routing.rs` through the fused stream the bench executes.
The walk and densify rows use an expectation terminal (single Z observable,
one map walk) so row composition does not depend on the host memory cap the
dense probability readback consults.

## Scope

- [x] Build, CI, or tooling
- [x] Documentation

## Benchmarks

Full Criterion tier, 30 samples per row, i7-6700K, quiet host verified before
each run, one bench process at a time.

Existing rows, adjacent-binary A/B against `main` (5b2e54a), two agreeing
runs, both PASS. The only library change is a trivial accessor, and the gate
rows read as the expected null; worst deltas below, each inside or near its
own control:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `sparse/random_d10/20` | 12.75 ms | 12.44 ms | -2.4% then +0.9% | 4.1% / 3.6% worst side | yes (noise) |
| `compare/general_d10/sparse/16` | 2.42 ms | 2.37 ms | -1.7% then +1.3% | 2.6% / 3.9% | yes (noise) |
| `compare/clifford_d10/sparse/20` | 290.8 us | 280.5 us | -3.6% then +3.4% | 4.7% / 1.4% | yes (opposite signs, drift) |
| `sparse/random_d10/8` (control) | 57.9 us | 58.1 us | +0.4% then -0.2% | 0.7% | yes |

The microsecond compare rows at 4q and 12q were unresolvable in one run each
(same-code controls to 12.2%), consistent with their recorded behavior.

New rows have no counterpart in the reference binary, so their adoption
evidence is the same-code noise floor: `bench_ab.sh --ref-exe` with a copy of
the same executable on both sides, two invocations, plus a third on the
densify group. Worst same-code spreads across runs:

| Row | Time | Worst spread | Adopted role |
| --- | --- | --- | --- |
| `sparse/walk_k12/{32,48,64}` | 4.6 / 7.1 / 9.0 ms | 1.0% | gate row |
| `sparse/sampling/{24..64}` (refixtured, 20k shots) | 1.7-2.0 ms | 4.2% | empty-map control |
| `sparse/sampling_k12/{32,64}` (20k shots) | 4.8 / 6.9 ms | 2.2% | populated sampling denominator |
| `sparse/densify/dense/{8..20}` | 25.9-26.9 ms | 4.8% | flat dense reference |
| `sparse/densify/map/{12,16,18,20}` | 1.2 / 26.8 / 135 / 640 ms | 3.2% | crossover curve |
| `sparse/densify/map/{8,14}` | 145 us / 5.4-6.3 ms | 9-17% (bimodal) | curve points only, cannot gate; recorded in the benches README noise table |

The densify ladder runs one 20-qubit workload with the H prefix widening the
map from `2^8` to `2^20` entries while the layer stream stays identical:

| k | entries | load factor | map | dense | ratio |
| --- | ---: | ---: | ---: | ---: | ---: |
| 8 | 256 | 1/4096 | 143-149 us | 26 ms | 0.006 |
| 12 | 4096 | 1/256 | 1.15 ms | 26 ms | 0.044 |
| 14 | 16384 | 1/64 | 5.4-6.3 ms | 26 ms | 0.21-0.24 |
| 16 | 65536 | 1/16 | 26.7-27.0 ms | 25.9-26.1 ms | 1.02-1.04 |
| 18 | 262144 | 1/4 | 135 ms | 26 ms | 5.1 |
| 20 | 1048576 | 1 | 638-645 ms | 27 ms | 24 |

The map matches the dense statevector at `2^16` entries (load factor 1/16)
and its per-entry cost back-solves to about 16x the dense per-amplitude cost
on this workload.

The populated sampling rows are sized so the sampling loop is a measurable
share of the row: about 66% at n=32 and 52% at n=64 against the bare run of
the same fixture. A future change to the sampling loop should translate
row-level percentages through those shares; n=64 is the weaker denominator.

`sparse/sampling` keeps its Criterion id across a fixture and shot-count
change, so stored history for that id is cross-fixture and void; treat its
next A/B appearance as a new row.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2468 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] Docstrings on new `pub` items carry the pinned-entry invariant and the accessor's meaning
- [x] New fixtures have shape and routing pins in `tests/bench_fixture_routing.rs`

## Hotspot notes

N/A, no hot-path changes. The one library addition is a leaf accessor with no
callers in `src/` or `benches/`.

## Breaking changes

None. Additions only: `circuits::sparse_walk_circuit`,
`SparseBackend::entry_count`. Bench row families `sparse/low_entanglement`
removed, `sparse/walk_k12`, `sparse/sampling_k12`, `sparse/densify` added,
`sparse/sampling` refixtured.

## Risks and rollback

Bench corpus scope. The removed family measured the decomposed route, so no
prior claim rested on it; the one committed citation of it (the hasher
finalizer docstring) is reworded as a historical measurement. Reverting the
commit restores the old rows intact.
