### PR TITLE
feat(sparse): settable pruning threshold with honest exactness

### DIFF
--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -1,8 +1,10 @@
 //! Sparse state-vector simulation backend.
 //!
 //! Stores only non-zero amplitudes in a map keyed by basis-state index, giving
-//! O(k) memory where k is the number of non-zero basis states. Amplitudes below
-//! a configurable epsilon are pruned after each gate to maintain sparsity.
+//! O(k) memory where k is the number of non-zero basis states. Entries whose
+//! squared amplitude is at or below a pruning threshold (default 1e-16,
+//! raised via [`SparseBackend::set_prune_epsilon`]) are dropped after gates
+//! that can shrink or cancel amplitudes.
 //!
 //! Every gate walks the map, so the map hashes basis-state indices with the
 //! crate's multiply-xor hasher rather than the stdlib default.
@@ -62,6 +64,10 @@ pub struct SparseBackend {
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
     epsilon: f64,
+    pruned_weight: f64,
+    /// Whether the threshold has exceeded the default since the last `init`,
+    /// so lowering it mid-run cannot hide weight already discarded.
+    raised: bool,
     /// [`crate::backend::max_sparse_entries`] read once at construction, so the
     /// per-gate growth check is a field compare rather than an atomic load.
     entry_cap: usize,
@@ -77,6 +83,8 @@ impl SparseBackend {
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
             epsilon: DEFAULT_EPSILON,
+            pruned_weight: 0.0,
+            raised: false,
             entry_cap: crate::backend::max_sparse_entries(),
         }
     }
@@ -87,10 +95,46 @@ impl SparseBackend {
         self.state.len()
     }
 
+    /// Set the pruning threshold on squared amplitude magnitude.
+    ///
+    /// Entries with `norm_sqr` at or below `epsilon` are dropped after gates
+    /// that can shrink or cancel amplitudes; 0 drops exact zeros only. The
+    /// construction default of 1e-16 removes only numerical dust and the run
+    /// reports as exact; a larger threshold trades state weight for a smaller
+    /// map, the run reports `Approximate`, and the dropped weight feeds the
+    /// metadata's `fidelity_lower_bound` as a first-order estimate. Lowering
+    /// the threshold again keeps the run reporting `Approximate` until the
+    /// next [`Backend::init`]; the threshold itself survives `init`, the
+    /// accumulated weight does not. The state is never renormalized after a
+    /// prune: expectations renormalize on read, but probability export and
+    /// shot sampling see the reduced weight, and the sampling CDF folds the
+    /// missing weight into the highest kept basis state.
+    ///
+    /// # Panics
+    /// Panics unless `0 <= epsilon < 1`.
+    pub fn set_prune_epsilon(&mut self, epsilon: f64) {
+        assert!(
+            (0.0..1.0).contains(&epsilon),
+            "prune epsilon must lie in [0, 1)"
+        );
+        self.epsilon = epsilon;
+        self.raised = self.raised || epsilon > DEFAULT_EPSILON;
+    }
+
     #[inline(always)]
     fn prune(&mut self) {
         let eps = self.epsilon;
-        self.state.retain(|_, amp| amp.norm_sqr() >= eps);
+        let mut dropped = 0.0;
+        self.state.retain(|_, amp| {
+            let weight = amp.norm_sqr();
+            if weight > eps {
+                true
+            } else {
+                dropped += weight;
+                false
+            }
+        });
+        self.pruned_weight += dropped;
     }
 
     /// Reject a gate whose worst-case fan-out would grow the map past the
@@ -588,10 +632,26 @@ impl Backend for SparseBackend {
         crate::sim::ResolvedBackend::Sparse
     }
 
+    /// At the default threshold pruning removes only numerical dust and the
+    /// route is exact; a raised threshold can discard real weight, so the
+    /// route reports `Approximate` whether or not this run pruned anything,
+    /// the same convention the MPS backend uses for its bond cap.
+    fn exactness(&self) -> crate::sim::Exactness {
+        if self.raised {
+            crate::sim::Exactness::Approximate {
+                fidelity_lower_bound: Some((1.0 - self.pruned_weight).max(0.0)),
+            }
+        } else {
+            crate::sim::Exactness::Exact
+        }
+    }
+
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
         self.num_qubits = num_qubits;
         self.state.clear();
         self.state.insert(0, Complex64::new(1.0, 0.0));
+        self.pruned_weight = 0.0;
+        self.raised = self.epsilon > DEFAULT_EPSILON;
         crate::backend::init_classical_bits(&mut self.classical_bits, num_classical_bits);
         Ok(())
     }
