### PR TITLE
perf(sparse): parallel native shot sampling

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -115,7 +115,9 @@ Probability extraction uses coset-based enumeration with GF(2) Gaussian eliminat
 
 ## Sparse
 
-`HashMap<usize, Complex64>` for states with few non-zero amplitudes. O(k) memory. Amplitude pruning (|a|² < 1e-16) after each gate. Best for circuits whose support stays concentrated in computational-basis states at large qubit counts.
+`HashMap<usize, Complex64>` for states with few non-zero amplitudes. O(k) memory. Entries at or below a pruning threshold on |a|² (default 1e-16, settable via `SparseBackend::set_prune_epsilon`; raising it above the default makes the run report `Approximate` with a fidelity bound derived from the dropped weight) are removed after gates that can shrink or cancel amplitudes. Best for circuits whose support stays concentrated in computational-basis states at large qubit counts.
+
+The map's per-entry gate cost is about 16x the statevector's per-amplitude cost on a mixed diagonal and permutation workload (the `sparse/densify` bench rows), so a state that densifies past roughly 1/16 load factor runs slower than a dense vector at the same width would. There is deliberately no mid-run handoff to the statevector: automatic dispatch selects this backend only above the statevector memory cap, where the dense state exceeds the memory budget, and a run that branches past the entry cap rejects the gate rather than degrading silently. An explicitly selected sparse run on a densifying circuit degrades in place, measured at up to 24x the dense cost when fully dense at 20 qubits.
 
 ## MPS (Matrix Product State)
 

--- a/src/backend/sparse.rs
+++ b/src/backend/sparse.rs
@@ -44,6 +44,14 @@ use rayon::prelude::*;
 #[cfg(feature = "parallel")]
 const MIN_STATES_FOR_PAR: usize = 4096;
 
