### PR TITLE
perf(sparse): antidiagonal fast path for 1q gates

### DIFF
--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -48,7 +48,7 @@ use crate::backend::{
 };
 use crate::circuit::Instruction;
 use crate::error::Result;
-use crate::gates::{Gate, diag_entries_phase, is_diagonal_2x2};
+use crate::gates::{Gate, diag_entries_phase, is_antidiagonal_2x2, is_diagonal_2x2};
 use crate::hash::FxHashMap;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -126,6 +126,10 @@ impl SparseBackend {
             self.apply_diagonal_1q(target, mat[0][0], mat[1][1]);
             return Ok(());
         }
+        if is_antidiagonal_2x2(&mat) {
+            self.apply_antidiagonal_1q(target, mat[0][1], mat[1][0]);
+            return Ok(());
+        }
         self.check_entry_growth(2)?;
 
         let mask = 1usize << target;
@@ -155,6 +159,27 @@ impl SparseBackend {
             *amp *= if (*idx >> target) & 1 == 1 { d1 } else { d0 };
         }
         if d0.norm_sqr() < 1.0 - 1e-12 || d1.norm_sqr() < 1.0 - 1e-12 {
+            self.prune();
+        }
+    }
+
+    /// An antidiagonal 2x2 maps each basis state to exactly one partner, the
+    /// 1q case of the invariant `apply_cx` states, so the map is a 1:1 remap
+    /// with no accumulation. A sub-unit scale (a normalized Kraus branch
+    /// routed through a fused payload) can still shrink amplitudes below
+    /// epsilon, so only that case pays the prune pass, as `apply_monomial_2q`
+    /// does.
+    #[inline(always)]
+    fn apply_antidiagonal_1q(&mut self, target: usize, a01: Complex64, a10: Complex64) {
+        let mask = 1usize << target;
+        self.swap_buf.clear();
+        self.swap_buf.reserve(self.state.len());
+        self.swap_buf.extend(self.state.drain().map(|(idx, amp)| {
+            let scale = if idx & mask == 0 { a10 } else { a01 };
+            (idx ^ mask, amp * scale)
+        }));
+        std::mem::swap(&mut self.state, &mut self.swap_buf);
+        if a01.norm_sqr() < 1.0 - 1e-12 || a10.norm_sqr() < 1.0 - 1e-12 {
             self.prune();
         }
     }
@@ -936,6 +961,46 @@ mod tests {
         for (a, b) in p1.iter().zip(p2.iter()) {
             assert!((a - b).abs() < EPS);
         }
+    }
+
+    #[test]
+    fn test_y_gate_amplitude() {
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::Y, &[0]);
+        let b = run_sparse(&c);
+        assert_eq!(b.state.len(), 1);
+        assert!((b.state[&1] - Complex64::new(0.0, 1.0)).norm() < EPS);
+    }
+
+    // Distinct phases on the two antidiagonal coefficients, so a swapped
+    // a01/a10 assignment fails on amplitudes, not just norms.
+    #[test]
+    fn test_antidiagonal_fused_amplitudes() {
+        let t = Gate::T.matrix_2x2();
+        let zero = Complex64::new(0.0, 0.0);
+        let fused = [[zero, t[1][1]], [t[0][0], zero]];
+
+        let mut c = Circuit::new(1, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Fused(Box::new(fused)), &[0]);
+        let b = run_sparse(&c);
+
+        let h = 1.0 / 2.0_f64.sqrt();
+        assert_eq!(b.state.len(), 2);
+        assert!((b.state[&0] - t[1][1] * h).norm() < EPS);
+        assert!((b.state[&1] - t[0][0] * h).norm() < EPS);
+    }
+
+    #[test]
+    fn test_antidiagonal_subunit_prunes() {
+        let mut b = SparseBackend::new(42);
+        b.init(1, 0).unwrap();
+        b.state.insert(1, Complex64::new(1.5e-8, 0.0));
+        let zero = Complex64::new(0.0, 0.0);
+        let half = Complex64::new(0.5, 0.0);
+        b.apply_1q_matrix(0, &[[zero, half], [half, zero]]).unwrap();
+        assert_eq!(b.state.len(), 1);
+        assert!(b.state.contains_key(&1));
     }
 
     #[test]

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -1025,6 +1025,12 @@ pub(crate) fn is_diagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
     mat[0][1].norm() < IDENTITY_EPS && mat[1][0].norm() < IDENTITY_EPS
 }
 
