### PR TITLE
perf(dm): fold the Rzz sandwich into one buffer pass

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2650,6 +2650,62 @@ fn bench_density_matrix_unitary_layers(c: &mut Criterion) {
     group.finish();
 }
 
+/// The `Rzz` counterpart of `density_matrix/unitary_layers`: the denominator a
+/// change to the `Rzz` sandwich has to move, against a circuit that also runs
+/// `n` one-qubit rotations per layer.
+///
+/// Runs through `apply_instructions` like its sibling, so no fusion pass sees it
+/// and the backend receives bare `Rzz`. `qaoa_circuit` emits `n - 1` `Rzz` and
+/// `n` `Rx` per layer; depth 6 keeps the row's cost near `unitary_layers` at the
+/// same width. Read this row by its absolute delta rather than its percentage:
+/// the iteration builds a fresh backend, so a `4^n` allocation and first touch
+/// sit in the denominator alongside the gates.
+fn bench_density_matrix_rzz_layers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/rzz_layers");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let circuit = circuits::qaoa_circuit(n, 6, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                run_dm_apply_only(circ);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// One bare `Rzz` sandwich in isolation, at two target pairs that pin the route
+/// as position independent.
+///
+/// Both the two-pass register route and the combined single pass sweep the whole
+/// buffer contiguously and branch only on index bits, so neither reads an
+/// amplitude and neither depends on where the targets sit. `(2, 3)` and
+/// `(0, n - 1)` are the extremes of that claim and are expected to agree. A
+/// variant that skipped the entry classes whose combined phase is 1 would break
+/// the agreement, since those classes only fall on whole cache lines once
+/// `min(q0, q1)` is large enough; these rows are where that would show.
+fn bench_density_matrix_rzz_sandwich(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/rzz_sandwich");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        for &(q0, q1, label) in &[(2usize, 3usize, "adjacent"), (0, n - 1, "q0_qtop")] {
+            let instruction = Instruction::Gate {
+                gate: Gate::Rzz(0.7),
+                targets: SmallVec::from_slice(&[q0, q1]),
+            };
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, &n| {
+                let mut backend = dm_backend(n);
+                b.iter(|| backend.apply(&instruction).unwrap());
+            });
+        }
+    }
+
+    group.finish();
+}
+
 /// The same layers through the `Simulate` terminal, the only density-matrix
 /// entry point that runs `fuse_circuit`.
 ///
