### PR TITLE
feat(gpu): density matrix held in device memory

### DIFF
--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -1,4 +1,4 @@
-//! GPU benchmarks for the statevector and stabilizer GPU paths.
+//! GPU benchmarks for the statevector, stabilizer, and density-matrix GPU paths.
 //!
 //! Measures the end-to-end dispatch path (fusion plus independent-subsystem
 //! decomposition plus crossover plus kernel execution) against the same set
@@ -25,6 +25,7 @@ use std::time::{Duration, Instant};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use num_complex::Complex64;
 use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
 use prism_q::circuit::{Circuit, Instruction};
 use prism_q::circuits;
 use prism_q::gates::Gate;
@@ -826,6 +827,130 @@ fn bench_stab_gpu_shots_explicit(c: &mut Criterion) {
     }
 }
 
+// ---- Density matrix on the device ----
+//
+// `gpu_dm/noisy_channels` mirrors the CPU `density_matrix/noisy_channels` rows
+// at the same widths plus 13, the ceiling this card holds. Each row builds one
+// resident backend and times one kernel per iteration, synchronized so the
+// launch queue does not hide the sweep.
+
+fn dm_sweep_sizes() -> &'static [usize] {
+    if is_fast() { &[10] } else { &[10, 12, 13] }
+}
+
+fn dm_device_backend(ctx: &Arc<GpuContext>, n: usize) -> DensityMatrixBackend {
+    let circuit = circuits::random_circuit(n, 2, SEED);
+    let mut backend = DensityMatrixBackend::new(42).with_gpu(ctx.clone());
+    backend.init(n, 1).unwrap();
+    backend.apply_instructions(&circuit.instructions).unwrap();
+    ctx.synchronize().unwrap();
+    backend
+}
+
+/// Correlated `ZZ` dephasing, which compiles to a diagonal superoperator.
+fn correlated_zz_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = Complex64::new(0.0, 0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = Complex64::new(scale * sign, 0.0);
+        }
+        m
+    };
+    vec![
+        diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+        diag(p.sqrt(), [1.0, -1.0, -1.0, 1.0]),
+    ]
+}
+
+/// `{sqrt(1-p) I, sqrt(p) X(x)Z}`, which fills the 16x16 superoperator.
+fn h_conjugated_zz_kraus(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = Complex64::new(0.0, 0.0);
+    let mut k0 = [[zero; 4]; 4];
+    let mut k1 = [[zero; 4]; 4];
+    for t in 0..4 {
+        k0[t][t] = Complex64::new((1.0 - p).sqrt(), 0.0);
+        let sign = if t & 1 == 0 { 1.0 } else { -1.0 };
+        k1[t][t ^ 2] = Complex64::new(p.sqrt() * sign, 0.0);
+    }
+    vec![k0, k1]
+}
+
+fn bench_gpu_dm_noisy_channels(c: &mut Criterion) {
+    let Some(ctx) = shared_ctx() else { return };
+    let mut group = c.benchmark_group("gpu_dm/noisy_channels");
+    configure_group(&mut group);
+
+    for &n in dm_sweep_sizes() {
+        let amp_damp = amplitude_damping_kraus(0.05);
+        group.bench_with_input(BenchmarkId::new("kraus_amp_damp", n), &n, |b, &n| {
+            let mut backend = dm_device_backend(&ctx, n);
+            b.iter(|| {
+                backend.apply_1q_kraus(0, &amp_damp);
+                ctx.synchronize().unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("depolarizing_2q", n), &n, |b, &n| {
+            let mut backend = dm_device_backend(&ctx, n);
+            b.iter(|| {
+                backend.apply_2q_depolarizing(0, n - 1, 0.02);
+                ctx.synchronize().unwrap();
+            });
+        });
+
+        let zz = correlated_zz_kraus(0.02);
+        group.bench_with_input(BenchmarkId::new("kraus_2q_adjacent", n), &n, |b, &n| {
+            let mut backend = dm_device_backend(&ctx, n);
+            b.iter(|| {
+                backend.apply_2q_kraus(2, 3, &zz);
+                ctx.synchronize().unwrap();
+            });
+        });
+
+        let hzz = h_conjugated_zz_kraus(0.02);
+        group.bench_with_input(BenchmarkId::new("kraus_2q_dense", n), &n, |b, &n| {
+            let mut backend = dm_device_backend(&ctx, n);
+            b.iter(|| {
+                backend.apply_2q_kraus(2, 3, &hzz);
+                ctx.synchronize().unwrap();
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("kraus_2q_dense_q0", n), &n, |b, &n| {
+            let mut backend = dm_device_backend(&ctx, n);
+            b.iter(|| {
+                backend.apply_2q_kraus(0, n - 1, &hzz);
+                ctx.synchronize().unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// The device sibling of `density_matrix/rzz_layers_fused`: a layer's
+/// commuting `Rzz` gates reach the backend as one `BatchRzz`, and the diagonal
+/// sandwich runs as one kernel over the `4^n` buffer.
+fn bench_gpu_dm_rzz_layers_fused(c: &mut Criterion) {
+    let Some(ctx) = shared_ctx() else { return };
+    let mut group = c.benchmark_group("gpu_dm/rzz_layers_fused");
+    configure_group(&mut group);
+    let kind = BackendKind::DensityMatrixGpu {
+        context: ctx.clone(),
+    };
+
+    for &n in &[10usize, 12] {
+        let circuit = circuits::qaoa_circuit(n, 6, SEED);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(run_with(kind.clone(), circ, SEED).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = common::criterion_config();
@@ -848,6 +973,8 @@ criterion_group! {
     bench_stab_bts_packed_cpu_vs_gpu,
     bench_stab_bts_marginals_cpu_vs_gpu,
     bench_stab_bts_device_counts_explicit,
-    bench_stab_gpu_shots_explicit
+    bench_stab_gpu_shots_explicit,
+    bench_gpu_dm_noisy_channels,
+    bench_gpu_dm_rzz_layers_fused
 }
 criterion_main!(benches);

--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -31,7 +31,8 @@ use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::gpu::GpuContext;
 use prism_q::{
-    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, StabilizerBackend, StatevectorBackend, sim,
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, Parameters, PauliTerm, StabilizerBackend,
+    StatevectorBackend, sim,
 };
 
 mod common;
@@ -951,6 +952,42 @@ fn bench_gpu_dm_rzz_layers_fused(c: &mut Criterion) {
     group.finish();
 }
 
+/// The device sibling of `gradient/density_matrix`: five exact evolutions of
+/// the mixture per iteration, each resident on the card.
+fn bench_gpu_dm_gradient(c: &mut Criterion) {
+    let Some(ctx) = shared_ctx() else { return };
+    let mut group = c.benchmark_group("gpu_dm/gradient");
+    configure_group(&mut group);
+    let kind = BackendKind::DensityMatrixGpu {
+        context: ctx.clone(),
+    };
+
+    for &n in &[10usize, 12] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 1, SEED);
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let mut params = Parameters::new(2);
+        params.link(0, 0);
+        params.link(1, 1);
+        let ham: Vec<(f64, Vec<PauliTerm>)> = (0..n - 1)
+            .map(|q| (1.0, vec![PauliTerm::z(q), PauliTerm::z(q + 1)]))
+            .collect();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(kind.clone())
+                        .noise(&noise)
+                        .seed(SEED)
+                        .expectation_gradient_shift(&ham, &params)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = common::criterion_config();
@@ -975,6 +1012,7 @@ criterion_group! {
     bench_stab_bts_device_counts_explicit,
     bench_stab_gpu_shots_explicit,
     bench_gpu_dm_noisy_channels,
-    bench_gpu_dm_rzz_layers_fused
+    bench_gpu_dm_rzz_layers_fused,
+    bench_gpu_dm_gradient
 }
 criterion_main!(benches);

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1694,6 +1694,36 @@ fn bench_gradient(c: &mut Criterion) {
     group.finish();
 }
 
+/// Parameter shift under a noise model: every evaluation evolves the exact
+/// mixture, so two linked slots cost five density-matrix evolutions.
+fn bench_gradient_density_matrix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gradient/density_matrix");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 1, SEED);
+        let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let mut params = Parameters::new(2);
+        params.link(0, 0);
+        params.link(1, 1);
+        let ham = z_chain_hamiltonian(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(BackendKind::DensityMatrix)
+                        .noise(&noise)
+                        .seed(SEED)
+                        .expectation_gradient_shift(&ham, &params)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_gradient_qaoa(c: &mut Criterion) {
     let mut group = c.benchmark_group("gradient/qaoa_l1");
     configure_group(&mut group);
@@ -2997,6 +3027,45 @@ fn bench_density_matrix_noisy_shots(c: &mut Criterion) {
     group.finish();
 }
 
+/// The per-shot density-matrix route: a mid-circuit measurement feeding a
+/// conditional keeps the shot loop off the terminal-probabilities shortcut,
+/// so every shot replays the circuit the shot path fused (or did not).
+fn bench_density_matrix_shots_fused(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/shots_fused");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let mut circuit = circuits::random_circuit(n, 4, SEED);
+        circuit.num_classical_bits = n;
+        let middle = circuit.instructions.len() / 2;
+        circuit.instructions.insert(
+            middle,
+            Instruction::Conditional {
+                condition: ClassicalCondition::BitIsOne(0),
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[1]),
+            },
+        );
+        circuit.instructions.insert(
+            middle,
+            Instruction::Measure {
+                qubit: 0,
+                classical_bit: 0,
+            },
+        );
+        for q in 0..n {
+            circuit.add_measure(q, q);
+        }
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(run_shots_with(BackendKind::DensityMatrix, circ, 2, SEED).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
 /// Clifford layers over `n` qubits, emitted either as bare instructions or as
 /// one guarded region per layer.
 ///
@@ -3244,6 +3313,7 @@ criterion_group! {
     // Adjoint gradient (adjoint vs finite-difference per parameter)
     bench_gradient,
     bench_gradient_qaoa,
+    bench_gradient_density_matrix,
     bench_gradient_prefix,
     // Variational loop iteration (rebuild vs rebind under simulation cost)
     bench_vqe_loop,
@@ -3286,6 +3356,7 @@ criterion_group! {
     bench_density_matrix_exact_vs_trajectory,
     bench_density_matrix_noisy_channels,
     bench_density_matrix_noisy_shots,
+    bench_density_matrix_shots_fused,
     bench_density_matrix_neutrality,
     // Dynamic circuits (guard cost, dead-region predicate, per-shot cliff)
     bench_dynamic_guarded_region,

--- a/bindings/python/src/backend.rs
+++ b/bindings/python/src/backend.rs
@@ -132,6 +132,24 @@ impl PyBackendKind {
         }
     }
 
+    /// Exact mixed state held on the supplied device. Explicit only, with no
+    /// host fallback: the `4^n` buffer is budgeted against free device memory
+    /// before allocation and a width that does not fit raises `PrismError`.
+    #[staticmethod]
+    fn density_matrix_gpu(context: &PyGpuContext) -> PyPrismResult<Self> {
+        #[cfg(feature = "gpu")]
+        {
+            Ok(Self(BackendKind::DensityMatrixGpu {
+                context: context.inner.clone(),
+            }))
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            let _ = context;
+            Err(crate::gpu::unsupported())
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!("BackendKind({:?})", self.0)
     }

--- a/bindings/python/tests/test_gpu.py
+++ b/bindings/python/tests/test_gpu.py
@@ -17,7 +17,15 @@ import os
 import numpy as np
 import pytest
 
-from prism_q import BackendKind, CircuitBuilder, GpuContext, PrismError, circuits, simulate
+from prism_q import (
+    BackendKind,
+    CircuitBuilder,
+    GpuContext,
+    NoiseModel,
+    PrismError,
+    circuits,
+    simulate,
+)
 
 SUPPORTED = GpuContext.is_supported()
 AVAILABLE = GpuContext.is_available()
@@ -40,7 +48,7 @@ def test_prism_require_gpu_is_honoured():
 
 
 def test_gpu_surface_exists_in_every_build():
-    for name in ("statevector_gpu", "stabilizer_gpu", "auto_gpu"):
+    for name in ("statevector_gpu", "stabilizer_gpu", "density_matrix_gpu", "auto_gpu"):
         assert hasattr(BackendKind, name)
 
 
@@ -74,6 +82,22 @@ def test_gpu_statevector_below_the_crossover_matches_host():
     device = simulate(circuit).backend(BackendKind.statevector_gpu(context)).seed(42).run()
     host = simulate(circuit).backend(BackendKind.statevector()).seed(42).run()
     np.testing.assert_allclose(device.probabilities, host.probabilities, atol=1e-12)
+
+
+@requires_device
+def test_gpu_density_matrix_matches_host_mixture():
+    circuit = _entangled_chain(6)
+    model = NoiseModel.uniform_depolarizing(circuit, 0.05)
+    context = GpuContext(0)
+    device = simulate(circuit).backend(BackendKind.density_matrix_gpu(context)).noise(model).seed(42)
+    host = simulate(circuit).backend(BackendKind.density_matrix()).noise(model).seed(42)
+    np.testing.assert_allclose(device.run().probabilities, host.run().probabilities, atol=1e-12)
+    observables = [[(0, "Z")], [(1, "X"), (2, "Z")]]
+    np.testing.assert_allclose(
+        device.expectation_values(observables),
+        host.expectation_values(observables),
+        atol=1e-12,
+    )
 
 
 @requires_device

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -172,8 +172,14 @@ diagonal, so the ket and bra phases cancel wherever the two registers agree on t
 pair's parity, and the sandwich collapses to a single pass over a combined table.
 
 Memory is `16 * 4^n` bytes, so the ceiling is about 14 qubits on a 16 GiB host and 15 on
-32 GiB (`PRISM_MAX_DM_QUBITS` moves it within the statevector budget). This backend is
-CPU-only and explicit-dispatch only; `Auto` never selects it.
+32 GiB (`PRISM_MAX_DM_QUBITS` moves it within the statevector budget). With a device
+attached (`BackendKind::DensityMatrixGpu`, or `with_gpu` on the backend) the buffer
+lives in VRAM, budgeted against free memory at `init`: an 11 GiB card holds 13 qubits,
+so the device lifts the ceiling by about one qubit and is a throughput arm rather than
+a width arm. On the device the unitary half still runs the dense statevector kernels
+over the embedded buffer, while the channels, projection, reset, and the diagonal and
+Pauli readouts have kernels of their own. Both kinds are explicit-dispatch only;
+`Auto` and `AutoGpu` never select them, and the device kind has no host fallback.
 
 Selecting it with a noise model attached is the exact route for every `Simulate`
 terminal except the two gradient terminals: the mixture is evolved once and observables,

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -182,12 +182,12 @@ Pauli readouts have kernels of their own. Both kinds are explicit-dispatch only;
 `Auto` and `AutoGpu` never select them, and the device kind has no host fallback.
 
 Selecting it with a noise model attached is the exact route for every `Simulate`
-terminal except the two gradient terminals: the mixture is evolved once and observables,
-marginals, probabilities, and shots all read that one evolution. Gradients are excluded
-for two different reasons: the adjoint backpropagates against a pure state and a channel
-has no reverse evolution to walk, while parameter shift is exact on a mixture and simply
-not wired. See [Noise across the terminals](./engine.md) for
-what that route accepts and what stays on trajectory averaging.
+terminal except the adjoint gradient: the mixture is evolved once and observables,
+marginals, probabilities, and shots all read that one evolution, and the parameter-shift
+gradient evaluates the mixture once per shifted angle. The adjoint stays excluded because
+it backpropagates against a pure state and a channel has no reverse evolution to walk.
+See [Noise across the terminals](./engine.md) for what that route accepts and what stays
+on trajectory averaging.
 
 ## What a backend reports about its own result
 

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -86,9 +86,10 @@ same property that makes the density matrix the mixture oracle rather than a com
 participant in the branching families of `tests/conformance_matrix.rs`.
 
 `expectation_gradient` rejects a noise model on every backend, because the adjoint method
-backpropagates through a pure state. `expectation_gradient_shift` rejects one too, though
-the obstacle there is only that the path is not wired: the shift rule holds under a
-parameter-independent channel, so the density matrix could serve it.
+backpropagates through a pure state. `expectation_gradient_shift` accepts one on the
+density-matrix kinds: the channels do not depend on the shifted angle, so the shift rule
+holds and each of the `1 + 2 * links` evaluations reads the exact mixture. Every other
+backend rejects the pair, naming the density matrix.
 
 ## Result provenance
 

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -10,8 +10,8 @@ cargo build --release --features "parallel gpu"
 cargo test --features "parallel gpu" --test golden_gpu
 ```
 
-CUDA acceleration covers statevector execution, stabilizer execution, and compiled
-BTS sampling. Six entry points are available:
+CUDA acceleration covers statevector execution, stabilizer execution, density-matrix
+execution, and compiled BTS sampling. Seven entry points are available:
 
 - **`BackendKind::AutoGpu { context }`** (`simulate(circuit).gpu_auto(ctx)`).
   Automatic backend selection with the device opted in. The shape-based decision
@@ -35,6 +35,15 @@ BTS sampling. Six entry points are available:
   diagnostic readbacks from `probabilities()`, `export_tableau()`, and
   `export_statevector()`. Golden tests cover every kernel path, including 500q GHZ
   measure-all.
+- **`BackendKind::DensityMatrixGpu { context }`**. The exact mixture held in device
+  memory. Explicit only: neither `Auto` nor `AutoGpu` selects it, there is no
+  crossover, and there is no host fallback. `init` budgets the `4^n` buffer against
+  the free VRAM and errors before allocating when it does not fit, so an 11 GiB card
+  holds 13 qubits (1 GiB at 13, 4 GiB at 14 plus scratch). The unitary half reuses the
+  dense statevector kernels on the embedded `2n`-qubit buffer, and every channel,
+  measurement, and readout sweep runs as a kernel of its own. The noisy `Simulate`
+  terminals answer from the device mixture exactly as `DensityMatrix` does.
+  `DensityMatrixBackend::new(seed).with_gpu(ctx)` is the direct form.
 - **`StatevectorBackend::new(seed).with_gpu(ctx)`**. Direct statevector GPU opt-in.
   Every instruction routes to CUDA after the context is attached. No crossover or
   subsystem decomposition applies.

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -68,7 +68,7 @@ currently free VRAM is rejected at `init` with an error naming the requested and
 device memory; `GpuContext::max_qubits_for_statevector` reports the advisory cap from
 free memory.
 
-The three `BackendKind` entry points are also reachable from Python, from a build
+The four `BackendKind` entry points are also reachable from Python, from a build
 carrying the `gpu` feature. See [Python Bindings](python.md#gpu-backends).
 
 ## Module layout (`src/gpu/`)

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -251,7 +251,7 @@ Pass an explicit one to override it.
 | `density_matrix()` | Exact mixed states, never chosen by `auto()` |
 | `stochastic_pauli(num_samples=1000)` | Sampled Pauli propagation |
 | `deterministic_pauli(epsilon=0.0, max_terms=65536)` | Truncated Pauli propagation |
-| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
+| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)`, `density_matrix_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
 
 The density-matrix backend stores `4^n` amplitudes, so its qubit ceiling is
 about half the statevector cap; exceeding it raises `PrismError` naming the cap.
@@ -285,6 +285,12 @@ therefore normal, not a failure signal.
 (`PRISM_STABILIZER_GPU_MIN_QUBITS`), so it runs on the host tableau unless that
 override is lowered. The device tableau is correct; the default stays high until
 benchmarks justify lowering it.
+
+`density_matrix_gpu(context)` holds the exact mixed state on the device and is the
+one device kind with no crossover and no host fallback: `auto_gpu` never selects it,
+every noisy terminal that `density_matrix()` serves answers from the device buffer,
+and a width whose `4^n` buffer does not fit in free device memory raises `PrismError`
+before anything is allocated (13 qubits on an 11 GiB card).
 
 The published wheels are built without CUDA, because two of the three wheel
 targets have no CUDA toolkit and macOS has no CUDA at all. In those wheels the

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -54,10 +54,9 @@
 //! - Noisy circuits with mid-circuit measurement or classical conditioning.
 //!   The mixture holds every branch at once, so per-shot feedback cannot be
 //!   replayed from it and the noisy terminals reject those shapes.
-//! - Gradients under noise. Both gradient terminals decline a noise model, for
-//!   different reasons: the adjoint backpropagates against a pure state and a
-//!   channel has no reverse evolution to walk, while parameter shift is exact
-//!   on a mixture and simply not wired.
+//! - Adjoint gradients under noise. The adjoint backpropagates against a pure
+//!   state and a channel has no reverse evolution to walk; the parameter-shift
+//!   terminal serves the noisy gradient from the mixture instead.
 
 use std::borrow::Cow;
 #[cfg(feature = "gpu")]

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -12,8 +12,11 @@
 //! # Memory layout
 //!
 //! Memory is `16 * 4^n` bytes (`4^n` `Complex64` entries), so the practical
-//! ceiling is about 14 qubits on a 16 GiB host and 15 on a 32 GiB host. CPU only.
-//! This backend is explicit-dispatch only and is never chosen by `Auto`.
+//! ceiling is about 14 qubits on a 16 GiB host and 15 on a 32 GiB host. With a
+//! device attached through [`DensityMatrixBackend::with_gpu`] the buffer lives in
+//! VRAM instead, where an 11 GiB card holds 13 qubits (1 GiB at 13, 4 GiB at 14
+//! plus scratch), and every sweep runs as a kernel over the embedded buffer. This
+//! backend is explicit-dispatch only and is never chosen by `Auto`.
 //!
 //! # Gate support
 //!
@@ -57,6 +60,8 @@
 //!   on a mixture and simply not wired.
 
 use std::borrow::Cow;
+#[cfg(feature = "gpu")]
+use std::sync::Arc;
 
 use num_complex::Complex64;
 use rand::{RngExt, SeedableRng};
@@ -69,6 +74,8 @@ use crate::backend::{Backend, NORM_CLAMP_MIN};
 use crate::circuit::{ClassicalCondition, Instruction};
 use crate::error::Result;
 use crate::gates::{DiagEntry, Gate, McuData, diag_entries_phase, mat_mul_4x4};
+#[cfg(feature = "gpu")]
+use crate::gpu::{GpuContext, GpuState, kernels::density as dk};
 use crate::sim::i_pow;
 use crate::sim::unified_pauli::PauliTerm;
 
@@ -281,12 +288,48 @@ fn ket_register_gate(gate: &Gate, n: usize) -> Cow<'_, Gate> {
     }
 }
 
+/// Reject a mixture the device cannot hold before anything is allocated: the
+/// `4^n` buffer at 16 bytes per entry plus the `2^n` diagonal scratch. A
+/// context that cannot report free memory falls through to the allocation,
+/// whose own error stays authoritative.
+#[cfg(feature = "gpu")]
+fn check_device_budget(context: &GpuContext, num_qubits: usize) -> Result<()> {
+    if 2 * num_qubits >= usize::BITS as usize - 4 {
+        return Ok(());
+    }
+    let Ok(free) = context.vram_available() else {
+        return Ok(());
+    };
+    let needed = (1usize << (2 * num_qubits)) * 16 + (1usize << num_qubits) * 8;
+    if needed > free {
+        return Err(crate::error::PrismError::IncompatibleBackend {
+            backend: "density_matrix-gpu".to_string(),
+            reason: format!(
+                "circuit has {num_qubits} qubits needing {} MiB of device memory for the \
+                 4^n mixture, exceeding the {} MiB free on the GPU",
+                needed >> 20,
+                free >> 20
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// The channel entry points are infallible by signature, so a device launch
+/// that fails under one has nowhere to report and stops the run instead.
+#[cfg(feature = "gpu")]
+fn launched<T>(result: Result<T>) -> T {
+    result.unwrap_or_else(|e| panic!("density-matrix device kernel failed: {e}"))
+}
+
 /// Exact density-matrix simulator. See the module docs for the state layout.
 pub struct DensityMatrixBackend {
     num_qubits: usize,
     classical_bits: Vec<bool>,
     rng: ChaCha8Rng,
     sv: StatevectorBackend,
+    #[cfg(feature = "gpu")]
+    gpu_context: Option<Arc<GpuContext>>,
 }
 
 impl DensityMatrixBackend {
@@ -297,11 +340,45 @@ impl DensityMatrixBackend {
             classical_bits: Vec::new(),
             rng: ChaCha8Rng::seed_from_u64(seed),
             sv: StatevectorBackend::new(seed),
+            #[cfg(feature = "gpu")]
+            gpu_context: None,
         }
+    }
+
+    /// Hold the mixture on the device bound to `context`.
+    ///
+    /// [`Backend::init`] then allocates the `4^n` buffer in device memory after a
+    /// budget check against the free VRAM, and every sweep runs as a kernel. A
+    /// device that cannot hold the state is an error at `init`, never a host
+    /// fallback. The channel entry points keep their infallible signatures, so
+    /// a kernel launch that fails under one of them panics.
+    #[cfg(feature = "gpu")]
+    pub fn with_gpu(mut self, context: Arc<GpuContext>) -> Self {
+        self.gpu_context = Some(context.clone());
+        self.sv = self.sv.with_gpu(context);
+        self
+    }
+
+    /// The device state with its context, when the mixture is resident there.
+    #[cfg(feature = "gpu")]
+    fn device(&mut self) -> Option<(Arc<GpuContext>, &mut GpuState)> {
+        let gpu = self.sv.gpu_state_mut()?;
+        let ctx = gpu.context().clone();
+        Some((ctx, gpu))
+    }
+
+    /// The full `4^n` buffer, row-major as the module docs lay it out. Reads
+    /// back from the device when the mixture is resident there.
+    pub fn density_matrix(&self) -> Result<Vec<Complex64>> {
+        self.sv.export_statevector()
     }
 
     /// Purity `Tr(rho^2)`, equal to `1` for a pure state and less otherwise.
     pub fn purity(&self) -> f64 {
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.sv.gpu_state() {
+            return launched(dk::norm_sqr(gpu.context(), gpu, self.num_qubits));
+        }
         crate::backend::state_norm_sqr(&self.sv.state)
     }
 
@@ -310,7 +387,14 @@ impl DensityMatrixBackend {
         1usize << self.num_qubits
     }
 
-    fn conjugate_buffer(&mut self) {
+    fn conjugate_buffer(&mut self) -> Result<()> {
+        #[cfg(feature = "gpu")]
+        {
+            let n = self.num_qubits;
+            if let Some((ctx, gpu)) = self.device() {
+                return dk::conjugate(&ctx, gpu, n);
+            }
+        }
         #[cfg(feature = "parallel")]
         {
             use rayon::prelude::*;
@@ -319,12 +403,23 @@ impl DensityMatrixBackend {
                     .state
                     .par_iter_mut()
                     .for_each(|amp| *amp = amp.conj());
-                return;
+                return Ok(());
             }
         }
         for amp in self.sv.state.iter_mut() {
             *amp = amp.conj();
         }
+        Ok(())
+    }
+
+    /// A two-qubit matrix on the embedded buffer, on whichever side holds it.
+    fn fused_2q(&mut self, q0: usize, q1: usize, mat: &[[Complex64; 4]; 4]) -> Result<()> {
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return crate::gpu::kernels::dense::launch_apply_fused_2q(&ctx, gpu, q0, q1, mat);
+        }
+        self.sv.apply_fused_2q(q0, q1, mat);
+        Ok(())
     }
 
     /// Apply a compiled one-qubit block superoperator in a single buffer pass.
@@ -334,9 +429,9 @@ impl DensityMatrixBackend {
     /// statevector two-qubit kernel applies `S` directly. That kernel indexes
     /// its matrix as `2 * bit(q0) + bit(q1)`, matching the block index `2a + b`
     /// once the row bit is passed as `q0`.
-    fn apply_block_superoperator(&mut self, qubit: usize, s: &[[Complex64; 4]; 4]) {
+    fn apply_block_superoperator(&mut self, qubit: usize, s: &[[Complex64; 4]; 4]) -> Result<()> {
         let n = self.num_qubits;
-        self.sv.apply_fused_2q(qubit + n, qubit, s);
+        self.fused_2q(qubit + n, qubit, s)
     }
 
     /// Evolve `rho -> U rho U^dagger` for the unitary `gate` on `targets`.
@@ -381,14 +476,13 @@ impl DensityMatrixBackend {
                 return Ok(());
             }
             Gate::Rzz(theta) => {
-                self.apply_rzz_sandwich(targets[0], targets[1], *theta);
-                return Ok(());
+                return self.apply_rzz_sandwich(targets[0], targets[1], *theta);
             }
             Gate::Multi2q(data) => {
                 for &(q0, q1, ref mat) in data.gates.iter() {
-                    self.sv.apply_fused_2q(q0 + n, q1 + n, mat);
+                    self.fused_2q(q0 + n, q1 + n, mat)?;
                 }
-                if kernels::multi_2q_single_tier(&data.gates) {
+                if !self.sv.is_gpu_resident() && kernels::multi_2q_single_tier(&data.gates) {
                     let conjugated: Vec<(usize, usize, [[Complex64; 4]; 4])> = data
                         .gates
                         .iter()
@@ -397,7 +491,7 @@ impl DensityMatrixBackend {
                     self.sv.apply_multi_2q(&conjugated);
                 } else {
                     for &(q0, q1, ref mat) in data.gates.iter() {
-                        self.sv.apply_fused_2q(q0, q1, &conjugate_4x4(mat));
+                        self.fused_2q(q0, q1, &conjugate_4x4(mat))?;
                     }
                 }
                 return Ok(());
@@ -406,8 +500,7 @@ impl DensityMatrixBackend {
         }
 
         if let Some(entries) = diagonal_batch_entries(gate, targets) {
-            self.apply_diagonal_sandwich(&entries);
-            return Ok(());
+            return self.apply_diagonal_sandwich(&entries);
         }
 
         let ket_targets: SmallVec<[usize; 4]> = targets.iter().map(|&t| t + n).collect();
@@ -424,26 +517,24 @@ impl DensityMatrixBackend {
             });
         }
 
-        self.conjugate_buffer();
+        self.conjugate_buffer()?;
         self.sv.apply(&Instruction::Gate {
             gate: gate.clone(),
             targets: bra_targets,
         })?;
-        self.conjugate_buffer();
-        Ok(())
+        self.conjugate_buffer()
     }
 
     /// Evolve `rho -> U rho U^dagger` for a one-qubit `U`.
     ///
-    /// Above the parallel threshold the two products compile to one block
-    /// superoperator and sweep the buffer once; below it the superoperator's
-    /// dense 4x4 block loses to two cheap register passes.
+    /// Above the parallel threshold, and always on the device, the two products
+    /// compile to one block superoperator and sweep the buffer once; below it
+    /// the superoperator's dense 4x4 block loses to two cheap register passes.
     fn apply_1q_sandwich(&mut self, qubit: usize, matrix: &[[Complex64; 2]; 2]) -> Result<()> {
         let n = self.num_qubits;
-        if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
+        if self.sv.is_gpu_resident() || 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
             let s = block_superoperator(&[*matrix]);
-            self.apply_block_superoperator(qubit, &s);
-            return Ok(());
+            return self.apply_block_superoperator(qubit, &s);
         }
         self.sv.apply_1q_matrix(qubit + n, matrix)?;
         self.sv.apply_1q_matrix(qubit, &conjugate_2x2(matrix))
@@ -460,7 +551,7 @@ impl DensityMatrixBackend {
     /// generic route's two register passes therefore collapse onto the single
     /// contiguous pass [`DensityMatrixBackend::kraus_2q_diagonal_sweep`]
     /// already runs for a diagonal channel.
-    fn apply_rzz_sandwich(&mut self, q0: usize, q1: usize, theta: f64) {
+    fn apply_rzz_sandwich(&mut self, q0: usize, q1: usize, theta: f64) -> Result<()> {
         let phase = [
             Complex64::from_polar(1.0, -theta / 2.0),
             Complex64::from_polar(1.0, theta / 2.0),
@@ -473,7 +564,7 @@ impl DensityMatrixBackend {
                 diag[4 * tr + tc] = phase[pr] * phase[pc].conj();
             }
         }
-        self.kraus_2q_diagonal_sweep(&diag, q0, q1);
+        self.kraus_2q_diagonal_sweep(&diag, q0, q1)
     }
 
     /// Evolve `rho -> D rho D^dagger` for a diagonal batch `D` in one buffer
@@ -490,10 +581,16 @@ impl DensityMatrixBackend {
     ///
     /// Entry order does not matter, all of them being diagonal, so the tier
     /// reordering the tiled payloads have to avoid cannot arise here.
-    fn apply_diagonal_sandwich(&mut self, entries: &[DiagEntry]) {
+    fn apply_diagonal_sandwich(&mut self, entries: &[DiagEntry]) -> Result<()> {
         let n = self.num_qubits;
         let d = self.dim();
         let ket: Vec<Complex64> = (0..d).map(|r| diag_entries_phase(r, entries)).collect();
+
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return dk::diagonal_sandwich(&ctx, gpu, n, &ket);
+        }
+
         let bra: Vec<Complex64> = ket.iter().map(|f| f.conj()).collect();
 
         #[cfg(feature = "parallel")]
@@ -509,39 +606,51 @@ impl DensityMatrixBackend {
                 .for_each(|(idx, amp)| {
                     *amp *= ket[idx >> n] * bra[idx & (d - 1)];
                 });
-            return;
+            return Ok(());
         }
 
         for (idx, amp) in self.sv.state.iter_mut().enumerate() {
             *amp *= ket[idx >> n] * bra[idx & (d - 1)];
         }
+        Ok(())
     }
 
     /// `P(qubit = |1>) = Tr(P_1 rho)`, the sum of the diagonal `rho` entries
     /// whose row index has `qubit` set.
-    fn prob_one(&self, qubit: usize) -> f64 {
+    fn prob_one(&self, qubit: usize) -> Result<f64> {
         let d = self.dim();
         let bit = 1usize << qubit;
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.sv.gpu_state() {
+            let diag = dk::diagonal(gpu.context(), gpu, self.num_qubits)?;
+            let p1: f64 = diag
+                .iter()
+                .enumerate()
+                .filter(|(r, _)| r & bit != 0)
+                .map(|(_, p)| p)
+                .sum();
+            return Ok(p1.clamp(0.0, 1.0));
+        }
         let mut p1 = 0.0;
         for r in 0..d {
             if r & bit != 0 {
                 p1 += self.sv.state[r * d + r].re;
             }
         }
-        p1.clamp(0.0, 1.0)
+        Ok(p1.clamp(0.0, 1.0))
     }
 
     /// Sample and project qubit `qubit`, recording the outcome in
     /// `classical_bit`. Collapses `rho -> P_m rho P_m / p_m`, which in the
     /// embedded layout zeroes every entry whose row or column disagrees with
     /// the outcome on `qubit` and rescales the survivors to unit trace.
-    fn apply_measure(&mut self, qubit: usize, classical_bit: usize) {
-        let p1 = self.prob_one(qubit);
+    fn apply_measure(&mut self, qubit: usize, classical_bit: usize) -> Result<()> {
+        let p1 = self.prob_one(qubit)?;
         let u: f64 = self.rng.random();
         let outcome = u < p1;
         self.classical_bits[classical_bit] = outcome;
         let p = if outcome { p1 } else { 1.0 - p1 };
-        self.project(qubit, outcome, p);
+        self.project(qubit, outcome, p)
     }
 
     /// Deterministic reset `rho -> |0><0| (x) tr_q rho`: fold the block with
@@ -549,8 +658,12 @@ impl DensityMatrixBackend {
     /// then zero the three sibling entries that still touch `qubit`. The four
     /// entry classes are contiguous runs of the buffer, so the pass walks
     /// `2 * rmask` blocks rather than scattering per block base.
-    fn apply_reset(&mut self, qubit: usize) {
+    fn apply_reset(&mut self, qubit: usize) -> Result<()> {
         let n = self.num_qubits;
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return dk::reset(&ctx, gpu, n, qubit);
+        }
         let rmask = 1usize << (qubit + n);
         let cmask = 1usize << qubit;
         let block_size = rmask << 1;
@@ -569,7 +682,7 @@ impl DensityMatrixBackend {
                         let (r0, r1) = block.split_at_mut(rmask);
                         reset_fold_pair(r0, r1, cmask);
                     });
-                return;
+                return Ok(());
             }
 
             let tile = row_aligned_tile(cmask, rmask);
@@ -579,22 +692,28 @@ impl DensityMatrixBackend {
                     .zip(r1.par_chunks_mut(tile))
                     .for_each(|(t0, t1)| reset_fold_pair(t0, t1, cmask));
             }
-            return;
+            return Ok(());
         }
 
         for block in self.sv.state.chunks_mut(block_size) {
             let (r0, r1) = block.split_at_mut(rmask);
             reset_fold_pair(r0, r1, cmask);
         }
+        Ok(())
     }
 
     /// Project `rho` onto the `outcome` subspace of `qubit` with outcome
     /// probability `p`, renormalizing the survivors to unit trace.
-    fn project(&mut self, qubit: usize, outcome: bool, p: f64) {
+    fn project(&mut self, qubit: usize, outcome: bool, p: f64) -> Result<()> {
         let n = self.num_qubits;
         let rmask = 1usize << (qubit + n);
         let cmask = 1usize << qubit;
         let scale = Complex64::new(1.0 / p.clamp(NORM_CLAMP_MIN, 1.0), 0.0);
+
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return dk::project(&ctx, gpu, n, qubit, outcome, scale.re);
+        }
 
         #[cfg(feature = "parallel")]
         if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
@@ -610,12 +729,13 @@ impl DensityMatrixBackend {
                 .for_each(|(t, chunk)| {
                     project_tile(chunk, t * tile, rmask, cmask, outcome, scale);
                 });
-            return;
+            return Ok(());
         }
 
         for (t, chunk) in self.sv.state.chunks_mut(rmask).enumerate() {
             project_tile(chunk, t * rmask, rmask, cmask, outcome, scale);
         }
+        Ok(())
     }
 
     fn apply_conditional(
@@ -636,7 +756,18 @@ impl DensityMatrixBackend {
     /// buffer is swept once with no per-element allocation.
     pub fn apply_1q_kraus(&mut self, qubit: usize, kraus: &[[[Complex64; 2]; 2]]) {
         let s = block_superoperator(kraus);
-        self.apply_block_superoperator(qubit, &s);
+        self.apply_block_superoperator_infallible(qubit, &s);
+    }
+
+    /// [`DensityMatrixBackend::apply_block_superoperator`] for the entry points
+    /// that carry no error channel: the host path cannot fail and a device
+    /// launch failure stops the run.
+    fn apply_block_superoperator_infallible(&mut self, qubit: usize, s: &[[Complex64; 4]; 4]) {
+        let result = self.apply_block_superoperator(qubit, s);
+        #[cfg(feature = "gpu")]
+        launched(result);
+        #[cfg(not(feature = "gpu"))]
+        result.expect("host block superoperator is infallible");
     }
 
     /// Apply `gate` and then every Kraus set in `channels`, all one-qubit maps
@@ -660,7 +791,7 @@ impl DensityMatrixBackend {
         for kraus in channels {
             s = mat_mul_4x4(&block_superoperator(kraus), &s);
         }
-        self.apply_block_superoperator(qubit, &s);
+        self.apply_block_superoperator_infallible(qubit, &s);
         true
     }
 
@@ -683,6 +814,15 @@ impl DensityMatrixBackend {
         let alpha = 1.0 - 16.0 * p / 15.0;
         let beta = 4.0 * p / 15.0;
         let (positions, flats, num_groups) = self.block_layout(q0, q1);
+
+        #[cfg(feature = "gpu")]
+        {
+            let n = self.num_qubits;
+            if let Some((ctx, gpu)) = self.device() {
+                launched(dk::depolarizing_2q(&ctx, gpu, n, q0, q1, alpha, beta));
+                return;
+            }
+        }
 
         #[cfg(feature = "parallel")]
         if 2 * self.num_qubits >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
@@ -820,8 +960,21 @@ impl DensityMatrixBackend {
             .all(|(r, row)| row.iter().enumerate().all(|(c, &e)| r == c || e == zero));
         if diagonal {
             let diag = std::array::from_fn(|i| s[i][i]);
-            self.kraus_2q_diagonal_sweep(&diag, q0, q1);
+            let result = self.kraus_2q_diagonal_sweep(&diag, q0, q1);
+            #[cfg(feature = "gpu")]
+            launched(result);
+            #[cfg(not(feature = "gpu"))]
+            result.expect("host diagonal sweep is infallible");
             return;
+        }
+
+        #[cfg(feature = "gpu")]
+        {
+            let n = self.num_qubits;
+            if let Some((ctx, gpu)) = self.device() {
+                launched(dk::kraus_2q_dense(&ctx, gpu, n, q0, q1, &s));
+                return;
+            }
         }
 
         #[cfg(target_arch = "x86_64")]
@@ -888,8 +1041,18 @@ impl DensityMatrixBackend {
     /// Apply a diagonal block superoperator in one contiguous pass: the
     /// amplitude at `idx` is scaled by `diag[diag_slot(idx, q0, q1, n)]`, one
     /// complex multiply against the dense sweep's 16 multiply-accumulates.
-    fn kraus_2q_diagonal_sweep(&mut self, diag: &[Complex64; 16], q0: usize, q1: usize) {
+    fn kraus_2q_diagonal_sweep(
+        &mut self,
+        diag: &[Complex64; 16],
+        q0: usize,
+        q1: usize,
+    ) -> Result<()> {
         let n = self.num_qubits;
+
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return dk::kraus_2q_diagonal(&ctx, gpu, n, q0, q1, diag);
+        }
 
         #[cfg(feature = "parallel")]
         if 2 * n >= crate::backend::PARALLEL_THRESHOLD_QUBITS {
@@ -905,12 +1068,13 @@ impl DensityMatrixBackend {
                 .for_each(move |(idx, amp)| {
                     *amp *= diag[diag_slot(idx, q0, q1, n)];
                 });
-            return;
+            return Ok(());
         }
 
         for (idx, amp) in self.sv.state.iter_mut().enumerate() {
             *amp *= diag[diag_slot(idx, q0, q1, n)];
         }
+        Ok(())
     }
 
     /// Sweep the buffer applying the compiled 16x16 block superoperator `s`,
@@ -1024,6 +1188,19 @@ impl DensityMatrixBackend {
     /// an observable is unchanged.
     pub fn expectations_pauli(&self, masks: &[(usize, usize, u32)]) -> Vec<f64> {
         let d = self.dim();
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.sv.gpu_state() {
+            let pairs: Vec<(u64, u64)> = masks
+                .iter()
+                .map(|&(x, z, _)| (x as u64, z as u64))
+                .collect();
+            let sums = launched(dk::pauli_sums(gpu.context(), gpu, self.num_qubits, &pairs));
+            return sums
+                .iter()
+                .zip(masks)
+                .map(|(value, &(_, _, num_y))| (value * i_pow(num_y)).re)
+                .collect();
+        }
         let mut acc = vec![Complex64::new(0.0, 0.0); masks.len()];
         for j in 0..d {
             let row = &self.sv.state[j * d..(j + 1) * d];
@@ -1052,7 +1229,25 @@ impl Backend for DensityMatrixBackend {
         crate::sim::ResolvedBackend::DensityMatrix
     }
 
+    fn placement(&self) -> crate::sim::Placement {
+        if self.sv.is_gpu_resident() {
+            crate::sim::Placement::Device
+        } else {
+            crate::sim::Placement::Host
+        }
+    }
+
+    /// With a device attached the host cap does not apply: the mixture is
+    /// budgeted against free VRAM instead, before anything is allocated.
     fn init(&mut self, num_qubits: usize, num_classical_bits: usize) -> Result<()> {
+        #[cfg(feature = "gpu")]
+        if let Some(ctx) = &self.gpu_context {
+            check_device_budget(ctx, num_qubits)?;
+            self.num_qubits = num_qubits;
+            self.classical_bits = vec![false; num_classical_bits];
+            return self.sv.init(2 * num_qubits, 0);
+        }
+
         crate::backend::check_state_allocation(
             "density_matrix",
             num_qubits,
@@ -1081,6 +1276,11 @@ impl Backend for DensityMatrixBackend {
         let num_qubits = amplitudes.len().trailing_zeros() as usize;
         self.init(num_qubits, num_classical_bits)?;
 
+        #[cfg(feature = "gpu")]
+        if let Some((ctx, gpu)) = self.device() {
+            return dk::outer_product(&ctx, gpu, num_qubits, &amplitudes);
+        }
+
         let d = amplitudes.len();
         for (row, &amp) in amplitudes.iter().enumerate() {
             let dst = &mut self.sv.state[row * d..(row + 1) * d];
@@ -1098,14 +1298,8 @@ impl Backend for DensityMatrixBackend {
             Instruction::Measure {
                 qubit,
                 classical_bit,
-            } => {
-                self.apply_measure(*qubit, *classical_bit);
-                Ok(())
-            }
-            Instruction::Reset { qubit } => {
-                self.apply_reset(*qubit);
-                Ok(())
-            }
+            } => self.apply_measure(*qubit, *classical_bit),
+            Instruction::Reset { qubit } => self.apply_reset(*qubit),
             Instruction::Conditional {
                 condition,
                 gate,
@@ -1121,6 +1315,14 @@ impl Backend for DensityMatrixBackend {
 
     fn probabilities(&self) -> Result<Vec<f64>> {
         let d = self.dim();
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.sv.gpu_state() {
+            let mut diag = dk::diagonal(gpu.context(), gpu, self.num_qubits)?;
+            for p in &mut diag {
+                *p = p.max(0.0);
+            }
+            return Ok(diag);
+        }
         let mut probs = vec![0.0f64; d];
         for (k, p) in probs.iter_mut().enumerate() {
             *p = self.sv.state[k * d + k].re.max(0.0);
@@ -1146,12 +1348,11 @@ impl Backend for DensityMatrixBackend {
     }
 
     fn qubit_probability(&self, qubit: usize) -> Result<f64> {
-        Ok(self.prob_one(qubit))
+        self.prob_one(qubit)
     }
 
     fn reset(&mut self, qubit: usize) -> Result<()> {
-        self.apply_reset(qubit);
-        Ok(())
+        self.apply_reset(qubit)
     }
 
     fn supports_pauli_expectation(&self) -> bool {
@@ -1169,10 +1370,23 @@ impl Backend for DensityMatrixBackend {
         Ok(self.expectations_pauli(&masks))
     }
 
+    /// On the device the four entries come from the Pauli sums `T`, `Z`, `X`,
+    /// and `Y` on `qubit`: the diagonal is `(T +- Z) / 2` and the off-diagonal
+    /// pair is `(X +- Y) / 2`, where `Y` carries the row sign and no `i`.
     fn reduced_density_matrix_1q(&self, qubit: usize) -> Result<[[Complex64; 2]; 2]> {
         let n = self.num_qubits;
         let d = self.dim();
         let bit = 1usize << qubit;
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = self.sv.gpu_state() {
+            let b = bit as u64;
+            let sums = dk::pauli_sums(gpu.context(), gpu, n, &[(0, 0), (0, b), (b, 0), (b, b)])?;
+            let (t, z, x, y) = (sums[0], sums[1], sums[2], sums[3]);
+            return Ok([
+                [(t + z) * 0.5, (x + y) * 0.5],
+                [(x - y) * 0.5, (t - z) * 0.5],
+            ]);
+        }
         let others = 1usize << (n - 1);
         let mut r00 = Complex64::new(0.0, 0.0);
         let mut r01 = Complex64::new(0.0, 0.0);

--- a/src/backend/statevector/mod.rs
+++ b/src/backend/statevector/mod.rs
@@ -567,6 +567,16 @@ impl StatevectorBackend {
         false
     }
 
+    #[cfg(feature = "gpu")]
+    pub(crate) fn gpu_state(&self) -> Option<&GpuState> {
+        self.gpu_state.as_ref()
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn gpu_state_mut(&mut self) -> Option<&mut GpuState> {
+        self.gpu_state.as_mut()
+    }
+
     /// Initialize the backend from a pre-computed state vector.
     ///
     /// Accepts ownership of the amplitude vector, bypassing the default |0...0⟩

--- a/src/gpu/kernels/density.rs
+++ b/src/gpu/kernels/density.rs
@@ -1,0 +1,754 @@
+//! Density-matrix kernels over the embedded `2n`-qubit buffer, CUDA C source plus
+//! launch helpers.
+//!
+//! The buffer is the statevector layout of `4^n` amplitudes with the ket index in
+//! the high `n` bits and the bra index in the low `n`, so the unitary half of the
+//! backend reuses the dense kernels unchanged. The kernels here are the channel,
+//! measurement, and readout sweeps that have no statevector counterpart.
+
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+use num_complex::Complex64;
+
+use crate::error::{PrismError, Result};
+
+use super::super::{GpuBuffer, GpuContext, GpuState};
+use super::{ensure_scratch, launch_err, linear_cfg, stream_and_fn};
+
+const BLOCK_SIZE: u32 = 256;
+
+pub(crate) const KERNEL_SOURCE: &str = r#"
+// ============================================================================
+// Density-matrix sweeps. `n` is the circuit width; the buffer holds 4^n
+// amplitudes indexed (ket << n) | bra.
+// ============================================================================
+
+__device__ __forceinline__ unsigned long long dm_insert_zero(unsigned long long m, int pos)
+{
+    unsigned long long low = (1ULL << pos) - 1ULL;
+    return ((m & ~low) << 1) | (m & low);
+}
+
+__device__ __forceinline__ double2 dm_mul(double2 a, double2 b)
+{
+    return make_double2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+// Base of the (q0, q1) block for compacted index m: a zero bit inserted at
+// each of the four block positions in ascending order.
+__device__ __forceinline__ unsigned long long dm_block_base(
+    unsigned long long m, int q0, int q1, int n)
+{
+    int p[4] = {q0, q1, q0 + n, q1 + n};
+    for (int i = 1; i < 4; ++i) {
+        int v = p[i];
+        int j = i - 1;
+        while (j >= 0 && p[j] > v) { p[j + 1] = p[j]; --j; }
+        p[j + 1] = v;
+    }
+    unsigned long long base = m;
+    for (int i = 0; i < 4; ++i) base = dm_insert_zero(base, p[i]);
+    return base;
+}
+
+// Offset of block slot 4 * tr + tc from the block base.
+__device__ __forceinline__ unsigned long long dm_block_offset(int slot, int q0, int q1, int n)
+{
+    int tr = slot >> 2;
+    int tc = slot & 3;
+    unsigned long long off = 0;
+    if (tr & 2) off |= 1ULL << (q0 + n);
+    if (tr & 1) off |= 1ULL << (q1 + n);
+    if (tc & 2) off |= 1ULL << q0;
+    if (tc & 1) off |= 1ULL << q1;
+    return off;
+}
+
+// out[r] = Re rho[r][r]. Launch over d = 2^n threads.
+extern "C" __global__ void dm_diagonal(const double2 *state, unsigned long long d, double *out)
+{
+    unsigned long long r = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (r >= d) return;
+    out[r] = state[r * d + r].x;
+}
+
+// Per-block partials of sum |a|^2 over the whole buffer; finalize with
+// measure_prob_one_finalize.
+extern "C" __global__ void dm_norm_sqr(const double2 *state, unsigned long long len, double *out_partials)
+{
+    extern __shared__ double sdata[];
+    unsigned long long tid = threadIdx.x;
+    unsigned long long i = (unsigned long long)blockIdx.x * (blockDim.x * 2) + tid;
+    double s = 0.0;
+    if (i < len) { double2 a = state[i]; s += a.x * a.x + a.y * a.y; }
+    unsigned long long i2 = i + blockDim.x;
+    if (i2 < len) { double2 a = state[i2]; s += a.x * a.x + a.y * a.y; }
+    sdata[tid] = s;
+    __syncthreads();
+    for (unsigned long long stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) sdata[tid] += sdata[tid + stride];
+        __syncthreads();
+    }
+    if (tid == 0) out_partials[blockIdx.x] = sdata[0];
+}
+
+// Keep the entries whose row and column both agree with `outcome` on the
+// measured qubit, scaled by `scale`; zero the rest.
+extern "C" __global__ void dm_project(
+    double2 *state, unsigned long long len,
+    unsigned long long rmask, unsigned long long cmask, int outcome, double scale)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= len) return;
+    int row = ((i & rmask) != 0ULL) ? 1 : 0;
+    int col = ((i & cmask) != 0ULL) ? 1 : 0;
+    double2 a = state[i];
+    if (row == outcome && col == outcome) {
+        state[i] = make_double2(a.x * scale, a.y * scale);
+    } else {
+        state[i] = make_double2(0.0, 0.0);
+    }
+}
+
+// rho -> |0><0| (x) tr_q rho. One thread per (row-clear, col-clear) entry owns
+// its three siblings, so no two threads touch the same amplitude.
+extern "C" __global__ void dm_reset(
+    double2 *state, unsigned long long groups, int qubit, int n)
+{
+    unsigned long long m = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (m >= groups) return;
+    unsigned long long base = dm_insert_zero(dm_insert_zero(m, qubit), qubit + n);
+    unsigned long long rmask = 1ULL << (qubit + n);
+    unsigned long long cmask = 1ULL << qubit;
+    double2 a = state[base];
+    double2 b = state[base | rmask | cmask];
+    state[base] = make_double2(a.x + b.x, a.y + b.y);
+    state[base | rmask] = make_double2(0.0, 0.0);
+    state[base | cmask] = make_double2(0.0, 0.0);
+    state[base | rmask | cmask] = make_double2(0.0, 0.0);
+}
+
+extern "C" __global__ void dm_conjugate(double2 *state, unsigned long long len)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= len) return;
+    state[i].y = -state[i].y;
+}
+
+// rho[r][c] *= f(r) * conj(f(c)) for the 2^n-entry phase table `table`.
+extern "C" __global__ void dm_diagonal_sandwich(
+    double2 *state, unsigned long long len, int n, const double2 *table)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= len) return;
+    unsigned long long d = 1ULL << n;
+    double2 k = table[i >> n];
+    double2 b = table[i & (d - 1ULL)];
+    b.y = -b.y;
+    state[i] = dm_mul(state[i], dm_mul(k, b));
+}
+
+// Diagonal 16-entry block superoperator: one complex multiply per amplitude,
+// slot 4 * tr + tc read from the ket bits (tr) and bra bits (tc) of (q0, q1).
+extern "C" __global__ void dm_kraus_2q_diagonal(
+    double2 *state, unsigned long long len, int q0, int q1, int n, const double2 *diag)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= len) return;
+    int slot = (int)(((i >> (q0 + n)) & 1ULL) << 3)
+             | (int)(((i >> (q1 + n)) & 1ULL) << 2)
+             | (int)(((i >> q0) & 1ULL) << 1)
+             | (int)((i >> q1) & 1ULL);
+    state[i] = dm_mul(state[i], diag[slot]);
+}
+
+// Dense 16x16 block superoperator `s` (row-major, 256 complex entries), one
+// block of 16 amplitudes per thread.
+extern "C" __global__ void dm_kraus_2q_dense(
+    double2 *state, unsigned long long groups, int q0, int q1, int n, const double2 *s)
+{
+    unsigned long long m = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (m >= groups) return;
+    unsigned long long base = dm_block_base(m, q0, q1, n);
+    unsigned long long idx[16];
+    double2 v[16];
+    for (int k = 0; k < 16; ++k) {
+        idx[k] = base | dm_block_offset(k, q0, q1, n);
+        v[k] = state[idx[k]];
+    }
+    for (int row = 0; row < 16; ++row) {
+        double re = 0.0, im = 0.0;
+        for (int col = 0; col < 16; ++col) {
+            double2 c = s[row * 16 + col];
+            re += c.x * v[col].x - c.y * v[col].y;
+            im += c.x * v[col].y + c.y * v[col].x;
+        }
+        state[idx[row]] = make_double2(re, im);
+    }
+}
+
+// Symmetric two-qubit depolarizing on each block: B -> alpha B + beta Tr(B) I.
+extern "C" __global__ void dm_depolarizing_2q(
+    double2 *state, unsigned long long groups, int q0, int q1, int n, double alpha, double beta)
+{
+    unsigned long long m = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (m >= groups) return;
+    unsigned long long base = dm_block_base(m, q0, q1, n);
+    double tr_re = 0.0, tr_im = 0.0;
+    for (int t = 0; t < 4; ++t) {
+        double2 a = state[base | dm_block_offset(5 * t, q0, q1, n)];
+        tr_re += a.x;
+        tr_im += a.y;
+    }
+    double shift_re = tr_re * beta;
+    double shift_im = tr_im * beta;
+    for (int k = 0; k < 16; ++k) {
+        unsigned long long i = base | dm_block_offset(k, q0, q1, n);
+        double2 a = state[i];
+        double re = a.x * alpha;
+        double im = a.y * alpha;
+        if ((k % 5) == 0) { re += shift_re; im += shift_im; }
+        state[i] = make_double2(re, im);
+    }
+}
+
+// rho = |psi><psi| from the 2^n amplitudes `amps`. Launch over 4^n threads.
+extern "C" __global__ void dm_outer_product(
+    double2 *state, unsigned long long len, int n, const double2 *amps)
+{
+    unsigned long long i = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= len) return;
+    unsigned long long d = 1ULL << n;
+    double2 k = amps[i >> n];
+    double2 b = amps[i & (d - 1ULL)];
+    b.y = -b.y;
+    state[i] = dm_mul(k, b);
+}
+
+// Per-block complex partials of sum_j (-1)^{popcount(j & z)} rho[j][j ^ x] for
+// mask k = blockIdx.y; j runs over the 2^n rows, two per thread. Partials are
+// laid out [k][block][re, im].
+extern "C" __global__ void dm_pauli_expect(
+    const double2 *state, unsigned long long d,
+    const unsigned long long *xmasks, const unsigned long long *zmasks, double *out_partials)
+{
+    extern __shared__ double sdata[];
+    double *sr = sdata;
+    double *si = sdata + blockDim.x;
+    unsigned long long tid = threadIdx.x;
+    unsigned int k = blockIdx.y;
+    unsigned long long x = xmasks[k];
+    unsigned long long z = zmasks[k];
+    double re = 0.0, im = 0.0;
+    unsigned long long j = (unsigned long long)blockIdx.x * (blockDim.x * 2) + tid;
+    for (int rep = 0; rep < 2; ++rep) {
+        if (j < d) {
+            double2 e = state[j * d + (j ^ x)];
+            double sign = (__popcll(j & z) & 1) ? -1.0 : 1.0;
+            re += sign * e.x;
+            im += sign * e.y;
+        }
+        j += blockDim.x;
+    }
+    sr[tid] = re;
+    si[tid] = im;
+    __syncthreads();
+    for (unsigned long long stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            sr[tid] += sr[tid + stride];
+            si[tid] += si[tid + stride];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        unsigned long long slot = ((unsigned long long)k * gridDim.x + blockIdx.x) * 2ULL;
+        out_partials[slot] = sr[0];
+        out_partials[slot + 1] = si[0];
+    }
+}
+
+// One block per mask: sums that mask's `count` partial pairs into result[2k..].
+extern "C" __global__ void dm_pauli_expect_finalize(
+    const double *partials, unsigned int count, double *result)
+{
+    extern __shared__ double sdata[];
+    double *sr = sdata;
+    double *si = sdata + blockDim.x;
+    unsigned int tid = threadIdx.x;
+    unsigned int k = blockIdx.x;
+    double re = 0.0, im = 0.0;
+    for (unsigned int i = tid; i < count; i += blockDim.x) {
+        unsigned long long slot = ((unsigned long long)k * count + i) * 2ULL;
+        re += partials[slot];
+        im += partials[slot + 1];
+    }
+    sr[tid] = re;
+    si[tid] = im;
+    __syncthreads();
+    for (unsigned int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            sr[tid] += sr[tid + stride];
+            si[tid] += si[tid + stride];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        result[2 * k] = sr[0];
+        result[2 * k + 1] = si[0];
+    }
+}
+"#;
+
+fn grid_for(count: u64) -> u32 {
+    count.div_ceil(BLOCK_SIZE as u64).max(1) as u32
+}
+
+fn shared_cfg(grid: u32, columns: u32) -> LaunchConfig {
+    LaunchConfig {
+        grid_dim: (grid, 1, 1),
+        block_dim: (BLOCK_SIZE, 1, 1),
+        shared_mem_bytes: columns * BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
+    }
+}
+
+/// Buffer length of the `n`-qubit mixture, `4^n`, and a check that the device
+/// state is the embedded `2n`-qubit buffer.
+fn buffer_len(state: &GpuState, n: usize) -> u64 {
+    debug_assert_eq!(
+        state.num_qubits(),
+        2 * n,
+        "device buffer is not the 2n-qubit embedding"
+    );
+    1u64 << (2 * n)
+}
+
+/// A device buffer of exactly `len` elements in `slot`, reallocated on any size
+/// change so a readback of its full length matches the request.
+fn ensure_exact<'a>(
+    slot: &'a mut Option<GpuBuffer<f64>>,
+    device: &super::super::GpuDevice,
+    len: usize,
+) -> Result<&'a mut GpuBuffer<f64>> {
+    let len = len.max(1);
+    if slot.as_ref().is_none_or(|buf| buf.len() != len) {
+        *slot = Some(GpuBuffer::<f64>::alloc_zeros(device, len)?);
+    }
+    Ok(slot.as_mut().unwrap())
+}
+
+fn flatten(values: &[Complex64]) -> Vec<f64> {
+    let mut flat = Vec::with_capacity(2 * values.len());
+    for v in values {
+        flat.push(v.re);
+        flat.push(v.im);
+    }
+    flat
+}
+
+fn check_pair(n: usize, q0: usize, q1: usize) -> Result<()> {
+    if q0 >= n || q1 >= n || q0 == q1 {
+        return Err(PrismError::InvalidQubit {
+            index: q0.max(q1),
+            register_size: n,
+        });
+    }
+    Ok(())
+}
+
+/// `Re rho[r][r]` for every `r`, the `2^n` diagonal of the `4^n` buffer.
+pub(crate) fn diagonal(ctx: &GpuContext, state: &GpuState, n: usize) -> Result<Vec<f64>> {
+    buffer_len(state, n);
+    let d: u64 = 1u64 << n;
+    let device = ctx.device();
+    let (stream, func) = stream_and_fn(ctx, "dm_diagonal")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(d));
+    let mut scratch = ctx.launcher_scratch();
+    let out = ensure_exact(&mut scratch.dm_diag, device, d as usize)?;
+    let mut builder = stream.launch_builder(&func);
+    builder.arg(state.buffer().raw()).arg(&d).arg(out.raw_mut());
+    // SAFETY: signature matches the kernel; the grid covers `d` rows, each read
+    // at `r * d + r` inside the `d * d` buffer, and `out` holds `d` f64s.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_diagonal", e))?;
+    }
+    let mut host = vec![0.0_f64; d as usize];
+    out.copy_to_host(device, &mut host)?;
+    Ok(host)
+}
+
+/// `sum |rho[r][c]|^2` over the buffer, the purity `Tr(rho^2)`.
+pub(crate) fn norm_sqr(ctx: &GpuContext, state: &GpuState, n: usize) -> Result<f64> {
+    let len = buffer_len(state, n);
+    let elems_per_block = 2u64 * BLOCK_SIZE as u64;
+    let num_blocks = len.div_ceil(elems_per_block).max(1) as u32;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let stage1 = device.function("dm_norm_sqr")?;
+    let stage2 = device.function("measure_prob_one_finalize")?;
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let partials =
+        super::ensure_capacity(&mut scratch.measure_partials, device, num_blocks as usize)?;
+    {
+        let mut builder = stream.launch_builder(&stage1);
+        builder
+            .arg(state.buffer().raw())
+            .arg(&len)
+            .arg(partials.raw_mut());
+        // SAFETY: signature matches the kernel; `num_blocks` blocks of two
+        // elements per thread cover `len`, and `partials` holds one f64 per block.
+        unsafe {
+            builder
+                .launch(shared_cfg(num_blocks, 1))
+                .map_err(|e| launch_err("dm_norm_sqr", e))?;
+        }
+    }
+    let result = super::ensure_capacity(&mut scratch.measure_result, device, 1)?;
+    {
+        let mut builder = stream.launch_builder(&stage2);
+        builder
+            .arg(scratch.measure_partials.as_ref().unwrap().raw())
+            .arg(&num_blocks)
+            .arg(result.raw_mut());
+        // SAFETY: signature matches the kernel; one block strides over
+        // `num_blocks` partials, both buffers held by the scratch guard.
+        unsafe {
+            builder
+                .launch(shared_cfg(1, 1))
+                .map_err(|e| launch_err("measure_prob_one_finalize", e))?;
+        }
+    }
+    let mut host = [0.0_f64];
+    scratch
+        .measure_result
+        .as_ref()
+        .unwrap()
+        .copy_to_host(device, &mut host)?;
+    Ok(host[0])
+}
+
+/// Collapse onto the `outcome` subspace of `qubit`, scaling survivors by `scale`.
+pub(crate) fn project(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    qubit: usize,
+    outcome: bool,
+    scale: f64,
+) -> Result<()> {
+    let len = buffer_len(state, n);
+    let rmask: u64 = 1u64 << (qubit + n);
+    let cmask: u64 = 1u64 << qubit;
+    let outcome_i: i32 = i32::from(outcome);
+    let (stream, func) = stream_and_fn(ctx, "dm_project")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(len));
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&len)
+        .arg(&rmask)
+        .arg(&cmask)
+        .arg(&outcome_i)
+        .arg(&scale);
+    // SAFETY: signature matches the kernel and the grid covers `len`; each
+    // thread touches its own amplitude only.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_project", e))?;
+    }
+    Ok(())
+}
+
+/// `rho -> |0><0| (x) tr_q rho` for `qubit`.
+pub(crate) fn reset(ctx: &GpuContext, state: &mut GpuState, n: usize, qubit: usize) -> Result<()> {
+    let groups = buffer_len(state, n) >> 2;
+    let qubit_i = qubit as i32;
+    let n_i = n as i32;
+    let (stream, func) = stream_and_fn(ctx, "dm_reset")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(groups));
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&groups)
+        .arg(&qubit_i)
+        .arg(&n_i);
+    // SAFETY: signature matches the kernel. Inserting a zero bit at `qubit` and
+    // `qubit + n` is a bijection from the `4^n / 4` compacted indices onto the
+    // block bases, so the four amplitudes one thread touches are disjoint from
+    // every other thread's.
+    unsafe {
+        builder.launch(cfg).map_err(|e| launch_err("dm_reset", e))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn conjugate(ctx: &GpuContext, state: &mut GpuState, n: usize) -> Result<()> {
+    let len = buffer_len(state, n);
+    let (stream, func) = stream_and_fn(ctx, "dm_conjugate")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(len));
+    let mut builder = stream.launch_builder(&func);
+    builder.arg(state.buffer_mut().raw_mut()).arg(&len);
+    // SAFETY: signature matches the kernel and the grid covers `len`.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_conjugate", e))?;
+    }
+    Ok(())
+}
+
+/// `rho[r][c] *= table[r] * conj(table[c])` for a `2^n`-entry phase table.
+pub(crate) fn diagonal_sandwich(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    table: &[Complex64],
+) -> Result<()> {
+    let len = buffer_len(state, n);
+    debug_assert_eq!(table.len(), 1usize << n);
+    let n_i = n as i32;
+    let device = ctx.device();
+    let (stream, func) = stream_and_fn(ctx, "dm_diagonal_sandwich")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(len));
+    let mut scratch = ctx.launcher_scratch();
+    let table_buf = ensure_scratch(&mut scratch.f64_a, device, &flatten(table))?;
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&len)
+        .arg(&n_i)
+        .arg(table_buf.raw());
+    // SAFETY: signature matches the kernel; the grid covers `len`, every table
+    // read is below `2^n`, and the table is held by the scratch guard.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_diagonal_sandwich", e))?;
+    }
+    Ok(())
+}
+
+/// One complex multiply per amplitude by the diagonal block superoperator
+/// `diag`, indexed `4 * tr + tc`.
+pub(crate) fn kraus_2q_diagonal(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    q0: usize,
+    q1: usize,
+    diag: &[Complex64; 16],
+) -> Result<()> {
+    check_pair(n, q0, q1)?;
+    let len = buffer_len(state, n);
+    let (q0_i, q1_i, n_i) = (q0 as i32, q1 as i32, n as i32);
+    let device = ctx.device();
+    let (stream, func) = stream_and_fn(ctx, "dm_kraus_2q_diagonal")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(len));
+    let mut scratch = ctx.launcher_scratch();
+    let diag_buf = ensure_scratch(&mut scratch.f64_a, device, &flatten(diag))?;
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&len)
+        .arg(&q0_i)
+        .arg(&q1_i)
+        .arg(&n_i)
+        .arg(diag_buf.raw());
+    // SAFETY: signature matches the kernel; the grid covers `len` and the slot
+    // index is four bits, inside the 16-entry table the scratch guard holds.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_kraus_2q_diagonal", e))?;
+    }
+    Ok(())
+}
+
+/// Dense 16x16 block superoperator sweep, `s` indexed `[4 * tr + tc][4 * trp + tcp]`.
+pub(crate) fn kraus_2q_dense(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    q0: usize,
+    q1: usize,
+    s: &[[Complex64; 16]; 16],
+) -> Result<()> {
+    check_pair(n, q0, q1)?;
+    let groups = buffer_len(state, n) >> 4;
+    let (q0_i, q1_i, n_i) = (q0 as i32, q1 as i32, n as i32);
+    let device = ctx.device();
+    let (stream, func) = stream_and_fn(ctx, "dm_kraus_2q_dense")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(groups));
+    let flat: Vec<Complex64> = s.iter().flat_map(|row| row.iter().copied()).collect();
+    let mut scratch = ctx.launcher_scratch();
+    let s_buf = ensure_scratch(&mut scratch.f64_a, device, &flatten(&flat))?;
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&groups)
+        .arg(&q0_i)
+        .arg(&q1_i)
+        .arg(&n_i)
+        .arg(s_buf.raw());
+    // SAFETY: signature matches the kernel. Inserting a zero bit at each of the
+    // four block positions is a bijection from the compacted index onto the
+    // block bases, so the 16 amplitudes one thread touches are disjoint from
+    // every other thread's; the superoperator is held by the scratch guard.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_kraus_2q_dense", e))?;
+    }
+    Ok(())
+}
+
+/// `B -> alpha B + beta Tr(B) I` on every `(q0, q1)` block.
+pub(crate) fn depolarizing_2q(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    q0: usize,
+    q1: usize,
+    alpha: f64,
+    beta: f64,
+) -> Result<()> {
+    check_pair(n, q0, q1)?;
+    let groups = buffer_len(state, n) >> 4;
+    let (q0_i, q1_i, n_i) = (q0 as i32, q1 as i32, n as i32);
+    let (stream, func) = stream_and_fn(ctx, "dm_depolarizing_2q")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(groups));
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&groups)
+        .arg(&q0_i)
+        .arg(&q1_i)
+        .arg(&n_i)
+        .arg(&alpha)
+        .arg(&beta);
+    // SAFETY: signature matches the kernel; block bases are disjoint as in
+    // `kraus_2q_dense`, so each thread owns its 16 amplitudes.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_depolarizing_2q", e))?;
+    }
+    Ok(())
+}
+
+/// Fill the buffer with `|psi><psi|` for the `2^n` amplitudes `amps`.
+pub(crate) fn outer_product(
+    ctx: &GpuContext,
+    state: &mut GpuState,
+    n: usize,
+    amps: &[Complex64],
+) -> Result<()> {
+    let len = buffer_len(state, n);
+    debug_assert_eq!(amps.len(), 1usize << n);
+    let n_i = n as i32;
+    let device = ctx.device();
+    let (stream, func) = stream_and_fn(ctx, "dm_outer_product")?;
+    let cfg = linear_cfg(BLOCK_SIZE, grid_for(len));
+    let mut scratch = ctx.launcher_scratch();
+    let amps_buf = ensure_scratch(&mut scratch.f64_a, device, &flatten(amps))?;
+    let mut builder = stream.launch_builder(&func);
+    builder
+        .arg(state.buffer_mut().raw_mut())
+        .arg(&len)
+        .arg(&n_i)
+        .arg(amps_buf.raw());
+    // SAFETY: signature matches the kernel; the grid covers `len`, every
+    // amplitude read is below `2^n`, and the table is held by the scratch guard.
+    unsafe {
+        builder
+            .launch(cfg)
+            .map_err(|e| launch_err("dm_outer_product", e))?;
+    }
+    Ok(())
+}
+
+/// `sum_j (-1)^{popcount(j & zmask)} rho[j][j ^ xmask]` per `(xmask, zmask)`
+/// pair, the complex accumulator behind `Tr(rho P)` before the `i^{num_y}`
+/// factor. Two launches and a `16 * masks.len()` byte readback.
+pub(crate) fn pauli_sums(
+    ctx: &GpuContext,
+    state: &GpuState,
+    n: usize,
+    masks: &[(u64, u64)],
+) -> Result<Vec<Complex64>> {
+    buffer_len(state, n);
+    if masks.is_empty() {
+        return Ok(Vec::new());
+    }
+    let d: u64 = 1u64 << n;
+    let elems_per_block = 2u64 * BLOCK_SIZE as u64;
+    let blocks_per_mask = d.div_ceil(elems_per_block).max(1) as u32;
+    let num_masks = super::require_u32("dm_pauli_expect", "masks", masks.len())?;
+    let device = ctx.device();
+    let stream = device.stream()?;
+    let stage1 = device.function("dm_pauli_expect")?;
+    let stage2 = device.function("dm_pauli_expect_finalize")?;
+    let xmasks: Vec<u64> = masks.iter().map(|m| m.0).collect();
+    let zmasks: Vec<u64> = masks.iter().map(|m| m.1).collect();
+
+    let mut scratch = ctx.launcher_scratch();
+    let scratch = &mut *scratch;
+    let partial_len = 2 * masks.len() * blocks_per_mask as usize;
+    super::ensure_capacity(&mut scratch.measure_partials, device, partial_len)?;
+    ensure_scratch(&mut scratch.u64_a, device, &xmasks)?;
+    ensure_scratch(&mut scratch.u64_b, device, &zmasks)?;
+    ensure_exact(&mut scratch.dm_result, device, 2 * masks.len())?;
+    let partials = scratch.measure_partials.as_mut().unwrap();
+    {
+        let cfg = LaunchConfig {
+            grid_dim: (blocks_per_mask, num_masks, 1),
+            block_dim: (BLOCK_SIZE, 1, 1),
+            shared_mem_bytes: 2 * BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
+        };
+        let mut builder = stream.launch_builder(&stage1);
+        builder
+            .arg(state.buffer().raw())
+            .arg(&d)
+            .arg(scratch.u64_a.as_ref().unwrap().raw())
+            .arg(scratch.u64_b.as_ref().unwrap().raw())
+            .arg(partials.raw_mut());
+        // SAFETY: signature matches the kernel. `blocks_per_mask` blocks of two
+        // rows per thread cover the `d` rows of each of the `num_masks` masks,
+        // every read `j * d + (j ^ x)` stays inside the `d * d` buffer because
+        // `x < d`, and `partials` holds two f64s per (mask, block).
+        unsafe {
+            builder
+                .launch(cfg)
+                .map_err(|e| launch_err("dm_pauli_expect", e))?;
+        }
+    }
+    let result = scratch.dm_result.as_mut().unwrap();
+    {
+        let cfg = LaunchConfig {
+            grid_dim: (num_masks, 1, 1),
+            block_dim: (BLOCK_SIZE, 1, 1),
+            shared_mem_bytes: 2 * BLOCK_SIZE * std::mem::size_of::<f64>() as u32,
+        };
+        let mut builder = stream.launch_builder(&stage2);
+        builder
+            .arg(scratch.measure_partials.as_ref().unwrap().raw())
+            .arg(&blocks_per_mask)
+            .arg(result.raw_mut());
+        // SAFETY: signature matches the kernel; one block per mask strides over
+        // that mask's `blocks_per_mask` partial pairs, and `result` holds two
+        // f64s per mask. Both buffers are held by the scratch guard.
+        unsafe {
+            builder
+                .launch(cfg)
+                .map_err(|e| launch_err("dm_pauli_expect_finalize", e))?;
+        }
+    }
+    let mut host = vec![0.0_f64; 2 * masks.len()];
+    result.copy_to_host(device, &mut host)?;
+    Ok(host
+        .chunks_exact(2)
+        .map(|pair| Complex64::new(pair[0], pair[1]))
+        .collect())
+}

--- a/src/gpu/kernels/mod.rs
+++ b/src/gpu/kernels/mod.rs
@@ -8,6 +8,7 @@
 
 pub(crate) mod bts;
 pub(crate) mod dense;
+pub(crate) mod density;
 pub(crate) mod stabilizer;
 
 use std::sync::Arc;
@@ -79,6 +80,8 @@ pub(crate) struct LauncherScratch {
     pub(crate) i32_b: Option<GpuBuffer<i32>>,
     pub(crate) i32_c: Option<GpuBuffer<i32>>,
     pub(crate) u32_a: Option<GpuBuffer<u32>>,
+    pub(crate) u64_a: Option<GpuBuffer<u64>>,
+    pub(crate) u64_b: Option<GpuBuffer<u64>>,
     /// Per-block partials for [`super::dense::measure_prob_one`]. Sized by the
     /// number of grid blocks at the largest qubit count seen so far.
     pub(crate) measure_partials: Option<GpuBuffer<f64>>,
@@ -87,6 +90,10 @@ pub(crate) struct LauncherScratch {
     /// Four-element output for the reduced-density-matrix finalize reduction.
     /// Separate from `measure_result`: readback length must match the buffer.
     pub(crate) rdm_result: Option<GpuBuffer<f64>>,
+    /// The `2^n` diagonal of a density matrix, sized to the mixture width.
+    pub(crate) dm_diag: Option<GpuBuffer<f64>>,
+    /// Two f64s per Pauli mask for the density-matrix expectation finalize.
+    pub(crate) dm_result: Option<GpuBuffer<f64>>,
 }
 
 /// Ensure `slot` has at least `host.len()` elements allocated, growing if not,
@@ -141,6 +148,8 @@ pub(crate) fn kernel_source() -> String {
     src.push_str(&stabilizer::kernel_source());
     src.push('\n');
     src.push_str(&bts::kernel_source());
+    src.push('\n');
+    src.push_str(density::KERNEL_SOURCE);
     src
 }
 
@@ -192,6 +201,19 @@ pub(crate) const KERNEL_NAMES: &[&str] = &[
     "bts_transpose_meas_to_shot",
     "bts_apply_noise_masks_meas_major",
     "bts_generate_and_apply_noise_meas_major_by_row",
+    // Density-matrix sweeps over the embedded 2n-qubit buffer.
+    "dm_diagonal",
+    "dm_norm_sqr",
+    "dm_project",
+    "dm_reset",
+    "dm_conjugate",
+    "dm_diagonal_sandwich",
+    "dm_kraus_2q_diagonal",
+    "dm_kraus_2q_dense",
+    "dm_depolarizing_2q",
+    "dm_outer_product",
+    "dm_pauli_expect",
+    "dm_pauli_expect_finalize",
 ];
 
 #[cfg(test)]

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -12,6 +12,8 @@
 //! - `kernels::dense`: statevector kernels (CUDA C source plus launch helpers)
 //! - `kernels::stabilizer`: stabilizer tableau and measurement kernels
 //! - `kernels::bts`: compiled-sampler BTS kernels
+//! - `kernels::density`: channel and readout sweeps for the density matrix,
+//!   which embeds its `4^n` buffer as a `2n`-qubit statevector
 //!
 //! # Device state layout
 //!
@@ -258,6 +260,19 @@ impl GpuContext {
             Some(bytes) => Ok(bytes <= self.vram_available()?),
             None => Ok(false),
         }
+    }
+
+    /// Block until every kernel queued on this context's stream has finished.
+    ///
+    /// Launches are asynchronous, so a caller timing device work must call
+    /// this before reading the clock; a readback synchronizes on its own.
+    pub fn synchronize(&self) -> Result<()> {
+        self.device.stream()?.synchronize().map_err(|e| {
+            crate::error::PrismError::BackendUnsupported {
+                backend: "gpu".to_string(),
+                operation: format!("synchronize: {e}"),
+            }
+        })
     }
 
     pub(crate) fn device(&self) -> &GpuDevice {

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -111,9 +111,9 @@ pub enum BackendKind {
     /// Explicit-dispatch only: [`BackendKind::Auto`] never selects it. Stores
     /// `4^n` `Complex64` amplitudes, so the qubit ceiling is roughly half the
     /// statevector cap (14 on a 16 GiB host); `PRISM_MAX_DM_QUBITS` moves it
-    /// within that bound. Fusion is skipped for this backend: the sandwich
-    /// applies a fused payload as one ket pass plus three bra passes, which no
-    /// benchmark row covers today.
+    /// within that bound. Fused payloads are accepted, with every fusion floor
+    /// gated on the `2n`-qubit buffer the backend sweeps rather than on the
+    /// circuit width.
     ///
     /// Under an attached noise model this is the exact route: the mixture is
     /// evolved once and every terminal reads it, so shot counts carry sampling
@@ -167,6 +167,20 @@ pub enum BackendKind {
     /// against the crossover independently.
     #[cfg(feature = "gpu")]
     StatevectorGpu {
+        context: Arc<GpuContext>,
+    },
+    /// Density matrix held in device memory on the supplied context.
+    ///
+    /// Explicit-dispatch only: neither [`BackendKind::Auto`] nor
+    /// [`BackendKind::AutoGpu`] selects it. There is no crossover and no host
+    /// fallback: every run allocates the `4^n` mixture on the device, after a
+    /// budget check against the free VRAM that errors before allocating. An
+    /// 11 GiB card holds 13 qubits (1 GiB at 13, 4 GiB at 14 plus scratch).
+    /// Every channel, measurement, and readout sweep runs as a kernel; the
+    /// noisy terminals answer from the exact mixture as
+    /// [`BackendKind::DensityMatrix`] does.
+    #[cfg(feature = "gpu")]
+    DensityMatrixGpu {
         context: Arc<GpuContext>,
     },
     /// Stabilizer backend backed by a CUDA GPU tableau.
@@ -225,8 +239,17 @@ impl BackendKind {
             BackendKind::StabilizerRank
                 | BackendKind::StochasticPauli { .. }
                 | BackendKind::DeterministicPauli { .. }
-                | BackendKind::DensityMatrix
-        )
+        ) && !self.is_density_matrix()
+    }
+
+    /// True for the two kinds that hold the exact mixture, host or device.
+    pub(crate) fn is_density_matrix(&self) -> bool {
+        match self {
+            BackendKind::DensityMatrix => true,
+            #[cfg(feature = "gpu")]
+            BackendKind::DensityMatrixGpu { .. } => true,
+            _ => false,
+        }
     }
 
     /// True for kinds that can run non-Pauli channels (damping, thermal
@@ -243,7 +266,9 @@ impl BackendKind {
             | BackendKind::TensorNetwork
             | BackendKind::DensityMatrix => true,
             #[cfg(feature = "gpu")]
-            BackendKind::AutoGpu { .. } | BackendKind::StatevectorGpu { .. } => true,
+            BackendKind::AutoGpu { .. }
+            | BackendKind::StatevectorGpu { .. }
+            | BackendKind::DensityMatrixGpu { .. } => true,
             _ => false,
         }
     }
@@ -267,7 +292,7 @@ impl BackendKind {
     pub(crate) fn general_noise_backend_names() -> &'static str {
         #[cfg(feature = "gpu")]
         {
-            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, Factored, TensorNetwork, or DensityMatrix"
+            "Auto, Statevector, StatevectorGpu, Sparse, Mps, ProductState, Factored, TensorNetwork, DensityMatrix, or DensityMatrixGpu"
         }
         #[cfg(not(feature = "gpu"))]
         {
@@ -378,7 +403,11 @@ struct GpuCapability {
 /// Families with a `gpu_capability` row. Keep in sync with the match below;
 /// a new device family needs an entry in both.
 #[cfg(feature = "gpu")]
-const GPU_CAPABLE_FAMILIES: [Family; 2] = [Family::Statevector, Family::Stabilizer];
+const GPU_CAPABLE_FAMILIES: [Family; 3] = [
+    Family::Statevector,
+    Family::Stabilizer,
+    Family::DensityMatrix,
+];
 
 #[cfg(feature = "gpu")]
 fn gpu_capability(family: Family) -> Option<GpuCapability> {
@@ -391,13 +420,19 @@ fn gpu_capability(family: Family) -> Option<GpuCapability> {
             min_qubits: crate::gpu::stabilizer_min_qubits,
             fits: |ctx, n| ctx.fits_tableau(n).unwrap_or(false),
         }),
+        // Explicit-only: no crossover, and the `Auto` tree never selects the
+        // family, so the soft fit gate is never consulted. The hard path budgets
+        // the `4^n` buffer at `init`.
+        Family::DensityMatrix => Some(GpuCapability {
+            min_qubits: || 0,
+            fits: |ctx, n| ctx.fits_statevector_with_scratch(2 * n).unwrap_or(false),
+        }),
         Family::ProductState
         | Family::Sparse
         | Family::Mps
         | Family::Factored
         | Family::FactoredStabilizer
-        | Family::TensorNetwork
-        | Family::DensityMatrix => None,
+        | Family::TensorNetwork => None,
     }
 }
 
@@ -442,6 +477,9 @@ fn gpu_request(kind: &BackendKind, family: Family) -> Option<(&Arc<GpuContext>, 
         (BackendKind::AutoGpu { context }, _) => Some((context, true)),
         (BackendKind::StatevectorGpu { context }, Family::Statevector) => Some((context, false)),
         (BackendKind::StabilizerGpu { context }, Family::Stabilizer) => Some((context, false)),
+        (BackendKind::DensityMatrixGpu { context }, Family::DensityMatrix) => {
+            Some((context, false))
+        }
         _ => None,
     }
 }
@@ -478,6 +516,14 @@ pub(super) fn build_statevector(accel: &Accel, seed: u64) -> StatevectorBackend 
             context,
             soft: false,
         } => StatevectorBackend::new(seed).with_gpu(context.clone()),
+    }
+}
+
+pub(super) fn build_density_matrix(accel: &Accel, seed: u64) -> DensityMatrixBackend {
+    match accel {
+        Accel::Cpu => DensityMatrixBackend::new(seed),
+        #[cfg(feature = "gpu")]
+        Accel::Gpu { context, .. } => DensityMatrixBackend::new(seed).with_gpu(context.clone()),
     }
 }
 
@@ -544,7 +590,9 @@ pub(super) enum BackendPlan {
     Statevector {
         accel: Accel,
     },
-    DensityMatrix,
+    DensityMatrix {
+        accel: Accel,
+    },
     #[cfg(feature = "distributed")]
     Distributed(Arc<DistributedContext>),
 }
@@ -562,7 +610,7 @@ impl BackendPlan {
             BackendPlan::Mps { .. } => ResolvedBackend::Mps,
             BackendPlan::Stabilizer { .. } => ResolvedBackend::Stabilizer,
             BackendPlan::Statevector { .. } => ResolvedBackend::Statevector,
-            BackendPlan::DensityMatrix => ResolvedBackend::DensityMatrix,
+            BackendPlan::DensityMatrix { .. } => ResolvedBackend::DensityMatrix,
             #[cfg(feature = "distributed")]
             BackendPlan::Distributed(_) => ResolvedBackend::Distributed,
         }
@@ -582,7 +630,7 @@ impl BackendPlan {
                 Box::new(build_stabilizer(accel, *lazy, seed))
             }
             BackendPlan::Statevector { accel } => Box::new(build_statevector(accel, seed)),
-            BackendPlan::DensityMatrix => Box::new(DensityMatrixBackend::new(seed)),
+            BackendPlan::DensityMatrix { accel } => Box::new(build_density_matrix(accel, seed)),
             #[cfg(feature = "distributed")]
             BackendPlan::Distributed(context) => {
                 Box::new(DistributedStatevectorBackend::new(context.clone(), seed))
@@ -592,9 +640,9 @@ impl BackendPlan {
 
     pub(super) fn is_gpu(&self) -> bool {
         match self {
-            BackendPlan::Stabilizer { accel, .. } | BackendPlan::Statevector { accel } => {
-                !matches!(accel, Accel::Cpu)
-            }
+            BackendPlan::Stabilizer { accel, .. }
+            | BackendPlan::Statevector { accel }
+            | BackendPlan::DensityMatrix { accel } => !matches!(accel, Accel::Cpu),
             _ => false,
         }
     }
@@ -607,7 +655,7 @@ impl BackendPlan {
             self,
             BackendPlan::Stabilizer { .. }
                 | BackendPlan::FactoredStabilizer
-                | BackendPlan::DensityMatrix
+                | BackendPlan::DensityMatrix { .. }
         )
     }
 
@@ -622,7 +670,7 @@ impl BackendPlan {
             BackendPlan::Mps { .. } => Family::Mps,
             BackendPlan::Stabilizer { .. } => Family::Stabilizer,
             BackendPlan::Statevector { .. } => Family::Statevector,
-            BackendPlan::DensityMatrix => Family::DensityMatrix,
+            BackendPlan::DensityMatrix { .. } => Family::DensityMatrix,
             #[cfg(feature = "distributed")]
             BackendPlan::Distributed(_) => Family::Statevector,
         }
@@ -631,7 +679,9 @@ impl BackendPlan {
     #[cfg(test)]
     pub(super) fn accel(&self) -> &Accel {
         match self {
-            BackendPlan::Stabilizer { accel, .. } | BackendPlan::Statevector { accel } => accel,
+            BackendPlan::Stabilizer { accel, .. }
+            | BackendPlan::Statevector { accel }
+            | BackendPlan::DensityMatrix { accel } => accel,
             _ => &Accel::Cpu,
         }
     }
@@ -711,7 +761,9 @@ pub(super) fn plan_for_family(
         Family::Statevector => BackendPlan::Statevector {
             accel: accel_for(kind, Family::Statevector, num_qubits),
         },
-        Family::DensityMatrix => BackendPlan::DensityMatrix,
+        Family::DensityMatrix => BackendPlan::DensityMatrix {
+            accel: accel_for(kind, Family::DensityMatrix, num_qubits),
+        },
     }
 }
 
@@ -760,6 +812,8 @@ pub(super) fn resolve(
         BackendKind::StatevectorGpu { .. } => Family::Statevector,
         #[cfg(feature = "gpu")]
         BackendKind::StabilizerGpu { .. } => Family::Stabilizer,
+        #[cfg(feature = "gpu")]
+        BackendKind::DensityMatrixGpu { .. } => Family::DensityMatrix,
         #[cfg(feature = "distributed")]
         BackendKind::StatevectorDistributed { context } => {
             return ExecutionPlan::Backend(BackendPlan::Distributed(context.clone()));
@@ -792,7 +846,11 @@ pub(super) fn initial_state_plan(kind: &BackendKind, num_qubits: usize) -> Resul
         BackendKind::AutoGpu { .. } | BackendKind::StatevectorGpu { .. } => {
             Ok(plan_for_family(kind, Family::Statevector, num_qubits))
         }
-        BackendKind::DensityMatrix => Ok(BackendPlan::DensityMatrix),
+        BackendKind::DensityMatrix => Ok(plan_for_family(kind, Family::DensityMatrix, num_qubits)),
+        #[cfg(feature = "gpu")]
+        BackendKind::DensityMatrixGpu { .. } => {
+            Ok(plan_for_family(kind, Family::DensityMatrix, num_qubits))
+        }
         other => Err(PrismError::IncompatibleBackend {
             backend: format!("{other:?}"),
             reason: "a start state other than |0...0> runs on the statevector or the density \

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -647,18 +647,6 @@ impl BackendPlan {
         }
     }
 
-    /// Whether the fusion pipeline should synthesize fused-matrix gates for
-    /// this plan. Tableau-based families reject non-Clifford fused matrices;
-    /// every dense or factored representation accepts them.
-    pub(super) fn supports_fused(&self) -> bool {
-        !matches!(
-            self,
-            BackendPlan::Stabilizer { .. }
-                | BackendPlan::FactoredStabilizer
-                | BackendPlan::DensityMatrix { .. }
-        )
-    }
-
     #[cfg(test)]
     pub(super) fn family(&self) -> Family {
         match self {
@@ -1517,11 +1505,11 @@ mod dispatch_matrix_tests {
                 );
             }
         }
-        // Explicit selection maps 1:1 onto the density-matrix plan, which skips
-        // fusion.
+        // Explicit selection maps 1:1 onto the density-matrix plan, and the
+        // backend it builds accepts fused payloads on every terminal.
         let plan = resolved(&BackendKind::DensityMatrix, &dense(6), false);
         assert_eq!(plan.family(), Family::DensityMatrix);
-        assert!(!plan.supports_fused(), "density matrix must skip fusion");
+        assert!(plan.build(42).supports_fused_gates());
         assert!(matches!(plan.accel(), Accel::Cpu));
     }
 

--- a/src/sim/gradient.rs
+++ b/src/sim/gradient.rs
@@ -23,6 +23,7 @@ use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 use crate::gates::{Gate, GeneratorKind, pauli_rot_masks};
 
+use super::noise::NoiseModel;
 use super::unified_pauli::PauliTerm;
 use super::{BackendKind, i_pow, pauli_masks, pauli_sandwich};
 
@@ -312,7 +313,15 @@ pub fn run_expectation_gradient_shift(
     params: &Parameters,
     seed: u64,
 ) -> Result<ExpectationGradient> {
-    shift_gradient(&BackendKind::Auto, circuit, hamiltonian, params, None, seed)
+    shift_gradient(
+        &BackendKind::Auto,
+        circuit,
+        hamiltonian,
+        params,
+        None,
+        None,
+        seed,
+    )
 }
 
 /// Parameter-shift gradient on the backend `kind` selects, optionally from a
@@ -329,28 +338,44 @@ pub fn run_expectation_gradient_shift(
 /// Gates sharing a parameter slot are shifted one at a time and summed. Shifting
 /// them together is a different quantity: two `Rx(θ)` on one qubit under `⟨Z⟩`
 /// give `cos 2θ`, whose joint ±π/2 shift is zero rather than `-2 sin 2θ`.
+///
+/// Under `noise` every forward evaluation reads the exact mixture, so `kind`
+/// must be a density-matrix kind, which the caller checks. The channels do not
+/// depend on the shifted angle, so `⟨H⟩` stays a degree-1 trigonometric
+/// polynomial in it and the shift is still exact.
 pub(crate) fn shift_gradient(
     kind: &BackendKind,
     circuit: &Circuit,
     hamiltonian: &[(f64, Vec<PauliTerm>)],
     params: &Parameters,
+    noise: Option<&NoiseModel>,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<ExpectationGradient> {
     params.validate(circuit)?;
-    if initial_state.is_some() {
+    if initial_state.is_some() || noise.is_some() {
         super::require_unitary_circuit(kind, circuit)?;
     }
 
     let observables: Vec<Vec<PauliTerm>> =
         hamiltonian.iter().map(|(_, terms)| terms.clone()).collect();
     let evaluate = |c: &Circuit| -> Result<f64> {
-        let per_term = match initial_state {
-            Some(state) => {
+        let per_term = match (noise, initial_state) {
+            (Some(noise), _) => super::noise::dm_expectation_values(
+                kind,
+                c,
+                &observables,
+                Some(noise),
+                initial_state,
+                seed,
+            )?,
+            (None, Some(state)) => {
                 super::expectation_values_from_initial_state(kind, c, state, &observables, seed)?
                     .into_values()
             }
-            None => super::run_expectation_values_with(kind.clone(), c, &observables, seed)?,
+            (None, None) => {
+                super::run_expectation_values_with(kind.clone(), c, &observables, seed)?
+            }
         };
         Ok(hamiltonian
             .iter()

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -175,8 +175,9 @@ impl<'c, SeedState> Simulate<'c, SeedState> {
     /// [`Simulate::run`], [`Simulate::marginals`], and
     /// [`Simulate::expectation_values`] answer from the exact mixture instead,
     /// which only [`BackendKind::DensityMatrix`] and its device sibling hold,
-    /// so they require one of those. [`Simulate::expectation_gradient`] rejects
-    /// a noise model on every backend.
+    /// so they require one of those, as does
+    /// [`Simulate::expectation_gradient_shift`]. [`Simulate::expectation_gradient`]
+    /// rejects a noise model on every backend.
     #[inline]
     pub fn noise(mut self, model: &'c noise::NoiseModel) -> Self {
         self.noise_model = Some(model);
@@ -535,8 +536,8 @@ impl<'c> Simulate<'c, Seeded> {
             return Err(PrismError::IncompatibleBackend {
                 backend: format!("{:?}", self.kind),
                 reason: "the adjoint method backpropagates through a pure state, so no backend \
-                         has a noisy gradient path; drop the noise model, or differentiate noisy \
-                         `expectation_values` numerically"
+                         has a noisy adjoint path; drop the noise model, or take \
+                         `expectation_gradient_shift` on the density-matrix backend"
                     .into(),
             });
         }
@@ -564,11 +565,14 @@ impl<'c> Simulate<'c, Seeded> {
     ///
     /// Serves the cases [`Simulate::expectation_gradient`] declines: any
     /// backend with a native observable path, circuits containing `QftBlock`,
-    /// and widths past the statevector cap. It differentiates the same gate set
-    /// (`Rx`, `Ry`, `Rz`, `Rzz`, `P`, `PauliRot`) at `1 + 2 * links` circuit evaluations
-    /// against the adjoint's one, so the adjoint stays the better choice where
-    /// it applies. A backend with no native observable path reports
-    /// `BackendUnsupported` naming itself. See
+    /// widths past the statevector cap, and a noise model. It differentiates the
+    /// same gate set (`Rx`, `Ry`, `Rz`, `Rzz`, `P`, `PauliRot`) at `1 + 2 * links`
+    /// circuit evaluations against the adjoint's one, so the adjoint stays the
+    /// better choice where it applies. A backend with no native observable path
+    /// reports `BackendUnsupported` naming itself. Under a noise model every
+    /// evaluation reads the exact mixture, so the backend must be
+    /// [`BackendKind::DensityMatrix`] or its device sibling; the shift stays
+    /// exact because the channels do not depend on the shifted angle. See
     /// [`gradient::run_expectation_gradient_shift`].
     #[inline]
     pub fn expectation_gradient_shift(
@@ -580,11 +584,13 @@ impl<'c> Simulate<'c, Seeded> {
         if self.require_exact {
             reject_approximate_route(&self.kind, self.circuit)?;
         }
-        if self.noise_model.is_some() {
+        if self.noise_model.is_some() && !self.kind.is_density_matrix() {
             return Err(PrismError::IncompatibleBackend {
                 backend: format!("{:?}", self.kind),
-                reason: "noisy parameter-shift gradients are not wired; drop the noise model, or \
-                         differentiate noisy `expectation_values` numerically"
+                reason: "a parameter-shift gradient under a noise model evaluates the exact \
+                         mixed state, which only the density-matrix backend holds; select \
+                         `BackendKind::DensityMatrix` or its device sibling, or drop the noise \
+                         model"
                     .into(),
             });
         }
@@ -593,6 +599,7 @@ impl<'c> Simulate<'c, Seeded> {
             self.circuit,
             hamiltonian,
             params,
+            self.noise_model,
             self.initial_state,
             seed,
         )
@@ -2761,10 +2768,7 @@ fn run_shots_per_shot(
             .map(|((sub, _, _), plan)| {
                 let probe = plan.build(seed);
                 let expanded = expand_for_backend(&*probe, sub);
-                std::borrow::Cow::Owned(
-                    crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused())
-                        .into_owned(),
-                )
+                std::borrow::Cow::Owned(fuse_for_backend(&*probe, &expanded).into_owned())
             })
             .collect();
 
@@ -2790,7 +2794,7 @@ fn run_shots_per_shot(
         let plan = resolve_backend(&kind, circuit, has_partial_independence);
         let probe = plan.build(seed);
         let expanded = expand_for_backend(&*probe, circuit);
-        let fused = crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused());
+        let fused = fuse_for_backend(&*probe, &expanded);
 
         collect_shots(circuit, num_shots, seed, plan.resolved(), |shot_seed| {
             let mut backend = plan.build(shot_seed);

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -174,9 +174,9 @@ impl<'c, SeedState> Simulate<'c, SeedState> {
     /// backend with a per-shot pure state, averaging trajectories.
     /// [`Simulate::run`], [`Simulate::marginals`], and
     /// [`Simulate::expectation_values`] answer from the exact mixture instead,
-    /// which only [`BackendKind::DensityMatrix`] holds, so they require that
-    /// backend. [`Simulate::expectation_gradient`] rejects a noise model on
-    /// every backend.
+    /// which only [`BackendKind::DensityMatrix`] and its device sibling hold,
+    /// so they require one of those. [`Simulate::expectation_gradient`] rejects
+    /// a noise model on every backend.
     #[inline]
     pub fn noise(mut self, model: &'c noise::NoiseModel) -> Self {
         self.noise_model = Some(model);
@@ -282,15 +282,20 @@ impl<'c> Simulate<'c, Seeded> {
         }
         if let Some(noise_model) = self.noise_model {
             require_exact_mixture(&self.kind, "a single run")?;
-            let probabilities =
-                exact_noisy_probabilities(self.circuit, noise_model, self.initial_state, seed)?;
+            let probabilities = exact_noisy_probabilities(
+                &self.kind,
+                self.circuit,
+                noise_model,
+                self.initial_state,
+                seed,
+            )?;
             let classical_bits =
                 sample_exact_noisy_shots(&probabilities, self.circuit, noise_model, 1, seed)
                     .swap_remove(0);
             return Ok(RunOutcome {
                 classical_bits,
                 probabilities: Some(probabilities),
-                metadata: RunMetadata::exact(ResolvedBackend::DensityMatrix),
+                metadata: exact_mixture_metadata(&self.kind),
             });
         }
         if let Some(state) = self.initial_state {
@@ -371,11 +376,16 @@ impl<'c> Simulate<'c, Seeded> {
         }
         if let Some(noise_model) = self.noise_model {
             require_exact_mixture(&self.kind, "marginals")?;
-            let probs =
-                exact_noisy_probabilities(self.circuit, noise_model, self.initial_state, seed)?;
+            let probs = exact_noisy_probabilities(
+                &self.kind,
+                self.circuit,
+                noise_model,
+                self.initial_state,
+                seed,
+            )?;
             return Ok(MarginalsResult {
                 marginals: probs.marginals(),
-                metadata: RunMetadata::exact(ResolvedBackend::DensityMatrix),
+                metadata: exact_mixture_metadata(&self.kind),
             });
         }
         let result = if let Some(state) = self.initial_state {
@@ -419,6 +429,7 @@ impl<'c> Simulate<'c, Seeded> {
             require_exact_mixture(&self.kind, "expectation values")?;
             require_unitary_circuit(&self.kind, self.circuit)?;
             let values = noise::dm_expectation_values(
+                &self.kind,
                 self.circuit,
                 observables,
                 Some(noise_model),
@@ -427,7 +438,7 @@ impl<'c> Simulate<'c, Seeded> {
             )?;
             return Ok(analytic_expectations(
                 values,
-                RunMetadata::exact(ResolvedBackend::DensityMatrix),
+                exact_mixture_metadata(&self.kind),
             ));
         }
         if let Some(state) = self.initial_state {
@@ -466,6 +477,7 @@ impl<'c> Simulate<'c, Seeded> {
             require_exact_mixture(&self.kind, "expectation values")?;
             require_unitary_circuit(&self.kind, self.circuit)?;
             let values = noise::dm_expectation_values(
+                &self.kind,
                 self.circuit,
                 &observable_vecs(observable),
                 Some(noise_model),
@@ -476,7 +488,7 @@ impl<'c> Simulate<'c, Seeded> {
                 observable,
                 &values,
                 None,
-                RunMetadata::exact(ResolvedBackend::DensityMatrix),
+                exact_mixture_metadata(&self.kind),
             ));
         }
         if let Some(state) = self.initial_state {
@@ -623,7 +635,7 @@ pub fn simulate(circuit: &Circuit) -> Simulate<'_, Unseeded> {
 /// Gate for the terminals that answer a noise model from the exact mixture,
 /// which only the density matrix holds.
 fn require_exact_mixture(kind: &BackendKind, terminal: &str) -> Result<()> {
-    if matches!(kind, BackendKind::DensityMatrix) {
+    if kind.is_density_matrix() {
         return Ok(());
     }
     Err(PrismError::IncompatibleBackend {
@@ -887,16 +899,33 @@ fn require_unitary_circuit(kind: &BackendKind, circuit: &Circuit) -> Result<()> 
     Ok(())
 }
 
+/// Provenance of a result read off the exact mixture: the density matrix,
+/// placed wherever `kind` holds it.
+fn exact_mixture_metadata(kind: &BackendKind) -> RunMetadata {
+    let metadata = RunMetadata::exact(ResolvedBackend::DensityMatrix);
+    #[cfg(feature = "gpu")]
+    if matches!(kind, BackendKind::DensityMatrixGpu { .. }) {
+        let mut on_device = metadata;
+        on_device.placement = Placement::Device;
+        return on_device;
+    }
+    #[cfg(not(feature = "gpu"))]
+    let _ = kind;
+    metadata
+}
+
 /// Exact output distribution of `circuit` under `noise_model`, evolved once on
 /// the density matrix. The mixture carries every measurement branch at once,
 /// so it answers for a whole shot only when the measurements are terminal.
 fn exact_noisy_probabilities(
+    kind: &BackendKind,
     circuit: &Circuit,
     noise_model: &noise::NoiseModel,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<Probabilities> {
     Ok(Probabilities::Dense(noise::density_matrix_probabilities(
+        kind,
         circuit,
         noise_model,
         initial_state,
@@ -2844,13 +2873,13 @@ pub(crate) fn run_shots_with_noise(
         });
     }
 
-    if matches!(kind, BackendKind::DensityMatrix) {
-        let probs = exact_noisy_probabilities(circuit, noise_model, None, seed)?;
+    if kind.is_density_matrix() {
+        let probs = exact_noisy_probabilities(&kind, circuit, noise_model, None, seed)?;
         return Ok(ShotsResult::from_shots(
             sample_exact_noisy_shots(&probs, circuit, noise_model, num_shots, seed),
             circuit.num_classical_bits,
         )
-        .with_metadata(RunMetadata::exact(ResolvedBackend::DensityMatrix)));
+        .with_metadata(exact_mixture_metadata(&kind)));
     }
 
     if !kind.supports_noisy_per_shot() {

--- a/src/sim/noise.rs
+++ b/src/sim/noise.rs
@@ -13,10 +13,10 @@ use crate::backend::stabilizer::StabilizerBackend;
 use crate::circuit::{Circuit, Instruction, SmallVec};
 use crate::error::Result;
 use crate::gates::Gate;
-use crate::sim::ShotsResult;
 use crate::sim::compiled::{
     PackedShots, batch_propagate_backward, compile_measurements, xor_words,
 };
+use crate::sim::{BackendKind, ShotsResult};
 
 /// A single-qubit (or two-qubit, for `TwoQubitDepolarizing`) noise channel.
 ///
@@ -2680,17 +2680,23 @@ pub(crate) fn apply_noise_event_dm(dm: &mut DensityMatrixBackend, event: &NoiseE
 /// density-matrix qubit cap and the noise model is validated before any
 /// allocation.
 fn evolve_density_matrix(
+    kind: &BackendKind,
     circuit: &Circuit,
     noise: Option<&NoiseModel>,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<DensityMatrixBackend> {
-    crate::backend::check_state_allocation(
-        "density_matrix",
-        circuit.num_qubits,
-        crate::backend::max_density_matrix_qubits(),
-        crate::backend::DM_QUBIT_CAP_ENV,
-    )?;
+    use super::dispatch::{Accel, Family, accel_for, build_density_matrix};
+
+    let accel = accel_for(kind, Family::DensityMatrix, circuit.num_qubits);
+    if matches!(accel, Accel::Cpu) {
+        crate::backend::check_state_allocation(
+            "density_matrix",
+            circuit.num_qubits,
+            crate::backend::max_density_matrix_qubits(),
+            crate::backend::DM_QUBIT_CAP_ENV,
+        )?;
+    }
     if !circuit.has_terminal_measurements_only() {
         return Err(crate::error::PrismError::IncompatibleBackend {
             backend: "density_matrix".into(),
@@ -2705,7 +2711,7 @@ fn evolve_density_matrix(
         noise.validate_for(circuit)?;
     }
 
-    let mut dm = DensityMatrixBackend::new(seed);
+    let mut dm = build_density_matrix(&accel, seed);
     match initial_state {
         Some(state) => {
             crate::sim::check_initial_state_len(state, circuit.num_qubits)?;
@@ -2750,12 +2756,13 @@ fn evolve_density_matrix(
 /// the distribution answers for a whole shot only when every measurement is
 /// terminal; callers gate on that shape.
 pub(crate) fn density_matrix_probabilities(
+    kind: &BackendKind,
     circuit: &Circuit,
     noise: &NoiseModel,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<Vec<f64>> {
-    evolve_density_matrix(circuit, Some(noise), initial_state, seed)?.probabilities()
+    evolve_density_matrix(kind, circuit, Some(noise), initial_state, seed)?.probabilities()
 }
 
 /// Exact per-classical-bit measurement marginals under a noise model, evolved
@@ -2768,7 +2775,13 @@ pub(crate) fn dm_noisy_marginals(
     noise: &NoiseModel,
     seed: u64,
 ) -> Result<Vec<f64>> {
-    let dm = evolve_density_matrix(circuit, Some(noise), None, seed)?;
+    let dm = evolve_density_matrix(
+        &BackendKind::DensityMatrix,
+        circuit,
+        Some(noise),
+        None,
+        seed,
+    )?;
     let mut result = vec![0.5f64; circuit.num_classical_bits];
     for inst in &circuit.instructions {
         if let Instruction::Measure {
@@ -2796,20 +2809,28 @@ pub fn density_matrix_expectation_values(
     noise: Option<&NoiseModel>,
     seed: u64,
 ) -> Result<Vec<f64>> {
-    dm_expectation_values(circuit, observables, noise, None, seed)
+    dm_expectation_values(
+        &BackendKind::DensityMatrix,
+        circuit,
+        observables,
+        noise,
+        None,
+        seed,
+    )
 }
 
 /// [`density_matrix_expectation_values`] with a caller-supplied start state,
 /// which `Simulate::expectation_values` carries and the public entry point
 /// leaves at |0...0>.
 pub(crate) fn dm_expectation_values(
+    kind: &BackendKind,
     circuit: &Circuit,
     observables: &[Vec<crate::PauliTerm>],
     noise: Option<&NoiseModel>,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<Vec<f64>> {
-    let dm = evolve_density_matrix(circuit, noise, initial_state, seed)?;
+    let dm = evolve_density_matrix(kind, circuit, noise, initial_state, seed)?;
     let masks = observables
         .iter()
         .map(|obs| crate::sim::pauli_masks(obs, circuit.num_qubits))

--- a/tests/expectation_gradient_noisy.rs
+++ b/tests/expectation_gradient_noisy.rs
@@ -1,0 +1,179 @@
+//! Parameter-shift gradients under a noise model: the density-matrix route
+//! against central finite differences of the noisy expectation values, and the
+//! rejections every other backend keeps.
+
+mod common;
+
+use common::SEED;
+use prism_q::circuits;
+use prism_q::{
+    BackendKind, Circuit, Gate, Instruction, NoiseModel, Parameters, PauliTerm, simulate,
+};
+
+type Hamiltonian = Vec<(f64, Vec<PauliTerm>)>;
+
+fn fixture() -> (Circuit, NoiseModel, Parameters, Hamiltonian) {
+    let circuit = circuits::hardware_efficient_ansatz(6, 2, SEED);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let params = Parameters::all_rotations(&circuit);
+    let hamiltonian = vec![
+        (0.7, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (-0.3, vec![PauliTerm::x(2)]),
+        (0.5, vec![PauliTerm::y(3), PauliTerm::z(4)]),
+        (0.2, vec![PauliTerm::z(5)]),
+    ];
+    (circuit, noise, params, hamiltonian)
+}
+
+fn noisy_expval(circuit: &Circuit, noise: &NoiseModel, hamiltonian: &Hamiltonian) -> f64 {
+    let observables: Vec<Vec<PauliTerm>> = hamiltonian.iter().map(|(_, p)| p.clone()).collect();
+    let per_term = simulate(circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(noise)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    hamiltonian
+        .iter()
+        .zip(per_term)
+        .map(|((c, _), v)| c * v)
+        .sum()
+}
+
+fn shift_slot(circuit: &Circuit, params: &Parameters, slot: usize, delta: f64) -> Circuit {
+    let mut out = circuit.clone();
+    for link in params.links().iter().filter(|l| l.slot == slot) {
+        if let Instruction::Gate { gate, .. } = &mut out.instructions[link.instruction] {
+            *gate = match gate {
+                Gate::Ry(t) => Gate::Ry(*t + delta),
+                Gate::Rz(t) => Gate::Rz(*t + delta),
+                other => panic!("fixture carries only Ry and Rz rotations, found {other:?}"),
+            };
+        }
+    }
+    out
+}
+
+#[test]
+fn noisy_shift_matches_finite_differences_of_noisy_expectation_values() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    let g = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+
+    assert!((g.value - noisy_expval(&circuit, &noise, &hamiltonian)).abs() < 1e-12);
+    assert_eq!(g.gradient.len(), params.num_slots());
+    let eps = 1e-4;
+    let mut largest = 0.0_f64;
+    for slot in 0..params.num_slots() {
+        let plus = noisy_expval(
+            &shift_slot(&circuit, &params, slot, eps),
+            &noise,
+            &hamiltonian,
+        );
+        let minus = noisy_expval(
+            &shift_slot(&circuit, &params, slot, -eps),
+            &noise,
+            &hamiltonian,
+        );
+        let fd = (plus - minus) / (2.0 * eps);
+        assert!(
+            (g.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: shift {} vs finite difference {fd}",
+            g.gradient[slot]
+        );
+        largest = largest.max(g.gradient[slot].abs());
+    }
+    assert!(
+        largest > 1e-3,
+        "the fixture must have a non-trivial gradient"
+    );
+}
+
+#[test]
+fn noisy_shift_differs_from_the_noiseless_gradient() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    let noisy = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+    let clean = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+    let moved = noisy
+        .gradient
+        .iter()
+        .zip(&clean.gradient)
+        .any(|(a, b)| (a - b).abs() > 1e-3);
+    assert!(moved, "depolarizing at 2% per gate must move the gradient");
+}
+
+#[test]
+fn noisy_shift_rejects_backends_without_the_mixture() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    for kind in [
+        BackendKind::Auto,
+        BackendKind::Statevector,
+        BackendKind::Sparse,
+    ] {
+        let err = simulate(&circuit)
+            .backend(kind.clone())
+            .noise(&noise)
+            .seed(SEED)
+            .expectation_gradient_shift(&hamiltonian, &params)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("density-matrix") && err.contains("noise model"),
+            "{kind:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn adjoint_still_rejects_noise_and_names_the_shift_route() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    for kind in [BackendKind::Auto, BackendKind::DensityMatrix] {
+        let err = simulate(&circuit)
+            .backend(kind.clone())
+            .noise(&noise)
+            .seed(SEED)
+            .expectation_gradient(&hamiltonian, &params)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("expectation_gradient_shift"),
+            "{kind:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn noisy_shift_rejects_mid_circuit_measurement() {
+    let (mut circuit, _, _, hamiltonian) = fixture();
+    circuit.num_classical_bits = 1;
+    circuit.instructions.insert(
+        3,
+        Instruction::Measure {
+            qubit: 0,
+            classical_bit: 0,
+        },
+    );
+    let params = Parameters::all_rotations(&circuit);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let err = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("measurement"), "{err}");
+}

--- a/tests/golden_gpu_density_matrix.rs
+++ b/tests/golden_gpu_density_matrix.rs
@@ -1,0 +1,721 @@
+//! Device against host for the density matrix: every channel, terminal, and
+//! gate shape runs on both, and the full `4^n` buffer must agree within 1e-12.
+//! A diagonal sandwich leaves every diagonal entry of rho alone, so a
+//! probabilities comparison would pass on a broken arm; the buffer is what is
+//! compared. Without a usable GPU every test returns before asserting; set
+//! `PRISM_REQUIRE_GPU=1` to make that a hard failure.
+
+#![cfg(feature = "gpu")]
+
+mod common;
+
+use std::sync::Arc;
+
+use common::{SEED, all_pauli_masks, assert_probs_close};
+use num_complex::Complex64;
+use prism_q::backend::Backend;
+use prism_q::backend::density_matrix::DensityMatrixBackend;
+use prism_q::circuit::fusion::fuse_circuit_for_width;
+use prism_q::circuit::{Circuit, ClassicalCondition, Instruction, SmallVec, smallvec};
+use prism_q::gates::{
+    BatchPhaseData, BatchRzzData, DiagEntry, DiagonalBatchData, Gate, McuData, Multi2qData,
+    MultiFusedData,
+};
+use prism_q::gpu::GpuContext;
+use prism_q::{
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, PauliTerm, Placement, circuits, sim,
+};
+
+const EPS: f64 = 1e-12;
+
+struct Fixture {
+    ctx: Arc<GpuContext>,
+}
+
+impl Fixture {
+    fn try_new() -> Option<Self> {
+        match GpuContext::new(0) {
+            Ok(ctx) => Some(Self { ctx }),
+            Err(e) => {
+                assert!(
+                    std::env::var_os("PRISM_REQUIRE_GPU").is_none(),
+                    "PRISM_REQUIRE_GPU is set but no usable GPU was found ({e}). \
+                     Unset it to allow this suite to skip."
+                );
+                eprintln!("SKIP: no usable GPU ({e})");
+                None
+            }
+        }
+    }
+
+    fn kind(&self) -> BackendKind {
+        BackendKind::DensityMatrixGpu {
+            context: self.ctx.clone(),
+        }
+    }
+
+    fn device_backend(&self) -> DensityMatrixBackend {
+        DensityMatrixBackend::new(SEED).with_gpu(self.ctx.clone())
+    }
+
+    /// Host and device backends holding the same mixed `n`-qubit state: a random
+    /// circuit followed by amplitude damping, so every entry class of rho is
+    /// populated and the off-diagonals are not a pure state's.
+    fn prepared_pair(&self, n: usize) -> (DensityMatrixBackend, DensityMatrixBackend) {
+        let circuit = circuits::random_circuit(n, 4, SEED);
+        let mut cpu = DensityMatrixBackend::new(SEED);
+        let mut gpu = self.device_backend();
+        for backend in [&mut cpu, &mut gpu] {
+            backend.init(n, n).unwrap();
+            backend.apply_instructions(&circuit.instructions).unwrap();
+            backend.apply_1q_kraus(n - 2, &amplitude_damping(0.3));
+        }
+        (cpu, gpu)
+    }
+}
+
+fn assert_same_mixture(cpu: &DensityMatrixBackend, gpu: &DensityMatrixBackend, label: &str) {
+    assert_eq!(
+        cpu.classical_results(),
+        gpu.classical_results(),
+        "{label}: classical bits mismatch"
+    );
+    let want = cpu.density_matrix().unwrap();
+    let got = gpu.density_matrix().unwrap();
+    assert_eq!(want.len(), got.len(), "{label}: buffer length mismatch");
+    for (i, (c, g)) in want.iter().zip(&got).enumerate() {
+        let diff = (c - g).norm();
+        assert!(
+            diff < EPS,
+            "{label}: entry {i} cpu={c:?} gpu={g:?} |diff|={diff}"
+        );
+    }
+}
+
+fn g(gate: Gate, targets: &[usize]) -> Instruction {
+    let mut tv: SmallVec<[usize; 4]> = smallvec![];
+    tv.extend_from_slice(targets);
+    Instruction::Gate { gate, targets: tv }
+}
+
+fn c(re: f64) -> Complex64 {
+    Complex64::new(re, 0.0)
+}
+
+fn amplitude_damping(gamma: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let zero = c(0.0);
+    vec![
+        [[c(1.0), zero], [zero, c((1.0 - gamma).sqrt())]],
+        [[zero, c(gamma.sqrt())], [zero, zero]],
+    ]
+}
+
+fn depolarizing_1q(p: f64) -> Vec<[[Complex64; 2]; 2]> {
+    let zero = c(0.0);
+    let w = c((p / 3.0).sqrt());
+    let iw = Complex64::new(0.0, (p / 3.0).sqrt());
+    vec![
+        [[c((1.0 - p).sqrt()), zero], [zero, c((1.0 - p).sqrt())]],
+        [[zero, w], [w, zero]],
+        [[zero, -iw], [iw, zero]],
+        [[w, zero], [zero, -w]],
+    ]
+}
+
+/// Correlated `ZZ` dephasing: compiles to a diagonal superoperator.
+fn correlated_zz(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = c(0.0);
+    let diag = |scale: f64, signs: [f64; 4]| {
+        let mut m = [[zero; 4]; 4];
+        for (t, sign) in signs.iter().enumerate() {
+            m[t][t] = c(scale * sign);
+        }
+        m
+    };
+    vec![
+        diag((1.0 - p).sqrt(), [1.0, 1.0, 1.0, 1.0]),
+        diag(p.sqrt(), [1.0, -1.0, -1.0, 1.0]),
+    ]
+}
+
+/// `{sqrt(1-p) I, sqrt(p) X(x)Z}`: fills the 16x16 superoperator.
+fn h_conjugated_zz(p: f64) -> Vec<[[Complex64; 4]; 4]> {
+    let zero = c(0.0);
+    let mut k0 = [[zero; 4]; 4];
+    let mut k1 = [[zero; 4]; 4];
+    for t in 0..4 {
+        k0[t][t] = c((1.0 - p).sqrt());
+        let sign = if t & 1 == 0 { 1.0 } else { -1.0 };
+        k1[t][t ^ 2] = c(p.sqrt() * sign);
+    }
+    vec![k0, k1]
+}
+
+fn sample_2x2() -> [[Complex64; 2]; 2] {
+    [
+        [Complex64::new(0.6, -0.1), Complex64::new(-0.3, 0.2)],
+        [Complex64::new(0.2, 0.4), Complex64::new(0.7, -0.2)],
+    ]
+}
+
+fn sample_4x4() -> [[Complex64; 4]; 4] {
+    let mut mat = [[c(0.0); 4]; 4];
+    for (r, row) in mat.iter_mut().enumerate() {
+        for (col, entry) in row.iter_mut().enumerate() {
+            *entry = Complex64::new(0.1 * (r as f64 + 1.0), 0.07 * (col as f64 + 1.0));
+        }
+    }
+    mat
+}
+
+fn pauli_rot_sample() -> Gate {
+    let mut circuit = Circuit::new(3, 0);
+    circuit.add_pauli_rotation(0.53, &[PauliTerm::x(0), PauliTerm::y(1), PauliTerm::z(2)]);
+    match &circuit.instructions[0] {
+        Instruction::Gate { gate, .. } => gate.clone(),
+        _ => unreachable!("add_pauli_rotation appends a gate"),
+    }
+}
+
+/// One instruction per `Gate` variant on a six-qubit register.
+fn gate_instructions() -> Vec<Instruction> {
+    let m2 = sample_2x2();
+    let m4 = sample_4x4();
+    vec![
+        g(Gate::Id, &[0]),
+        g(Gate::X, &[1]),
+        g(Gate::Y, &[2]),
+        g(Gate::Z, &[3]),
+        g(Gate::H, &[4]),
+        g(Gate::S, &[5]),
+        g(Gate::Sdg, &[0]),
+        g(Gate::T, &[1]),
+        g(Gate::Tdg, &[2]),
+        g(Gate::SX, &[3]),
+        g(Gate::SXdg, &[4]),
+        g(Gate::Rx(0.37), &[5]),
+        g(Gate::Ry(1.11), &[0]),
+        g(Gate::Rz(-0.62), &[1]),
+        g(Gate::P(0.44), &[2]),
+        g(Gate::Fused(Box::new(m2)), &[3]),
+        g(Gate::Rzz(0.3), &[0, 5]),
+        g(Gate::Cx, &[1, 4]),
+        g(Gate::Cz, &[2, 3]),
+        g(Gate::Swap, &[0, 3]),
+        g(Gate::Cu(Box::new(m2)), &[4, 1]),
+        g(
+            Gate::Mcu(Box::new(McuData {
+                mat: m2,
+                num_controls: 2,
+            })),
+            &[0, 2, 5],
+        ),
+        g(
+            Gate::BatchPhase(Box::new(BatchPhaseData {
+                phases: smallvec![
+                    (2usize, Complex64::from_polar(1.0, 0.5)),
+                    (4usize, Complex64::from_polar(1.0, -1.3))
+                ],
+            })),
+            &[1],
+        ),
+        g(
+            Gate::BatchRzz(Box::new(BatchRzzData {
+                edges: vec![(0, 1, 0.3), (2, 5, 0.5), (3, 4, -0.9)],
+            })),
+            &[0, 1, 2, 3, 4, 5],
+        ),
+        g(
+            Gate::DiagonalBatch(Box::new(DiagonalBatchData {
+                entries: vec![
+                    DiagEntry::Phase1q {
+                        qubit: 0,
+                        d0: Complex64::from_polar(1.0, 0.2),
+                        d1: Complex64::from_polar(1.0, -0.3),
+                    },
+                    DiagEntry::Phase2q {
+                        q0: 1,
+                        q1: 2,
+                        phase: Complex64::from_polar(1.0, 0.5),
+                    },
+                    DiagEntry::Parity2q {
+                        q0: 3,
+                        q1: 5,
+                        same: Complex64::from_polar(1.0, 0.1),
+                        diff: Complex64::from_polar(1.0, -0.4),
+                    },
+                ],
+            })),
+            &[0, 1, 2, 3, 5],
+        ),
+        g(
+            Gate::MultiFused(Box::new(MultiFusedData {
+                gates: vec![(0, m2), (3, m2), (5, m2)],
+                all_diagonal: false,
+            })),
+            &[0, 1, 2, 3, 4, 5],
+        ),
+        g(Gate::Fused2q(Box::new(m4)), &[2, 4]),
+        g(
+            Gate::Multi2q(Box::new(Multi2qData {
+                gates: vec![(0, 1, m4), (3, 5, m4)],
+            })),
+            &[0, 1, 3, 5],
+        ),
+        g(Gate::QftBlock { start: 1, num: 4 }, &[1, 2, 3, 4]),
+        g(pauli_rot_sample(), &[0, 2, 5]),
+    ]
+}
+
+#[test]
+fn dm_gpu_every_gate_variant_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let (mut cpu, mut gpu) = f.prepared_pair(6);
+    for inst in gate_instructions() {
+        cpu.apply(&inst).unwrap();
+        gpu.apply(&inst).unwrap();
+        assert_same_mixture(&cpu, &gpu, &format!("after {inst:?}"));
+    }
+}
+
+type Step = Box<dyn Fn(&mut DensityMatrixBackend)>;
+
+#[test]
+fn dm_gpu_channel_kernels_match_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    for n in [8usize, 10] {
+        let (mut cpu, mut gpu) = f.prepared_pair(n);
+        let steps: Vec<(&str, Step)> = vec![
+            (
+                "amp damp q0",
+                Box::new(|b| b.apply_1q_kraus(0, &amplitude_damping(0.05))),
+            ),
+            (
+                "depolarizing 1q qtop",
+                Box::new(move |b| b.apply_1q_kraus(n - 1, &depolarizing_1q(0.02))),
+            ),
+            (
+                "depolarizing 2q (0, qtop)",
+                Box::new(move |b| b.apply_2q_depolarizing(0, n - 1, 0.02)),
+            ),
+            (
+                "depolarizing 2q (3, 1)",
+                Box::new(|b| b.apply_2q_depolarizing(3, 1, 0.07)),
+            ),
+            (
+                "diagonal 2q kraus (2, 3)",
+                Box::new(|b| b.apply_2q_kraus(2, 3, &correlated_zz(0.02))),
+            ),
+            (
+                "diagonal 2q kraus (0, qtop)",
+                Box::new(move |b| b.apply_2q_kraus(0, n - 1, &correlated_zz(0.02))),
+            ),
+            (
+                "dense 2q kraus (2, 3)",
+                Box::new(|b| b.apply_2q_kraus(2, 3, &h_conjugated_zz(0.02))),
+            ),
+            (
+                "dense 2q kraus (0, qtop)",
+                Box::new(move |b| b.apply_2q_kraus(0, n - 1, &h_conjugated_zz(0.02))),
+            ),
+            (
+                "dense 2q kraus (qtop, 1)",
+                Box::new(move |b| b.apply_2q_kraus(n - 1, 1, &h_conjugated_zz(0.05))),
+            ),
+        ];
+        for (label, step) in steps {
+            step(&mut cpu);
+            step(&mut gpu);
+            assert_same_mixture(&cpu, &gpu, &format!("{n}q {label}"));
+        }
+    }
+}
+
+/// A model that fires every `NoiseChannel` variant, one after each of the
+/// first eight gates, with a two-qubit channel wherever the gate has a pair.
+fn every_channel_model(circuit: &Circuit) -> NoiseModel {
+    let kinds: Vec<NoiseChannel> = vec![
+        NoiseChannel::Pauli {
+            px: 0.01,
+            py: 0.02,
+            pz: 0.03,
+        },
+        NoiseChannel::Depolarizing { p: 0.04 },
+        NoiseChannel::AmplitudeDamping { gamma: 0.05 },
+        NoiseChannel::PhaseDamping { gamma: 0.06 },
+        NoiseChannel::ThermalRelaxation {
+            t1: 50.0,
+            t2: 30.0,
+            gate_time: 1.0,
+        },
+        NoiseChannel::Custom {
+            kraus: amplitude_damping(0.07),
+        },
+        NoiseChannel::TwoQubitDepolarizing { p: 0.03 },
+        NoiseChannel::Kraus2q {
+            kraus: h_conjugated_zz(0.04),
+        },
+    ];
+    let mut next = 0usize;
+    let after_gate = circuit
+        .instructions
+        .iter()
+        .map(|inst| {
+            let Instruction::Gate { targets, .. } = inst else {
+                return Vec::new();
+            };
+            let mut events = Vec::new();
+            if let Some(channel) = kinds.get(next).cloned() {
+                if channel.num_qubits() == 1 {
+                    next += 1;
+                    events.push(NoiseEvent {
+                        channel,
+                        qubits: [targets[0]].into_iter().collect(),
+                    });
+                } else if targets.len() == 2 {
+                    next += 1;
+                    events.push(NoiseEvent {
+                        channel,
+                        qubits: [targets[0], targets[1]].into_iter().collect(),
+                    });
+                }
+            }
+            events
+        })
+        .collect();
+    assert_eq!(
+        next,
+        kinds.len(),
+        "the fixture must place every channel kind"
+    );
+    NoiseModel {
+        after_gate,
+        readout: vec![None; circuit.num_classical_bits],
+    }
+}
+
+fn single_qubit_observables(n: usize) -> Vec<Vec<PauliTerm>> {
+    let mut observables = Vec::new();
+    for q in 0..n {
+        observables.push(vec![PauliTerm::x(q)]);
+        observables.push(vec![PauliTerm::y(q)]);
+        observables.push(vec![PauliTerm::z(q)]);
+    }
+    observables.push(vec![PauliTerm::x(0), PauliTerm::y(n - 1)]);
+    observables.push(vec![PauliTerm::y(1), PauliTerm::z(2), PauliTerm::x(3)]);
+    observables
+}
+
+#[test]
+fn dm_gpu_every_noise_channel_kind_matches_cpu_through_simulate() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 8;
+    let unitary = circuits::random_circuit(n, 3, SEED);
+    let unitary_noise = every_channel_model(&unitary);
+    let mut circuit = unitary.clone();
+    circuit.measure_all();
+    let mut noise = every_channel_model(&unitary);
+    noise
+        .after_gate
+        .resize(circuit.instructions.len(), Vec::new());
+    noise.readout = vec![None; circuit.num_classical_bits];
+
+    let host = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .run()
+        .unwrap();
+    let device = sim::simulate(&circuit)
+        .backend(f.kind())
+        .noise(&noise)
+        .seed(SEED)
+        .run()
+        .unwrap();
+    assert_eq!(device.metadata.placement, Placement::Device);
+    assert_probs_close(
+        &device.probabilities.unwrap().to_vec(),
+        &host.probabilities.unwrap().to_vec(),
+        EPS,
+        "every channel kind, probabilities",
+    );
+
+    let observables = single_qubit_observables(n);
+    let host = sim::simulate(&unitary)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&unitary_noise)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    let device = sim::simulate(&unitary)
+        .backend(f.kind())
+        .noise(&unitary_noise)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    for (k, (h, d)) in host.iter().zip(&device).enumerate() {
+        assert!(
+            (h - d).abs() < EPS,
+            "every channel kind, observable {k}: host {h} device {d}"
+        );
+    }
+}
+
+#[test]
+fn dm_gpu_measure_reset_and_conditional_match_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 8;
+    let (mut cpu, mut gpu) = f.prepared_pair(n);
+    let steps = [
+        Instruction::Measure {
+            qubit: 0,
+            classical_bit: 0,
+        },
+        Instruction::Reset { qubit: 1 },
+        Instruction::Conditional {
+            condition: ClassicalCondition::BitIsOne(0),
+            gate: Gate::X,
+            targets: smallvec![2],
+        },
+        Instruction::Conditional {
+            condition: ClassicalCondition::BitIsZero(0),
+            gate: Gate::H,
+            targets: smallvec![3],
+        },
+        g(Gate::H, &[n - 1]),
+        Instruction::Measure {
+            qubit: n - 1,
+            classical_bit: 1,
+        },
+        Instruction::Measure {
+            qubit: 4,
+            classical_bit: 2,
+        },
+        Instruction::Reset { qubit: n - 1 },
+        Instruction::Reset { qubit: 0 },
+        g(Gate::Rx(0.7), &[0]),
+        Instruction::Measure {
+            qubit: 0,
+            classical_bit: 3,
+        },
+    ];
+    for inst in steps {
+        cpu.apply(&inst).unwrap();
+        gpu.apply(&inst).unwrap();
+        assert_same_mixture(&cpu, &gpu, &format!("after {inst:?}"));
+    }
+    assert!(
+        cpu.classical_results().iter().any(|&b| b),
+        "the fixture must record at least one 1 outcome"
+    );
+}
+
+fn count_gates(circuit: &Circuit, want: impl Fn(&Gate) -> bool) -> usize {
+    circuit
+        .instructions
+        .iter()
+        .filter(|inst| matches!(inst, Instruction::Gate { gate, .. } if want(gate)))
+        .count()
+}
+
+#[test]
+fn dm_gpu_fused_stream_matches_unfused_cpu() {
+    // The device path serves the same fused payloads the host accepts, and the
+    // payloads are asserted so a fusion change cannot quietly drain the test.
+    let Some(f) = Fixture::try_new() else { return };
+    const N: usize = 8;
+    for (label, circuit, want) in [
+        (
+            "qaoa",
+            circuits::qaoa_circuit(N, 3, SEED),
+            &[("BatchRzz", 1usize), ("DiagonalBatch", 0)][..],
+        ),
+        (
+            "diagonal mixed",
+            circuits::diagonal_mixed_circuit(N, 3, SEED),
+            &[("BatchRzz", 1), ("DiagonalBatch", 1)][..],
+        ),
+        (
+            "random",
+            circuits::random_circuit(N, 4, SEED),
+            &[("Multi2q", 1), ("MultiFused", 1)][..],
+        ),
+    ] {
+        let fused = fuse_circuit_for_width(&circuit, true, 2 * N).into_owned();
+        for &(form, count) in want {
+            let got = count_gates(&fused, |gate| match form {
+                "BatchRzz" => matches!(gate, Gate::BatchRzz(_)),
+                "DiagonalBatch" => matches!(gate, Gate::DiagonalBatch(_)),
+                "Multi2q" => matches!(gate, Gate::Multi2q(_)),
+                "MultiFused" => matches!(gate, Gate::MultiFused(_)),
+                _ => unreachable!(),
+            });
+            assert!(got >= count, "{label}: expected {count} {form}, got {got}");
+        }
+        let mut cpu = DensityMatrixBackend::new(SEED);
+        cpu.init(N, 0).unwrap();
+        cpu.apply_instructions(&circuit.instructions).unwrap();
+        let mut gpu = f.device_backend();
+        gpu.init(N, 0).unwrap();
+        gpu.apply_instructions(&fused.instructions).unwrap();
+        assert_same_mixture(
+            &cpu,
+            &gpu,
+            &format!("{label} fused on device vs unfused on host"),
+        );
+
+        let outcome = sim::simulate(&circuit)
+            .backend(f.kind())
+            .seed(SEED)
+            .run()
+            .unwrap();
+        assert_eq!(outcome.metadata.placement, Placement::Device);
+        assert_probs_close(
+            &outcome.probabilities.unwrap().to_vec(),
+            &cpu.probabilities().unwrap(),
+            EPS,
+            &format!("{label} dispatched device run"),
+        );
+    }
+}
+
+#[test]
+fn dm_gpu_terminals_match_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 5;
+    let (cpu, gpu) = f.prepared_pair(n);
+
+    assert_probs_close(
+        &gpu.probabilities().unwrap(),
+        &cpu.probabilities().unwrap(),
+        EPS,
+        "probabilities",
+    );
+    assert!(
+        (cpu.purity() - gpu.purity()).abs() < EPS,
+        "purity: cpu {} gpu {}",
+        cpu.purity(),
+        gpu.purity()
+    );
+    assert!(cpu.purity() < 0.999, "the fixture must be mixed");
+
+    let masks = all_pauli_masks(n);
+    let want = cpu.expectations_pauli(&masks);
+    let got = gpu.expectations_pauli(&masks);
+    for (k, (w, g)) in want.iter().zip(&got).enumerate() {
+        assert!((w - g).abs() < EPS, "pauli {:?}: cpu {w} gpu {g}", masks[k]);
+    }
+    let observables = single_qubit_observables(n);
+    let want = cpu.pauli_expectations(&observables).unwrap();
+    let got = gpu.pauli_expectations(&observables).unwrap();
+    for (k, (w, g)) in want.iter().zip(&got).enumerate() {
+        assert!((w - g).abs() < EPS, "observable {k}: cpu {w} gpu {g}");
+    }
+
+    for q in 0..n {
+        let want = cpu.reduced_density_matrix_1q(q).unwrap();
+        let got = gpu.reduced_density_matrix_1q(q).unwrap();
+        for r in 0..2 {
+            for col in 0..2 {
+                assert!(
+                    (want[r][col] - got[r][col]).norm() < EPS,
+                    "rdm q{q} [{r}][{col}]: cpu {:?} gpu {:?}",
+                    want[r][col],
+                    got[r][col]
+                );
+            }
+        }
+        let want = cpu.qubit_probability(q).unwrap();
+        let got = gpu.qubit_probability(q).unwrap();
+        assert!(
+            (want - got).abs() < EPS,
+            "qubit_probability q{q}: cpu {want} gpu {got}"
+        );
+    }
+}
+
+#[test]
+fn dm_gpu_init_from_amplitudes_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let n = 6;
+    let mut amps: Vec<Complex64> = (0..1usize << n)
+        .map(|i| Complex64::new(0.3 + 0.01 * i as f64, -0.2 + 0.02 * (i % 7) as f64))
+        .collect();
+    let norm = amps.iter().map(|a| a.norm_sqr()).sum::<f64>().sqrt();
+    for a in &mut amps {
+        *a /= norm;
+    }
+    let mut cpu = DensityMatrixBackend::new(SEED);
+    let mut gpu = f.device_backend();
+    cpu.init_from_amplitudes(amps.clone(), 0).unwrap();
+    gpu.init_from_amplitudes(amps, 0).unwrap();
+    assert_same_mixture(&cpu, &gpu, "outer product");
+    for inst in [
+        g(Gate::H, &[2]),
+        g(Gate::Cx, &[2, 5]),
+        g(Gate::Rzz(0.4), &[0, 4]),
+    ] {
+        cpu.apply(&inst).unwrap();
+        gpu.apply(&inst).unwrap();
+    }
+    assert_same_mixture(&cpu, &gpu, "gates after a start state");
+}
+
+#[test]
+fn dm_gpu_over_budget_init_names_the_mixture() {
+    let Some(f) = Fixture::try_new() else { return };
+    let over = f.ctx.max_qubits_for_statevector().unwrap() / 2 + 1;
+    let mut backend = f.device_backend();
+    match backend.init(over, 0).unwrap_err() {
+        prism_q::PrismError::IncompatibleBackend { backend, reason } => {
+            assert_eq!(backend, "density_matrix-gpu");
+            assert!(
+                reason.contains("free on the GPU") && reason.contains("4^n"),
+                "expected the mixture budget message, got: {reason}"
+            );
+            assert!(reason.contains(&format!("{over} qubits")));
+        }
+        other => panic!("expected the device budget error, got {other:?}"),
+    }
+}
+
+#[test]
+fn dm_gpu_kind_is_explicit_only() {
+    // The noisy terminals accept only the two mixture kinds, so an AutoGpu run
+    // under noise is rejected rather than routed to the device mixture.
+    let Some(f) = Fixture::try_new() else { return };
+    let mut circuit = circuits::random_circuit(6, 2, SEED);
+    circuit.measure_all();
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+    let err = sim::simulate(&circuit)
+        .backend(BackendKind::AutoGpu {
+            context: f.ctx.clone(),
+        })
+        .noise(&noise)
+        .seed(SEED)
+        .run()
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("density-matrix backend"),
+        "unexpected rejection: {err}"
+    );
+
+    let device = sim::simulate(&circuit)
+        .backend(f.kind())
+        .noise(&noise)
+        .seed(SEED)
+        .shots(64)
+        .unwrap();
+    assert_eq!(device.metadata.placement, Placement::Device);
+    let host = sim::simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .shots(64)
+        .unwrap();
+    assert_eq!(
+        device.counts(),
+        host.counts(),
+        "shots drawn from the same distribution"
+    );
+}

--- a/tests/golden_gpu_density_matrix.rs
+++ b/tests/golden_gpu_density_matrix.rs
@@ -23,7 +23,8 @@ use prism_q::gates::{
 };
 use prism_q::gpu::GpuContext;
 use prism_q::{
-    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, PauliTerm, Placement, circuits, sim,
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, Parameters, PauliTerm, Placement, circuits,
+    sim,
 };
 
 const EPS: f64 = 1e-12;
@@ -718,4 +719,35 @@ fn dm_gpu_kind_is_explicit_only() {
         host.counts(),
         "shots drawn from the same distribution"
     );
+}
+
+#[test]
+fn dm_gpu_noisy_shift_gradient_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let circuit = circuits::hardware_efficient_ansatz(8, 1, 7);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let params = Parameters::all_rotations(&circuit);
+    let hamiltonian: Vec<(f64, Vec<PauliTerm>)> = vec![
+        (0.7, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (-0.3, vec![PauliTerm::x(2)]),
+        (0.5, vec![PauliTerm::y(3), PauliTerm::z(4)]),
+        (0.2, vec![PauliTerm::z(7)]),
+    ];
+    let gradient = |kind: BackendKind| {
+        sim::simulate(&circuit)
+            .backend(kind)
+            .noise(&noise)
+            .seed(42)
+            .expectation_gradient_shift(&hamiltonian, &params)
+            .unwrap()
+    };
+    let device = gradient(f.kind());
+    let host = gradient(BackendKind::DensityMatrix);
+
+    assert!((device.value - host.value).abs() < 1e-10);
+    assert_eq!(device.gradient.len(), host.gradient.len());
+    for (slot, (d, h)) in device.gradient.iter().zip(&host.gradient).enumerate() {
+        assert!((d - h).abs() < 1e-10, "slot {slot}: device {d} vs host {h}");
+    }
+    assert!(host.gradient.iter().any(|g| g.abs() > 1e-3));
 }


### PR DESCRIPTION
## Summary

`BackendKind::DensityMatrixGpu { context }` keeps the exact mixture resident on the
device. The CPU backend already embeds `rho` as a `2n`-qubit statevector, so the
unitary half and the 1q Kraus channels reuse the dense statevector kernels over that
buffer; the 2q channels, projection, reset, and the diagonal and Pauli readouts get
NVRTC kernels of their own, because device residency is exclusive and every direct
index into the host buffer had to move together. The kind is explicit only: neither
`Auto` nor `AutoGpu` selects it, and there is no host fallback. `init` budgets the
`4^n` buffer against free VRAM before allocating, so an 11 GiB card holds 13 qubits.

## Benchmark summary

Host: Windows 10, i7-6700K, GTX 1080 Ti (11264 MiB, sm 6.1, FP64 at 1/32 rate),
rustc 1.97, CUDA 12.4, `--features "parallel gpu"` for device rows and `parallel` for
host rows, 30 samples per row, quiet host (foreign load gone at 21:33).

Device rows are new, so they have no reference binary; two direct runs of the same
binary agree within 1%. Host rows are the reference column of the CPU control A/B on
the same evening.

| Benchmark | Device | Host row | Ratio |
|-----------|-------:|---------:|------:|
| gpu_dm/noisy_channels/kraus_2q_dense/10 | 0.621 ms | 1.27 ms | 2.0x |
| gpu_dm/noisy_channels/kraus_2q_dense/12 | 7.76 ms | 23.61 ms | 3.0x |
| gpu_dm/noisy_channels/kraus_2q_dense/13 | 30.5 ms | past the host cap | |
| gpu_dm/noisy_channels/kraus_2q_dense_q0/12 | 7.78 ms | 26.78 ms | 3.4x |
| gpu_dm/noisy_channels/kraus_2q_adjacent/12 | 1.60 ms | 23.10 ms | 14.4x |
| gpu_dm/noisy_channels/depolarizing_2q/12 | 3.34 ms | 25.08 ms | 7.5x |
| gpu_dm/noisy_channels/kraus_amp_damp/12 | 2.87 ms | 23.52 ms | 8.2x |
| gpu_dm/rzz_layers_fused/12 | 207 ms | 1.989 s | 9.6x |

The 13.8x projection was a bandwidth ratio and it holds where the kernel stays on the
memory floor: `kraus_2q_adjacent/12` moves 512 MiB in 1.60 ms (335 GB/s) and lands at
14.4x. `kraus_2q_dense/{10,12}` does not, and the mechanism is the card, not the
port: a dense 16x16 superoperator costs 64 FP64 FMAs per amplitude, and a GP102 runs
FP64 at 1/32 rate (about 177 GFMA/s), so the flop floor at 12 qubits is 6.1 ms against
a 1.5 ms memory floor. The kernel runs at 7.6 to 7.8 ms, 80% of FP64 peak, and the
best ratio this card can reach on that row is 3.6x. A probe that issues 50 launches per
synchronize reproduces every row within 3%, so the Criterion numbers are kernel time,
not host scheduling. The row is compute-bound on consumer Pascal and would meet the
projection on a card with full-rate FP64.

Controls (A/B against the parent commit, same-code control column):

| Benchmark | Before | After | Change | Control (ref) | Control (new) |
|-----------|-------:|------:|-------:|--------------:|--------------:|
| gpu/direct/random_d10/10 | 346.6 us | 351.5 us | +1.4% | +1.0% | -1.4% |
| gpu/direct/random_d10/14 | 567.6 us | 562.8 us | -0.8% | -1.1% | -0.5% |
| gpu/direct/random_d10/16 | 985.6 us | 979.6 us | -0.6% | -0.1% | -0.4% |
| gpu/direct/random_d10/18 | 5.85 ms | 5.85 ms | +0.1% | -0.4% | +0.7% |
| gpu/direct/random_d10/20 | 25.39 ms | 25.41 ms | +0.0% | +0.2% | +0.2% |
| gpu/direct/random_d10/22 | 110.8 ms | 110.6 ms | -0.2% | +0.6% | +0.5% |
| density_matrix/noisy_channels/depolarizing_2q/12 | 25.08 ms | 25.03 ms | -0.2% | -0.9% | -0.5% |
| density_matrix/noisy_channels/kraus_2q_adjacent/12 | 23.10 ms | 23.22 ms | +0.5% | +0.1% | +0.2% |
| density_matrix/noisy_channels/kraus_2q_dense/12 | 23.61 ms | 24.10 ms | +2.1% | +0.5% | +2.1% |
| density_matrix/noisy_channels/kraus_2q_dense_q0/12 | 26.78 ms | 26.96 ms | +0.7% | -0.4% | +1.4% |
| density_matrix/noisy_channels/kraus_amp_damp/12 | 23.52 ms | 23.44 ms | -0.3% | +1.0% | +0.6% |
| density_matrix/rzz_layers_fused/10 | 88.13 ms | 88.19 ms | +0.1% | -0.1% | -1.9% |
| density_matrix/rzz_layers_fused/12 | 1.989 s | 1.991 s | +0.1% | -0.2% | -0.2% |

The five 10-qubit host rows read -4.4% to +1.0% with controls up to 3.2% and are noise.

## Regression verdict

PASS at 5%. No host row moves outside its own control column (worst same-code spread 3.2%), and the device control rows read noise (worst 1.4%). The dense device row falls short of the 13.8x projection for the FP64 reason above, which is a property of the card rather than a regression.

## Tests

`tests/golden_gpu_density_matrix.rs`, run with `PRISM_REQUIRE_GPU=1`: every gate
variant, every channel kernel, every `NoiseChannel` kind through `Simulate`,
measurement, reset and conditionals, the fused stream (`BatchRzz`, `DiagonalBatch`,
`Multi2q`, `MultiFused` asserted present), every terminal, `init_from_amplitudes`, the
over-budget rejection, and explicit-only dispatch. Full-buffer equality at 1e-12. Five
kernels were each broken deliberately (bra conjugate dropped, imaginary accumulator
dropped, Pauli row sign dropped, projection ignoring the column bit, reset leaving a
sibling) and each break failed at least one of these tests.

## Documentation

`docs/guides/gpu.md` and `docs/architecture/backends.md` carry the new kind, the
13-qubit ceiling, and the explicit-only rule. The `BackendKind::DensityMatrix`
docstring no longer claims fusion is skipped.