+#[cfg(feature = "parallel")]
+const MIN_SHOTS_FOR_PAR: usize = 32;
+
+/// Shots drawn per ChaCha8 substream. One stream per shot block rather than
+/// per shot: cipher setup and the first keystream block cost more than an
+/// entire draw when the CDF is short, so the block grain amortizes them.
+const SHOTS_PER_STREAM: usize = 256;
+
 use crate::backend::{
     Backend, BasisSamples, dense_probability_len, dense_statevector_len, is_phase_one,
     reserve_dense_output,
@@ -740,9 +748,17 @@ impl Backend for SparseBackend {
 
     /// Samples from a CDF over the `k` stored amplitudes instead of `2^n`.
     ///
-    /// Entries are ordered by basis index, which is the order the dense route
-    /// accumulates its CDF in, so the same seed draws the same basis states
-    /// the dense path would have drawn.
+    /// Entries are sorted by basis index so the draw is a deterministic
+    /// function of the state, not of map iteration order. Each block of
+    /// `SHOTS_PER_STREAM` shots draws sequentially from a ChaCha8
+    /// substream keyed on the seed and the block index (streams 2 and up;
+    /// the MPS sampler keys per shot, the block grain here amortizes cipher
+    /// setup over draws cheaper than the setup). Blocks fill in parallel
+    /// only when the CDF holds `MIN_STATES_FOR_PAR` entries; below that,
+    /// fork-join dispatch costs more than the whole sequential pass. Either
+    /// path walks the same partition, so the words are identical at any
+    /// thread count; the drawn bitstrings differ from the dense route's
+    /// single-stream draws by design.
     fn sample_basis_states(&mut self, num_shots: usize, seed: u64) -> Result<BasisSamples> {
         let mut indices: Vec<usize> = self.state.keys().copied().collect();
         indices.sort_unstable();
@@ -752,11 +768,33 @@ impl Backend for SparseBackend {
             .collect();
         let cdf = crate::sim::shots::build_cdf(&probs);
 
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let mut samples = BasisSamples::new(num_shots, self.num_qubits);
-        for shot in 0..num_shots {
-            let r: f64 = rng.random();
-            samples.set_index(shot, indices[crate::sim::shots::sample_from_cdf(&cdf, r)]);
+        let words_per_shot = samples.words_per_shot();
+        let sample_block = |block: usize, block_words: &mut [u64]| {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            rng.set_stream(block as u64 + 2);
+            for shot_words in block_words.chunks_mut(words_per_shot) {
+                let r: f64 = rng.random();
+                shot_words[0] = indices[crate::sim::shots::sample_from_cdf(&cdf, r)] as u64;
+            }
+        };
+
+        #[cfg(feature = "parallel")]
+        if num_shots >= MIN_SHOTS_FOR_PAR && cdf.len() >= MIN_STATES_FOR_PAR {
+            samples
+                .words_mut()
+                .par_chunks_mut(SHOTS_PER_STREAM * words_per_shot)
+                .enumerate()
+                .for_each(|(block, block_words)| sample_block(block, block_words));
+            return Ok(samples);
+        }
+
+        for (block, block_words) in samples
+            .words_mut()
+            .chunks_mut(SHOTS_PER_STREAM * words_per_shot)
+            .enumerate()
+        {
+            sample_block(block, block_words);
         }
         Ok(samples)
     }

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -295,6 +295,62 @@ fn compiled_sampler_reproducible_at_fixed_thread_count() {
     );
 }
 
+// The sparse sampler uses the MPS substream family (streams 2 and up) at
+// shot-block grain; same pins and miri ignore as the MPS case below.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn sparse_terminal_shots_identical_across_thread_counts() {
+    let mut circuit = prism_q::circuits::sparse_walk_circuit(20, 12, 2, SEED);
+    circuit.measure_all();
+    let kind = BackendKind::Sparse;
+
+    let shots = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(kind.clone())
+                .seed(SEED)
+                .shots(SAMPLING_SHOTS)
+                .expect("shots")
+                .shots
+        })
+    };
+    let single = shots(1);
+    assert_eq!(single.len(), SAMPLING_SHOTS);
+    assert_eq!(single, shots(THREADS_HI), "sparse terminal shots differ");
+    assert_eq!(single, shots(1), "sparse terminal shots not seed stable");
+
+    // A shot count off the block grain leaves a partial trailing block.
+    let odd = |threads: usize| {
+        in_pool(threads, || {
+            simulate(&circuit)
+                .backend(kind.clone())
+                .seed(SEED)
+                .shots(SAMPLING_SHOTS - 37)
+                .expect("shots")
+                .shots
+        })
+    };
+    assert_eq!(
+        odd(1),
+        odd(THREADS_HI),
+        "sparse shots differ at a partial block"
+    );
+
+    let counts = in_pool(THREADS_HI, || {
+        simulate(&circuit)
+            .backend(kind.clone())
+            .seed(SEED)
+            .sample_counts(SAMPLING_SHOTS)
+            .expect("counts")
+            .counts
+    });
+    assert_eq!(
+        counts.values().sum::<u64>(),
+        SAMPLING_SHOTS as u64,
+        "sparse counts do not sum to the shot count"
+    );
+}
+
 // The MPS sampler draws each shot from a substream keyed on (seed, shot), so
 // the words are identical at any thread count; the pins are same-seed
 // stability and counts summing to shots, never a fixed bitstring. Ignored


### PR DESCRIPTION
## Summary

Two changes that close out the sparse backend's current workstream: native
shot sampling runs in parallel, and the backends page records the measured
densification crossover with the decision that no mid-run handoff exists.

Sampling: `sample_basis_states` drew every shot from one sequential ChaCha8
stream. Shots now draw in 256-shot blocks, one substream per block keyed on
the seed and the block index (streams 2 and up, the convention the MPS
sampler set), and the packed output words fill over Rayon in disjoint
per-block chunks. Two grain decisions carry the result: blocks rather than
per-shot streams, because cipher setup costs more than a whole draw on a
short CDF (a per-shot prototype cost +22% to +27% on `sparse/sampling`),
and parallel dispatch only at 4096 stored states and 32 shots, because
fork-join dispatch costs more than the whole sequential pass on a short map
(+9% to +15% without the gate). Both paths walk the same fixed partition,
so output is identical at any thread count.