@@ -3193,6 +3249,8 @@ criterion_group! {
     bench_coalesce_baseline,
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
+    bench_density_matrix_rzz_layers,
+    bench_density_matrix_rzz_sandwich,
     bench_density_matrix_fused_layers,
     bench_density_matrix_exact_vs_trajectory,
     bench_density_matrix_noisy_channels,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -176,8 +176,11 @@ Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host a
 CPU-only and explicit-dispatch only; `Auto` never selects it.
 
 Selecting it with a noise model attached is the exact route for every `Simulate`
-terminal: the mixture is evolved once and observables, marginals, probabilities, and
-shots all read that one evolution. See [Noise across the terminals](./engine.md) for
+terminal except the two gradient terminals: the mixture is evolved once and observables,
+marginals, probabilities, and shots all read that one evolution. Gradients are excluded
+for two different reasons: the adjoint backpropagates against a pure state and a channel
+has no reverse evolution to walk, while parameter shift is exact on a mixture and simply
+not wired. See [Noise across the terminals](./engine.md) for
 what that route accepts and what stays on trajectory averaging.
 
 ## What a backend reports about its own result

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -163,9 +163,13 @@ Exact mixed-state evolution. Stores the full density operator `rho` for `n` qubi
 `4^n` `Complex64` buffer laid out row-major: index `(r << n) | c` holds `⟨r|rho|c⟩`. That
 layout is isomorphic to a `2n`-qubit statevector whose high `n` qubits index the ket (row)
 and low `n` qubits index the bra (column), so gate application reuses the statevector
-kernels with no new gate math. A unitary `U` on the ket register gives the left product
-`U rho`; the same `U` on the bra register of a conjugated buffer gives the right product
-`rho U^dagger`, so `U rho U^dagger` costs two statevector passes and two conjugations.
+kernels. A unitary `U` on the ket register gives the left product `U rho`; the right
+product `rho U^dagger` takes the gate's conjugate form on the bra register where one
+exists, and otherwise conjugates the buffer around the pass. So `U rho U^dagger` costs
+two statevector passes, plus two conjugations only for the variants with no conjugate
+form. `Rzz` is the exception that carries gate math of its own: both factors are
+diagonal, so the ket and bra phases cancel wherever the two registers agree on the target
+pair's parity, and the sandwich collapses to a single pass over a combined table.
 
 Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host and 15 on
 32 GiB (`PRISM_MAX_DM_QUBITS` moves it within the statevector budget). This backend is

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -30,7 +30,8 @@
 //! (`MultiFused`, `Multi2q`) apply their constituent gates one at a time
 //! instead. See [`Backend::supports_fused_gates`] for the ordering contract
 //! that requires it. `Rzz` is the one two-qubit gate that does not take the
-//! two-product route; see [`DensityMatrixBackend::apply_rzz_sandwich`].
+//! two-product route: both of its factors are diagonal, so the ket and bra
+//! phases combine into a single table and the buffer is swept once.
 //!
 //! # When to prefer this backend
 //!

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -29,7 +29,8 @@
 //! remapped onto the ket register before the left product; the tiled shapes
 //! (`MultiFused`, `Multi2q`) apply their constituent gates one at a time
 //! instead. See [`Backend::supports_fused_gates`] for the ordering contract
-//! that requires it.
+//! that requires it. `Rzz` is the one two-qubit gate that does not take the
+//! two-product route; see [`DensityMatrixBackend::apply_rzz_sandwich`].
 //!
 //! # When to prefer this backend
 //!
@@ -336,7 +337,9 @@ impl DensityMatrixBackend {
     /// conjugating the whole buffer around the gate, which costs two extra
     /// passes.
     ///
-    /// One-qubit gates take [`DensityMatrixBackend::apply_1q_sandwich`].
+    /// One-qubit gates take [`DensityMatrixBackend::apply_1q_sandwich`], and
+    /// `Rzz` takes [`DensityMatrixBackend::apply_rzz_sandwich`], which folds
+    /// both products into one pass rather than taking its conjugate form here.
     ///
     /// `Multi2q` carries a gate list that the statevector kernel partitions by
     /// cache tier and runs one tier at a time, which preserves application
@@ -362,6 +365,10 @@ impl DensityMatrixBackend {
                 for (qubit, mat) in data.gates.iter() {
                     self.apply_1q_sandwich(*qubit, mat)?;
                 }
+                return Ok(());
+            }
+            Gate::Rzz(theta) => {
+                self.apply_rzz_sandwich(targets[0], targets[1], *theta);
                 return Ok(());
             }
             Gate::Multi2q(data) => {
@@ -422,6 +429,33 @@ impl DensityMatrixBackend {
         }
         self.sv.apply_1q_matrix(qubit + n, matrix)?;
         self.sv.apply_1q_matrix(qubit, &conjugate_2x2(matrix))
+    }
+
+    /// Evolve `rho -> R rho R^dagger` for `R = Rzz(theta)` in one buffer pass.
+    ///
+    /// Both factors are diagonal, so the entry at `(r, c)` picks up
+    /// `phase(p_r) * conj(phase(p_c))` where `p` is the parity of the target
+    /// pair in that register and `phase` is the statevector kernel's
+    /// `[exp(-i theta/2), exp(+i theta/2)]`. Conjugate phases cancel wherever
+    /// the two registers agree on parity, which is half the sixteen entry
+    /// classes, and the rest carry `exp(-i theta)` or its conjugate. The
+    /// generic route's two register passes therefore collapse onto the single
+    /// contiguous pass [`DensityMatrixBackend::kraus_2q_diagonal_sweep`]
+    /// already runs for a diagonal channel.
+    fn apply_rzz_sandwich(&mut self, q0: usize, q1: usize, theta: f64) {
+        let phase = [
+            Complex64::from_polar(1.0, -theta / 2.0),
+            Complex64::from_polar(1.0, theta / 2.0),
+        ];
+        let mut diag = [Complex64::new(1.0, 0.0); 16];
+        for tr in 0..4usize {
+            for tc in 0..4usize {
+                let pr = ((tr >> 1) ^ tr) & 1;
+                let pc = ((tc >> 1) ^ tc) & 1;
+                diag[4 * tr + tc] = phase[pr] * phase[pc].conj();
+            }
+        }
+        self.kraus_2q_diagonal_sweep(&diag, q0, q1);
     }
 
     /// `P(qubit = |1>) = Tr(P_1 rho)`, the sum of the diagonal `rho` entries
@@ -651,8 +685,12 @@ impl DensityMatrixBackend {
     ///
     /// The four positions must be distinct and inside the register, or the
     /// zero-bit insertion in [`block_base`] stops being a bijection onto the
-    /// block bases and the sweep reads and writes the wrong entries. Both
-    /// callers are public, so this is the choke point that enforces it.
+    /// block bases and the sweep reads and writes the wrong entries. Both channel
+    /// entry points are public and route through here, so this is their choke
+    /// point. It is not the sweep's:
+    /// [`DensityMatrixBackend::apply_rzz_sandwich`] builds its table and calls
+    /// the sweep directly, where equal targets yield the identity table that the
+    /// two register passes it replaced also produced.
     fn block_layout(&self, q0: usize, q1: usize) -> ([usize; 4], [usize; 16], usize) {
         let n = self.num_qubits;
         assert!(

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -36,8 +36,8 @@
 //!
 //! - Exact noise-channel evolution: one run yields the exact mixed state,
 //!   where trajectory averaging converges as `1/sqrt(shots)`. Selecting it
-//!   with a noise model attached routes every `Simulate` terminal to that one
-//!   evolution.
+//!   with a noise model attached routes every `Simulate` terminal except the two
+//!   gradient terminals to that one evolution.
 //! - Mixed-state diagnostics: purity and exact `Tr(rho P)` observables.
 //!
 //! # When NOT to use this backend
@@ -49,6 +49,10 @@
 //! - Noisy circuits with mid-circuit measurement or classical conditioning.
 //!   The mixture holds every branch at once, so per-shot feedback cannot be
 //!   replayed from it and the noisy terminals reject those shapes.
+//! - Gradients under noise. Both gradient terminals decline a noise model, for
+//!   different reasons: the adjoint backpropagates against a pure state and a
+//!   channel has no reverse evolution to walk, while parameter shift is exact
+//!   on a mixture and simply not wired.
 
 use std::borrow::Cow;
 

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -1487,3 +1487,131 @@ fn dm_multi_2q_batched_bra_preserves_gate_order() {
         "batched bra Multi2q vs per-constituent",
     );
 }
+
+// `Rzz` is diagonal, so it leaves probabilities untouched and the cross-backend
+// probability matrix above cannot see it at all. These two pin it instead: the
+// first against the general channel route over full Pauli tomography, the
+// second against the statevector with H layers making the phase observable.
+#[test]
+fn dm_rzz_sandwich_matches_channel_route() {
+    const N: usize = 5;
+    let base = circuits::random_circuit(N, 4, SEED);
+    let masks = all_pauli_masks(N);
+
+    for &(q0, q1) in &[(0usize, 1usize), (2, 3), (1, 2), (0, N - 1)] {
+        for theta in [0.0, 0.3, 1.0, std::f64::consts::PI, -2.4] {
+            for mixed in [false, true] {
+                let prepare = || {
+                    let mut backend = run_dm(&base);
+                    if mixed {
+                        backend.apply_1q_kraus(N - 2, &amplitude_damping(0.3));
+                    }
+                    backend
+                };
+
+                let mut sandwich = prepare();
+                sandwich
+                    .apply(&prism_q::circuit::Instruction::Gate {
+                        gate: Gate::Rzz(theta),
+                        targets: [q0, q1].into_iter().collect(),
+                    })
+                    .unwrap();
+
+                let mut channel = prepare();
+                channel.apply_2q_kraus(q0, q1, &[Gate::Rzz(theta).matrix_4x4()]);
+
+                let got = sandwich.expectations_pauli(&masks);
+                let want = channel.expectations_pauli(&masks);
+                for (k, (a, b)) in got.iter().zip(&want).enumerate() {
+                    assert!(
+                        (a - b).abs() < DM_EPS,
+                        "pair=({q0},{q1}) theta={theta} mixed={mixed} pauli {:?}: sandwich {a}, channel {b}",
+                        masks[k]
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn dm_rzz_phase_shows_in_probabilities_under_basis_change() {
+    // PAR_N puts the buffer at 2n = 14 qubits, so the sweep takes its rayon arm;
+    // the tomography test above stays small and covers the scalar one.
+    const N: usize = PAR_N;
+    for &(q0, q1) in &[(0usize, 1usize), (1, 2), (0, N - 1)] {
+        let mut circuit = Circuit::new(N, 0);
+        for q in 0..N {
+            circuit.add_gate(Gate::H, &[q]);
+        }
+        circuit.add_gate(Gate::Rzz(0.9), &[q0, q1]);
+        for q in 0..N {
+            circuit.add_gate(Gate::H, &[q]);
+        }
+        assert_matches_statevector(&circuit, &format!("rzz sandwich ({q0}, {q1})"));
+    }
+}
+
+// Probabilities cannot see a global conjugation of rho: a density matrix has a
+// real diagonal, so `conj(rho)` and `rho` give identical probabilities at every
+// width and for every circuit. The channel-route comparison above shares
+// `diag_slot` with the code under test, so it cannot pin the ket and bra sides
+// to their own registers either. Full Pauli tomography against the statevector
+// is independent of both: `conj(Y) = -Y`, so every Y-bearing string flips sign
+// under a conjugation and the comparison fails.
+#[test]
+fn dm_rzz_sandwich_matches_statevector_over_full_tomography() {
+    use prism_q::{BackendKind, PauliTerm};
+
+    const N: usize = 4;
+    let mut circuit = Circuit::new(N, 0);
+    for q in 0..N {
+        circuit.add_gate(Gate::H, &[q]);
+    }
+    circuit.add_gate(Gate::T, &[1]);
+    circuit.add_gate(Gate::Rzz(0.7), &[0, 1]);
+    circuit.add_gate(Gate::Rzz(-1.3), &[1, N - 1]);
+    circuit.add_gate(Gate::Ry(0.4), &[2]);
+
+    let masks: Vec<(usize, usize, u32)> = all_pauli_masks(N)
+        .into_iter()
+        .filter(|&(x, z, _)| x != 0 || z != 0)
+        .collect();
+    let observables: Vec<Vec<PauliTerm>> = masks
+        .iter()
+        .map(|&(x, z, _)| {
+            (0..N)
+                .filter_map(|q| match ((x >> q) & 1 == 1, (z >> q) & 1 == 1) {
+                    (true, true) => Some(PauliTerm::y(q)),
+                    (true, false) => Some(PauliTerm::x(q)),
+                    (false, true) => Some(PauliTerm::z(q)),
+                    (false, false) => None,
+                })
+                .collect()
+        })
+        .collect();
+
+    let got = dm_backend(&circuit, SEED).expectations_pauli(&masks);
+    let want = sim::simulate(&circuit)
+        .backend(BackendKind::Statevector)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+
+    let sensitive = masks
+        .iter()
+        .zip(&want)
+        .filter(|((x, z, _), v)| (x & z) != 0 && v.abs() > 0.1)
+        .count();
+    assert!(
+        sensitive > 0,
+        "fixture is vacuous: no Y-bearing string has a reference value clear of zero"
+    );
+    for (k, (a, b)) in got.iter().zip(&want).enumerate() {
+        assert!(
+            (a - b).abs() < DM_EPS,
+            "pauli {:?}: density matrix {a}, statevector {b}",
+            masks[k]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`Rzz` is diagonal on both sides of `rho -> R rho R^dagger`, so the ket and bra phases
cancel wherever the two registers agree on the target pair's parity, which is eight of
the sixteen entry classes. Building the combined factor as a 16-entry table sends the
gate through the diagonal channel sweep the density-matrix backend already runs, so two
full-buffer register passes become one and no new kernel exists. Fusion rewrites
`CX-Rz-CX` ladders into native `Rzz` at every qubit count, so this reaches circuits that
never wrote one.

The two new bench groups came first: no density-matrix row exercised a two-qubit
diagonal gate, so this path had nothing gating it.

## Scope

- [x] Performance improvement
- [x] Documentation

## Benchmarks

Gate tier, 30 samples, adjacent-binary A/B, `--features parallel`. i7-6700K, Windows 10
19045, rustc 1.97.0, `lto = "fat"`, `codegen-units = 1`.

**Read the same-lane column, not the cross-binary one.** This host could not gate the
cross-binary ratio: five of six runs breached their control column, the last on thermal
drift alone, where every ref-side control read positive (+4.1% to +24.6%) while every
new-side control sat at zero. That is structural, not bad luck: `ref` averages passes 1
and 4 and `new` averages 2 and 3, so a machine that heats across the run biases `ref`
high, which flatters the change. The same-lane ratio compares the target against an
untouched neighbour measured in the same pass of the same binary, so drift cancels
exactly.

Same-lane: `rzz_sandwich/*/12` divided by the untouched `noisy_channels/kraus_2q_*/12`
row beside it.

| Run | Before | After |
| --- | ---: | ---: |
| 1 | 1.982, 1.992 | 1.000, 1.000 |
| 5 | 1.997, 1.982 | 1.000, 0.995 |
| 6 | 1.999, 1.978 | 1.006, 0.998 |

Two, to one, three times over. The gate now costs one sweep of the buffer, which is where
the diagonal two-qubit Kraus rows already sat. `noisy_channels/purity/12`, a read-only
sweep of the same buffer, reads 11.5 to 12.0 ms against the 22.5 ms read-modify-write
floor, so the floor is bandwidth rather than kernel cost.

Cross-binary, quoted only where the controls were tight:

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | --- | --- | --- | --- | --- |
| `density_matrix/rzz_sandwich/adjacent/12` | 44.85 ms | 22.66 ms | -49.5% | +0.0% / -0.5% | yes |
| `density_matrix/rzz_sandwich/q0_qtop/12` | 45.07 ms | 22.65 ms | -49.8% | +1.0% / -0.2% | yes |
| `density_matrix/unitary_layers/10` (control) | 153.21 ms | 154.13 ms | +0.6% | +0.1% / +0.1% | noise |
| `density_matrix/unitary_layers/8` (control) | 5.77 ms | 5.85 ms | +1.4% | -0.5% / -1.6% | noise |
| `density_matrix/unitary_layers/4` (control) | 17.93 us | 17.93 us | -0.0% | +0.1% / +0.0% | noise |
| `density_matrix/noisy_channels/kraus_2q_dense/12` (control) | 23.34 ms | 23.44 ms | +0.4% | +0.1% / -0.4% | noise |
| `density_matrix/noisy_channels/depolarizing_2q/12` (control) | 24.75 ms | 24.58 ms | -0.7% | +0.7% / -0.2% | noise |

`density_matrix/rzz_layers/12`, normalized against `kraus_2q_adjacent/12` in the same
binary, reads -33.8% and -31.6% across two runs against -32.4% predicted from pass
counting: `qaoa_circuit(12, 6)` is 204 buffer passes before and 138 after. Both runs put
the new side at 148.5 sweep-equivalents against the predicted 138, and the residual 10.5
is the fresh `4^n` allocation and first touch that the row pays inside `b.iter`. Read
that row by its normalization or its absolute delta, never by its raw percentage.

Rows reported unmeasured rather than passed:

- The 10-qubit rows of both new groups. They sit in the 1 to 2 ms band this host is
  already known to read bimodally per copied binary, and their controls confirmed it in
  every run (-17.9%, -13.9%, +26.9%). One clean run put them at -50.1% and -49.1% with
  controls at or under 2.5%, consistent with the 12-qubit result, but one run is not a
  gate and they are not claimed.
- `density_matrix/unitary_layers/12`, left out of the filter because it costs as much per
  run as the target rows and the 12-qubit `noisy_channels` family already supplies
  same-width controls the diff cannot reach.

Regression verdict: PASS. Every control row the diff cannot reach reads noise.

## Correctness

- [x] `cargo nextest run --features "parallel gpu distributed"` passes locally (2481 tests)
- [x] `cargo test --doc --features "parallel gpu distributed"` passes (18)
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo fmt --check` passes
- [x] Golden tests against the statevector backend

Two tomography tests pin the table from different sides, and they catch different faults.
`dm_rzz_sandwich_matches_channel_route` compares against the general two-qubit channel
route, whose table is compiled independently from `Gate::matrix_4x4`, over every Pauli
mask at five angles, both pure and mixed. `dm_rzz_sandwich_matches_statevector_over_full_tomography`
compares against the statevector, which is the one that catches a transposed table:
probabilities cannot see a conjugated `rho` at any width, because a density matrix has a
real diagonal, and `conj(Y) = -Y` makes the Y-bearing strings flip sign instead. Both were
mutation-checked: dropping the conjugate fails both, transposing the table fails the
statevector comparison while the probability comparison passes, which is what the second
test exists for. The probability test runs at seven qubits so the sweep takes its rayon
arm.

## Hotspot notes

`DensityMatrixBackend::apply_unitary` gains one match arm; the work moves to
`kraus_2q_diagonal_sweep`, which is unchanged and already carried the diagonal channel
route. Both the old and the new path are one complex multiply per amplitude over a
contiguous `par_iter_mut`, and both switch to the parallel arm at the same predicate, so
per-pass cost is unchanged and only the pass count drops. That is visible in the numbers:
the after-side rows equal the untouched diagonal-Kraus rows beside them to within 0.6%.

The route is position independent by construction, since it sweeps the whole buffer and
branches only on index bits. The two target pairs, `(2, 3)` and `(0, n - 1)`, are the
extremes of that claim and agree, which is what the pair of rows is for.

## Architecture or design changes

- [x] `docs/architecture/` updated

The backends page claimed gate application reuses the statevector kernels "with no new
gate math" and that a sandwich costs "two statevector passes and two conjugations". The
first is now false for `Rzz`, and the second was already imprecise, since the conjugations
are paid only by variants with no conjugate form. Both corrected.

The third commit is unrelated to the rest and is here to keep it from getting lost: the
backend module header and the backends page both said an attached noise model routes every
`Simulate` terminal to the exact mixture. Two decline it, for unrelated reasons, and the
narrower gap was being presented as the whole one.

## Breaking changes

None. Results move by about one unit in the last place on `Rzz`, since the new route does
one complex multiply per amplitude where the old did two.

## Risks and rollback

Small. One match arm routes `Rzz` to a new private method; deleting the arm restores the
previous behavior exactly, with no flag or dispatch guard involved. Every other gate is
untouched. The arm is unreachable for a malformed `Rzz` on equal targets, which yields the
identity table, as the two register passes it replaced also did.

## Pre-merge checklist

- [x] Commit messages follow the style rules
- [x] No TODO or FIXME markers
- [x] No secrets, credentials, or local config added
- [x] No new dependencies
