### PR TITLE
feat(python): density_matrix_gpu backend kind

### DIFF
--- a/bindings/python/src/backend.rs
+++ b/bindings/python/src/backend.rs
@@ -132,6 +132,24 @@ impl PyBackendKind {
         }
     }
 
+    /// Exact mixed state held on the supplied device. Explicit only, with no
+    /// host fallback: the `4^n` buffer is budgeted against free device memory
+    /// before allocation and a width that does not fit raises `PrismError`.
+    #[staticmethod]
+    fn density_matrix_gpu(context: &PyGpuContext) -> PyPrismResult<Self> {
+        #[cfg(feature = "gpu")]
+        {
+            Ok(Self(BackendKind::DensityMatrixGpu {
+                context: context.inner.clone(),
+            }))
+        }
+        #[cfg(not(feature = "gpu"))]
+        {
+            let _ = context;
+            Err(crate::gpu::unsupported())
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!("BackendKind({:?})", self.0)
     }

--- a/bindings/python/tests/test_gpu.py
+++ b/bindings/python/tests/test_gpu.py
@@ -17,7 +17,15 @@ import os
 import numpy as np
 import pytest
 
-from prism_q import BackendKind, CircuitBuilder, GpuContext, PrismError, circuits, simulate
+from prism_q import (
+    BackendKind,
+    CircuitBuilder,
+    GpuContext,
+    NoiseModel,
+    PrismError,
+    circuits,
+    simulate,
+)
 
 SUPPORTED = GpuContext.is_supported()
 AVAILABLE = GpuContext.is_available()
@@ -40,7 +48,7 @@ def test_prism_require_gpu_is_honoured():
 
 
 def test_gpu_surface_exists_in_every_build():
-    for name in ("statevector_gpu", "stabilizer_gpu", "auto_gpu"):
+    for name in ("statevector_gpu", "stabilizer_gpu", "density_matrix_gpu", "auto_gpu"):
         assert hasattr(BackendKind, name)
 
 
@@ -74,6 +82,22 @@ def test_gpu_statevector_below_the_crossover_matches_host():
     device = simulate(circuit).backend(BackendKind.statevector_gpu(context)).seed(42).run()
     host = simulate(circuit).backend(BackendKind.statevector()).seed(42).run()
     np.testing.assert_allclose(device.probabilities, host.probabilities, atol=1e-12)
+
+
+@requires_device
+def test_gpu_density_matrix_matches_host_mixture():
+    circuit = _entangled_chain(6)
+    model = NoiseModel.uniform_depolarizing(circuit, 0.05)
+    context = GpuContext(0)
+    device = simulate(circuit).backend(BackendKind.density_matrix_gpu(context)).noise(model).seed(42)
+    host = simulate(circuit).backend(BackendKind.density_matrix()).noise(model).seed(42)
+    np.testing.assert_allclose(device.run().probabilities, host.run().probabilities, atol=1e-12)
+    observables = [[(0, "Z")], [(1, "X"), (2, "Z")]]
+    np.testing.assert_allclose(
+        device.expectation_values(observables),
+        host.expectation_values(observables),
+        atol=1e-12,
+    )
 
 
 @requires_device

--- a/docs/guides/gpu.md
+++ b/docs/guides/gpu.md
@@ -68,7 +68,7 @@ currently free VRAM is rejected at `init` with an error naming the requested and
 device memory; `GpuContext::max_qubits_for_statevector` reports the advisory cap from
 free memory.
 
-The three `BackendKind` entry points are also reachable from Python, from a build
+The four `BackendKind` entry points are also reachable from Python, from a build
 carrying the `gpu` feature. See [Python Bindings](python.md#gpu-backends).
 
 ## Module layout (`src/gpu/`)

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -251,7 +251,7 @@ Pass an explicit one to override it.
 | `density_matrix()` | Exact mixed states, never chosen by `auto()` |
 | `stochastic_pauli(num_samples=1000)` | Sampled Pauli propagation |
 | `deterministic_pauli(epsilon=0.0, max_terms=65536)` | Truncated Pauli propagation |
-| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
+| `auto_gpu(context)`, `statevector_gpu(context)`, `stabilizer_gpu(context)`, `density_matrix_gpu(context)` | CUDA device paths, see [GPU backends](#gpu-backends) |
 
 The density-matrix backend stores `4^n` amplitudes, so its qubit ceiling is
 about half the statevector cap; exceeding it raises `PrismError` naming the cap.
@@ -285,6 +285,12 @@ therefore normal, not a failure signal.
 (`PRISM_STABILIZER_GPU_MIN_QUBITS`), so it runs on the host tableau unless that
 override is lowered. The device tableau is correct; the default stays high until
 benchmarks justify lowering it.
+
+`density_matrix_gpu(context)` holds the exact mixed state on the device and is the
+one device kind with no crossover and no host fallback: `auto_gpu` never selects it,
+every noisy terminal that `density_matrix()` serves answers from the device buffer,
+and a width whose `4^n` buffer does not fit in free device memory raises `PrismError`
+before anything is allocated (13 qubits on an 11 GiB card).
 
 The published wheels are built without CUDA, because two of the three wheel
 targets have no CUDA toolkit and macOS has no CUDA at all. In those wheels the


### PR DESCRIPTION
## Summary

`BackendKind.density_matrix_gpu(context)` reaches the device-resident mixture from
Python in the shape of the other device kinds.

## Benchmark summary

N/A, no hot-path changes.

## Tests

`bindings/python/tests/test_gpu.py`: the constructor exists in every build, and with a
device the noisy `run` and `expectation_values` terminals match the host mixture at
1e-12 (skips without a device). Run from a `--features gpu` wheel:
41 passed, 2 skipped across `test_gpu.py`, `test_density_matrix.py`, `test_noise.py`,
`test_backends.py`.

## Documentation

`docs/guides/python.md` lists the kind and its no-fallback rule; `docs/guides/gpu.md`
counts four Python-reachable entry points.