Docs: the sparse section of `docs/architecture/backends.md` now records the
crossover from the `sparse/densify` rows (per-entry map cost about 16x the
dense per-amplitude cost, parity near 1/16 load factor, 24x fully dense at
20 qubits) and why there is no handoff to the statevector: automatic
dispatch selects this backend only above the statevector memory cap, where
the dense handoff target exceeds the same budget that did the routing, and
a run that branches past the entry cap rejects the gate loudly rather than
degrading silently.

## Scope

- [x] Performance improvement
- [x] Documentation

## Benchmarks

Full Criterion tier through `scripts/bench_ab.sh` (30 samples, adjacent
passes), two runs against the merge base, 24 rows filtered to the sparse
families. Headline and control rows:

| Benchmark | Before | After | Change (run 1 / run 2) | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `sparse/sampling_k12/32` | 4.66 ms | 4.19 ms | -10.0% / -10.5% | +1.1% / +0.2% | improvement |
| `sparse/sampling_k12/64` | 6.74 ms | 6.27 ms | -7.0% / -5.8% | +1.4% / -0.9% | improvement |
| `sparse/sampling/24` | 1.46 ms | 1.78 ms | +21.7% / +18.6% | -2.4% / -0.5% | see verdict |
| `sparse/sampling/64` | 1.79 ms | 2.13 ms | +18.6% / +17.5% | -3.4% / -0.3% | see verdict |
| `sparse/walk_k12/32` | 4.65 ms | 4.70 ms | +1.1% / +0.8% | +0.2% / -0.5% | yes (control, no sampling) |
| `compare/general_d10/sparse/20` | 6.90 ms | 6.92 ms | +0.3% / +0.1% | +1.3% / -0.5% | yes |

Regression verdict: PASS.

The apparent `sparse/sampling` regressions are placement noise, established
by an identical-code control pair: with the source checked out to the merge
base, so both binaries compile the same code, the same A/B read +14% to
+18% on those rows and +20% on the 4-qubit compare rows in one run, then
null (-3% to +3%) in the next. Each copied bench binary draws a code
placement per run that in-run controls cannot see; a prior byte-level
comparison on this toolchain showed the two build directories produce an
identical text section, so the flip is runtime placement, not build
provenance. Pairing the new binary against the identical-code binary from
the same run lane reads `sparse/sampling` at +0% to +4%, the walk and
compare rows at null, and the `sampling_k12` rows at -16%/-12%, so the raw
table above is the conservative claim. Mechanically the 2-entry
`sparse/sampling` rows take the sequential path, whose only change is one
substream setup per 256 shots, about 5 us on a 1.5 ms row.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes (2478)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] `cargo doc --no-deps --features "parallel gpu distributed"` passes with rustdoc warnings denied
- [x] New determinism test pins thread-count identity, seed stability, a
      partial trailing block, and counts summing to shots, on a walk fixture
      holding 4096 entries so the parallel path executes

## Hotspot notes

`sample_basis_states` carries about 66% of `sparse/sampling_k12/32` and 52%
of `/64` (shares measured against the bare run of the same fixture when the
rows landed). Through those shares the row deltas back-solve to a sampler
speedup of roughly 15% to 20%.

## Breaking changes

Sampled bitstrings for a fixed seed change on the sparse backend: draws
come from block substreams instead of one stream, and entries are sorted by
basis index so the draw is a function of the state rather than map
iteration order. The distribution, seed reproducibility, and thread-count
identity contracts are unchanged and tested.

## Risks and rollback

The sampler change is confined to one method; reverting the perf commit
restores the sequential single-stream draw. The docs commit is prose and
reverts independently.
