### PR TITLE
perf(dm): gate fusion on buffer width and batch the diagonal sandwich

### DIFF
--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2676,6 +2676,36 @@ fn bench_density_matrix_rzz_layers(c: &mut Criterion) {
     group.finish();
 }
 
+/// The same layers through the `Simulate` terminal, the entry point that runs
+/// the fusion pipeline.
+///
+/// `density_matrix/rzz_layers` calls `apply_instructions` directly and receives
+/// bare `Rzz` whatever the fusion floors say, so it cannot see a batching
+/// change. This row is where a layer's commuting `Rzz` gates reach the backend
+/// as one `BatchRzz`. The floors are gated on buffer width, which for this
+/// backend is `2n`, so both widths here clear the diagonal batch floor.
+fn bench_density_matrix_rzz_layers_fused(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/rzz_layers_fused");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let circuit = circuits::qaoa_circuit(n, 6, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(BackendKind::DensityMatrix)
+                        .seed(SEED)
+                        .run()
+                        .unwrap(),
+                );
+            });
+        });
+    }
+
+    group.finish();
+}
+
 /// One bare `Rzz` sandwich in isolation, at two target pairs that pin the route
 /// as position independent.
 ///
@@ -3250,6 +3280,7 @@ criterion_group! {
     // Density matrix (explicit backend)
     bench_density_matrix_unitary_layers,
     bench_density_matrix_rzz_layers,
+    bench_density_matrix_rzz_layers_fused,
     bench_density_matrix_rzz_sandwich,
     bench_density_matrix_fused_layers,
     bench_density_matrix_exact_vs_trajectory,

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -24,14 +24,15 @@
 //! `apply_2q_depolarizing` taking the twirled closed form instead), and
 //! exact `Tr(rho P)` expectation (`expectation_pauli`, reachable through
 //! `pauli_expectations`). Fused gates are accepted, so `sim` fuses for this
-//! backend. The diagonal batches (`QftBlock`, `BatchPhase`, `BatchRzz`,
-//! `DiagonalBatch`) carry qubit indices outside the instruction targets and are
-//! remapped onto the ket register before the left product; the tiled shapes
-//! (`MultiFused`, `Multi2q`) apply their constituent gates one at a time
-//! instead. See [`Backend::supports_fused_gates`] for the ordering contract
-//! that requires it. `Rzz` is the one two-qubit gate that does not take the
-//! two-product route: both of its factors are diagonal, so the ket and bra
-//! phases combine into a single table and the buffer is swept once.
+//! backend, and at the `2n` width its buffer actually costs rather than at the
+//! circuit width. `QftBlock` carries qubit indices outside the instruction
+//! targets and is remapped onto the ket register before the left product; the
+//! tiled shapes (`MultiFused`, `Multi2q`) apply their constituent gates one at
+//! a time instead. See [`Backend::supports_fused_gates`] for the ordering
+//! contract that requires it. Diagonal gates do not take the two-product route
+//! at all: their two factors combine into one table, so `Rzz` and the diagonal
+//! batches (`BatchPhase`, `BatchRzz`, `DiagonalBatch`) each sweep the buffer
+//! once.
 //!
 //! # When to prefer this backend
 //!
@@ -67,7 +68,7 @@ use crate::backend::statevector::{StatevectorBackend, insert_zero_bit, kernels};
 use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
-use crate::gates::{DiagEntry, Gate, McuData, mat_mul_4x4};
+use crate::gates::{DiagEntry, Gate, McuData, diag_entries_phase, mat_mul_4x4};
 use crate::sim::i_pow;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -230,43 +231,48 @@ fn conjugate_gate(gate: &Gate) -> Option<Gate> {
 }
 
 /// The gate with every qubit index stored inside its payload shifted onto the
-/// ket register. Offsetting the instruction targets is not enough for the
-/// diagonal batches, whose application indices live in the payload, nor for
+/// ket register. Offsetting the instruction targets is not enough for
 /// `QftBlock`, whose whole range lives in the variant. Borrows the gate when it
 /// carries no such index.
 ///
 /// `MultiFused` and `Multi2q` are deliberately absent: shifting a `Multi2q`
-/// payload reorders it, so both apply their constituents directly.
+/// payload reorders it, so both apply their constituents directly. The diagonal
+/// batches are absent for a different reason, that
+/// [`DensityMatrixBackend::apply_diagonal_sandwich`] takes them before the
+/// two-product route is reached.
+/// The batch payload as a flat [`DiagEntry`] list, or `None` for a gate that is
+/// not a diagonal batch. `BatchPhase` keeps its shared control in the
+/// instruction targets rather than in the payload, so it arrives separately.
+fn diagonal_batch_entries(gate: &Gate, targets: &[usize]) -> Option<Vec<DiagEntry>> {
+    match gate {
+        Gate::BatchPhase(data) => Some(
+            data.phases
+                .iter()
+                .map(|&(target, phase)| DiagEntry::Phase2q {
+                    q0: targets[0],
+                    q1: target,
+                    phase,
+                })
+                .collect(),
+        ),
+        Gate::BatchRzz(data) => Some(
+            data.edges
+                .iter()
+                .map(|&(q0, q1, theta)| DiagEntry::Parity2q {
+                    q0,
+                    q1,
+                    same: Complex64::from_polar(1.0, -theta / 2.0),
+                    diff: Complex64::from_polar(1.0, theta / 2.0),
+                })
+                .collect(),
+        ),
+        Gate::DiagonalBatch(data) => Some(data.entries.clone()),
+        _ => None,
+    }
+}
+
 fn ket_register_gate(gate: &Gate, n: usize) -> Cow<'_, Gate> {
     match gate {
-        Gate::BatchPhase(data) => {
-            let mut data = data.clone();
-            for entry in &mut data.phases {
-                entry.0 += n;
-            }
-            Cow::Owned(Gate::BatchPhase(data))
-        }
-        Gate::BatchRzz(data) => {
-            let mut data = data.clone();
-            for entry in &mut data.edges {
-                entry.0 += n;
-                entry.1 += n;
-            }
-            Cow::Owned(Gate::BatchRzz(data))
-        }
-        Gate::DiagonalBatch(data) => {
-            let mut data = data.clone();
-            for entry in &mut data.entries {
-                match entry {
-                    DiagEntry::Phase1q { qubit, .. } => *qubit += n,
-                    DiagEntry::Phase2q { q0, q1, .. } | DiagEntry::Parity2q { q0, q1, .. } => {
-                        *q0 += n;
-                        *q1 += n;
-                    }
-                }
-            }
-            Cow::Owned(Gate::DiagonalBatch(data))
-        }
         Gate::QftBlock { start, num } => Cow::Owned(Gate::QftBlock {
             start: start + n as u8,
             num: *num,
@@ -342,9 +348,11 @@ impl DensityMatrixBackend {
     /// conjugating the whole buffer around the gate, which costs two extra
     /// passes.
     ///
-    /// One-qubit gates take [`DensityMatrixBackend::apply_1q_sandwich`], and
-    /// `Rzz` takes [`DensityMatrixBackend::apply_rzz_sandwich`], which folds
-    /// both products into one pass rather than taking its conjugate form here.
+    /// One-qubit gates take [`DensityMatrixBackend::apply_1q_sandwich`], `Rzz`
+    /// takes [`DensityMatrixBackend::apply_rzz_sandwich`], and the diagonal
+    /// batches take [`DensityMatrixBackend::apply_diagonal_sandwich`]. All
+    /// three fold both products into one pass rather than taking a conjugate
+    /// form here.
     ///
     /// `Multi2q` carries a gate list that the statevector kernel partitions by
     /// cache tier and runs one tier at a time, which preserves application
@@ -395,6 +403,11 @@ impl DensityMatrixBackend {
                 return Ok(());
             }
             _ => {}
+        }
+
+        if let Some(entries) = diagonal_batch_entries(gate, targets) {
+            self.apply_diagonal_sandwich(&entries);
+            return Ok(());
         }
 
         let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
@@ -461,6 +474,47 @@ impl DensityMatrixBackend {
             }
         }
         self.kraus_2q_diagonal_sweep(&diag, q0, q1);
+    }
+
+    /// Evolve `rho -> D rho D^dagger` for a diagonal batch `D` in one buffer
+    /// pass.
+    ///
+    /// A diagonal `D` scales `<r|rho|c>` by `f(r) * conj(f(c))`, where `f` is
+    /// the combined phase the payload puts on a basis index. The embedded
+    /// layout splits the buffer index into exactly those two operands, `r` in
+    /// the high `n` bits and `c` in the low `n`, so one table of `2^n` phases
+    /// serves both registers and the sweep reads it twice per amplitude. The
+    /// table costs `2^n` against the `4^n` buffer it saves three passes on: the
+    /// generic route has no conjugate form for these variants and pays two
+    /// register passes plus two buffer conjugations.
+    ///
+    /// Entry order does not matter, all of them being diagonal, so the tier
+    /// reordering the tiled payloads have to avoid cannot arise here.
+    fn apply_diagonal_sandwich(&mut self, entries: &[DiagEntry]) {
+        let n = self.num_qubits;
+        let d = self.dim();
+        let ket: Vec<Complex64> = (0..d).map(|r| diag_entries_phase(r, entries)).collect();
+        let bra: Vec<Complex64> = ket.iter().map(|f| f.conj()).collect();
+
+        #[cfg(feature = "parallel")]
+        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+            use crate::backend::MIN_PAR_ELEMS;
+            use rayon::prelude::*;
+
+            self.sv
+                .state
+                .par_iter_mut()
+                .enumerate()
+                .with_min_len(MIN_PAR_ELEMS)
+                .for_each(|(idx, amp)| {
+                    *amp *= ket[idx >> n] * bra[idx & (d - 1)];
+                });
+            return;
+        }
+
+        for (idx, amp) in self.sv.state.iter_mut().enumerate() {
+            *amp *= ket[idx >> n] * bra[idx & (d - 1)];
+        }
     }
 
     /// `P(qubit = |1>) = Tr(P_1 rho)`, the sum of the diagonal `rho` entries
@@ -1083,6 +1137,12 @@ impl Backend for DensityMatrixBackend {
     /// indices would reorder.
     fn supports_fused_gates(&self) -> bool {
         true
+    }
+
+    /// The mixture is a `2n`-qubit statevector, so every fusion floor is
+    /// reached at half the circuit width the statevector needs.
+    fn fusion_state_qubits(&self, num_qubits: usize) -> usize {
+        2 * num_qubits
     }
 
     fn qubit_probability(&self, qubit: usize) -> Result<f64> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -518,6 +518,17 @@ pub trait Backend {
         true
     }
 
+    /// Width in qubits of the buffer this backend sweeps for an `n`-qubit
+    /// circuit.
+    ///
+    /// The fusion floors are calibrated against the cost of one statevector
+    /// pass, so `sim` gates them on this rather than on the circuit width. The
+    /// two coincide everywhere except the density matrix, which holds an
+    /// `n`-qubit mixture as a `2n`-qubit statevector.
+    fn fusion_state_qubits(&self, num_qubits: usize) -> usize {
+        num_qubits
+    }
+
     /// Whether this backend has a native kernel for `Gate::QftBlock`.
     ///
     /// Native support is currently limited to whole-state CPU statevector QFT.

--- a/src/circuit/fusion.rs
+++ b/src/circuit/fusion.rs
@@ -1358,7 +1358,7 @@ where
 /// The tracer is left alone deliberately: this pass rewrites region payloads in
 /// place, and a region carries no provenance of its own, so the input mapping
 /// still describes the output exactly.
-pub(super) fn fuse_region_bodies<'a>(circuit: &'a Circuit) -> Cow<'a, Circuit> {
+fn fuse_region_bodies<'a>(circuit: &'a Circuit, n: usize) -> Cow<'a, Circuit> {
     let insts = &circuit.instructions;
     let mut out: Option<Vec<Instruction>> = None;
 