+/// Whether a 2x2 matrix is antidiagonal (both diagonal norms below `IDENTITY_EPS`).
+#[inline]
+pub(crate) fn is_antidiagonal_2x2(mat: &[[Complex64; 2]; 2]) -> bool {
+    mat[0][0].norm() < IDENTITY_EPS && mat[1][1].norm() < IDENTITY_EPS
+}
+
 /// Whether a 4x4 matrix is diagonal (all off-diagonal norms below `IDENTITY_EPS`).
 #[inline]
 pub(crate) fn is_diagonal_4x4(mat: &[[Complex64; 4]; 4]) -> bool {


### PR DESCRIPTION
## Summary

An antidiagonal 2x2 (X, Y, and any fused 1q product carrying an odd number of
them) took the sparse backend's general branching path: two hash inserts per
map entry, one of them a zero contribution, then a prune pass. It is a 1:1 key
remap, the 1q case of the invariant `apply_cx` relies on, so it now remaps the
way `apply_cx` does, with the two antidiagonal coefficients applied per source
bit and prune paid only for sub-unit scales. Fusion leaves these gates rare
standalone, but `MultiFused` expansion still reaches the kernel on random
circuits, and the removed path also reserved twice the entry count, bloating
the table every later walk iterates, so the win exceeds the per-firing saving.

## Scope

- [x] Performance improvement

## Benchmarks

Full Criterion tier, 30 samples per row, i7-6700K, quiet host verified, one
bench process. Adjacent-binary A/B against `main` (35c1a4f), two independent
runs; both PASS at 5%. Values below are run 2 / run 3 of the same commit pair.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `sparse/random_d10/20` | 13.30 / 12.87 ms | 7.06 / 7.01 ms | -46.9% / -45.6% | 4.6% / 0.7% worst side | improvement |
| `compare/general_d10/sparse/20` | 12.89 / 12.78 ms | 7.15 / 6.99 ms | -44.5% / -45.3% | 4.2% / 0.5% | improvement (same fixture as the row above; agreement is the replication check) |
| `compare/clifford_d10/sparse/16` | 2.08 / 2.06 ms | 1.37 / 1.30 ms | -34.1% / -37.1% | 5.3% / 2.9% | improvement |
| `sparse/random_d10/8` | 58.6 / 57.8 us | 47.1 / 47.4 us | -19.5% / -18.1% | 3.2% / 1.0% | improvement |
| `compare/clifford_d10/sparse/8` | 38.9 / 37.8 us | 28.8 / 29.0 us | -26.0% / -23.2% | 4.8% / 1.0% | improvement |
| `compare/general_d10/sparse/8` | 58.6 / 58.0 us | 47.5 / 47.3 us | -18.9% / -18.5% | 1.7% / 1.1% | improvement |
| `sparse/random_d10/16` | 2.53 / 2.50 ms | 1.83 / 1.46 ms | -27.8% / -41.5% | 33.3% / 1.2% | resolved in one run only: the first run's own control spread was 33%, the recorded bimodality of rows at this entry count. Quoted from the resolvable run, direction consistent in both |
| `sparse/walk_k12/32` (control) | 4.67 / 4.57 ms | 4.64 / 4.59 ms | -0.6% / +0.6% | 3.3% / 0.7% | null, as expected: no 1q matrix reaches the kernel on this fixture |
| `sparse/walk_k12/64` (control) | 9.12 / 9.04 ms | 9.10 / 9.11 ms | -0.2% / +0.8% | 1.4% / 0.4% | null, as expected |
| `sparse/sampling_k12/{32,64}` (control) | 4.90 / 6.96 ms | 4.95 / 6.87 ms | +0.9% to -2.3% | at or under 4.1% | null |
| `sparse/sampling/{24..64}` (control) | 1.7-2.1 ms | 1.7-2.1 ms | -4.0% to +0.9% | to 7.8% | null |

`sparse/walk_k12/48` moved -3.5% / -2.2% (controls at or under 1.4%): the one
fixture in the walk family whose fused stream reaches the kernel, one firing
at 4096 entries; direction and size match the mechanism, below the 5% gate,
reported as a sub-threshold move.

`sparse/random_d10/12` read +11.6% in run 2 and -6.9%-inside-control in run 3,
opposite signs on a 90 us row whose fused stream contains no antidiagonal 1q
gate, so the kernel cannot fire there; this is the recorded microsecond-row
layout noise, not a regression. The 4q and 12q rows are non-gating on this
host. `compare/general_d10/sparse/20` is on record as sign-flipping under
earlier A/B pairs and is quoted here as replication, not as a gating row.

`sparse/densify` was excluded from the gating filter: its map/20 row costs
about 25 s per pass, its map/{8,14} rows are recorded as unable to gate, and
the miss-path cost of the new branch is one to two vector norms per standalone
1q gate on fixtures whose 1q gates fuse into 2q payloads.

Mechanism check for the magnitude, which exceeds the naive per-firing sum: a
kernel probe measured the general path at 152/1438 us per gate against 46/397
us for the remap at 4096/32768 entries, and the general path's two-times
reserve leaves the map at 113,687 buckets against 57,344 for the same 32768
entries, making every subsequent map walk 52% slower (94.6 vs 62.2 us per
diagonal walk). Removing the general-path visits removes that inflation for
the rest of the run.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2471 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] New tests: coefficient orientation pinned with distinct phases on the two
      antidiagonal entries (a swap fails on amplitudes, not norms), the Y gate
      amplitude, and the sub-unit prune branch
- [x] Cross-backend contract suites (`backend_matrix`, `measurement_matrix`,
      `backend_equivalence`, `fusion_correctness`, `conformance_matrix`) pass

## Hotspot notes

`SparseBackend::apply_single_qubit` dispatch: diagonal test first,
antidiagonal second, general last. The general path now pays one extra
`norm()` per gate (not per entry), against a per-entry map walk measured at
37-44 ns per entry. `apply_antidiagonal_1q` reuses the retained swap buffer;
no allocation in the loop.

## Breaking changes

None. Both additions are crate-private.

## Risks and rollback

The new branch changes which kernel serves antidiagonal matrices on one
backend; equivalence and golden suites pin the amplitudes, and reverting the
commit restores the general path.