@@ -961,6 +1021,91 @@ mod tests {
         for (a, b) in p1.iter().zip(p2.iter()) {
             assert!((a - b).abs() < EPS);
         }
+    }
+
+    #[test]
+    fn test_default_epsilon_reports_exact() {
+        let mut c = Circuit::new(2, 0);
+        c.add_gate(Gate::H, &[0]);
+        c.add_gate(Gate::Cx, &[0, 1]);
+        let b = run_sparse(&c);
+        assert_eq!(b.epsilon, DEFAULT_EPSILON);
+        assert_eq!(b.exactness(), crate::sim::Exactness::Exact);
+    }
+
+    #[test]
+    fn test_zero_epsilon_still_drops_exact_zeros() {
+        let mut b = SparseBackend::new(42);
+        b.set_prune_epsilon(0.0);
+        b.init(1, 0).unwrap();
+        b.state.insert(1, Complex64::new(0.0, 0.0));
+        let zero = Complex64::new(0.0, 0.0);
+        let half = Complex64::new(0.5, 0.0);
+        b.apply_1q_matrix(0, &[[half, zero], [zero, half]]).unwrap();
+        assert_eq!(b.state.len(), 1);
+        assert!(b.state.contains_key(&0));
+    }
+
+    #[test]
+    fn test_lowering_epsilon_keeps_the_approximate_report() {
+        let theta = 2.0 * (0.1_f64).sqrt().asin();
+        let mut b = SparseBackend::new(42);
+        b.set_prune_epsilon(0.2);
+        b.init(1, 0).unwrap();
+        b.apply_1q_matrix(0, &Gate::Ry(theta).matrix_2x2()).unwrap();
+        b.set_prune_epsilon(DEFAULT_EPSILON);
+        match b.exactness() {
+            crate::sim::Exactness::Approximate {
+                fidelity_lower_bound: Some(bound),
+            } => assert!((bound - 0.9).abs() < EPS),
+            other => panic!("lowering the threshold hid discarded weight: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_raised_epsilon_drops_weight_and_reports_bound() {
+        // Ry puts weight 0.1 on |1>; a 0.2 threshold drops it at the prune
+        // after the general-path gate.
+        let theta = 2.0 * (0.1_f64).sqrt().asin();
+        let mut b = SparseBackend::new(42);
+        b.set_prune_epsilon(0.2);
+        b.init(1, 0).unwrap();
+        b.apply(&Instruction::Gate {
+            gate: Gate::Ry(theta),
+            targets: crate::circuit::SmallVec::from_slice(&[0]),
+        })
+        .unwrap();
+        assert_eq!(b.state.len(), 1);
+        assert!(b.state.contains_key(&0));
+        match b.exactness() {
+            crate::sim::Exactness::Approximate {
+                fidelity_lower_bound: Some(bound),
+            } => assert!((bound - 0.9).abs() < EPS),
+            other => panic!("expected a bounded Approximate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_epsilon_survives_init_weight_does_not() {
+        let theta = 2.0 * (0.1_f64).sqrt().asin();
+        let mut b = SparseBackend::new(42);
+        b.set_prune_epsilon(0.2);
+        b.init(1, 0).unwrap();
+        b.apply_1q_matrix(0, &Gate::Ry(theta).matrix_2x2()).unwrap();
+        assert!(b.pruned_weight > 0.0);
+        b.init(1, 0).unwrap();
+        match b.exactness() {
+            crate::sim::Exactness::Approximate {
+                fidelity_lower_bound: Some(bound),
+            } => assert_eq!(bound, 1.0),
+            other => panic!("expected Approximate after init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "prune epsilon")]
+    fn test_prune_epsilon_rejects_one() {
+        SparseBackend::new(42).set_prune_epsilon(1.0);
     }
 
     #[test]

--- a/src/sim/metadata.rs
+++ b/src/sim/metadata.rs
@@ -139,9 +139,12 @@ impl RunMetadata {
     /// discarded weights: a first-order truncation estimate, not a
     /// certificate. Truncation errors compound across SVDs, and realized
     /// fidelity has measured below the reported value by up to a factor of
-    /// about 2.4 in the implied error on deep truncating runs. The budgeted
-    /// Pauli engines leave this `None` and report their additive observable
-    /// bound on the result types instead.
+    /// about 2.4 in the implied error on deep truncating runs. The sparse
+    /// backend at a raised pruning threshold reports 1 minus the absolute
+    /// squared weight it dropped, the same first-order estimate on an
+    /// unrenormalized state. The budgeted Pauli engines leave this `None`
+    /// and report their additive observable bound on the result types
+    /// instead.
     pub fn fidelity_lower_bound(&self) -> Option<f64> {
         match self.exactness {
             Exactness::Exact => None,


### PR DESCRIPTION
## Summary

The sparse module header called the pruning epsilon configurable and no setter
existed. `SparseBackend::set_prune_epsilon` ships it in the shape the MPS SVD
setter took: the 1e-16 default is unchanged and pinned by test, the panic
contract is `[0, 1)`, and the threshold survives `init`. The knob is honest
about what it costs: the backend accumulates the squared weight it drops, a
run at a raised threshold reports `Approximate` with `1 - dropped` as a
first-order `fidelity_lower_bound`, and the report latches so lowering the
threshold mid-run cannot hide weight already discarded. Pruning now drops
at-or-below the threshold, so 0 means exact zeros only; keeping exact zeros
at 0 would have broken the invariant the remap kernels rely on and inflated
the map toward the entry cap.

A threshold sweep on the corpus fixtures settles whether a raised default
would pay: it would not. At 1e-12 and 1e-8 nothing prunes (entry counts and
machine-precision errors identical to the default on `random_d10/{16,20}`
and `walk_k12/32`; random-circuit weights never occupy the window between
1e-16 and 1e-8). At 1e-4 the damage is structural: 27% of state weight
dropped at 16 qubits (total variation error 0.136), and at 20 qubits one
prune wipes the entire map because every weight sits near 3e-5. The metadata
certified the damage at each point (bounds 0.729 and 0.0). The default
stands on that measurement.

## Scope

- [x] New feature
- [x] Documentation

## Benchmarks

The retained-entry prune path does identical work (one `norm_sqr`, one
compare); the dropped path adds one add to a stack local. Must-not-move A/B
against `main` (36b880f), full Criterion tier, 30 samples, quiet host, two
independent runs over the 24 sparse gate and control rows: both PASS at 5%,
no row beyond its own control with consistent sign. Run 1 carried a one-sided
lean to +5% on three sampling rows that dissolved in run 2 (worst example:
`sparse/sampling_k12/64` +5.4% inside a 7.8% control, then -0.1%).

| Benchmark | Before | After | Change (run 1 / run 2) | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `sparse/random_d10/20` | 7.12 / 7.40 ms | 6.87 / 7.40 ms | -3.5% / +0.1% | 8.3% / 1.9% worst side | yes (noise) |
| `sparse/walk_k12/{32,48,64}` | 4.6-9.1 ms | 4.6-9.1 ms | -0.3% to +1.9% | at or under 1.6% | yes (noise) |
| `sparse/sampling_k12/{32,64}` | 4.8 / 6.9 ms | 4.9-5.0 / 6.9-7.1 ms | +5.4% then -0.1% (64) | 7.8% / 0.0% | yes (run 2 dissolves run 1's lean) |
| `compare/general_d10/sparse/20` | 7.05 / 7.41 ms | 7.13 / 7.40 ms | +1.1% / -0.1% | 9.8% / 1.8% | yes (noise) |
| `sparse/random_d10/16` | 1.44 / 1.41 ms | 1.84 / 1.84 ms | +27.4% / +29.8% | 32.8% / 49.5% | unresolvable: same-code controls exceed the change in both runs, the recorded bimodality of rows at 16384 entries; the 20q sibling with the same kernels at twice the entries reads +0.1% |

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2477 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes
- [x] New tests: the default reports exact, a raised threshold drops the
      expected weight and reports the bound, the threshold survives `init`
      while the weight does not, lowering mid-run keeps the `Approximate`
      report, epsilon 0 still drops exact zeros, out-of-range panics
- [x] Measurement and reset collapse paths verified not to count as pruned
      weight

## Hotspot notes

`SparseBackend::prune` is inlined at seven pre-existing call sites. The
retain closure captures the threshold by copy and a stack-local accumulator;
`exactness` and the `init` reset run once per run.

## Breaking changes

None. The setter is a new method; every dispatched route runs at the default
and reports exactly as before. Entries with squared weight exactly equal to
the threshold now drop instead of staying, a measure-zero boundary change.

## Risks and rollback

The knob is reachable only by driving `SparseBackend` directly; the sim
builder cannot raise it. Documented and accepted: the state is never
renormalized after a prune, so at a raised threshold probability export sees
the reduced weight and the sampling CDF folds the missing weight into the
highest kept basis state; expectations renormalize on read. Reverting the
commit restores the previous behavior everywhere.