@@ -1366,7 +1366,7 @@ pub(super) fn fuse_region_bodies<'a>(circuit: &'a Circuit) -> Cow<'a, Circuit> {
         let fused_region = match inst {
             Instruction::Region(region) => {
                 let body = circuit.with_instructions(region.body().to_vec());
-                match fuse_traced(&body, &mut Tracer::off()) {
+                match fuse_at_width(&body, n, &mut Tracer::off()) {
                     Cow::Owned(fused) => Some(Instruction::Region(Box::new(GuardedRegion::new(
                         region.condition().clone(),
                         fused.instructions,
@@ -1396,17 +1396,39 @@ pub(super) fn fuse_region_bodies<'a>(circuit: &'a Circuit) -> Cow<'a, Circuit> {
 /// Returns `Cow::Borrowed` when no fusion is profitable (zero overhead).
 /// Set `supports_fused` to `false` for backends that cannot handle fused gates
 /// (e.g., stabilizer).
+///
+/// Gates the passes at the circuit's own width. A backend whose buffer is wider
+/// than a `num_qubits` statevector takes
+/// [`fuse_circuit_for_width`] instead.
 pub fn fuse_circuit<'a>(circuit: &'a Circuit, supports_fused: bool) -> Cow<'a, Circuit> {
+    fuse_circuit_for_width(circuit, supports_fused, circuit.num_qubits)
+}
+
+/// Fuse for a backend that sweeps a `state_qubits`-wide buffer.
+///
+/// Every floor here is calibrated against the cost of one statevector pass, so
+/// the gate is buffer width rather than circuit width. They coincide for a
+/// statevector and part company for the density matrix, which holds an
+/// `n`-qubit mixture as a `2n`-qubit statevector and so reaches each floor at
+/// half the circuit width.
+pub fn fuse_circuit_for_width<'a>(
+    circuit: &'a Circuit,
+    supports_fused: bool,
+    state_qubits: usize,
+) -> Cow<'a, Circuit> {
     if !supports_fused {
         return Cow::Borrowed(circuit);
     }
-    fuse_traced(circuit, &mut Tracer::off())
+    fuse_at_width(circuit, state_qubits, &mut Tracer::off())
 }
 
-/// The pass pipeline, recording provenance into `t` when it is tracking.
+/// The pass pipeline at the circuit's own width, recording provenance into `t`.
 pub(super) fn fuse_traced<'a>(circuit: &'a Circuit, t: &mut Tracer) -> Cow<'a, Circuit> {
-    let n = circuit.num_qubits;
-    let pass_r = fuse_region_bodies(circuit);
+    fuse_at_width(circuit, circuit.num_qubits, t)
+}
+
+fn fuse_at_width<'a>(circuit: &'a Circuit, n: usize, t: &mut Tracer) -> Cow<'a, Circuit> {
+    let pass_r = fuse_region_bodies(circuit, n);
     let pass0 = apply_pass(pass_r, t, cancel_self_inverse_pairs);
     let pass0r = apply_pass(pass0, t, fuse_rzz);
     let pass0b = gated(pass0r, n, MIN_QUBITS_FOR_DIAG_BATCH, |c| {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -711,11 +711,24 @@ fn expand_for_backend<'c>(
     }
 }
 
