### PR TITLE
perf(sim): fuse the density matrix on the shot path

### DIFF
--- a/benches/bench_gpu.rs
+++ b/benches/bench_gpu.rs
@@ -31,7 +31,8 @@ use prism_q::circuits;
 use prism_q::gates::Gate;
 use prism_q::gpu::GpuContext;
 use prism_q::{
-    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, StabilizerBackend, StatevectorBackend, sim,
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, Parameters, PauliTerm, StabilizerBackend,
+    StatevectorBackend, sim,
 };
 
 mod common;
@@ -951,6 +952,42 @@ fn bench_gpu_dm_rzz_layers_fused(c: &mut Criterion) {
     group.finish();
 }
 
+/// The device sibling of `gradient/density_matrix`: five exact evolutions of
+/// the mixture per iteration, each resident on the card.
+fn bench_gpu_dm_gradient(c: &mut Criterion) {
+    let Some(ctx) = shared_ctx() else { return };
+    let mut group = c.benchmark_group("gpu_dm/gradient");
+    configure_group(&mut group);
+    let kind = BackendKind::DensityMatrixGpu {
+        context: ctx.clone(),
+    };
+
+    for &n in &[10usize, 12] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 1, SEED);
+        let noise = NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let mut params = Parameters::new(2);
+        params.link(0, 0);
+        params.link(1, 1);
+        let ham: Vec<(f64, Vec<PauliTerm>)> = (0..n - 1)
+            .map(|q| (1.0, vec![PauliTerm::z(q), PauliTerm::z(q + 1)]))
+            .collect();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(kind.clone())
+                        .noise(&noise)
+                        .seed(SEED)
+                        .expectation_gradient_shift(&ham, &params)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = common::criterion_config();
@@ -975,6 +1012,7 @@ criterion_group! {
     bench_stab_bts_device_counts_explicit,
     bench_stab_gpu_shots_explicit,
     bench_gpu_dm_noisy_channels,
-    bench_gpu_dm_rzz_layers_fused
+    bench_gpu_dm_rzz_layers_fused,
+    bench_gpu_dm_gradient
 }
 criterion_main!(benches);

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -1694,6 +1694,36 @@ fn bench_gradient(c: &mut Criterion) {
     group.finish();
 }
 