+/// Fuse `circuit` against what `backend` accepts and how wide a buffer it
+/// sweeps, the two backend facts the pass pipeline is gated on.
+fn fuse_for_backend<'a>(
+    backend: &dyn Backend,
+    circuit: &'a Circuit,
+) -> std::borrow::Cow<'a, Circuit> {
+    crate::circuit::fusion::fuse_circuit_for_width(
+        circuit,
+        backend.supports_fused_gates(),
+        backend.fusion_state_qubits(circuit.num_qubits),
+    )
+}
+
 /// Fuse `circuit` for `backend` and apply it, leaving initialization to the
 /// caller. The start-state analogue of [`execute`], which owns the |0...0⟩ init.
 fn apply_fused_circuit(backend: &mut dyn Backend, circuit: &Circuit) -> Result<()> {
     let expanded = expand_for_backend(&*backend, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    let fused = fuse_for_backend(&*backend, &expanded);
     backend.apply_instructions(&fused.instructions)
 }
 
@@ -774,7 +787,7 @@ fn shots_from_initial_state(
     let plan = initial_state_plan(kind, circuit.num_qubits)?;
     let probe = plan.build(seed);
     let expanded = expand_for_backend(&*probe, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, probe.supports_fused_gates());
+    let fused = fuse_for_backend(&*probe, &expanded);
 
     collect_shots(circuit, num_shots, seed, plan.resolved(), |shot_seed| {
         let mut backend = plan.build(shot_seed);
@@ -936,7 +949,7 @@ fn try_backend_probabilities(backend: &dyn Backend) -> Result<Option<Probabiliti
 /// Core execution: fuse, init, apply, extract.
 fn execute(backend: &mut dyn Backend, circuit: &Circuit, opts: &SimOptions) -> Result<RunOutcome> {
     let expanded = expand_for_backend(&*backend, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    let fused = fuse_for_backend(&*backend, &expanded);
     execute_circuit(backend, &fused, opts)
 }
 
@@ -1380,7 +1393,7 @@ fn try_terminal_statevector_backend(
     let accel = accel_for(kind, Family::Statevector, stripped.num_qubits);
     let mut backend = build_statevector(&accel, seed);
     let expanded = expand_for_backend(&backend, &stripped);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    let fused = fuse_for_backend(&backend, &expanded);
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
 
@@ -2066,7 +2079,7 @@ fn grouped_expectation_statevector(
     let accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
     let mut backend = build_statevector(&accel, seed);
     let expanded = expand_for_backend(&backend, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    let fused = fuse_for_backend(&backend, &expanded);
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
 
@@ -2243,7 +2256,7 @@ fn expectation_values_statevector(
     let accel = accel_for(kind, Family::Statevector, circuit.num_qubits);
     let mut backend = build_statevector(&accel, seed);
     let expanded = expand_for_backend(&backend, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, backend.supports_fused_gates());
+    let fused = fuse_for_backend(&backend, &expanded);
     backend.init(fused.num_qubits, fused.num_classical_bits)?;
     backend.apply_instructions(&fused.instructions)?;
 
@@ -2563,7 +2576,7 @@ fn run_shots_distributed(
 
     let probe = DistributedStatevectorBackend::new(context.clone(), seed);
     let expanded = expand_for_backend(&probe, circuit);
-    let fused = crate::circuit::fusion::fuse_circuit(&expanded, probe.supports_fused_gates());
+    let fused = fuse_for_backend(&probe, &expanded);
     let opts = SimOptions::classical_only();
     let mut shots = Vec::with_capacity(num_shots);
     let mut metadata = RunMetadata::exact(ResolvedBackend::Distributed);

--- a/tests/bench_fixture_routing.rs
+++ b/tests/bench_fixture_routing.rs
@@ -72,6 +72,16 @@ fn scalability_sweep_rows_reach_their_backend() {
     }
 }
 
+// `density_matrix/rzz_layers_fused` is the one density-matrix row that runs
+// through `simulate`, so it is the one that can be claimed by the decomposed
+// route instead. 10 qubits alone: the fixture is a line graph at every width,
+// and a 12-qubit mixture costs seconds per run.
+#[test]
+fn density_matrix_fused_row_reaches_its_backend() {
+    let circuit = circuits::qaoa_circuit(10, 6, SEED);
+    assert_resolves("rzz_layers_fused/10", BackendKind::DensityMatrix, &circuit);
+}
+
 #[test]
 fn diagonal_mixed_rows_reach_their_backend() {
     for n in [16usize, 20, 22, 24, 26] {

--- a/tests/density_matrix_correctness.rs
+++ b/tests/density_matrix_correctness.rs
@@ -663,29 +663,31 @@ fn count_gates(circuit: &Circuit, want: fn(&Gate) -> bool) -> usize {
 
 #[test]
 fn dm_fused_route_matches_unfused_across_fusion_widths() {
-    // 8 is below MIN_QUBITS_FOR_FUSION and fuses nothing, 10 admits one-qubit
-    // fusion, 12 the two-qubit and Multi2q passes. MultiFused needs 14 and the
-    // diagonal batches 16, both past the 4^n ceiling, so neither is reachable
-    // here and neither is covered. The payload assertions are what keep the
-    // widths meaningful: a reorder that dropped 12q to Fused2q-only would still
-    // match probabilities, and Multi2q ordering is the reason this test exists.
-    for (n, want_multi2q, want_fused1q) in [(8usize, 0, 0), (10, 0, 1), (12, 1, 0)] {
+    // The floors are gated on buffer width, and this backend's buffer at `n` is
+    // a `2n`-qubit statevector, so each one is reached at half the circuit width
+    // a statevector needs: 5 for one-qubit fusion, 6 for the two-qubit and
+    // Multi2q passes, 7 for MultiFused, 8 for the diagonal batches. 4 is below
+    // all of them and is the in-group control. The payload assertions are what
+    // keep the widths meaningful: a reorder that dropped 6q to Fused2q-only
+    // would still match probabilities, and Multi2q ordering is the reason this
+    // test exists.
+    for (n, want_multi2q, want_multifused) in [(4usize, 0, 0), (5, 0, 0), (6, 1, 0), (8, 1, 1)] {
         let circuit = circuits::random_circuit(n, 4, SEED);
-        let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+        let fused = dm_fused(&circuit);
         assert!(
             count_gates(&fused, |g| matches!(g, Gate::Multi2q(_))) >= want_multi2q,
-            "expected {want_multi2q} Multi2q at {n}q, got {:?}",
+            "expected {want_multi2q} Multi2q at {n}q, got {}",
             count_gates(&fused, |g| matches!(g, Gate::Multi2q(_)))
         );
         assert!(
-            count_gates(&fused, |g| matches!(g, Gate::Fused(_))) >= want_fused1q,
-            "expected {want_fused1q} fused 1q run at {n}q"
+            count_gates(&fused, |g| matches!(g, Gate::MultiFused(_))) >= want_multifused,
+            "expected {want_multifused} MultiFused at {n}q"
         );
-        if n == 8 {
+        if n == 4 {
             assert_eq!(
                 fused.instructions.len(),
                 circuit.instructions.len(),
-                "8q must fuse nothing, it is the control"
+                "4q must fuse nothing, it is the control"
             );
         }
         assert_fused_matches_unfused(
@@ -695,6 +697,123 @@ fn dm_fused_route_matches_unfused_across_fusion_widths() {
             &format!("density matrix fused vs unfused at {n}q"),
         );
     }
+}
+
+/// `circuit` fused the way `sim` fuses it for this backend, at the `2n` buffer
+/// width rather than the circuit width.
+fn dm_fused(circuit: &Circuit) -> Circuit {
+    prism_q::circuit::fusion::fuse_circuit_for_width(circuit, true, 2 * circuit.num_qubits)
+        .into_owned()
+}
+
+/// Probabilities after `instructions`, read in the Z, X, and Y bases.
+///
+/// A diagonal sandwich scales `<r|rho|c>` by `f(r) * conj(f(c))`, which is 1 on
+/// every diagonal entry, so a Z readout is blind to this arm however wrong it
+/// is. The two rotated readouts are what make its off-diagonal work visible.
+fn dm_probs_in_three_bases(n: usize, instructions: &[prism_q::circuit::Instruction]) -> Vec<f64> {
+    use prism_q::circuit::Instruction;
+
+    let mut out = Vec::new();
+    for basis in [&[][..], &[Gate::H][..], &[Gate::Sdg, Gate::H][..]] {
+        let mut backend = DensityMatrixBackend::new(SEED);
+        backend.init(n, 0).unwrap();
+        backend.apply_instructions(instructions).unwrap();
+        for gate in basis {
+            for q in 0..n {
+                backend
+                    .apply(&Instruction::Gate {
+                        gate: gate.clone(),
+                        targets: [q].into_iter().collect(),
+                    })
+                    .unwrap();
+            }
+        }
+        out.extend(backend.probabilities().unwrap());
+    }
+    out
+}
+
+#[test]
+fn dm_batched_diagonal_layer_matches_the_per_gate_route() {
+    // 8 qubits is where the diagonal batch floor lands for this backend. Both
+    // fixtures are seeded, and both fuse to a batch the per-gate stream has to
+    // reproduce entry for entry.
+    const N: usize = 8;
+    for (label, circuit, want_batch_rzz, want_diagonal_batch) in [
+        ("qaoa", circuits::qaoa_circuit(N, 3, SEED), 1, 0),
+        (
+            "diagonal mixed",
+            circuits::diagonal_mixed_circuit(N, 3, SEED),
+            1,
+            1,
+        ),
+    ] {
+        let fused = dm_fused(&circuit);
+        assert!(
+            count_gates(&fused, |g| matches!(g, Gate::BatchRzz(_))) >= want_batch_rzz,
+            "{label}: expected a BatchRzz at {N}q"
+        );
+        assert!(
+            count_gates(&fused, |g| matches!(g, Gate::DiagonalBatch(_))) >= want_diagonal_batch,
+            "{label}: expected a DiagonalBatch at {N}q"
+        );
+        assert_probs_close(
+            &dm_probs_in_three_bases(N, &fused.instructions),
+            &dm_probs_in_three_bases(N, &circuit.instructions),
+            DM_EPS,
+            &format!("{label} batched diagonal layer vs the per-gate route"),
+        );
+    }
+}
+
+#[test]
+fn dm_multi_entry_batch_phase_matches_the_per_gate_route() {
+    // No circuit here fuses to a BatchPhase, the controlled-phase runs that
+    // would being claimed by QftBlock first, so the payload is built directly.
+    // Targets carry the shared control alone, which is where the sandwich reads
+    // it from. The preparation has to leave real coherences behind: on a
+    // computational basis state a diagonal gate is a global phase and no
+    // readout can see it.
+    use prism_q::circuit::Instruction;
+    use prism_q::gates::BatchPhaseData;
+
+    const N: usize = 5;
+    let control = 1usize;
+    let phases: Vec<(usize, f64)> = vec![(0, 0.37), (2, 1.94), (4, -0.83)];
+
+    let mut prep = Circuit::new(N, 0);
+    for q in 0..N {
+        prep.add_gate(Gate::H, &[q]);
+    }
+    for q in 0..N - 1 {
+        prep.add_gate(Gate::Cx, &[q, q + 1]);
+    }
+    for q in 0..N {
+        prep.add_gate(Gate::Ry(0.3 + 0.2 * q as f64), &[q]);
+    }
+
+    let mut per_gate = prep.clone();
+    for &(target, theta) in &phases {
+        per_gate.add_gate(Gate::cphase(theta), &[control, target]);
+    }
+
+    prep.instructions.push(Instruction::Gate {
+        gate: Gate::BatchPhase(Box::new(BatchPhaseData {
+            phases: phases
+                .iter()
+                .map(|&(target, theta)| (target, Complex64::from_polar(1.0, theta)))
+                .collect(),
+        })),
+        targets: [control].into_iter().collect(),
+    });
+
+    assert_probs_close(
+        &dm_probs_in_three_bases(N, &prep.instructions),
+        &dm_probs_in_three_bases(N, &per_gate.instructions),
+        DM_EPS,
+        "multi-entry batch phase vs the per-gate route",
+    );
 }
 
 #[test]

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -42,6 +42,15 @@ const SAMPLING_SHOTS: usize = 4096;
 #[cfg(miri)]
 const SAMPLING_SHOTS: usize = 256;
 
+// The size at which the dense circuit reaches every fused family named in
+// `the_dense_circuit_still_reaches_the_fused_kernel_families`. Native needs 18
+// for the diagonal batch floor; the miri floors all drop to 8, so 10 does it
+// there.
+#[cfg(not(miri))]
+const FUSED_COVERAGE_QUBITS: usize = 18;
+#[cfg(miri)]
+const FUSED_COVERAGE_QUBITS: usize = 10;
+
 const REDUCTION_EPS: f64 = 1e-12;
 
 fn in_pool<T: Send>(threads: usize, op: impl FnOnce() -> T + Send) -> T {
@@ -124,6 +133,41 @@ fn assert_bitwise_equal(base: &[Complex64], other: &[Complex64], label: &str) {
         assert!(
             a.re.to_bits() == b.re.to_bits() && a.im.to_bits() == b.im.to_bits(),
             "{label}: amplitude {idx} differs bitwise: {a} vs {b}"
+        );
+    }
+}
+
+fn count_gates(circuit: &Circuit, want: impl Fn(&Gate) -> bool) -> usize {
+    circuit
+        .instructions
+        .iter()
+        .filter(
+            |inst| matches!(inst, prism_q::circuit::Instruction::Gate { gate, .. } if want(gate)),
+        )
+        .count()
+}
+
+// Everything below asserts bitwise agreement, which unfused kernels satisfy
+// just as well as fused ones, so a fusion floor moving out of reach would drain
+// this file's coverage without turning a single test red. Pin the forms the
+// circuit is built to produce instead. The three named here are the ones that
+// survive both configurations: at the miri sizes the two-qubit runs are all
+// swallowed by Multi2q, and a bare Fused2q appears only at the native width.
+#[test]
+fn the_dense_circuit_still_reaches_the_fused_kernel_families() {
+    let circuit = representative_dense_circuit(FUSED_COVERAGE_QUBITS);
+    let fused = prism_q::circuit::fusion::fuse_circuit(&circuit, true);
+    for (label, want) in [
+        (
+            "Fused",
+            &(|g: &Gate| matches!(g, Gate::Fused(_))) as &dyn Fn(&Gate) -> bool,
+        ),
+        ("Multi2q", &|g: &Gate| matches!(g, Gate::Multi2q(_))),
+        ("BatchRzz", &|g: &Gate| matches!(g, Gate::BatchRzz(_))),
+    ] {
+        assert!(
+            count_gates(&fused, want) > 0,
+            "the {FUSED_COVERAGE_QUBITS}q fused stream carries no {label}, so the              parallel kernel it stands for is no longer covered here"
         );
     }
 }


### PR DESCRIPTION
## Summary

Every fusion floor in `circuit/fusion.rs` is calibrated against the cost of one
statevector pass, but `fuse_circuit` gated all of them on `circuit.num_qubits`.
The density matrix holds an `n`-qubit mixture as a `2n`-qubit statevector, so it
reached each floor at twice the circuit width it should: `MIN_QUBITS_FOR_DIAG_BATCH`
sits at 16, and a 16-qubit mixture is 68.7 GB against a ceiling near 14, so the
diagonal batch families were unreachable at every width this backend can hold and
a QAOA layer's commuting `Rzz` gates stayed separate sweeps.

`Backend::fusion_state_qubits` now reports the buffer width a backend sweeps,
defaulting to the circuit width, and the density matrix returns `2n`. A layer's
commuting rotations reach the backend as one `BatchRzz`, which a new combined
sandwich applies in one pass rather than four.

## Scope

- [x] Performance improvement

## Benchmarks

`density_matrix/rzz_layers` cannot show this change. It calls `apply_instructions`
directly, so no fusion pass sees it and the backend receives bare `Rzz` whatever
the floors say. `density_matrix/rzz_layers_fused` is the same `qaoa_circuit(n, 6)`
through the `Simulate` terminal, this backend's only fusing entry point, and is
added here as its own commit so the reference binary carries it.

Adjacent-binary A/B, `scripts/bench_ab.sh`, gate tier at 30 samples, i7-6700K,
rustc 1.97.0, `--features parallel`. Two runs on a host measured at 4 to 9% idle.

| Benchmark | Before | After | Change | Control (same code) | Within 5% threshold? |
| --- | ---: | ---: | ---: | ---: | --- |
| `density_matrix/rzz_layers_fused/12` | 3.694 s | 2.072 s | -43.9% | -4.2% / -0.9% | yes, faster |
| `density_matrix/rzz_layers_fused/12` (second run) | 3.441 s | 1.963 s | -43.0% | -5.2% / -0.3% | yes, faster |
| `density_matrix/rzz_layers_fused/10` | 176.06 ms | 104.40 ms | -40.7% | -1.5% / -1.5% | yes, faster |
| `density_matrix/rzz_layers_fused/10` (second run) | 153.10 ms | 82.36 ms | -46.2% | -21.4% / +0.1% | unresolved |
| `density_matrix/fused_layers/10` | 118.64 ms | 62.99 ms | -46.9% | -4.3% / +2.7% | yes, faster |
| `density_matrix/fused_layers/10` (second run) | 93.25 ms | 51.98 ms | -44.3% | -2.0% / -1.8% | yes, faster |
| `density_matrix/fused_layers/12` | 1.068 s | 1.067 s | -0.2% | +0.6% / +3.3% | noise |
| `density_matrix/fused_layers/12` (second run) | 1.015 s | 1.010 s | -0.5% | -0.2% / -0.7% | noise |
| `density_matrix/fused_layers/8` | 9.71 ms | 3.80 ms | -60.8% | -16.6% / -2.2% | unresolved |
| `density_matrix/noisy_channels/kraus_2q_adjacent/12` | 24.22 ms | 24.42 ms | +0.8% | -1.0% / -1.0% | noise |
| `density_matrix/noisy_channels/kraus_2q_dense/12` | 24.52 ms | 24.33 ms | -0.8% | +3.9% / -0.1% | noise |
| `density_matrix/noisy_channels/kraus_2q_adjacent/10` | 1.46 ms | 1.46 ms | +0.6% | +5.2% / +8.7% | noise |
| `density_matrix/noisy_channels/kraus_2q_dense/10` | 1.70 ms | 1.72 ms | +1.6% | +1.6% / +4.8% | noise |
| `density_matrix/rzz_layers/10` | 164.18 ms | 180.47 ms | +9.9% | +27.0% / +1.1% | unresolved |
| `density_matrix/unitary_layers/10` | 175.05 ms | 196.68 ms | +12.4% | +32.1% / +2.3% | unresolved |

The four `noisy_channels/kraus_2q_*` rows are the controls the diff cannot reach:
they enter the backend through `apply_2q_kraus` and never through fusion. All
four moved between -0.8% and +1.6% across both runs. `rzz_layers/10` and
`unitary_layers/10` bypass the fusion pipeline too and must not move; both carry
reference-side control spreads of 26 to 32%, so their change columns are reported
unresolved rather than flat.

The claim is the 12-qubit row, and it rests on the same-lane ratio rather than on
the cross-binary column. Dividing by `noisy_channels/kraus_2q_adjacent/12`
measured in the same pass of the same binary, the reference side reads 152.5
sweep-equivalents in both runs, to four significant figures, for identical code.
The new side reads 84.85 and 87.05. That is -44.4% and -42.9% against a -43.5%
prediction from pass counting alone: at 12 qubits 138 buffer passes become 78,
and at 10 qubits 114 become 66. The residual above the predicted pass count is
the fresh `4^n` allocation and first touch inside `b.iter`.

Two results here are not wins and are reported as they read. `fused_layers/12` is
a measured null: at 12 circuit qubits the old floors already admitted one-qubit,
two-qubit and tiled fusion, and the passes this change newly unlocks find nothing
to batch in `random_circuit`. `fused_layers/8` moves furthest of anything in the
table because it fused nothing at all before, but its reference control reads
-16.6% and -37.8%, so it is directional rather than gate-precise. The 10-qubit
rows sit in the low-millisecond band this host is bimodal on, which shows in
their own denominators: `kraus_2q_adjacent/10` read 1.46 ms in one run and
1.07 ms in the other.

A third run was discarded outright rather than reported. Its two
fusion-bypassing rows read +406% and +478% at same-code control spreads up to
87.5%, which is a disturbed host and not a regression.

Regression verdict: PASS

## Correctness

- [x] `cargo nextest run --features parallel` passes locally
- [x] The distributed suite passes at `--features "parallel distributed"`
- [x] `cargo test --doc --features parallel` passes
- [x] `cargo clippy --all-targets --features "parallel gpu distributed" -- -D warnings -D clippy::undocumented_unsafe_blocks` passes
- [x] `cargo check --all-targets --features "parallel gpu distributed"` passes
- [x] `cargo fmt --check` passes
- [x] Docstrings on new and changed `pub` items add information the name and
      signature do not carry

A diagonal sandwich multiplies the entry at `(r, r)` by `f(r) * conj(f(r))`,
which is 1, so every diagonal entry of rho is untouched however wrong the arm is,
and a `probabilities()` comparison passes on a broken implementation. The three
equivalence tests read the Z, X and Y bases for that reason, and each was
confirmed to fail against a deliberately broken arm before being kept. One of
them was rewritten after that check: its first preparation reduced to a
computational basis state, where a diagonal gate is a global phase that no
readout in any basis can see.

`tests/determinism.rs` asserted only bitwise agreement across thread counts,
which unfused kernels satisfy as well as fused ones, so a floor moving out of
reach would have drained its kernel coverage while every test stayed green. It
now pins the fused forms its circuit produces, at 18 qubits natively and 10 under
miri, where the reduced floors put the same forms in reach.

`tests/bench_fixture_routing.rs` pins the new bench row to the backend it names.
It is the one density-matrix row that runs through `simulate`, so it is the one
an interaction graph that splits could reroute to the decomposed engine.

## Hotspot notes

`DensityMatrixBackend::apply_unitary` is the dispatch point. The new
`apply_diagonal_sandwich` replaces a four-pass route: the batch variants have no
`conjugate_gate` form, so the generic path paid two register passes plus two
whole-buffer conjugations around the bra half.

The phase table is built by evaluating `diag_entries_phase` over `2^n` indices,
which is the square root of the buffer it saves three passes on, 64 KB against
256 MB at 12 qubits. It has no failure mode, where the statevector kernel's own
group tables have two, more than four groups and a two-qubit entry spanning a
group boundary, so the arm needs no fallback and the diagonal batch arms in
`ket_register_gate` are deleted rather than kept as one.

The reordering hazard that made the tiled payloads unsound on the ket register
was checked rather than assumed, and does not reach this arm: the entries are all
diagonal and commute, so no order exists to break; nothing is index-shifted, the
ket bits being read in place; and no tier-partitioned kernel runs, the sweep
being flat over the buffer.

## Architecture or design changes

None structural. `Backend::fusion_state_qubits` is a new trait method with a
default that preserves current behavior for every backend but this one.

## Breaking changes

None to the public API. `fuse_circuit` keeps its signature and its meaning, and
`fuse_circuit_for_width` is added beside it.

Behavioral difference a caller may notice: a density-matrix run through
`simulate` now fuses at widths where it previously did not, from 5 circuit qubits
rather than 10. Results are unchanged, pinned by the equivalence tests above.

Two call sites are deliberately left on the circuit width.
`BackendPlan::supports_fused` reports false for this backend, so the two
shot-path sites it gates fuse nothing here whatever width they receive. That
contradicts `DensityMatrixBackend::supports_fused_gates`, which reports true, so
the same circuit fuses through one terminal and not the other. It is a
pre-existing inconsistency, it is not this change, and moving it would alter
shot-path behavior with no bench row covering those sites.

## Risks and rollback

The blast radius is one backend. `fusion_state_qubits` defaults to the circuit
width, so every other backend takes the identical pass sequence it took before,
and reverting the density matrix override alone restores the old behavior without
touching the sandwich arm. The arm itself is reachable only through the three
batch variants, which nothing but fusion produces.