+/// Parameter shift under a noise model: every evaluation evolves the exact
+/// mixture, so two linked slots cost five density-matrix evolutions.
+fn bench_gradient_density_matrix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gradient/density_matrix");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let circuit = circuits::hardware_efficient_ansatz(n, 1, SEED);
+        let noise = prism_q::NoiseModel::uniform_depolarizing(&circuit, 0.01);
+        let mut params = Parameters::new(2);
+        params.link(0, 0);
+        params.link(1, 1);
+        let ham = z_chain_hamiltonian(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(
+                    sim::simulate(circ)
+                        .backend(BackendKind::DensityMatrix)
+                        .noise(&noise)
+                        .seed(SEED)
+                        .expectation_gradient_shift(&ham, &params)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_gradient_qaoa(c: &mut Criterion) {
     let mut group = c.benchmark_group("gradient/qaoa_l1");
     configure_group(&mut group);
@@ -3283,6 +3313,7 @@ criterion_group! {
     // Adjoint gradient (adjoint vs finite-difference per parameter)
     bench_gradient,
     bench_gradient_qaoa,
+    bench_gradient_density_matrix,
     bench_gradient_prefix,
     // Variational loop iteration (rebuild vs rebind under simulation cost)
     bench_vqe_loop,

--- a/benches/circuits.rs
+++ b/benches/circuits.rs
@@ -2997,6 +2997,45 @@ fn bench_density_matrix_noisy_shots(c: &mut Criterion) {
     group.finish();
 }
 
+/// The per-shot density-matrix route: a mid-circuit measurement feeding a
+/// conditional keeps the shot loop off the terminal-probabilities shortcut,
+/// so every shot replays the circuit the shot path fused (or did not).
+fn bench_density_matrix_shots_fused(c: &mut Criterion) {
+    let mut group = c.benchmark_group("density_matrix/shots_fused");
+    configure_group(&mut group);
+
+    for &n in &[10, 12] {
+        let mut circuit = circuits::random_circuit(n, 4, SEED);
+        circuit.num_classical_bits = n;
+        let middle = circuit.instructions.len() / 2;
+        circuit.instructions.insert(
+            middle,
+            Instruction::Conditional {
+                condition: ClassicalCondition::BitIsOne(0),
+                gate: Gate::X,
+                targets: SmallVec::from_slice(&[1]),
+            },
+        );
+        circuit.instructions.insert(
+            middle,
+            Instruction::Measure {
+                qubit: 0,
+                classical_bit: 0,
+            },
+        );
+        for q in 0..n {
+            circuit.add_measure(q, q);
+        }
+        group.bench_with_input(BenchmarkId::from_parameter(n), &circuit, |b, circ| {
+            b.iter(|| {
+                black_box(run_shots_with(BackendKind::DensityMatrix, circ, 2, SEED).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
 /// Clifford layers over `n` qubits, emitted either as bare instructions or as
 /// one guarded region per layer.
 ///
@@ -3286,6 +3325,7 @@ criterion_group! {
     bench_density_matrix_exact_vs_trajectory,
     bench_density_matrix_noisy_channels,
     bench_density_matrix_noisy_shots,
+    bench_density_matrix_shots_fused,
     bench_density_matrix_neutrality,
     // Dynamic circuits (guard cost, dead-region predicate, per-shot cliff)
     bench_dynamic_guarded_region,

--- a/bindings/python/src/backend.rs
+++ b/bindings/python/src/backend.rs
@@ -132,6 +132,24 @@ impl PyBackendKind {
         }
     }
 
+    /// Exact mixed state held on the supplied device. Explicit only, with no
+    /// host fallback: the `4^n` buffer is budgeted against free device memory
+    /// before allocation and a width that does not fit raises `PrismError`.
+    #[staticmethod]
+    fn density_matrix_gpu(context: &PyGpuContext) -> PyPrismResult<Self> {
+        #[cfg(feature = "gpu")]
+        {
+            Ok(Self(BackendKind::DensityMatrixGpu {
+                context: context.inner.clone(),
+            }))
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            let _ = context;
+            Err(crate::gpu::unsupported())
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!("BackendKind({:?})", self.0)
     }

--- a/bindings/python/tests/test_gpu.py
+++ b/bindings/python/tests/test_gpu.py
@@ -17,7 +17,15 @@ import os
 import numpy as np
 import pytest
 
-from prism_q import BackendKind, CircuitBuilder, GpuContext, PrismError, circuits, simulate
+from prism_q import (
+    BackendKind,
+    CircuitBuilder,
+    GpuContext,
+    NoiseModel,
+    PrismError,
+    circuits,
+    simulate,
+)
 
 SUPPORTED = GpuContext.is_supported()
 AVAILABLE = GpuContext.is_available()
@@ -40,7 +48,7 @@ def test_prism_require_gpu_is_honoured():
 
 
 def test_gpu_surface_exists_in_every_build():
-    for name in ("statevector_gpu", "stabilizer_gpu", "auto_gpu"):
+    for name in ("statevector_gpu", "stabilizer_gpu", "density_matrix_gpu", "auto_gpu"):
         assert hasattr(BackendKind, name)
 
 
@@ -74,6 +82,22 @@ def test_gpu_statevector_below_the_crossover_matches_host():
     device = simulate(circuit).backend(BackendKind.statevector_gpu(context)).seed(42).run()
     host = simulate(circuit).backend(BackendKind.statevector()).seed(42).run()
     np.testing.assert_allclose(device.probabilities, host.probabilities, atol=1e-12)
+
+
+@requires_device
+def test_gpu_density_matrix_matches_host_mixture():
+    circuit = _entangled_chain(6)
+    model = NoiseModel.uniform_depolarizing(circuit, 0.05)
+    context = GpuContext(0)
+    device = simulate(circuit).backend(BackendKind.density_matrix_gpu(context)).noise(model).seed(42)
+    host = simulate(circuit).backend(BackendKind.density_matrix()).noise(model).seed(42)
+    np.testing.assert_allclose(device.run().probabilities, host.run().probabilities, atol=1e-12)
+    observables = [[(0, "Z")], [(1, "X"), (2, "Z")]]
+    np.testing.assert_allclose(
+        device.expectation_values(observables),
+        host.expectation_values(observables),
+        atol=1e-12,
+    )
 
 
 @requires_device

--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -182,12 +182,12 @@ Pauli readouts have kernels of their own. Both kinds are explicit-dispatch only;
 `Auto` and `AutoGpu` never select them, and the device kind has no host fallback.
 
 Selecting it with a noise model attached is the exact route for every `Simulate`
-terminal except the two gradient terminals: the mixture is evolved once and observables,
-marginals, probabilities, and shots all read that one evolution. Gradients are excluded
-for two different reasons: the adjoint backpropagates against a pure state and a channel
-has no reverse evolution to walk, while parameter shift is exact on a mixture and simply
-not wired. See [Noise across the terminals](./engine.md) for
-what that route accepts and what stays on trajectory averaging.
+terminal except the adjoint gradient: the mixture is evolved once and observables,
+marginals, probabilities, and shots all read that one evolution, and the parameter-shift
+gradient evaluates the mixture once per shifted angle. The adjoint stays excluded because
+it backpropagates against a pure state and a channel has no reverse evolution to walk.
+See [Noise across the terminals](./engine.md) for what that route accepts and what stays
+on trajectory averaging.
 
 ## What a backend reports about its own result
 

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -86,9 +86,10 @@ same property that makes the density matrix the mixture oracle rather than a com
 participant in the branching families of `tests/conformance_matrix.rs`.
 
 `expectation_gradient` rejects a noise model on every backend, because the adjoint method
-backpropagates through a pure state. `expectation_gradient_shift` rejects one too, though
-the obstacle there is only that the path is not wired: the shift rule holds under a
-parameter-independent channel, so the density matrix could serve it.
+backpropagates through a pure state. `expectation_gradient_shift` accepts one on the
+density-matrix kinds: the channels do not depend on the shifted angle, so the shift rule
+holds and each of the `1 + 2 * links` evaluations reads the exact mixture. Every other
+backend rejects the pair, naming the density matrix.
 
 ## Result provenance
 

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -68,7 +68,7 @@ currently free VRAM is rejected at `init` with an error naming the requested and
 device memory; `GpuContext::max_qubits_for_statevector` reports the advisory cap from
 free memory.
 
-The three `BackendKind` entry points are also reachable from Python, from a build
+The four `BackendKind` entry points are also reachable from Python, from a build
 carrying the `gpu` feature. See [Python Bindings](python.md#gpu-backends).
 
 ## Module layout (`src/gpu/`)

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -251,7 +251,7 @@ Pass an explicit one to override it.
 | `density_matrix()` | Exact mixed states, never chosen by `auto()` |
 | `stochastic_pauli(num_samples=1000)` | Sampled Pauli propagation |
 | `deterministic_pauli(epsilon=0.0, max_terms=65536)` | Truncated Pauli propagation |
-| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
+| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)`, `density_matrix_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
 
 The density-matrix backend stores `4^n` amplitudes, so its qubit ceiling is
 about half the statevector cap; exceeding it raises `PrismError` naming the cap.
@@ -285,6 +285,12 @@ therefore normal, not a failure signal.
 (`PRISM_STABILIZER_GPU_MIN_QUBITS`), so it runs on the host tableau unless that
 override is lowered. The device tableau is correct; the default stays high until
 benchmarks justify lowering it.
+
+`density_matrix_gpu(context)` holds the exact mixed state on the device and is the
+one device kind with no crossover and no host fallback: `auto_gpu` never selects it,
+every noisy terminal that `density_matrix()` serves answers from the device buffer,
+and a width whose `4^n` buffer does not fit in free device memory raises `PrismError`
+before anything is allocated (13 qubits on an 11 GiB card).
 
 The published wheels are built without CUDA, because two of the three wheel
 targets have no CUDA toolkit and macOS has no CUDA at all. In those wheels the

--- a/src/backend/density_matrix.rs
+++ b/src/backend/density_matrix.rs
@@ -54,10 +54,9 @@
 //! - Noisy circuits with mid-circuit measurement or classical conditioning.
 //!   The mixture holds every branch at once, so per-shot feedback cannot be
 //!   replayed from it and the noisy terminals reject those shapes.
-//! - Gradients under noise. Both gradient terminals decline a noise model, for
-//!   different reasons: the adjoint backpropagates against a pure state and a
-//!   channel has no reverse evolution to walk, while parameter shift is exact
-//!   on a mixture and simply not wired.
+//! - Adjoint gradients under noise. The adjoint backpropagates against a pure
+//!   state and a channel has no reverse evolution to walk; the parameter-shift
+//!   terminal serves the noisy gradient from the mixture instead.
 
 use std::borrow::Cow;
 #[cfg(feature = "gpu")]

--- a/src/sim/dispatch.rs
+++ b/src/sim/dispatch.rs
@@ -647,18 +647,6 @@ impl BackendPlan {
         }
     }
 
-    /// Whether the fusion pipeline should synthesize fused-matrix gates for
-    /// this plan. Tableau-based families reject non-Clifford fused matrices;
-    /// every dense or factored representation accepts them.
-    pub(super) fn supports_fused(&self) -> bool {
-        !matches!(
-            self,
-            BackendPlan::Stabilizer { .. }
-                | BackendPlan::FactoredStabilizer
-                | BackendPlan::DensityMatrix { .. }
-        )
-    }
-
     #[cfg(test)]
     pub(super) fn family(&self) -> Family {
         match self {
@@ -1517,11 +1505,11 @@ mod dispatch_matrix_tests {
                 );
             }
         }
-        // Explicit selection maps 1:1 onto the density-matrix plan, which skips
-        // fusion.
+        // Explicit selection maps 1:1 onto the density-matrix plan, and the
+        // backend it builds accepts fused payloads on every terminal.
         let plan = resolved(&BackendKind::DensityMatrix, &dense(6), false);
         assert_eq!(plan.family(), Family::DensityMatrix);
-        assert!(!plan.supports_fused(), "density matrix must skip fusion");
+        assert!(plan.build(42).supports_fused_gates());
         assert!(matches!(plan.accel(), Accel::Cpu));
     }
 

--- a/src/sim/gradient.rs
+++ b/src/sim/gradient.rs
@@ -23,6 +23,7 @@ use crate::circuit::{Circuit, Instruction};
 use crate::error::{PrismError, Result};
 use crate::gates::{Gate, GeneratorKind, pauli_rot_masks};
 
+use super::noise::NoiseModel;
 use super::unified_pauli::PauliTerm;
 use super::{BackendKind, i_pow, pauli_masks, pauli_sandwich};
 
@@ -312,7 +313,15 @@ pub fn run_expectation_gradient_shift(
     params: &Parameters,
     seed: u64,
 ) -> Result<ExpectationGradient> {
-    shift_gradient(&BackendKind::Auto, circuit, hamiltonian, params, None, seed)
+    shift_gradient(
+        &BackendKind::Auto,
+        circuit,
+        hamiltonian,
+        params,
+        None,
+        None,
+        seed,
+    )
 }
 
 /// Parameter-shift gradient on the backend `kind` selects, optionally from a
@@ -329,28 +338,44 @@ pub fn run_expectation_gradient_shift(
 /// Gates sharing a parameter slot are shifted one at a time and summed. Shifting
 /// them together is a different quantity: two `Rx(θ)` on one qubit under `⟨Z⟩`
 /// give `cos 2θ`, whose joint ±π/2 shift is zero rather than `-2 sin 2θ`.
+///
+/// Under `noise` every forward evaluation reads the exact mixture, so `kind`
+/// must be a density-matrix kind, which the caller checks. The channels do not
+/// depend on the shifted angle, so `⟨H⟩` stays a degree-1 trigonometric
+/// polynomial in it and the shift is still exact.
 pub(crate) fn shift_gradient(
     kind: &BackendKind,
     circuit: &Circuit,
     hamiltonian: &[(f64, Vec<PauliTerm>)],
     params: &Parameters,
+    noise: Option<&NoiseModel>,
     initial_state: Option<&[Complex64]>,
     seed: u64,
 ) -> Result<ExpectationGradient> {
     params.validate(circuit)?;
-    if initial_state.is_some() {
+    if initial_state.is_some() || noise.is_some() {
         super::require_unitary_circuit(kind, circuit)?;
     }
 
     let observables: Vec<Vec<PauliTerm>> =
         hamiltonian.iter().map(|(_, terms)| terms.clone()).collect();
     let evaluate = |c: &Circuit| -> Result<f64> {
-        let per_term = match initial_state {
-            Some(state) => {
+        let per_term = match (noise, initial_state) {
+            (Some(noise), _) => super::noise::dm_expectation_values(
+                kind,
+                c,
+                &observables,
+                Some(noise),
+                initial_state,
+                seed,
+            )?,
+            (None, Some(state)) => {
                 super::expectation_values_from_initial_state(kind, c, state, &observables, seed)?
                     .into_values()
             }
-            None => super::run_expectation_values_with(kind.clone(), c, &observables, seed)?,
+            (None, None) => {
+                super::run_expectation_values_with(kind.clone(), c, &observables, seed)?
+            }
         };
         Ok(hamiltonian
             .iter()

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -175,8 +175,9 @@ impl<'c, SeedState> Simulate<'c, SeedState> {
     /// [`Simulate::run`], [`Simulate::marginals`], and
     /// [`Simulate::expectation_values`] answer from the exact mixture instead,
     /// which only [`BackendKind::DensityMatrix`] and its device sibling hold,
-    /// so they require one of those. [`Simulate::expectation_gradient`] rejects
-    /// a noise model on every backend.
+    /// so they require one of those, as does
+    /// [`Simulate::expectation_gradient_shift`]. [`Simulate::expectation_gradient`]
+    /// rejects a noise model on every backend.
     #[inline]
     pub fn noise(mut self, model: &'c noise::NoiseModel) -> Self {
         self.noise_model = Some(model);
@@ -535,8 +536,8 @@ impl<'c> Simulate<'c, Seeded> {
             return Err(PrismError::IncompatibleBackend {
                 backend: format!("{:?}", self.kind),
                 reason: "the adjoint method backpropagates through a pure state, so no backend \
-                         has a noisy gradient path; drop the noise model, or differentiate noisy \
-                         `expectation_values` numerically"
+                         has a noisy adjoint path; drop the noise model, or take \
+                         `expectation_gradient_shift` on the density-matrix backend"
                     .into(),
             });
         }
@@ -564,11 +565,14 @@ impl<'c> Simulate<'c, Seeded> {
     ///
     /// Serves the cases [`Simulate::expectation_gradient`] declines: any
     /// backend with a native observable path, circuits containing `QftBlock`,
-    /// and widths past the statevector cap. It differentiates the same gate set
-    /// (`Rx`, `Ry`, `Rz`, `Rzz`, `P`, `PauliRot`) at `1 + 2 * links` circuit evaluations
-    /// against the adjoint's one, so the adjoint stays the better choice where
-    /// it applies. A backend with no native observable path reports
-    /// `BackendUnsupported` naming itself. See
+    /// widths past the statevector cap, and a noise model. It differentiates the
+    /// same gate set (`Rx`, `Ry`, `Rz`, `Rzz`, `P`, `PauliRot`) at `1 + 2 * links`
+    /// circuit evaluations against the adjoint's one, so the adjoint stays the
+    /// better choice where it applies. A backend with no native observable path
+    /// reports `BackendUnsupported` naming itself. Under a noise model every
+    /// evaluation reads the exact mixture, so the backend must be
+    /// [`BackendKind::DensityMatrix`] or its device sibling; the shift stays
+    /// exact because the channels do not depend on the shifted angle. See
     /// [`gradient::run_expectation_gradient_shift`].
     #[inline]
     pub fn expectation_gradient_shift(
@@ -580,11 +584,13 @@ impl<'c> Simulate<'c, Seeded> {
         if self.require_exact {
             reject_approximate_route(&self.kind, self.circuit)?;
         }
-        if self.noise_model.is_some() {
+        if self.noise_model.is_some() && !self.kind.is_density_matrix() {
             return Err(PrismError::IncompatibleBackend {
                 backend: format!("{:?}", self.kind),
-                reason: "noisy parameter-shift gradients are not wired; drop the noise model, or \
-                         differentiate noisy `expectation_values` numerically"
+                reason: "a parameter-shift gradient under a noise model evaluates the exact \
+                         mixed state, which only the density-matrix backend holds; select \
+                         `BackendKind::DensityMatrix` or its device sibling, or drop the noise \
+                         model"
                     .into(),
             });
         }
@@ -593,6 +599,7 @@ impl<'c> Simulate<'c, Seeded> {
             self.circuit,
             hamiltonian,
             params,
+            self.noise_model,
             self.initial_state,
             seed,
         )

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -2761,10 +2761,7 @@ fn run_shots_per_shot(
             .map(|((sub, _, _), plan)| {
                 let probe = plan.build(seed);
                 let expanded = expand_for_backend(&*probe, sub);
-                std::borrow::Cow::Owned(
-                    crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused())
-                        .into_owned(),
-                )
+                std::borrow::Cow::Owned(fuse_for_backend(&*probe, &expanded).into_owned())
             })
             .collect();
 
@@ -2790,7 +2787,7 @@ fn run_shots_per_shot(
         let plan = resolve_backend(&kind, circuit, has_partial_independence);
         let probe = plan.build(seed);
         let expanded = expand_for_backend(&*probe, circuit);
-        let fused = crate::circuit::fusion::fuse_circuit(&expanded, plan.supports_fused());
+        let fused = fuse_for_backend(&*probe, &expanded);
 
         collect_shots(circuit, num_shots, seed, plan.resolved(), |shot_seed| {
             let mut backend = plan.build(shot_seed);

--- a/tests/expectation_gradient_noisy.rs
+++ b/tests/expectation_gradient_noisy.rs
@@ -1,0 +1,179 @@
+//! Parameter-shift gradients under a noise model: the density-matrix route
+//! against central finite differences of the noisy expectation values, and the
+//! rejections every other backend keeps.
+
+mod common;
+
+use common::SEED;
+use prism_q::circuits;
+use prism_q::{
+    BackendKind, Circuit, Gate, Instruction, NoiseModel, Parameters, PauliTerm, simulate,
+};
+
+type Hamiltonian = Vec<(f64, Vec<PauliTerm>)>;
+
+fn fixture() -> (Circuit, NoiseModel, Parameters, Hamiltonian) {
+    let circuit = circuits::hardware_efficient_ansatz(6, 2, SEED);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let params = Parameters::all_rotations(&circuit);
+    let hamiltonian = vec![
+        (0.7, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (-0.3, vec![PauliTerm::x(2)]),
+        (0.5, vec![PauliTerm::y(3), PauliTerm::z(4)]),
+        (0.2, vec![PauliTerm::z(5)]),
+    ];
+    (circuit, noise, params, hamiltonian)
+}
+
+fn noisy_expval(circuit: &Circuit, noise: &NoiseModel, hamiltonian: &Hamiltonian) -> f64 {
+    let observables: Vec<Vec<PauliTerm>> = hamiltonian.iter().map(|(_, p)| p.clone()).collect();
+    let per_term = simulate(circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(noise)
+        .seed(SEED)
+        .expectation_values(&observables)
+        .unwrap();
+    hamiltonian
+        .iter()
+        .zip(per_term)
+        .map(|((c, _), v)| c * v)
+        .sum()
+}
+
+fn shift_slot(circuit: &Circuit, params: &Parameters, slot: usize, delta: f64) -> Circuit {
+    let mut out = circuit.clone();
+    for link in params.links().iter().filter(|l| l.slot == slot) {
+        if let Instruction::Gate { gate, .. } = &mut out.instructions[link.instruction] {
+            *gate = match gate {
+                Gate::Ry(t) => Gate::Ry(*t + delta),
+                Gate::Rz(t) => Gate::Rz(*t + delta),
+                other => panic!("fixture carries only Ry and Rz rotations, found {other:?}"),
+            };
+        }
+    }
+    out
+}
+
+#[test]
+fn noisy_shift_matches_finite_differences_of_noisy_expectation_values() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    let g = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+
+    assert!((g.value - noisy_expval(&circuit, &noise, &hamiltonian)).abs() < 1e-12);
+    assert_eq!(g.gradient.len(), params.num_slots());
+    let eps = 1e-4;
+    let mut largest = 0.0_f64;
+    for slot in 0..params.num_slots() {
+        let plus = noisy_expval(
+            &shift_slot(&circuit, &params, slot, eps),
+            &noise,
+            &hamiltonian,
+        );
+        let minus = noisy_expval(
+            &shift_slot(&circuit, &params, slot, -eps),
+            &noise,
+            &hamiltonian,
+        );
+        let fd = (plus - minus) / (2.0 * eps);
+        assert!(
+            (g.gradient[slot] - fd).abs() < 1e-6,
+            "slot {slot}: shift {} vs finite difference {fd}",
+            g.gradient[slot]
+        );
+        largest = largest.max(g.gradient[slot].abs());
+    }
+    assert!(
+        largest > 1e-3,
+        "the fixture must have a non-trivial gradient"
+    );
+}
+
+#[test]
+fn noisy_shift_differs_from_the_noiseless_gradient() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    let noisy = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+    let clean = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap();
+    let moved = noisy
+        .gradient
+        .iter()
+        .zip(&clean.gradient)
+        .any(|(a, b)| (a - b).abs() > 1e-3);
+    assert!(moved, "depolarizing at 2% per gate must move the gradient");
+}
+
+#[test]
+fn noisy_shift_rejects_backends_without_the_mixture() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    for kind in [
+        BackendKind::Auto,
+        BackendKind::Statevector,
+        BackendKind::Sparse,
+    ] {
+        let err = simulate(&circuit)
+            .backend(kind.clone())
+            .noise(&noise)
+            .seed(SEED)
+            .expectation_gradient_shift(&hamiltonian, &params)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("density-matrix") && err.contains("noise model"),
+            "{kind:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn adjoint_still_rejects_noise_and_names_the_shift_route() {
+    let (circuit, noise, params, hamiltonian) = fixture();
+    for kind in [BackendKind::Auto, BackendKind::DensityMatrix] {
+        let err = simulate(&circuit)
+            .backend(kind.clone())
+            .noise(&noise)
+            .seed(SEED)
+            .expectation_gradient(&hamiltonian, &params)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("expectation_gradient_shift"),
+            "{kind:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn noisy_shift_rejects_mid_circuit_measurement() {
+    let (mut circuit, _, _, hamiltonian) = fixture();
+    circuit.num_classical_bits = 1;
+    circuit.instructions.insert(
+        3,
+        Instruction::Measure {
+            qubit: 0,
+            classical_bit: 0,
+        },
+    );
+    let params = Parameters::all_rotations(&circuit);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let err = simulate(&circuit)
+        .backend(BackendKind::DensityMatrix)
+        .noise(&noise)
+        .seed(SEED)
+        .expectation_gradient_shift(&hamiltonian, &params)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("measurement"), "{err}");
+}

--- a/tests/golden_gpu_density_matrix.rs
+++ b/tests/golden_gpu_density_matrix.rs
@@ -23,7 +23,8 @@ use prism_q::gates::{
 };
 use prism_q::gpu::GpuContext;
 use prism_q::{
-    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, PauliTerm, Placement, circuits, sim,
+    BackendKind, NoiseChannel, NoiseEvent, NoiseModel, Parameters, PauliTerm, Placement, circuits,
+    sim,
 };
 
 const EPS: f64 = 1e-12;
@@ -718,4 +719,35 @@ fn dm_gpu_kind_is_explicit_only() {
         host.counts(),
         "shots drawn from the same distribution"
     );
+}
+
+#[test]
+fn dm_gpu_noisy_shift_gradient_matches_cpu() {
+    let Some(f) = Fixture::try_new() else { return };
+    let circuit = circuits::hardware_efficient_ansatz(8, 1, 7);
+    let noise = NoiseModel::uniform_depolarizing(&circuit, 0.02);
+    let params = Parameters::all_rotations(&circuit);
+    let hamiltonian: Vec<(f64, Vec<PauliTerm>)> = vec![
+        (0.7, vec![PauliTerm::z(0), PauliTerm::z(1)]),
+        (-0.3, vec![PauliTerm::x(2)]),
+        (0.5, vec![PauliTerm::y(3), PauliTerm::z(4)]),
+        (0.2, vec![PauliTerm::z(7)]),
+    ];
+    let gradient = |kind: BackendKind| {
+        sim::simulate(&circuit)
+            .backend(kind)
+            .noise(&noise)
+            .seed(42)
+            .expectation_gradient_shift(&hamiltonian, &params)
+            .unwrap()
+    };
+    let device = gradient(f.kind());
+    let host = gradient(BackendKind::DensityMatrix);
+
+    assert!((device.value - host.value).abs() < 1e-10);
+    assert_eq!(device.gradient.len(), host.gradient.len());
+    for (slot, (d, h)) in device.gradient.iter().zip(&host.gradient).enumerate() {
+        assert!((d - h).abs() < 1e-10, "slot {slot}: device {d} vs host {h}");
+    }
+    assert!(host.gradient.iter().any(|g| g.abs() > 1e-3));
 }


### PR DESCRIPTION
## Summary

The shot loop fused by a plan-level table that still listed the density matrix among
the families rejecting fused matrices, so the same circuit ran fused through `run` and
unfused through `shots`. Both shot-path sites now fuse through the probe backend they
already build, which is the rule the single-run terminal uses, and the table is gone:
the stabilizer families were its only other members and their probes already answer
false.

## Benchmark summary

`density_matrix/shots_fused/{10,12}` is new: the shot terminal over a circuit whose
mid-circuit measurement feeds a conditional, so every shot replays the circuit (the
terminal-probabilities shortcut never reaches the sites this touches). Two A/B runs
against the bench-row commit, 30 samples, i7-6700K, `--features parallel`. The host carried
foreign load during both runs; the 12-qubit rows resolved anyway.

| Benchmark | Before | After | Change | Control (ref) | Control (new) |
|-----------|-------:|------:|-------:|--------------:|--------------:|
| density_matrix/shots_fused/12 (run 1) | 4.187 s | 2.182 s | -47.9% | +0.8% | -2.0% |
| density_matrix/shots_fused/12 (run 2) | 4.083 s | 2.009 s | -50.8% | +2.1% | -0.7% |
| density_matrix/shots_fused/10 (run 1) | 192.5 ms | 112.0 ms | -41.8% | -12.1% | -6.6% |
| density_matrix/shots_fused/10 (run 2) | 186.4 ms | 93.9 ms | -49.7% | -12.6% | -11.8% |
| density_matrix/fused_layers/12 (run 1) | 1.113 s | 1.111 s | -0.2% | -2.2% | +0.8% |
| density_matrix/fused_layers/12 (run 2) | 1.051 s | 1.040 s | -1.0% | -3.9% | -1.9% |

`fused_layers/{8,10}` read noise in both runs with controls up to 32% (loaded host).

## Regression verdict

PASS at 5%: the control rows sit inside their own control column and the claim row
moves by 48% to 51% against a control under 2.1%.

## Tests

The `dispatch.rs` test that asserted "density matrix must skip fusion" now asserts the
plan builds a backend that accepts fused payloads. Full gate green at
`parallel gpu distributed`.
